### PR TITLE
Fixed unsafe formatting in logging calls.

### DIFF
--- a/src/appleseed/renderer/kernel/rendering/oiioerrorhandler.cpp
+++ b/src/appleseed/renderer/kernel/rendering/oiioerrorhandler.cpp
@@ -44,23 +44,23 @@ void OIIOErrorHandler::operator()(int errcode, const std::string& msg)
     switch (errcode)
     {
       case EH_WARNING:
-        RENDERER_LOG_WARNING(msg.c_str());
+        RENDERER_LOG_WARNING("%s", msg.c_str());
         break;
 
       case EH_ERROR:
-        RENDERER_LOG_ERROR(msg.c_str());
+        RENDERER_LOG_ERROR("%s", msg.c_str());
         break;
 
       case EH_SEVERE:
-        RENDERER_LOG_FATAL(msg.c_str());
+        RENDERER_LOG_FATAL("%s", msg.c_str());
         break;
 
       case EH_DEBUG:
-        RENDERER_LOG_DEBUG(msg.c_str());
+        RENDERER_LOG_DEBUG("%s", msg.c_str());
         break;
 
       default:
-        RENDERER_LOG_INFO(msg.c_str());
+        RENDERER_LOG_INFO("%s", msg.c_str());
     }
 }
 

--- a/src/appleseed/renderer/kernel/rendering/rendererservices.cpp
+++ b/src/appleseed/renderer/kernel/rendering/rendererservices.cpp
@@ -191,7 +191,7 @@ bool RendererServices::has_userdata(OIIO::ustring name,
 void RendererServices::log_error(const std::string& message)
 {
     if (!message.empty())
-        RENDERER_LOG_ERROR(message.c_str());    
+        RENDERER_LOG_ERROR("%s", message.c_str());
 }
 
 }   // namespace renderer


### PR DESCRIPTION
Without this, GCC 4.2.1 on OS X 10.7.5 complains with "warning: format not a string literal and no format arguments". With it I've got Appleseed built with OSL support on my mac, which is rather pleasing.
