### PR TITLE
Python bindings improvements

### DIFF
--- a/src/appleseed.python/CMakeLists.txt
+++ b/src/appleseed.python/CMakeLists.txt
@@ -86,6 +86,7 @@ set (sources
     bind_bsdf.cpp
     bind_camera.cpp
     bind_color.cpp
+    bind_display.cpp
     bind_edf.cpp
     bind_entity.cpp
     bind_environment.cpp
@@ -118,6 +119,11 @@ set (sources
     unaligned_matrix44.h
     unaligned_transformd44.h
 )
+if (WITH_OSL)
+    list (APPEND sources
+        bind_shadergroup.cpp
+    )
+endif ()
 list (APPEND appleseed.python_sources
     ${sources}
 )

--- a/src/appleseed.python/bind_assembly.cpp
+++ b/src/appleseed.python/bind_assembly.cpp
@@ -86,6 +86,9 @@ void bind_assembly()
         .def("colors", &BaseGroup::colors, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("textures", &BaseGroup::textures, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("texture_instances", &BaseGroup::texture_instances, bpy::return_value_policy<bpy::reference_existing_object>())
+#ifdef APPLESEED_WITH_OSL
+        .def("shader_groups", &BaseGroup::shader_groups, bpy::return_value_policy<bpy::reference_existing_object>())
+#endif
         .def("assemblies", &BaseGroup::assemblies, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("assembly_instances", &BaseGroup::assembly_instances, bpy::return_value_policy<bpy::reference_existing_object>());
 

--- a/src/appleseed.python/bind_display.cpp
+++ b/src/appleseed.python/bind_display.cpp
@@ -1,0 +1,63 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2012-2013 Esteban Tovagliari, Jupiter Jazz Limited
+// Copyright (c) 2014 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Has to be first, to avoid redefinition warnings.
+#include "bind_auto_release_ptr.h"
+
+// appleseed.python headers.
+#include "dict2dict.h"
+
+// appleseed.renderer headers.
+#include "renderer/api/display.h"
+
+// Standard headers.
+#include <cstddef>
+#include <string>
+
+namespace bpy = boost::python;
+using namespace foundation;
+using namespace renderer;
+
+namespace detail
+{
+
+auto_release_ptr<Display> create_display(
+    const std::string&  name,
+    const bpy::dict&    params)
+{
+    return DisplayFactory::create(name.c_str(), bpy_dict_to_param_array(params));
+}
+
+}
+
+void bind_display()
+{
+    bpy::class_<Display, auto_release_ptr<Display>, bpy::bases<Entity>, boost::noncopyable>("Display", bpy::no_init)
+        .def("__init__", bpy::make_constructor(detail::create_display));
+}

--- a/src/appleseed.python/bind_matrix.cpp
+++ b/src/appleseed.python/bind_matrix.cpp
@@ -29,6 +29,9 @@
 
 // Has to be first, to avoid redefinition warnings.
 #include "boost/python/detail/wrap_python.hpp"
+#ifdef APPLESEED_ENABLE_IMATH_INTEROP
+#include "boost/python/implicit.hpp"
+#endif
 
 // appleseed.python headers.
 #include "unaligned_matrix44.h"
@@ -226,4 +229,13 @@ void bind_matrix()
 {
     detail::bind_typed_matrix4<float>("Matrix4f");
     detail::bind_typed_matrix4<double>("Matrix4d");
+
+#ifdef APPLESEED_ENABLE_IMATH_INTEROP
+    bpy::implicitly_convertible<UnalignedMatrix44<float>, Imath::M44f>();
+    bpy::implicitly_convertible<Imath::M44f, UnalignedMatrix44<float> >();
+
+    bpy::implicitly_convertible<UnalignedMatrix44<double>, Imath::M44d>();
+    bpy::implicitly_convertible<Imath::M44d, UnalignedMatrix44<double> >();
+#endif
+
 }

--- a/src/appleseed.python/bind_project.cpp
+++ b/src/appleseed.python/bind_project.cpp
@@ -35,6 +35,7 @@
 #include "dict2dict.h"
 
 // appleseed.renderer headers.
+#include "renderer/api/display.h"
 #include "renderer/api/frame.h"
 #include "renderer/api/project.h"
 #include "renderer/api/scene.h"
@@ -202,6 +203,8 @@ void bind_project()
 
         .def("set_frame", &Project::set_frame)
         .def("get_frame", &Project::get_frame, bpy::return_value_policy<bpy::reference_existing_object>())
+
+        .def("set_display", &Project::set_display)
 
         .def("configurations", detail::project_get_configs, bpy::return_value_policy<bpy::reference_existing_object>())
 

--- a/src/appleseed.python/bind_quaternion.cpp
+++ b/src/appleseed.python/bind_quaternion.cpp
@@ -29,6 +29,9 @@
 
 // Has to be first, to avoid redefinition warnings.
 #include "boost/python/detail/wrap_python.hpp"
+#ifdef APPLESEED_ENABLE_IMATH_INTEROP
+#include "boost/python/implicit.hpp"
+#endif
 
 // appleseed.foundation headers.
 #include "foundation/math/quaternion.h"
@@ -156,4 +159,12 @@ void bind_quaternion()
 {
     detail::do_bind_quaternion<float>("Quaternionf");
     detail::do_bind_quaternion<double>("Quaterniond");
+
+#ifdef APPLESEED_ENABLE_IMATH_INTEROP
+    bpy::implicitly_convertible<Quaternionf, Imath::Quatf>();
+    bpy::implicitly_convertible<Imath::Quatf, Quaternionf>();
+
+    bpy::implicitly_convertible<Quaterniond, Imath::Quatd>();
+    bpy::implicitly_convertible<Imath::Quatd, Quaterniond>();
+#endif
 }

--- a/src/appleseed.python/bind_shadergroup.cpp
+++ b/src/appleseed.python/bind_shadergroup.cpp
@@ -1,0 +1,74 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2012-2013 Esteban Tovagliari, Jupiter Jazz Limited
+// Copyright (c) 2014 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Has to be first, to avoid redefinition warnings.
+#include "bind_auto_release_ptr.h"
+
+// appleseed.python headers.
+#include "bind_typed_entity_containers.h"
+#include "dict2dict.h"
+
+// appleseed.renderer headers.
+#include "renderer/api/shadergroup.h"
+
+// Standard headers.
+#include <cstddef>
+#include <string>
+
+namespace bpy = boost::python;
+using namespace foundation;
+using namespace renderer;
+
+namespace detail
+{
+    auto_release_ptr<ShaderGroup> create_shader_group(const std::string& name)
+    {
+        return ShaderGroupFactory::create(name.c_str());
+    }
+
+    void add_shader(
+        ShaderGroup*        sg,
+        const std::string&  type,
+        const std::string&  name,
+        const std::string&  layer,
+        bpy::dict           params)
+    {
+        sg->add_shader(type.c_str(), name.c_str(), layer.c_str(), bpy_dict_to_param_array(params));
+    }
+}
+
+void bind_shader_group()
+{
+    bpy::class_<ShaderGroup, auto_release_ptr<ShaderGroup>, bpy::bases<Entity>, boost::noncopyable>("ShaderGroup", bpy::no_init)
+        .def("__init__", bpy::make_constructor(detail::create_shader_group))
+        .def("add_shader", detail::add_shader)
+        .def("add_connection", &ShaderGroup::add_connection);
+
+    bind_typed_entity_vector<ShaderGroup>("ShaderGroupContainer");
+}

--- a/src/appleseed.python/bind_vector.cpp
+++ b/src/appleseed.python/bind_vector.cpp
@@ -29,6 +29,9 @@
 
 // Has to be first, to avoid redefinition warnings.
 #include "boost/python/detail/wrap_python.hpp"
+#ifdef APPLESEED_ENABLE_IMATH_INTEROP
+#include "boost/python/implicit.hpp"
+#endif
 
 // appleseed.foundation headers.
 #include "foundation/math/vector.h"
@@ -193,4 +196,27 @@ void bind_vector()
     detail::do_bind_vector<double, 3>("Vector3d");
 
     detail::do_bind_vector<int, 4>("Vector4i");
+
+#ifdef APPLESEED_ENABLE_IMATH_INTEROP
+    bpy::implicitly_convertible<Vector2i, Imath::V2i>();
+    bpy::implicitly_convertible<Imath::V2i, Vector2i>();
+
+    bpy::implicitly_convertible<Vector2f, Imath::V2f>();
+    bpy::implicitly_convertible<Imath::V2f, Vector2f>();
+
+    bpy::implicitly_convertible<Vector2d, Imath::V2d>();
+    bpy::implicitly_convertible<Imath::V2d, Vector2d>();
+
+    bpy::implicitly_convertible<Vector3i, Imath::V3i>();
+    bpy::implicitly_convertible<Imath::V3i, Vector3i>();
+
+    bpy::implicitly_convertible<Vector3f, Imath::V3f>();
+    bpy::implicitly_convertible<Imath::V3f, Vector3f>();
+
+    bpy::implicitly_convertible<Vector3d, Imath::V3d>();
+    bpy::implicitly_convertible<Imath::V3d, Vector3d>();
+
+    bpy::implicitly_convertible<Vector4i, Imath::V4i>();
+    bpy::implicitly_convertible<Imath::V4i, Vector4i>();
+#endif
 }

--- a/src/appleseed.python/module.cpp
+++ b/src/appleseed.python/module.cpp
@@ -39,6 +39,7 @@ void bind_bbox();
 void bind_bsdf();
 void bind_camera();
 void bind_color();
+void bind_display();
 void bind_edf();
 void bind_entity();
 void bind_environment();
@@ -55,6 +56,9 @@ void bind_project();
 void bind_quaternion();
 void bind_renderer_controller();
 void bind_scene();
+#ifdef APPLESEED_WITH_OSL
+void bind_shader_group();
+#endif
 void bind_surface_shader();
 void bind_texture();
 void bind_tile_callback();
@@ -79,6 +83,9 @@ BOOST_PYTHON_MODULE(_appleseedpython)
     bind_texture();
     bind_bsdf();
     bind_edf();
+#ifdef APPLESEED_WITH_OSL
+    bind_shader_group();
+#endif
     bind_surface_shader();
     bind_material();
     bind_light();
@@ -92,6 +99,7 @@ BOOST_PYTHON_MODULE(_appleseedpython)
 
     bind_image();
     bind_frame();
+    bind_display();
     bind_project();
 
     bind_renderer_controller();

--- a/src/appleseed.python/unaligned_matrix44.h
+++ b/src/appleseed.python/unaligned_matrix44.h
@@ -117,6 +117,24 @@ class UnalignedMatrix44
             m_data[i] = static_cast<T>(m[i]);
     }
 
+#ifdef APPLESEED_ENABLE_IMATH_INTEROP
+
+    UnalignedMatrix44(const Imath::Matrix44<T>& rhs)
+    {
+        Matrix<T, 4, 4> tmp(rhs);
+
+        for (int i = 0; i < 16; ++i)
+            m_data[i] = tmp[i];
+    }
+
+    operator Imath::Matrix44<T>() const
+    {
+        Matrix<T, 4, 4> tmp(as_foundation_matrix());
+        return tmp;
+    }
+
+#endif
+
     template <class U>
     UnalignedMatrix44<T>& operator=(const UnalignedMatrix44<U>& m)
     {


### PR DESCRIPTION
- Bind Display and Shadergroup classes.
- Enable implicit conversions between Imath and foundations types for arguments and return values.
