### PR TITLE
Removed unused UI elements. Issue #367

### DIFF
--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -498,7 +498,6 @@ void MainWindow::build_project_explorer()
 
     disable_osx_focus_rect(m_ui->treewidget_project_explorer_scene);
 
-
     connect(
         m_ui->lineedit_filter, SIGNAL(textChanged(const QString&)),
         SLOT(slot_filter_text_changed(const QString&)));

--- a/src/appleseed.studio/mainwindow/mainwindow.ui
+++ b/src/appleseed.studio/mainwindow/mainwindow.ui
@@ -167,7 +167,7 @@
   <widget class="QDockWidget" name="project_explorer">
    <property name="minimumSize">
     <size>
-     <width>213</width>
+     <width>200</width>
      <height>187</height>
     </size>
    </property>


### PR DESCRIPTION
Removed the following UI elements which aren't being used:

•edit menu
•render tab in the project explorer
•Alpha, depth and anomalies render widgets tabs
