### PR TITLE
Object instance item changes color when assigning material

### DIFF
--- a/src/appleseed.studio/mainwindow/project/materialassignmenteditorwindow.cpp
+++ b/src/appleseed.studio/mainwindow/project/materialassignmenteditorwindow.cpp
@@ -75,12 +75,14 @@ namespace appleseed {
 namespace studio {
 
 MaterialAssignmentEditorWindow::MaterialAssignmentEditorWindow(
-    QWidget*            parent,
-    ObjectInstance&     object_instance,
-    ProjectBuilder&     project_builder)
+    QWidget*                parent,
+    ObjectInstance&         object_instance,
+    ObjectInstanceItem&     object_instance_item,
+    ProjectBuilder&         project_builder)
   : QWidget(parent)
   , m_ui(new Ui::MaterialAssignmentEditorWindow())
   , m_object_instance(object_instance)
+  , m_object_instance_item(object_instance_item)
   , m_object(m_object_instance.find_object())
   , m_project_builder(project_builder)
 {
@@ -313,13 +315,16 @@ namespace
 {
     void do_assign_material(
         ObjectInstance&                 object_instance,
+        ObjectInstanceItem&             object_instance_item,
         const string&                   slot,
         const ObjectInstance::Side      side,
         const string&                   name)
     {
         if (name.empty())
             object_instance.unassign_material(slot.c_str(), side);
-        else object_instance.assign_material(slot.c_str(), side, name.c_str());
+        else
+            object_instance.assign_material(slot.c_str(), side, name.c_str());
+        object_instance_item.update_style();
     }
 
     class AssignMaterialDelayedAction
@@ -328,10 +333,12 @@ namespace
       public:
         AssignMaterialDelayedAction(
             ObjectInstance&             object_instance,
+            ObjectInstanceItem&         object_instance_item,
             const string&               slot,
             const ObjectInstance::Side  side,
             const string&               name)
           : m_object_instance(object_instance)
+          , m_object_instance_item(object_instance_item)
           , m_slot(slot)
           , m_side(side)
           , m_name(name)
@@ -342,11 +349,12 @@ namespace
             MasterRenderer&             master_renderer,
             Project&                    project) OVERRIDE
         {
-            do_assign_material(m_object_instance, m_slot, m_side, m_name);
+            do_assign_material(m_object_instance, m_object_instance_item, m_slot, m_side, m_name);
         }
 
       private:
         ObjectInstance&                 m_object_instance;
+        ObjectInstanceItem&             m_object_instance_item;
         const string                    m_slot;
         const ObjectInstance::Side      m_side;
         const string                    m_name;
@@ -377,6 +385,7 @@ void MaterialAssignmentEditorWindow::assign_material(const SlotValue& slot_value
             auto_ptr<RenderingManager::IDelayedAction>(
                 new AssignMaterialDelayedAction(
                     m_object_instance,
+                    m_object_instance_item,
                     slot_value.m_slot_name,
                     slot_value.m_side,
                     slot_value.m_material_name)));
@@ -385,6 +394,7 @@ void MaterialAssignmentEditorWindow::assign_material(const SlotValue& slot_value
     {
         do_assign_material(
             m_object_instance,
+            m_object_instance_item,
             slot_value.m_slot_name,
             slot_value.m_side,
             slot_value.m_material_name);

--- a/src/appleseed.studio/mainwindow/project/materialassignmenteditorwindow.h
+++ b/src/appleseed.studio/mainwindow/project/materialassignmenteditorwindow.h
@@ -47,6 +47,8 @@
 #include <string>
 
 // Forward declarations.
+
+namespace appleseed { namespace studio { class ObjectInstanceItem; } }
 namespace appleseed { namespace studio { class ProjectBuilder; } }
 namespace renderer  { class Object; }
 namespace Ui        { class MaterialAssignmentEditorWindow; }
@@ -67,6 +69,7 @@ class MaterialAssignmentEditorWindow
     MaterialAssignmentEditorWindow(
         QWidget*                        parent,
         renderer::ObjectInstance&       object_instance,
+        ObjectInstanceItem&             object_istance_item,
         ProjectBuilder&                 project_builder);
 
     ~MaterialAssignmentEditorWindow();
@@ -79,6 +82,7 @@ class MaterialAssignmentEditorWindow
     Ui::MaterialAssignmentEditorWindow* m_ui;
 
     renderer::ObjectInstance&           m_object_instance;
+    ObjectInstanceItem&                 m_object_instance_item;
     renderer::Object*                   m_object;
     ProjectBuilder&                     m_project_builder;
 

--- a/src/appleseed.studio/mainwindow/project/objectinstanceitem.cpp
+++ b/src/appleseed.studio/mainwindow/project/objectinstanceitem.cpp
@@ -201,6 +201,7 @@ void ObjectInstanceItem::slot_open_material_assignment_editor()
         new MaterialAssignmentEditorWindow(
             QTreeWidgetItem::treeWidget(),
             *m_entity,
+            *this,
             m_project_builder);
 
     editor_window->showNormal();

--- a/src/appleseed.studio/mainwindow/project/objectinstanceitem.h
+++ b/src/appleseed.studio/mainwindow/project/objectinstanceitem.h
@@ -36,6 +36,7 @@
 #include "mainwindow/project/itembase.h"
 #include "mainwindow/project/singlemodelentityitem.h"
 
+
 // appleseed.foundation headers.
 #include "foundation/platform/compiler.h"
 
@@ -133,6 +134,7 @@ class ObjectInstanceItem
         const bool                      font_side,
         const bool                      back_side);
 
+  public:
     void update_style();
 };
 


### PR DESCRIPTION
Until now the object instance item stayed pink when a material
was assigned. Now this issues has been solved and the style
is updated when a material is assigned through the
MaterialAssignmentEditorWindow.

Issue #509

Signed-off-by: Marius Avram marius.avram1309@gmail.com
