### PR TITLE
Blender continuous tile saving callback workaround

### DIFF
--- a/src/appleseed.cli/continuoussavingtilecallback.cpp
+++ b/src/appleseed.cli/continuoussavingtilecallback.cpp
@@ -37,15 +37,14 @@
 // reading incomplete EXR files (they should).
 //
 // - if APPLESEED_CLI_CONTINUOUSSAVINGTILECALLBACK_TILED is not defined,
-// the tile callback writes a complete EXR image after each tile is renderered.
+// the tile callback writes complete images after each tile is renderered.
 // This is helpful for applications that can't read incomplete images.
 // Because Blenderseed is the biggest user of this tile callback and Blender
 // does not read incomplete EXR files correctly, this is the default mode.
 //
-// PNG files are always written complete, independent of the define.
+// PNG files are always written complete, independent of the define,
+// as PNG does not support tiles.
 //
-
-//#define APPLESEED_CLI_CONTINUOUSSAVINGTILECALLBACK_TILED
 
 // Interface header.
 #include "continuoussavingtilecallback.h"
@@ -95,14 +94,14 @@ namespace
           , m_output_path(output_filename)
 #ifdef APPLESEED_CLI_CONTINUOUSSAVINGTILECALLBACK_TILED
           , m_exr_writer(&logger)
+          , m_write_tiled_image(false)
 #endif
         {
             filesystem::path ext = m_output_path.extension();
 
 #ifdef APPLESEED_CLI_CONTINUOUSSAVINGTILECALLBACK_TILED
+            // Only write tiled images if the format is EXR.
             m_write_tiled_image = ext.string() == ".exr";
-#else
-            m_write_tiled_image = false;
 #endif
             if (!m_write_tiled_image)
             {


### PR DESCRIPTION
By default the tile continuous tile saving callback now writes full images after each tile to a tmp file and then moves it to the final destination. 
This is a workaround for Blender's image reading bugs. I haven't seen Blender crash when using Blenderseed after this change on linux.

if APPLESEED_CLI_CONTINUOUSSAVINGTILECALLBACK_TILED is defined and the file format is EXR, 
the callback will write images tile by tile. It works better for applications that can read incomplete tiled EXR files correctly.

PNG files are always written complete independent of the define.
