### PR TITLE
OpenEXR 2.0 fix.

### DIFF
--- a/src/appleseed/foundation/image/exrutils.cpp
+++ b/src/appleseed/foundation/image/exrutils.cpp
@@ -35,7 +35,6 @@
 #include "foundation/utility/string.h"
 
 // OpenEXR headers.
-#include "OpenEXR/ImfHeader.h"
 #include "OpenEXR/ImfStandardAttributes.h"
 #include "OpenEXR/ImfStringAttribute.h"
 

--- a/src/appleseed/foundation/image/exrutils.h
+++ b/src/appleseed/foundation/image/exrutils.h
@@ -29,9 +29,11 @@
 #ifndef APPLESEED_FOUNDATION_IMAGE_EXRUTILS_H
 #define APPLESEED_FOUNDATION_IMAGE_EXRUTILS_H
 
+// OpenEXR headers.
+#include "OpenEXR/ImfHeader.h"
+
 // Forward declarations.
 namespace foundation    { class ImageAttributes; }
-namespace Imf           { class Header; }
 
 namespace foundation
 {

--- a/src/appleseed/foundation/image/progressiveexrimagefilereader.h
+++ b/src/appleseed/foundation/image/progressiveexrimagefilereader.h
@@ -32,6 +32,9 @@
 // appleseed.foundation headers.
 #include "foundation/image/iprogressiveimagefilereader.h"
 
+// OpenEXR headers.
+#include "OpenEXR/ImfChannelList.h"
+
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
@@ -43,7 +46,6 @@ namespace foundation    { class CanvasProperties; }
 namespace foundation    { class ImageAttributes; }
 namespace foundation    { class Logger; }
 namespace foundation    { class Tile; }
-namespace Imf           { struct Channel; }
 
 
 namespace foundation


### PR DESCRIPTION
EXR 2.0 uses versioned namespaces, so classes can't be forward declared.
