### PR TITLE
Split spectral input formats into spectrum only and spectrum+alpha. Issue #344.

### DIFF
--- a/src/appleseed/renderer/modeling/bsdf/ashikhminbrdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/ashikhminbrdf.h
@@ -57,10 +57,8 @@ namespace renderer
 DECLARE_INPUT_VALUES(AshikminBRDFInputValues)
 {
     Spectrum    m_rd;               // diffuse reflectance of the substrate
-    Alpha       m_rd_alpha;         // unused
     double      m_rd_multiplier;    // diffuse reflectance multiplier
     Spectrum    m_rg;               // glossy reflectance at normal incidence
-    Alpha       m_rg_alpha;         // unused
     double      m_rg_multiplier;    // glossy reflectance multiplier
     double      m_fr_multiplier;    // Fresnel multiplier
     double      m_nu;               // Phong-like exponent in first tangent direction

--- a/src/appleseed/renderer/modeling/bsdf/diffusebtdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/diffusebtdf.h
@@ -57,7 +57,6 @@ namespace renderer
 DECLARE_INPUT_VALUES(DiffuseBTDFInputValues)
 {
     Spectrum    m_transmittance;                // diffuse transmittance
-    Alpha       m_transmittance_alpha;          // unused
     double      m_transmittance_multiplier;     // diffuse transmittance multiplier
 };
 

--- a/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.cpp
@@ -445,10 +445,8 @@ namespace
         DECLARE_INPUT_VALUES(InputValues)
         {
             Spectrum            m_rm;                           // matte reflectance of the substrate
-            Alpha               m_rm_alpha;                     // unused
             double              m_rm_multiplier;                // matte reflectance multiplier
             Spectrum            m_rs;                           // specular reflectance at normal incidence
-            Alpha               m_rs_alpha;                     // unused
             double              m_rs_multiplier;                // specular reflectance multiplier
             double              m_roughness;                    // technically, root-mean-square of the microfacets slopes
         };

--- a/src/appleseed/renderer/modeling/bsdf/lambertianbrdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/lambertianbrdf.h
@@ -57,7 +57,6 @@ namespace renderer
 DECLARE_INPUT_VALUES(LambertianBRDFInputValues)
 {
     Spectrum    m_reflectance;              // diffuse reflectance (albedo, technically)
-    Alpha       m_reflectance_alpha;        // unused
     double      m_reflectance_multiplier;
 };
 

--- a/src/appleseed/renderer/modeling/bsdf/microfacetbrdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/microfacetbrdf.h
@@ -59,7 +59,6 @@ DECLARE_INPUT_VALUES(MicrofacetBRDFInputValues)
     double      m_glossiness;
     double      m_glossiness_multiplier;
     Spectrum    m_reflectance;
-    Alpha       m_reflectance_alpha;        // unused
     double      m_reflectance_multiplier;
     double      m_fr_multiplier;            // Fresnel multiplier
 };

--- a/src/appleseed/renderer/modeling/bsdf/specularbrdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/specularbrdf.h
@@ -57,7 +57,6 @@ namespace renderer
 DECLARE_INPUT_VALUES(SpecularBRDFInputValues)
 {
     Spectrum    m_reflectance;              // specular reflectance
-    Alpha       m_reflectance_alpha;        // unused
     double      m_reflectance_multiplier;   // specular reflectance multiplier
 };
 

--- a/src/appleseed/renderer/modeling/bsdf/specularbtdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/specularbtdf.h
@@ -57,10 +57,8 @@ namespace renderer
 DECLARE_INPUT_VALUES(SpecularBTDFInputValues)
 {
     Spectrum    m_reflectance;                  // specular reflectance
-    Alpha       m_reflectance_alpha;            // unused
     double      m_reflectance_multiplier;       // specular reflectance multiplier
     Spectrum    m_transmittance;                // specular transmittance
-    Alpha       m_transmittance_alpha;          // unused
     double      m_transmittance_multiplier;     // specular transmittance multiplier
     double      m_from_ior;                     // from this index of refraction
     double      m_to_ior;                       // to this index of refraction

--- a/src/appleseed/renderer/modeling/edf/coneedf.cpp
+++ b/src/appleseed/renderer/modeling/edf/coneedf.cpp
@@ -197,7 +197,6 @@ namespace
         DECLARE_INPUT_VALUES(InputValues)
         {
             Spectrum    m_radiance;             // emitted radiance in W.m^-2.sr^-1
-            Alpha       m_radiance_alpha;       // unused
             double      m_radiance_multiplier;  // emitted radiance multiplier
             double      m_angle;                // cone angle
         };

--- a/src/appleseed/renderer/modeling/edf/diffuseedf.cpp
+++ b/src/appleseed/renderer/modeling/edf/diffuseedf.cpp
@@ -195,7 +195,6 @@ namespace
         DECLARE_INPUT_VALUES(InputValues)
         {
             Spectrum    m_radiance;             // emitted radiance in W.m^-2.sr^-1
-            Alpha       m_radiance_alpha;       // unused
             double      m_radiance_multiplier;  // emitted radiance multiplier
         };
     };

--- a/src/appleseed/renderer/modeling/environmentedf/constantenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/constantenvironmentedf.cpp
@@ -148,7 +148,6 @@ namespace
         DECLARE_INPUT_VALUES(InputValues)
         {
             Spectrum    m_radiance;             // emitted radiance in W.m^-2.sr^-1
-            Alpha       m_radiance_alpha;       // unused
         };
 
         InputValues     m_values;

--- a/src/appleseed/renderer/modeling/environmentedf/constanthemisphereenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/constanthemisphereenvironmentedf.cpp
@@ -158,9 +158,7 @@ namespace
         DECLARE_INPUT_VALUES(InputValues)
         {
             Spectrum    m_upper_hemi_radiance;              // radiance emitted by the upper hemisphere, in W.m^-2.sr^-1
-            Alpha       m_upper_hemi_radiance_alpha;        // unused
             Spectrum    m_lower_hemi_radiance;              // radiance emitted by the lower hemisphere, in W.m^-2.sr^-1
-            Alpha       m_lower_hemi_radiance_alpha;        // unused
         };
 
         InputValues     m_values;

--- a/src/appleseed/renderer/modeling/environmentedf/gradientenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/gradientenvironmentedf.cpp
@@ -150,9 +150,7 @@ namespace
         DECLARE_INPUT_VALUES(InputValues)
         {
             Spectrum    m_horizon_radiance;             // radiance emitted at horizon, in W.m^-2.sr^-1
-            Alpha       m_horizon_radiance_alpha;       // unused
             Spectrum    m_zenith_radiance;              // radiance emitted at zenith, in W.m^-2.sr^-1
-            Alpha       m_zenith_radiance_alpha;        // unused
         };
 
         InputValues     m_values;

--- a/src/appleseed/renderer/modeling/environmentedf/latlongmapenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/latlongmapenvironmentedf.cpp
@@ -279,7 +279,6 @@ namespace
         DECLARE_INPUT_VALUES(InputValues)
         {
             Spectrum    m_radiance;             // emitted radiance in W.m^-2.sr^-1
-            Alpha       m_radiance_alpha;       // unused
             double      m_radiance_multiplier;  // emitted radiance multiplier
         };
 

--- a/src/appleseed/renderer/modeling/environmentedf/mirrorballmapenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/mirrorballmapenvironmentedf.cpp
@@ -150,7 +150,6 @@ namespace
         DECLARE_INPUT_VALUES(InputValues)
         {
             Spectrum    m_radiance;             // emitted radiance in W.m^-2.sr^-1
-            Alpha       m_radiance_alpha;       // unused
             double      m_radiance_multiplier;  // emitted radiance multiplier
         };
 

--- a/src/appleseed/renderer/modeling/input/colorsource.cpp
+++ b/src/appleseed/renderer/modeling/input/colorsource.cpp
@@ -119,7 +119,8 @@ namespace
         const Color3f&      linear_rgb,
         Spectrum&           spectrum)
     {
-        if (input_format == InputFormatSpectralReflectance)
+        if (input_format == InputFormatSpectralReflectance ||
+            input_format == InputFormatSpectralReflectanceWithAlpha)
         {
             linear_rgb_reflectance_to_spectrum(
                 linear_rgb,
@@ -127,7 +128,8 @@ namespace
         }
         else
         {
-            assert(input_format == InputFormatSpectralIlluminance);
+            assert(input_format == InputFormatSpectralIlluminance ||
+                   input_format == InputFormatSpectralIlluminanceWithAlpha);
             linear_rgb_illuminance_to_spectrum(
                 linear_rgb,
                 spectrum);
@@ -149,7 +151,10 @@ void ColorSource::initialize_from_3d_color(
 
     m_scalar = static_cast<double>(m_linear_rgb[0]);
 
-    if (input_format == InputFormatSpectralIlluminance || input_format == InputFormatSpectralReflectance)
+    if (input_format == InputFormatSpectralIlluminance ||
+        input_format == InputFormatSpectralReflectance ||
+        input_format == InputFormatSpectralIlluminanceWithAlpha ||
+        input_format == InputFormatSpectralReflectanceWithAlpha)
     {
         switch (color_entity.get_color_space())
         {

--- a/src/appleseed/renderer/modeling/input/inputarray.cpp
+++ b/src/appleseed/renderer/modeling/input/inputarray.cpp
@@ -100,6 +100,12 @@ namespace
               case InputFormatSpectralIlluminance:
                 size = align_to<Spectrum>(size);
                 size += sizeof(Spectrum);
+                break;
+
+              case InputFormatSpectralReflectanceWithAlpha:
+              case InputFormatSpectralIlluminanceWithAlpha:
+                size = align_to<Spectrum>(size);
+                size += sizeof(Spectrum);
                 size += sizeof(Alpha);
                 break;
             }
@@ -129,6 +135,21 @@ namespace
 
               case InputFormatSpectralReflectance:
               case InputFormatSpectralIlluminance:
+                {
+                    ptr = align_to<Spectrum>(ptr);
+                    Spectrum* out_spectrum = reinterpret_cast<Spectrum*>(ptr);
+
+                    if (m_source)
+                        m_source->evaluate(texture_cache, uv, *out_spectrum);
+                    else
+                        out_spectrum->set(0.0f);
+
+                    ptr += sizeof(Spectrum);
+                }
+                break;
+
+              case InputFormatSpectralReflectanceWithAlpha:
+              case InputFormatSpectralIlluminanceWithAlpha:
                 {
                     ptr = align_to<Spectrum>(ptr);
                     Spectrum* out_spectrum = reinterpret_cast<Spectrum*>(ptr);
@@ -170,6 +191,21 @@ namespace
 
               case InputFormatSpectralReflectance:
               case InputFormatSpectralIlluminance:
+                {
+                    ptr = align_to<Spectrum>(ptr);
+                    Spectrum* out_spectrum = reinterpret_cast<Spectrum*>(ptr);
+
+                    if (m_source && m_source->is_uniform())
+                        m_source->evaluate_uniform(*out_spectrum);
+                    else
+                        out_spectrum->set(0.0f);
+
+                    ptr += sizeof(Spectrum);
+                }
+                break;
+
+              case InputFormatSpectralReflectanceWithAlpha:
+              case InputFormatSpectralIlluminanceWithAlpha:
                 {
                     ptr = align_to<Spectrum>(ptr);
                     Spectrum* out_spectrum = reinterpret_cast<Spectrum*>(ptr);

--- a/src/appleseed/renderer/modeling/input/inputformat.h
+++ b/src/appleseed/renderer/modeling/input/inputformat.h
@@ -42,6 +42,8 @@ enum InputFormat
     InputFormatScalar,
     InputFormatSpectralReflectance,
     InputFormatSpectralIlluminance,
+    InputFormatSpectralReflectanceWithAlpha,
+    InputFormatSpectralIlluminanceWithAlpha,
     InputFormatEntity
 };
 

--- a/src/appleseed/renderer/modeling/input/texturesource.h
+++ b/src/appleseed/renderer/modeling/input/texturesource.h
@@ -183,7 +183,8 @@ inline void TextureSource::evaluate(
 {
     const foundation::Color4f color = sample_texture(texture_cache, uv);
 
-    if (m_input_format == InputFormatSpectralReflectance)
+    if (m_input_format == InputFormatSpectralReflectance ||
+        m_input_format == InputFormatSpectralReflectanceWithAlpha)
         foundation::linear_rgb_reflectance_to_spectrum(color.rgb(), spectrum);
     else foundation::linear_rgb_illuminance_to_spectrum(color.rgb(), spectrum);
 }
@@ -219,7 +220,8 @@ inline void TextureSource::evaluate(
 {
     const foundation::Color4f color = sample_texture(texture_cache, uv);
 
-    if (m_input_format == InputFormatSpectralReflectance)
+    if (m_input_format == InputFormatSpectralReflectance ||
+        m_input_format == InputFormatSpectralReflectanceWithAlpha)
         foundation::linear_rgb_reflectance_to_spectrum(color.rgb(), spectrum);
     else foundation::linear_rgb_illuminance_to_spectrum(color.rgb(), spectrum);
 

--- a/src/appleseed/renderer/modeling/light/directionallight.cpp
+++ b/src/appleseed/renderer/modeling/light/directionallight.cpp
@@ -152,7 +152,6 @@ namespace
         DECLARE_INPUT_VALUES(InputValues)
         {
             Spectrum    m_radiance;             // emitted radiance in W.m^-2.sr^-1
-            Alpha       m_radiance_alpha;       // unused
             double      m_radiance_multiplier;  // emitted radiance multiplier
         };
 

--- a/src/appleseed/renderer/modeling/light/pointlight.cpp
+++ b/src/appleseed/renderer/modeling/light/pointlight.cpp
@@ -134,7 +134,6 @@ namespace
         DECLARE_INPUT_VALUES(InputValues)
         {
             Spectrum    m_radiance;             // emitted radiance in W.m^-2.sr^-1
-            Alpha       m_radiance_alpha;       // unused
             double      m_radiance_multiplier;  // emitted radiance multiplier
         };
 

--- a/src/appleseed/renderer/modeling/light/spotlight.cpp
+++ b/src/appleseed/renderer/modeling/light/spotlight.cpp
@@ -162,7 +162,6 @@ namespace
         DECLARE_INPUT_VALUES(InputValues)
         {
             Spectrum    m_radiance;             // emitted radiance in W.m^-2.sr^-1
-            Alpha       m_radiance_alpha;       // unused
             double      m_radiance_multiplier;  // emitted radiance multiplier
         };
 

--- a/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
@@ -73,7 +73,7 @@ namespace
             const ParamArray&       params)
           : SurfaceShader(name, params)
         {
-            m_inputs.declare("color", InputFormatSpectralIlluminance);
+            m_inputs.declare("color", InputFormatSpectralIlluminanceWithAlpha);
             m_inputs.declare("color_multiplier", InputFormatScalar, "1.0");
             m_inputs.declare("alpha_multiplier", InputFormatScalar, "1.0");
 
@@ -82,7 +82,7 @@ namespace
                 m_alpha_source = AlphaSourceColor;
             else if (alpha_source == "material")
                 m_alpha_source = AlphaSourceMaterial;
-            else 
+            else
             {
                 RENDERER_LOG_ERROR(
                     "invalid value \"%s\" for parameter \"alpha_source\", "

--- a/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
@@ -223,9 +223,7 @@ namespace
             double      m_color_multiplier;
             double      m_alpha_multiplier;
             Spectrum    m_translucency;
-            Alpha       m_translucency_alpha;           // unused
             Spectrum    m_aerial_persp_sky_color;
-            Alpha       m_aerial_persp_sky_alpha;       // unused
         };
 
         enum AerialPerspMode


### PR DESCRIPTION
There are two types of input formats for spectral (color) inputs: InputFormatSpectralReflectance and InputFormatSpectralIlluminance.

The goal is to split these two input formats as follow:
InputFormatSpectralReflectance: the input evaluator will only emit a spectrum
InputFormatSpectralIlluminance: the input evaluator will only emit a spectrum
InputFormatSpectralReflectanceWithAlpha: the input evaluator will emit a (spectrum, alpha) pair
InputFormatSpectralIlluminanceWithAlpha: the input evaluator will emit a (spectrum, alpha) pair
