### PR TITLE
Avoid using invalid OSL ShaderGroups.

### DIFF
--- a/src/appleseed/renderer/modeling/material/oslmaterial.cpp
+++ b/src/appleseed/renderer/modeling/material/oslmaterial.cpp
@@ -143,7 +143,14 @@ namespace
 
         virtual const ShaderGroup* get_uncached_osl_surface() const OVERRIDE
         {
-            return static_cast<const ShaderGroup*>(m_inputs.get_entity("osl_surface"));
+            const ShaderGroup* sg =
+                static_cast<const ShaderGroup*>(m_inputs.get_entity("osl_surface"));
+
+            // Skip invalid ShaderGroups.
+            if (!sg->valid())
+                return 0;
+
+            return sg;
         }
     };
 }


### PR DESCRIPTION
If setup fails for a ShaderGroup, avoid using it.
