### PR TITLE
Fixing ifndef

### DIFF
--- a/src/appleseed/renderer/meta/tests/test_bsdfmix.cpp
+++ b/src/appleseed/renderer/meta/tests/test_bsdfmix.cpp
@@ -60,7 +60,7 @@
 using namespace foundation;
 using namespace renderer;
 
-#ifndef WITH_OSL
+#if not defined(WITH_OSL) && not defined(WITH_OIIO)
 
 TEST_SUITE(Renderer_Modeling_BSDF_BSDFMix)
 {


### PR DESCRIPTION
The call to the constructor of ShadingContext used in test_bsdfmix.cpp
is valid when both WITH_OSL and WITH_OIIO are not defined, ortherwise
it will result in a compilation problem.

Signed-off-by: Marius Avram marius.avram1309@gmail.com
