### PR TITLE
Fixed wrong includes for non x86 archs

### DIFF
--- a/src/appleseed/foundation/math/rng.h
+++ b/src/appleseed/foundation/math/rng.h
@@ -34,8 +34,6 @@
 #include "foundation/math/rng/distribution.h"
 #include "foundation/math/rng/lcg.h"
 #include "foundation/math/rng/mersennetwister.h"
-#include "foundation/math/rng/serialmersennetwister.h"
-#include "foundation/math/rng/simdmersennetwister.h"
 #include "foundation/math/rng/xorshift.h"
 
 #endif  // !APPLESEED_FOUNDATION_MATH_RNG_H


### PR DESCRIPTION
SIMD and serial mersenne twister rngs should not be included directly.
This was breaking the POWER8 build.
