### PR TITLE
Do travis builds out of source. Skip install and package targets.

### DIFF
--- a/travis-ci-build.sh
+++ b/travis-ci-build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+mkdir build
+cd build
 rm -f CMakeCache.txt
 
 cmake \
@@ -16,9 +18,9 @@ cmake \
     -D USE_EXTERNAL_XERCES=ON \
     -D CMAKE_BUILD_TYPE=Debug \
     -D CMAKE_INSTALL_PREFIX=./travis_install \
-    .
+    ..
 
-make all install package
+make
 
 # Unit tests (appleseed must be installed to function properly).
-env LD_LIBRARY_PATH=./travis_install/lib:$LD_LIBRARY_PATH ./travis_install/bin/appleseed.cli --run-unit-tests --verbose-unit-tests
+env LD_LIBRARY_PATH=../sandbox/lib/Debug:$LD_LIBRARY_PATH ../sandbox/bin/Debug/appleseed.cli --run-unit-tests --verbose-unit-tests


### PR DESCRIPTION
Run tests from sandbox.
