### PR TITLE
OSL emission code, refactor #1.

### DIFF
--- a/src/appleseed/renderer/kernel/lighting/lightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lightsampler.cpp
@@ -354,10 +354,7 @@ void LightSampler::collect_emitting_triangles(
                     emitting_triangle.m_triangle_support_plane = triangle_support_plane;
                     emitting_triangle.m_rcp_area = rcp_area;
                     emitting_triangle.m_triangle_prob = 0.0;    // will be initialized once the emitting triangle CDF is built
-                    emitting_triangle.m_edf = edf;
-#ifdef WITH_OSL
-                    emitting_triangle.m_shader_group = material->get_uncached_osl_surface();
-#endif
+                    emitting_triangle.m_material = material;
 
                     // Store the light-emitting triangle.
                     const size_t emitting_triangle_index = m_emitting_triangles.size();

--- a/src/appleseed/renderer/kernel/lighting/lightsampler.h
+++ b/src/appleseed/renderer/kernel/lighting/lightsampler.h
@@ -52,14 +52,11 @@
 // Forward declarations.
 namespace renderer  { class Assembly; }
 namespace renderer  { class AssemblyInstance; }
-namespace renderer  { class EDF; }
 namespace renderer  { class Intersector; }
 namespace renderer  { class Light; }
+namespace renderer  { class Material; }
 namespace renderer  { class ParamArray; }
 namespace renderer  { class Scene; }
-#ifdef WITH_OSL
-namespace renderer  { class ShaderGroup; }
-#endif
 namespace renderer  { class ShadingPoint; }
 
 namespace renderer
@@ -94,10 +91,7 @@ class EmittingTriangle
     TriangleSupportPlaneType    m_triangle_support_plane;       // support plane of the triangle in assembly space
     double                      m_rcp_area;                     // world space triangle area reciprocal
     double                      m_triangle_prob;                // probability density of this triangle
-    const EDF*                  m_edf;
-#ifdef WITH_OSL
-    const ShaderGroup*          m_shader_group;
-#endif
+    const Material*             m_material;
 };
 
 

--- a/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
@@ -53,9 +53,6 @@
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/camera/camera.h"
 #include "renderer/modeling/edf/edf.h"
-#ifdef WITH_OSL
-#include "renderer/modeling/edf/osledf.h"
-#endif
 #include "renderer/modeling/environment/environment.h"
 #include "renderer/modeling/environmentedf/environmentedf.h"
 #include "renderer/modeling/frame/frame.h"
@@ -573,33 +570,27 @@ namespace
                     light_sample.m_geometric_normal,
                     light_sample.m_shading_normal);
 
-            const EDF* edf = light_sample.m_triangle->m_edf;
+            const Material* material = light_sample.m_triangle->m_material;
+            const EDF* edf = material->get_edf();
 
             // Evaluate the EDF inputs.
             InputEvaluator input_evaluator(m_texture_cache);
 
             // TODO: refactor this code (est.).
+            ShadingPoint shading_point;
+            light_sample.make_shading_point(
+                shading_point,
+                light_sample.m_shading_normal,
+                m_shading_context.get_intersector());
 #ifdef WITH_OSL
-            if (edf->is_osl_edf())
+            if (const ShaderGroup* sg = material->get_osl_surface())
             {
-                const OSLEDF* osl_edf = static_cast<const OSLEDF*>(edf);
-                const ShaderGroup* sg = light_sample.m_triangle->m_shader_group;
-                assert(sg);
-
-                ShadingPoint shading_point;
-                light_sample.make_shading_point(
-                    shading_point,
-                    light_sample.m_shading_normal,
-                    m_shading_context.get_intersector());
-
                 // TODO: get object area somehow.
                 const float surface_area = 0.0f;
                 m_shading_context.execute_osl_emission(*sg, shading_point, surface_area);
-                osl_edf->evaluate_osl_inputs(input_evaluator, shading_point);
             }
-            else
 #endif
-                edf->evaluate_inputs(input_evaluator, light_sample.m_bary);
+            edf->evaluate_inputs(input_evaluator, shading_point);
 
             // Sample the EDF.
             sampling_context.split_in_place(2, 1);

--- a/src/appleseed/renderer/kernel/lighting/pathtracer.h
+++ b/src/appleseed/renderer/kernel/lighting/pathtracer.h
@@ -283,7 +283,7 @@ size_t PathTracer<PathVisitor, Adjoint>::trace(
         {
             vertex.m_bsdf->evaluate_inputs(
                 shading_context,
-                bsdf_input_evaluator, 
+                bsdf_input_evaluator,
                 *vertex.m_shading_point);
             vertex.m_bsdf_data = bsdf_input_evaluator.data();
         }

--- a/src/appleseed/renderer/kernel/lighting/pathvertex.cpp
+++ b/src/appleseed/renderer/kernel/lighting/pathvertex.cpp
@@ -33,9 +33,6 @@
 // appleseed.renderer headers.
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/modeling/edf/edf.h"
-#ifdef WITH_OSL
-#include "renderer/modeling/edf/osledf.h"
-#endif
 #include "renderer/modeling/input/inputevaluator.h"
 
 namespace renderer
@@ -60,20 +57,14 @@ void PathVertex::compute_emitted_radiance(
 
     // TODO: refactor this code (est.).
 #ifdef WITH_OSL
-    if (m_edf->is_osl_edf())
+    if (const ShaderGroup* sg = get_material()->get_osl_surface())
     {
-        const OSLEDF* osl_edf = static_cast<const OSLEDF*>(m_edf);
-        const ShaderGroup* sg = get_material()->get_osl_surface();
-        assert(sg);
-
         // TODO: get object area somehow.
         const float surface_area = 0.0f;
         shading_context.execute_osl_emission(*sg, *m_shading_point, surface_area);
-        osl_edf->evaluate_osl_inputs(input_evaluator, *m_shading_point);
     }
-    else
 #endif
-        m_edf->evaluate_inputs(input_evaluator, m_shading_point->get_uv(0));
+    m_edf->evaluate_inputs(input_evaluator, *m_shading_point);
 
     // Compute the emitted radiance.
     m_edf->evaluate(

--- a/src/appleseed/renderer/modeling/edf/edf.cpp
+++ b/src/appleseed/renderer/modeling/edf/edf.cpp
@@ -77,11 +77,6 @@ double EDF::get_uncached_light_near_start() const
     return m_params.get_optional<double>("light_near_start", 0.0);
 }
 
-bool EDF::is_osl_edf() const
-{
-    return false;
-}
-
 bool EDF::on_frame_begin(
     const Project&      project,
     const Assembly&     assembly,
@@ -118,10 +113,10 @@ void EDF::on_frame_end(
 }
 
 void EDF::evaluate_inputs(
-    InputEvaluator& input_evaluator,
-    const Vector2d& uv) const
+    InputEvaluator&     input_evaluator,
+    const ShadingPoint& shading_point) const
 {
-    input_evaluator.evaluate(get_inputs(), uv);
+    input_evaluator.evaluate(get_inputs(), shading_point.get_uv(0));
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/edf/edf.h
+++ b/src/appleseed/renderer/modeling/edf/edf.h
@@ -48,6 +48,7 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class InputEvaluator; }
 namespace renderer      { class ParamArray; }
 namespace renderer      { class Project; }
+namespace renderer      { class ShadingPoint; }
 
 namespace renderer
 {
@@ -96,9 +97,6 @@ class DLLSYMBOL EDF
     // Retrieve the light near start value.
     double get_uncached_light_near_start() const;
 
-    // Return true if the edf is an OSL edf.
-    virtual bool is_osl_edf() const;
-
     // This method is called once before rendering each frame.
     // Returns true on success, false otherwise.
     virtual bool on_frame_begin(
@@ -114,8 +112,8 @@ class DLLSYMBOL EDF
     // Evaluate the inputs of this EDF.
     // Input values are stored in the input evaluator.
     virtual void evaluate_inputs(
-        InputEvaluator&             input_evaluator,
-        const foundation::Vector2d& uv) const;
+        InputEvaluator&     input_evaluator,
+        const ShadingPoint& shading_point) const;
 
     // Sample the EDF and compute the emission direction, its probability
     // density and the value of the EDF for this direction.

--- a/src/appleseed/renderer/modeling/edf/osledf.h
+++ b/src/appleseed/renderer/modeling/edf/osledf.h
@@ -30,103 +30,16 @@
 #define APPLESEED_RENDERER_MODELING_EDF_OSLEDF_H
 
 // appleseed.renderer headers.
-#include "renderer/global/globaltypes.h"
 #include "renderer/modeling/edf/edf.h"
 
 // appleseed.foundation headers.
-#include "foundation/math/basis.h"
-#include "foundation/math/vector.h"
-#include "foundation/platform/compiler.h"
 #include "foundation/utility/autoreleaseptr.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
-// Forward declarations.
-namespace foundation    { class AbortSwitch; }
-namespace foundation    { class DictionaryArray; }
-namespace renderer      { class Assembly; }
-namespace renderer      { class InputEvaluator; }
-namespace renderer      { class ParamArray; }
-namespace renderer      { class Project; }
-namespace renderer      { class ShadingContext; }
-namespace renderer      { class ShadingPoint; }
-
 namespace renderer
 {
-
-//
-// OSL EDF.
-//
-
-class OSLEDF
-  : public EDF
-{
-  public:
-    virtual void release() OVERRIDE;
-
-    virtual const char* get_model() const OVERRIDE;
-
-    virtual bool is_osl_edf() const OVERRIDE;
-
-    virtual bool on_frame_begin(
-        const Project&              project,
-        const Assembly&             assembly,
-        foundation::AbortSwitch*    abort_switch) OVERRIDE;
-
-    virtual void on_frame_end(
-        const Project&              project,
-        const Assembly&             assembly);
-
-    virtual void evaluate_inputs(
-        InputEvaluator&             input_evaluator,
-        const foundation::Vector2d& uv) const OVERRIDE;
-
-    void evaluate_osl_inputs(
-        InputEvaluator&             input_evaluator,
-        const ShadingPoint&         shading_point) const;
-
-    virtual void sample(
-        SamplingContext&            sampling_context,
-        const void*                 data,
-        const foundation::Vector3d& geometric_normal,
-        const foundation::Basis3d&  shading_basis,
-        const foundation::Vector2d& s,
-        foundation::Vector3d&       outgoing,
-        Spectrum&                   value,
-        double&                     probability) const OVERRIDE;
-
-    virtual void evaluate(
-        const void*                 data,
-        const foundation::Vector3d& geometric_normal,
-        const foundation::Basis3d&  shading_basis,
-        const foundation::Vector3d& outgoing,
-        Spectrum&                   value) const OVERRIDE;
-
-    virtual void evaluate(
-        const void*                 data,
-        const foundation::Vector3d& geometric_normal,
-        const foundation::Basis3d&  shading_basis,
-        const foundation::Vector3d& outgoing,
-        Spectrum&                   value,
-        double&                     probability) const OVERRIDE;
-
-    virtual double evaluate_pdf(
-        const void*                 data,
-        const foundation::Vector3d& geometric_normal,
-        const foundation::Basis3d&  shading_basis,
-        const foundation::Vector3d& outgoing) const OVERRIDE;
-
-  private:
-    friend class OSLEDFFactory;
-
-    foundation::auto_release_ptr<EDF> m_diffuse_edf;
-
-    OSLEDF(
-        const char*                 name,
-        const ParamArray&           params);
-};
-
 
 //
 // OSL EDF factory.


### PR DESCRIPTION
Modified EDF interface to allow for OSL emission, instead of treating it as a special case 
to avoid creating a ShadingPoint (not so expensive in any case).
