### PR TITLE
Choose the right boost python lib for py3.

### DIFF
--- a/src/appleseed.python/CMakeLists.txt
+++ b/src/appleseed.python/CMakeLists.txt
@@ -37,11 +37,11 @@ string (SUBSTRING "${PYTHONLIBS_VERSION_STRING}" 0 1 PYTHON_MAJOR_VERSION)
 # Boost libraries.
 #--------------------------------------------------------------------------------------------------
 
-if(PYTHON_MAJOR_VERSION STREQUAL "3")
+if (PYTHON_MAJOR_VERSION STREQUAL "3")
     find_package (Boost 1.46 REQUIRED ${BOOST_NEEDED_LIBS} python3)
-else()
+else ()
     find_package (Boost 1.46 REQUIRED ${BOOST_NEEDED_LIBS} python)
-endif()
+endif ()
 
 
 #--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Find libboost_python3 when python 3 is used.
