### PR TITLE
Parameter can have value between tags

### DIFF
--- a/src/appleseed/renderer/modeling/project/project.xsd
+++ b/src/appleseed/renderer/modeling/project/project.xsd
@@ -31,8 +31,12 @@
         <xsd:documentation xml:lang="en">appleseed project file format</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType name="parameter">
-        <xsd:attribute name="name" type="xsd:string" use="required"/>
-        <xsd:attribute name="value" type="xsd:string" use="required"/>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="name" type="xsd:string" use="required"/>
+                <xsd:attribute name="value" type="xsd:string" use="optional"/>
+            </xsd:extension>
+        </xsd:simpleContent>
     </xsd:complexType>
     <xsd:complexType name="parameterSet">
         <xsd:choice minOccurs="0" maxOccurs="unbounded">

--- a/src/appleseed/renderer/modeling/project/projectfilereader.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilereader.cpp
@@ -419,6 +419,33 @@ namespace
             m_value = ElementHandlerBase::get_value(attrs, "value");
         }
 
+        virtual void characters(
+            const XMLCh* const  chars,
+            const XMLSize_t     length) OVERRIDE
+        {
+            const string inner_value = transcode(chars);
+            if (!m_value.empty() && !inner_value.empty())
+            {
+                RENDERER_LOG_ERROR(
+                    "while defining <parameter> element: value specified multiple times.");
+                m_context.get_event_counters().signal_error();
+            }
+            else
+            {
+                m_value = inner_value;
+            }
+        }
+
+        virtual void end_element() OVERRIDE
+        {
+            if (m_value.empty())
+            {
+                RENDERER_LOG_ERROR(
+                    "while defining <parameter> element: value not specified.");
+                m_context.get_event_counters().signal_error();
+            }
+        }
+
         const string& get_name() const
         {
             return m_name;


### PR DESCRIPTION
Until now there was only the possiblity to add a value for a parameter
using the value attribute. This had the disadvantage of not allowing
the preservation of some special characters such as newlines.

The solution to this problem is to enclose the value between a pair
of tags of the same type: e.g. <parameter name="metallic">15</parameter>.

This is particularly useful in the case of disney expressions.

Signed-off-by: Marius Avram marius.avram1309@gmail.com
