### PR TITLE
Fixed bug in ProjectFileWriter python binding

### DIFF
--- a/src/appleseed.python/bind_project.cpp
+++ b/src/appleseed.python/bind_project.cpp
@@ -117,7 +117,7 @@ namespace detail
         const ProjectFileWriter*            writer,
         const Project*                      project,
         const char*                         filepath,
-        const ProjectFileWriter::Options    opts)
+        int                                 opts)
     {
         return ProjectFileWriter::write(*project, filepath, opts);
     }


### PR DESCRIPTION
ProjectFileWriterOptions couldn't be combined before
