### PR TITLE
Importing and exporting disney materials

### DIFF
--- a/src/appleseed.studio/mainwindow/project/expressioneditorwindow.cpp
+++ b/src/appleseed.studio/mainwindow/project/expressioneditorwindow.cpp
@@ -37,6 +37,9 @@
 #include "renderer/modeling/material/disneymaterial.h"
 #include "renderer/modeling/project/project.h"
 
+// appleseed.studio headers.
+#include "mainwindow/project/tools.h"
+
 // appleseed.foundation headers.
 #include "foundation/utility/foreach.h"
 
@@ -180,19 +183,6 @@ void ExpressionEditorWindow::slot_clear_expression()
     m_editor->setExpr("");
 }
 
-namespace
-{
-    void show_message_box(const string& title, const string& text)
-    {
-        QMessageBox msgbox;
-        msgbox.setWindowTitle(QString::fromStdString(title));
-        msgbox.setIcon(QMessageBox::Warning);
-        msgbox.setText(QString::fromStdString(text));
-        msgbox.setStandardButtons(QMessageBox::Ok);
-        msgbox.exec();
-    }
-}
-
 void ExpressionEditorWindow::slot_save_script()
 {
     QFileDialog::Options options;
@@ -221,7 +211,7 @@ void ExpressionEditorWindow::slot_save_script()
         ofstream script_file(m_script_filepath.c_str());
         if (!script_file.is_open())
         {
-            show_message_box(
+            show_warning_message_box(
                 "Saving Error",
                 "Failed to save the expression script file " + m_script_filepath + ".");
             return;
@@ -253,7 +243,7 @@ void ExpressionEditorWindow::slot_load_script()
         ifstream script_file(filepath.toStdString().c_str());
         if (!script_file.is_open())
         {
-            show_message_box(
+            show_warning_message_box(
                 "Loading Error",
                 "Failed to load the expression script file " + filepath.toStdString() + ".");
             return;

--- a/src/appleseed.studio/mainwindow/project/materialcollectionitem.h
+++ b/src/appleseed.studio/mainwindow/project/materialcollectionitem.h
@@ -64,6 +64,7 @@ class MaterialCollectionItem
     void slot_create_generic();
 #ifdef WITH_DISNEY_MATERIAL
     void slot_create_disney();
+    void slot_import_disney();
 #endif
 #ifdef WITH_OSL
     void slot_create_osl();

--- a/src/appleseed.studio/mainwindow/project/materialitem.h
+++ b/src/appleseed.studio/mainwindow/project/materialitem.h
@@ -54,8 +54,13 @@ class MaterialItem
         MaterialCollectionItem*     collection_item,
         ProjectBuilder&             project_builder);
 
+    virtual QMenu* get_single_item_context_menu() const;
+
   private:
     virtual void slot_edit(AttributeEditor* attribute_editor) OVERRIDE;
+
+  public slots:
+    void slot_export();
 };
 
 }       // namespace studio

--- a/src/appleseed.studio/mainwindow/project/tools.cpp
+++ b/src/appleseed.studio/mainwindow/project/tools.cpp
@@ -42,6 +42,7 @@
 #include <QFileInfo>
 #include <QInputDialog>
 #include <QLineEdit>
+#include <QMessageBox>
 #include <QObject>
 #include <QString>
 
@@ -204,6 +205,16 @@ QString find_path_in_searchpaths(const SearchPaths& s, const QString& filename)
     }
 
     return filename;
+}
+
+void show_warning_message_box(const string& title, const string& text)
+{
+    QMessageBox msgbox;
+    msgbox.setWindowTitle(QString::fromStdString(title));
+    msgbox.setIcon(QMessageBox::Warning);
+    msgbox.setText(QString::fromStdString(text));
+    msgbox.setStandardButtons(QMessageBox::Ok);
+    msgbox.exec();
 }
 
 }   // namespace studio

--- a/src/appleseed.studio/mainwindow/project/tools.h
+++ b/src/appleseed.studio/mainwindow/project/tools.h
@@ -107,6 +107,8 @@ void open_entity_editor(
 
 QString find_path_in_searchpaths(const foundation::SearchPaths& s, const QString& filename);
 
+void show_warning_message_box(const std::string& title, const std::string& text);
+
 //
 // Implementation.
 //


### PR DESCRIPTION
They are exported using individual files. Currently the settings.xsd
format is used and some extra parameters are added to save the name
and the model of the materials.

Contains also a refactoring of show_message_box() from expressioneditorwindow
which now is required in multiple places. It has been moved to tools.cpp
and renamed to show_warning_message_box().

Signed-off-by: Marius Avram marius.avram1309@gmail.com
