### PR TITLE
Recompute slider range for out-of-range values (issue #262)

### DIFF
--- a/src/appleseed.studio/mainwindow/project/entityeditor.cpp
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.cpp
@@ -241,12 +241,12 @@ namespace
         void slot_set_slider_value(const QString& value)
         {
             m_slider->blockSignals(true);
-            double dbl = value.toDouble();
-            if(m_slider->maximum() < dbl)
+            const double new_value = value.toDouble();
+            if (m_slider->maximum() < new_value)
             {
-                double min = m_slider->minimum();
-                m_slider->setRange(min, dbl);
-                m_slider->setPageStep((dbl - min) / 10.0);
+                const double min = m_slider->minimum();
+                m_slider->setRange(min, new_value);
+                m_slider->setPageStep((new_value - min) / 10.0);
             }
             m_slider->setValue(value.toDouble());
             m_slider->blockSignals(false);
@@ -254,16 +254,16 @@ namespace
 
         void slot_apply_slider_value()
         {
-            // Only lower slider max when the user has finished typing
+            // Only lower slider max when the user has finished typing.
             m_slider->blockSignals(true);
-            double dbl = m_line_edit->text().toDouble();
-            if(m_slider->maximum() < dbl || m_slider->maximum() >= dbl*3.f)
+            const double new_value = m_line_edit->text().toDouble();
+            if (m_slider->maximum() < new_value || m_slider->maximum() >= new_value * 3.0)
             {
-                double min = m_slider->minimum();
-                m_slider->setRange(min, dbl);
-                m_slider->setPageStep((dbl - min) / 10.0);
+                const double min = m_slider->minimum();
+                m_slider->setRange(min, new_value);
+                m_slider->setPageStep((new_value - min) / 10.0);
             }
-            m_slider->setValue(dbl);
+            m_slider->setValue(new_value);
             m_slider->blockSignals(false);
         }
 


### PR DESCRIPTION
The maximum value of sliders will now be recomputed when the user enters a larger value in the LineEdit.
I was worried about users accidentally typing in big values and making the slider range too big so I made the maximum value shrink if the entered value is <= 1/3 the current max.
I don't know how you feel about this. Is there some other way you would prefer to handle it?
