### PR TITLE
Added test cases for parameter with newlines

### DIFF
--- a/sandbox/tests/unit tests/inputs/test_settings_settingsfilewithnewlinesparameters.xml
+++ b/sandbox/tests/unit tests/inputs/test_settings_settingsfilewithnewlinesparameters.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+    <parameter name="a" value="aa" />
+    <parameter name="b">bb
+bb
+bb</parameter>
+</settings>

--- a/src/appleseed/foundation/meta/tests/test_settings.cpp
+++ b/src/appleseed/foundation/meta/tests/test_settings.cpp
@@ -98,6 +98,18 @@ TEST_SUITE(Foundation_Utility_SettingsFileReader)
         EXPECT_EQ("aa", sub2.get<string>("a"));
         EXPECT_EQ("bb", sub2.get<string>("b"));
     }
+
+    TEST_CASE_F(Read_GivenSettingsFileWithNewlinesParameters_ReturnsDictionaryWithNewlinesParameters, Fixture)
+    {
+        const bool succeeded = read("unit tests/inputs/test_settings_settingsfilewithnewlinesparameters.xml");
+        ASSERT_TRUE(succeeded);
+
+        ASSERT_EQ(2, m_dictionary.strings().size());
+        ASSERT_EQ(0, m_dictionary.dictionaries().size());
+
+        EXPECT_EQ("aa", m_dictionary.get<string>("a"));
+        EXPECT_EQ("bb\nbb\nbb", m_dictionary.get<string>("b"));
+    }
 }
 
 TEST_SUITE(Foundation_Utility_SettingsFileWriter)
@@ -155,6 +167,23 @@ TEST_SUITE(Foundation_Utility_SettingsFileWriter)
             compare_text_files(
                 "unit tests/inputs/test_settings_settingsfilewithtwodictionaryparameters.xml",
                 "unit tests/outputs/test_settings_settingsfilewithtwodictionaryparameters.xml");
+
+        EXPECT_TRUE(identical);
+    }
+
+    TEST_CASE(Write_GiveDictionaryWithNewlinesParameters_WriteSettingsFileWithNewlinesParameters)
+    {
+        Dictionary dictionary;
+        dictionary.insert("a", "aa");
+        dictionary.insert("b", "bb\nbb\nbb");
+
+        SettingsFileWriter writer;
+        writer.write("unit tests/outputs/test_settings_settingsfilewithnewlinesparameters.xml", dictionary);
+
+        const bool identical =
+            compare_text_files(
+                "unit tests/inputs/test_settings_settingsfilewithnewlinesparameters.xml",
+                "unit tests/outputs/test_settings_settingsfilewithnewlinesparameters.xml");
 
         EXPECT_TRUE(identical);
     }

--- a/src/appleseed/foundation/utility/settings/settings.xsd
+++ b/src/appleseed/foundation/utility/settings/settings.xsd
@@ -30,8 +30,12 @@
         <xsd:documentation xml:lang="en">appleseed settings file format</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType name="parameter">
-        <xsd:attribute name="name" type="xsd:string" use="required"/>
-        <xsd:attribute name="value" type="xsd:string" use="required"/>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="name" type="xsd:string" use="required"/>
+                <xsd:attribute name="value" type="xsd:string" use="optional"/>
+            </xsd:extension>
+        </xsd:simpleContent>
     </xsd:complexType>
     <xsd:complexType name="parameterSet">
         <xsd:choice minOccurs="0" maxOccurs="unbounded">

--- a/src/appleseed/foundation/utility/settings/settingsfilereader.cpp
+++ b/src/appleseed/foundation/utility/settings/settingsfilereader.cpp
@@ -90,9 +90,18 @@ namespace
                     const DOMNode* name_attribute = attributes->getNamedItem(name_attribute_name.c_str());
                     const DOMNode* value_attribute = attributes->getNamedItem(value_attribute_name.c_str());
 
-                    dictionary.insert(
-                        transcode(name_attribute->getNodeValue()),
-                        transcode(value_attribute->getNodeValue()));
+                    if (value_attribute)
+                    {
+                        dictionary.insert(
+                            transcode(name_attribute->getNodeValue()),
+                            transcode(value_attribute->getNodeValue()));
+                    }
+                    else
+                    {
+                        dictionary.insert(
+                            transcode(name_attribute->getNodeValue()),
+                            transcode(node->getTextContent()));
+                    }
                 }
             }
 


### PR DESCRIPTION
Also the commit includes support for newlines in a setting file.
Until now the xsd schema for the setting file was the old one
without support for a parameter with newlines characters.

Test cases are placed until the setting file loading.

Signed-off-by: Marius Avram marius.avram1309@gmail.com
