### PR TITLE
Added textbox showing RGBA values.

### DIFF
--- a/sandbox/settings/appleseed.studio.xml
+++ b/sandbox/settings/appleseed.studio.xml
@@ -4,6 +4,9 @@
     <parameter name="print_final_average_luminance" value="false" />
     <parameter name="rendering_threads" value="auto" />
     <parameters name="ui">
+        <parameters name="filedialog">
+            <parameter name="lastdirectory" value="C:\Users\Liisa\Documents\koulu\graffa\asn2-me-c3100-computer-graphics\assn2\assets" />
+        </parameters>
         <parameters name="render_region">
             <parameter name="triggers_rendering" value="true" />
         </parameters>

--- a/src/appleseed.studio/mainwindow/rendering/rendertab.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/rendertab.cpp
@@ -55,6 +55,7 @@
 #include <QToolBar>
 #include <QToolButton>
 
+
 using namespace foundation;
 using namespace renderer;
 
@@ -174,6 +175,7 @@ void RenderTab::create_toolbar()
     m_toolbar = new QToolBar();
     m_toolbar->setObjectName(QString::fromUtf8("render_toolbar"));
     m_toolbar->setIconSize(QSize(18, 18));
+	
 
     // Create the Save Image button in the render toolbar.
     m_save_aovs_button = new QToolButton();
@@ -229,12 +231,28 @@ void RenderTab::create_toolbar()
     m_picking_mode_combo->setObjectName(QString::fromUtf8("picking_mode_combo"));
     m_toolbar->addWidget(m_picking_mode_combo);
 
-    m_toolbar->addSeparator();
+
+	m_toolbar->addSeparator();
 
     // Create a label to display various information such as mouse coordinates, etc.
     m_info_label = new QLabel();
     m_info_label->setObjectName(QString::fromUtf8("info_label"));
     m_toolbar->addWidget(m_info_label);
+
+
+	m_toolbar->addSeparator();
+
+
+	m_rgb_text = new QTextEdit();
+    m_rgb_text ->setObjectName(QString::fromUtf8("rgb_text"));
+	m_rgb_text->setReadOnly(true);
+	m_rgb_text->setMaximumHeight(18);
+    m_toolbar->addWidget(m_rgb_text );
+	
+
+
+
+	
 }
 
 void RenderTab::create_scrollarea()
@@ -271,7 +289,10 @@ void RenderTab::recreate_handlers()
     m_mouse_tracker.reset(
         new MouseCoordinatesTracker(
             m_render_widget,
-            m_info_label));
+            m_info_label,
+			m_rgb_text
+			));
+
 
     // Handler for picking scene entities in the render widget.
     m_picking_handler.reset(
@@ -281,7 +302,7 @@ void RenderTab::recreate_handlers()
             *m_mouse_tracker.get(),
             m_project_explorer,
             m_project));
-
+	
     // Handler for defining render regions with the mouse.
     m_render_region_handler.reset(
         new RenderRegionHandler(

--- a/src/appleseed.studio/mainwindow/rendering/rendertab.h
+++ b/src/appleseed.studio/mainwindow/rendering/rendertab.h
@@ -41,6 +41,7 @@
 // Qt headers.
 #include <QObject>
 #include <QWidget>
+#include <QTextEdit>
 
 // Standard headers.
 #include <memory>
@@ -113,6 +114,7 @@ class RenderTab
     QToolButton*                            m_clear_render_region_button;
     QComboBox*                              m_picking_mode_combo;
     QLabel*                                 m_info_label;
+    QTextEdit*                              m_rgb_text;
 
     ProjectExplorer&                        m_project_explorer;
     renderer::Project&                      m_project;
@@ -123,6 +125,7 @@ class RenderTab
     std::auto_ptr<ScenePickingHandler>      m_picking_handler;
     std::auto_ptr<RenderRegionHandler>      m_render_region_handler;
     std::auto_ptr<RenderClipboardHandler>   m_clipboard_handler;
+
 
     void create_render_widget();
     void create_toolbar();

--- a/src/appleseed.studio/mainwindow/rendering/scenepickinghandler.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/scenepickinghandler.cpp
@@ -180,7 +180,8 @@ void ScenePickingHandler::pick(const QPoint& point)
 
     const ScenePicker scene_picker(m_project.get_trace_context());
     const ScenePicker::PickingResult result = scene_picker.pick(ndc);
-
+	
+	
     stringstream sstr;
 
     sstr << "picking details:" << endl;
@@ -196,6 +197,7 @@ void ScenePickingHandler::pick(const QPoint& point)
     print_entity(sstr, "  surface shader   ", result.m_surface_shader);
     print_entity(sstr, "  bsdf             ", result.m_bsdf);
     print_entity(sstr, "  edf              ", result.m_edf);
+	
 
     RENDERER_LOG_INFO("%s", sstr.str().c_str());
 

--- a/src/appleseed.studio/utility/mousecoordinatestracker.cpp
+++ b/src/appleseed.studio/utility/mousecoordinatestracker.cpp
@@ -30,6 +30,7 @@
 // Interface header.
 #include "mousecoordinatestracker.h"
 
+
 // Qt headers.
 #include <QEvent>
 #include <QLabel>
@@ -38,20 +39,24 @@
 #include <QString>
 #include <QWidget>
 
+
 // Standard headers.
 #include <cassert>
 
 using namespace foundation;
 using namespace std;
 
+
 namespace appleseed {
 namespace studio {
 
 MouseCoordinatesTracker::MouseCoordinatesTracker(
-    QWidget*    widget,
-    QLabel*     label)
+    RenderWidget*	widget,
+    QLabel*			label,
+	QTextEdit*		rgb_text) 
   : m_widget(widget)
   , m_label(label)
+  , m_rgb_text(rgb_text)
   , m_content_width(widget->width())
   , m_content_height(widget->height())
 {
@@ -89,10 +94,12 @@ bool MouseCoordinatesTracker::eventFilter(QObject* object, QEvent* event)
     {
       case QEvent::MouseMove:
         set_label_text(static_cast<QMouseEvent*>(event)->pos());
+		set_rgb_text(static_cast<QMouseEvent*>(event)->pos());
         break;
 
       case QEvent::Leave:
         m_label->clear();
+		m_rgb_text->clear();
         break;
     }
 
@@ -102,14 +109,50 @@ bool MouseCoordinatesTracker::eventFilter(QObject* object, QEvent* event)
 void MouseCoordinatesTracker::set_label_text(const QPoint& point) const
 {
     const Vector2i pix = widget_to_pixel(point);
-    const Vector2d ndc = widget_to_ndc(point);
+    const Vector2d ndc = widget_to_ndc(point);	
 
-    m_label->setText(
-        QString("Pixel: %1, %2  -  NDC: %3, %4")
-            .arg(QString::number(pix.x))
-            .arg(QString::number(pix.y))
-            .arg(QString::number(ndc.x, 'f', 5))
-            .arg(QString::number(ndc.y, 'f', 5)));
+		
+	m_label->setText(
+		QString("Pixel: %1, %2 - NDC: %3, %4 ")
+			.arg(QString::number(pix.x), 4, '0')
+			.arg(QString::number(pix.y), 4, '0')
+			.arg(QString::number(ndc.x, 'f', 5))
+			.arg(QString::number(ndc.y, 'f', 5)));
+
+
+}
+
+void MouseCoordinatesTracker::set_rgb_text(const QPoint& point) const 
+{
+	const Vector2i pix = widget_to_pixel(point);
+	QRgb pixel_rgb = m_widget->get_image().pixel(pix.x, pix.y);
+					
+	m_rgb_text->clear();
+	QTextCursor cursor(m_rgb_text->textCursor());
+
+	//Set text color to red.
+	QTextCharFormat format;
+	format.setForeground(QColor(255,0,0));
+	cursor.setCharFormat(format);
+	// Insert the text at the position of the cursor.
+	cursor.insertText(QString(" %1").arg(QString::number(qRed(pixel_rgb)), 3, '0'));
+
+	//Move cursor to the end of the text. 
+	m_rgb_text->moveCursor(QTextCursor::End);
+	format.setForeground(QColor(0,255,0)); //green
+	cursor.setCharFormat(format);
+	cursor.insertText(QString(" %1").arg(QString::number(qGreen(pixel_rgb)), 3, '0'));
+
+	m_rgb_text->moveCursor(QTextCursor::End);
+	format.setForeground(QColor(0,0,255)); //blue
+	cursor.setCharFormat(format);
+	cursor.insertText(QString(" %1").arg(QString::number(qBlue(pixel_rgb)), 3, '0'));
+
+	m_rgb_text->moveCursor(QTextCursor::End);
+	format.clearForeground();
+	cursor.setCharFormat(format);
+	cursor.insertText(QString(" %1").arg(QString::number(qAlpha(pixel_rgb)), 3, '0'));
+	
 }
 
 }   // namespace studio

--- a/src/appleseed.studio/utility/mousecoordinatestracker.h
+++ b/src/appleseed.studio/utility/mousecoordinatestracker.h
@@ -30,11 +30,18 @@
 #ifndef APPLESEED_STUDIO_UTILITY_MOUSECOORDINATESTRACKER_H
 #define APPLESEED_STUDIO_UTILITY_MOUSECOORDINATESTRACKER_H
 
+// appleseed.renderer headers.
+#include "renderer/api/project.h"
+
 // appleseed.foundation headers.
 #include "foundation/math/vector.h"
 
+// appleseed.studio headers.
+#include "mainwindow/rendering/renderwidget.h"
+
 // Qt headers.
 #include <QObject>
+#include <QTextEdit>
 
 // Forward declarations.
 class QEvent;
@@ -52,8 +59,9 @@ class MouseCoordinatesTracker
 
   public:
     MouseCoordinatesTracker(
-        QWidget*    widget,
-        QLabel*     label);
+		RenderWidget*    widget,
+        QLabel*			label,
+		QTextEdit*		m_rgb_text);
 
     ~MouseCoordinatesTracker();
 
@@ -61,14 +69,19 @@ class MouseCoordinatesTracker
     foundation::Vector2i widget_to_pixel(const QPoint& point) const;
 
   private:
-    QWidget*        m_widget;
-    QLabel*         m_label;
-    const int       m_content_width;
-    const int       m_content_height;
+    RenderWidget*					m_widget;
+    QLabel*							m_label;
+	QTextEdit*						m_rgb_text;
+
+	
+    const int						m_content_width;
+    const int						m_content_height;
 
     virtual bool eventFilter(QObject* object, QEvent* event);
 
     void set_label_text(const QPoint& point) const;
+
+	void set_rgb_text(const QPoint& point) const;
 };
 
 }       // namespace studio


### PR DESCRIPTION
Added textbox showing RGBA values.
Added padding to pixel values.

This commit is related to issue
https://github.com/appleseedhq/appleseed/issues/364

The RGBA values of the current position of the cursor are shown when mouse is moved.
When the cursor is moved outside the image the field is cleared.
Values are currently taken from renderwidget, but this feature could be developed further to take
the values from frame buffer.

Liisa
