### PR TITLE
Fix for renamed _appleseed.dll

### DIFF
--- a/src/appleseed.python/module.cpp
+++ b/src/appleseed.python/module.cpp
@@ -59,7 +59,7 @@ void bind_utility();
 void bind_vector();
 
 // appleseed python module
-BOOST_PYTHON_MODULE( _appleseed)
+BOOST_PYTHON_MODULE( _appleseedpython)
 {
 	bind_utility();
 


### PR DESCRIPTION
I forgot about changing BOOST_PYTHON_MODULE( _appleseed) when the dll with the bindings was renamed.
