### PR TITLE
Fixed issue #316: Print a warning when doing multipass rendering but pixel decorrelation is off 

### DIFF
--- a/src/appleseed/renderer/kernel/rendering/final/uniformpixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/uniformpixelrenderer.cpp
@@ -94,6 +94,11 @@ namespace
 
                 if (primary)
                 {
+                    const int passes = params.get_optional<int>("passes", 1);
+
+                    if (passes > 1)
+                        RENDERER_LOG_WARNING("doing multipass rendering with pixel decorrelation off.");
+
                     RENDERER_LOG_INFO(
                         "effective max subpixel grid size: %d x %d",
                         m_sqrt_sample_count,

--- a/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
@@ -522,10 +522,13 @@ IRendererController::Status MasterRenderer::initialize_and_render_frame_sequence
 
         if (value == "uniform")
         {
+            ParamArray params = m_params.child("uniform_pixel_renderer");
+            copy_param(params, m_params.child("generic_frame_renderer"), "passes");
+
             pixel_renderer_factory.reset(
                 new UniformPixelRendererFactory(
                     sample_renderer_factory.get(),
-                    m_params.child("uniform_pixel_renderer")));
+                    params));
         }
         else if (value == "adaptive")
         {


### PR DESCRIPTION
Let me know if this does the trick. Thanks.
