### PR TITLE
minimize dock-widgets in a sidebar

### DIFF
--- a/sandbox/stylesheets/default.qss
+++ b/sandbox/stylesheets/default.qss
@@ -35,14 +35,14 @@
 
 #define BORDER_COLOR                        rgb(40, 40, 40)
 #define BORDER_STYLE                        1px solid BORDER_COLOR
-    
+
 #define DEFAULT_BACKGROUND_COLOR            rgb(50, 50, 50)
 #define INPUT_BACKGROUND_COLOR              rgb(43, 43, 43)
 #define DISABLED_INPUT_BACKGROUND_COLOR     rgb(45, 45, 45)
 #define ACTIVE_BACKGROUND_COLOR             rgb(60, 60, 60)
 #define HOVER_BACKGROUND_COLOR              rgb(190, 140, 50)
 #define SELECTED_BACKGROUND_COLOR           rgb(80, 80, 80)
-    
+
 #define DEFAULT_TEXT_COLOR                  rgb(210, 210, 210)
 #define DISABLED_TEXT_COLOR                 rgb(100, 100, 100)
 #define INFO_TEXT_COLOR                     rgb(100, 100, 100)
@@ -728,7 +728,7 @@ QRadioButton::indicator:unchecked:disabled
  * QAbstractSpinBox.
  * QComboBox.
  */
- 
+
 QLineEdit,
 QAbstractSpinBox,
 QComboBox
@@ -1015,4 +1015,28 @@ QLabel#info_label
 QPushButton#bind_entity_button
 {
     min-width: 30px;
+}
+
+QWidget#VerticalButtonOn
+{
+    background-color: SELECTED_BACKGROUND_COLOR;
+    color: DEFAULT_TEXT_COLOR;
+    border: BORDER_STYLE;
+}
+
+QWidget#VerticalButtonOn:hover
+{
+    background-color: HOVER_BACKGROUND_COLOR;
+}
+
+QWidget#VerticalButtonOff
+{
+    background-color: ACTIVE_BACKGROUND_COLOR;
+    color: DEFAULT_TEXT_COLOR;
+    border: BORDER_STYLE;
+}
+
+QWidget#VerticalButtonOff:hover
+{
+    background-color: HOVER_BACKGROUND_COLOR;
 }

--- a/src/appleseed.studio/mainwindow/mainwindow.h
+++ b/src/appleseed.studio/mainwindow/mainwindow.h
@@ -56,6 +56,7 @@
 // Forward declarations.
 namespace appleseed { namespace studio { class AttributeEditor; } }
 namespace appleseed { namespace studio { class ProjectExplorer; } }
+namespace appleseed { namespace studio { class VerticalButton; } }
 namespace Ui        { class MainWindow; }
 class QAction;
 class QCloseEvent;
@@ -102,6 +103,7 @@ class MainWindow
     QAction*                                m_action_stop_rendering;
 
     std::vector<QAction*>                   m_recently_opened;
+    std::vector<VerticalButton*>            m_minimize_buttons;
 
     StatusBar                               m_status_bar;
     std::auto_ptr<QtLogTarget>              m_log_target;
@@ -130,6 +132,8 @@ class MainWindow
 
     std::auto_ptr<StateBeforeProjectOpen>   m_state_before_project_open;
 
+    bool                                    m_fullscreen;
+
     void build_menus();
     void build_override_shading_menu_item();
     void update_override_shading_menu_item();
@@ -141,6 +145,8 @@ class MainWindow
     void build_toolbar();
     void build_log_panel();
     void build_project_explorer();
+    void build_minimize_buttons();
+    void build_minimize_toolbar();
 
     void build_connections();
 
@@ -186,6 +192,8 @@ class MainWindow
     void slot_save_project();
     void slot_save_project_as();
 
+    void slot_fullscreen();
+
     void slot_project_modified();
     void slot_frame_modified();
 
@@ -221,6 +229,7 @@ class MainWindow
     void slot_save_all_aovs();
     void slot_quicksave_all_aovs();
     void slot_clear_frame();
+
 };
 
 }       // namespace studio


### PR DESCRIPTION
For now there is a single sidebar since the number of widgets on
screen is small. Also the sidebar is allways on screen even if all
the widgets are on screen. Also a fullscreen toggle facility is
added.
