### PR TITLE
python module improvements

### DIFF
--- a/src/appleseed.python/CMakeLists.txt
+++ b/src/appleseed.python/CMakeLists.txt
@@ -178,6 +178,7 @@ include_directories (
 
 apply_preprocessor_definitions (appleseed.python)
 
+
 append_custom_preprocessor_definitions (appleseed.python
     APPLESEED_ENABLE_IMATH_INTEROP
 )

--- a/src/appleseed.python/CMakeLists.txt
+++ b/src/appleseed.python/CMakeLists.txt
@@ -178,6 +178,9 @@ include_directories (
 
 apply_preprocessor_definitions (appleseed.python)
 
+append_custom_preprocessor_definitions (appleseed.python
+    APPLESEED_ENABLE_IMATH_INTEROP
+)
 
 #--------------------------------------------------------------------------------------------------
 # Static libraries.

--- a/src/appleseed.python/bind_assembly.cpp
+++ b/src/appleseed.python/bind_assembly.cpp
@@ -48,7 +48,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     auto_release_ptr<Assembly> create_assembly(const std::string& name)
     {
@@ -78,6 +78,11 @@ namespace detail
     {
         return instance->transform_sequence();
     }
+
+    std::string get_assembly_name(AssemblyInstance *instance)
+    {
+        return instance->get_assembly_name();
+    }
 }
 
 void bind_assembly()
@@ -90,11 +95,12 @@ void bind_assembly()
         .def("shader_groups", &BaseGroup::shader_groups, bpy::return_value_policy<bpy::reference_existing_object>())
 #endif
         .def("assemblies", &BaseGroup::assemblies, bpy::return_value_policy<bpy::reference_existing_object>())
-        .def("assembly_instances", &BaseGroup::assembly_instances, bpy::return_value_policy<bpy::reference_existing_object>());
+        .def("assembly_instances", &BaseGroup::assembly_instances, bpy::return_value_policy<bpy::reference_existing_object>())
+        ;
 
     bpy::class_<Assembly, auto_release_ptr<Assembly>, bpy::bases<Entity, BaseGroup>, boost::noncopyable>("Assembly", bpy::no_init)
-        .def("__init__", bpy::make_constructor(detail::create_assembly))
-        .def("__init__", bpy::make_constructor(detail::create_assembly_with_params))
+        .def("__init__", bpy::make_constructor(create_assembly))
+        .def("__init__", bpy::make_constructor(create_assembly_with_params))
         .def("bsdfs", &Assembly::bsdfs, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("edfs", &Assembly::edfs, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("surface_shaders", &Assembly::surface_shaders, bpy::return_value_policy<bpy::reference_existing_object>())
@@ -103,15 +109,20 @@ void bind_assembly()
         .def("objects", &Assembly::objects, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("object_instances", &Assembly::object_instances, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("compute_local_bbox", &Assembly::compute_local_bbox)
-        .def("compute_non_hierarchical_local_bbox", &Assembly::compute_local_bbox);
+        .def("compute_non_hierarchical_local_bbox", &Assembly::compute_local_bbox)
+        ;
 
     bind_typed_entity_map<Assembly>("AssemblyContainer");
 
     bpy::class_<AssemblyInstance, auto_release_ptr<AssemblyInstance>, bpy::bases<Entity>, boost::noncopyable>("AssemblyInstance", bpy::no_init)
-        .def("__init__", bpy::make_constructor(detail::create_assembly_instance))
-        .def("transform_sequence", detail::get_transform_sequence, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("__init__", bpy::make_constructor(create_assembly_instance))
+        .def("transform_sequence", get_transform_sequence, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("get_vis_flags", &AssemblyInstance::get_vis_flags)
         .def("compute_parent_bbox", &AssemblyInstance::compute_parent_bbox)
-        .def("get_assembly", &AssemblyInstance::get_assembly, bpy::return_value_policy<bpy::reference_existing_object>());
+        .def("get_assembly", &AssemblyInstance::get_assembly, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("get_assembly_name", &get_assembly_name)
+        .def("find_assembly", &AssemblyInstance::find_assembly, bpy::return_value_policy<bpy::reference_existing_object>())
+        ;
 
     bind_typed_entity_map<AssemblyInstance>("AssemblyInstanceContainer");
 }

--- a/src/appleseed.python/bind_assembly.cpp
+++ b/src/appleseed.python/bind_assembly.cpp
@@ -79,7 +79,7 @@ namespace
         return instance->transform_sequence();
     }
 
-    std::string get_assembly_name(AssemblyInstance *instance)
+    std::string get_assembly_name(AssemblyInstance* instance)
     {
         return instance->get_assembly_name();
     }

--- a/src/appleseed.python/bind_auto_release_ptr.h
+++ b/src/appleseed.python/bind_auto_release_ptr.h
@@ -37,16 +37,18 @@
 #include "foundation/platform/python.h"
 #include "foundation/utility/autoreleaseptr.h"
 
-namespace boost {
-namespace python {
+namespace boost
+{
+namespace python
+{
 
 template <class T> struct pointee<foundation::auto_release_ptr<T> >
 {
     typedef T type;
 };
 
-}       // namespace python
-}       // namespace boost
+}
+}
 
 namespace foundation
 {
@@ -57,6 +59,6 @@ T* get_pointer(const auto_release_ptr<T>& p)
     return p.get();
 }
 
-}       // namespace foundation
+}
 
 #endif  // !APPLESEED_PYTHON_BIND_AUTO_RELEASE_PTR_H

--- a/src/appleseed.python/bind_auto_release_ptr.h
+++ b/src/appleseed.python/bind_auto_release_ptr.h
@@ -37,18 +37,16 @@
 #include "foundation/platform/python.h"
 #include "foundation/utility/autoreleaseptr.h"
 
-namespace boost
-{
-namespace python
-{
+namespace boost {
+namespace python {
 
 template <class T> struct pointee<foundation::auto_release_ptr<T> >
 {
     typedef T type;
 };
 
-}
-}
+}       // namespace python
+}       // namespace boost
 
 namespace foundation
 {
@@ -59,6 +57,6 @@ T* get_pointer(const auto_release_ptr<T>& p)
     return p.get();
 }
 
-}
+}       // namespace foundation
 
 #endif  // !APPLESEED_PYTHON_BIND_AUTO_RELEASE_PTR_H

--- a/src/appleseed.python/bind_bbox.cpp
+++ b/src/appleseed.python/bind_bbox.cpp
@@ -38,7 +38,7 @@
 namespace bpy = boost::python;
 using namespace foundation;
 
-namespace detail
+namespace
 {
     template <typename T>
     void bind_aabb3(const char* class_name)
@@ -49,12 +49,13 @@ namespace detail
 
             // Because of a bug in Boost.Python, this needs the extra self_ns qualification.
             .def(bpy::self_ns::str(bpy::self))
-            .def(bpy::self_ns::repr(bpy::self));
+            .def(bpy::self_ns::repr(bpy::self))
+            ;
     }
 }
 
 void bind_bbox()
 {
-    detail::bind_aabb3<float>("AABB3f");
-    detail::bind_aabb3<double>("AABB3d");
+    bind_aabb3<float>("AABB3f");
+    bind_aabb3<double>("AABB3d");
 }

--- a/src/appleseed.python/bind_bsdf.cpp
+++ b/src/appleseed.python/bind_bsdf.cpp
@@ -46,11 +46,11 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
-    auto_release_ptr<BSDF> create_bsdf(const std::string& bsdf_type,
-                                       const std::string& name,
-                                       const bpy::dict& params)
+    auto_release_ptr<BSDF> create_bsdf(const std::string&   bsdf_type,
+                                       const std::string&   name,
+                                       const bpy::dict&     params)
     {
         BSDFFactoryRegistrar factories;
         const IBSDFFactory* factory = factories.lookup(bsdf_type.c_str());
@@ -71,7 +71,9 @@ void bind_bsdf()
 {
     bpy::class_<BSDF, auto_release_ptr<BSDF>, bpy::bases<ConnectableEntity>, boost::noncopyable>("BSDF", bpy::no_init)
         .def("get_input_metadata", &detail::get_entity_input_metadata<BSDFFactoryRegistrar>).staticmethod("get_input_metadata")
-        .def("__init__", bpy::make_constructor(detail::create_bsdf));
+        .def("__init__", bpy::make_constructor(create_bsdf))
+        .def("get_model", &BSDF::get_model)
+        ;
 
     bind_typed_entity_vector<BSDF>("BSDFContainer");
 }

--- a/src/appleseed.python/bind_camera.cpp
+++ b/src/appleseed.python/bind_camera.cpp
@@ -41,9 +41,12 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
-    auto_release_ptr<Camera> create_camera(const std::string& camera_type, const std::string& name, const bpy::dict& params)
+    auto_release_ptr<Camera> create_camera(
+        const std::string&  camera_type,
+        const std::string&  name,
+        const bpy::dict&    params)
     {
         CameraFactoryRegistrar factories;
         const ICameraFactory* factory = factories.lookup(camera_type.c_str());
@@ -69,10 +72,11 @@ void bind_camera()
 {
     bpy::class_<Camera, auto_release_ptr<Camera>, bpy::bases<Entity>, boost::noncopyable>("Camera", bpy::no_init)
         .def("get_input_metadata", &detail::get_entity_input_metadata<CameraFactoryRegistrar>).staticmethod("get_input_metadata")
-        .def("__init__", bpy::make_constructor(detail::create_camera))
+        .def("__init__", bpy::make_constructor(create_camera))
         .def("get_model", &Camera::get_model)
-        .def("transform_sequence", detail::camera_get_transform_sequence, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("transform_sequence", camera_get_transform_sequence, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("get_shutter_open_time", &Camera::get_shutter_open_time)
         .def("get_shutter_close_time", &Camera::get_shutter_close_time)
-        .def("get_shutter_middle_time", &Camera::get_shutter_middle_time);
+        .def("get_shutter_middle_time", &Camera::get_shutter_middle_time)
+        ;
 }

--- a/src/appleseed.python/bind_color.cpp
+++ b/src/appleseed.python/bind_color.cpp
@@ -50,7 +50,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     ColorValueArray color_value_array_from_bpy_list(const bpy::list& vals)
     {
@@ -84,7 +84,9 @@ namespace detail
         return result;
     }
 
-    auto_release_ptr<ColorEntity> create_color_entity(const std::string& name, const bpy::dict& params)
+    auto_release_ptr<ColorEntity> create_color_entity(
+        const std::string&  name,
+        const bpy::dict&    params)
     {
         return ColorEntityFactory::create(name.c_str(), bpy_dict_to_param_array(params));
     }
@@ -135,11 +137,11 @@ void bind_color()
         .value("Spectral", ColorSpaceSpectral);
 
     bpy::class_<ColorEntity, auto_release_ptr<ColorEntity>, bpy::bases<Entity>, boost::noncopyable>("ColorEntity", bpy::no_init)
-        .def("__init__", bpy::make_constructor(detail::create_color_entity))
-        .def("__init__", bpy::make_constructor(detail::create_color_entity_vals))
-        .def("__init__", bpy::make_constructor(detail::create_color_entity_vals_alpha))
-        .def("get_values", detail::color_entity_get_vals)
-        .def("get_alpha", detail::color_entity_get_alpha)
+        .def("__init__", bpy::make_constructor(create_color_entity))
+        .def("__init__", bpy::make_constructor(create_color_entity_vals))
+        .def("__init__", bpy::make_constructor(create_color_entity_vals_alpha))
+        .def("get_values", color_entity_get_vals)
+        .def("get_alpha", color_entity_get_alpha)
         .def("get_color_space", &ColorEntity::get_color_space)
         .def("get_wavelength_range", &ColorEntity::get_wavelength_range, bpy::return_value_policy<bpy::copy_const_reference>())
         .def("get_multiplier", &ColorEntity::get_multiplier);

--- a/src/appleseed.python/bind_display.cpp
+++ b/src/appleseed.python/bind_display.cpp
@@ -44,7 +44,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
 
 auto_release_ptr<Display> create_display(
@@ -59,5 +59,6 @@ auto_release_ptr<Display> create_display(
 void bind_display()
 {
     bpy::class_<Display, auto_release_ptr<Display>, bpy::bases<Entity>, boost::noncopyable>("Display", bpy::no_init)
-        .def("__init__", bpy::make_constructor(detail::create_display));
+        .def("__init__", bpy::make_constructor(create_display))
+        ;
 }

--- a/src/appleseed.python/bind_edf.cpp
+++ b/src/appleseed.python/bind_edf.cpp
@@ -41,11 +41,11 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     auto_release_ptr<EDF> create_edf(const std::string& edf_type,
                                      const std::string& name,
-                                     const bpy::dict& params)
+                                     const bpy::dict&   params)
     {
         EDFFactoryRegistrar factories;
         const IEDFFactory* factory = factories.lookup(edf_type.c_str());
@@ -66,7 +66,8 @@ void bind_edf()
 {
     bpy::class_<EDF, auto_release_ptr<EDF>, bpy::bases<ConnectableEntity>, boost::noncopyable>("EDF", bpy::no_init)
         .def("get_input_metadata", &detail::get_entity_input_metadata<EDFFactoryRegistrar>).staticmethod("get_input_metadata")
-        .def("__init__", bpy::make_constructor(detail::create_edf))
+        .def("__init__", bpy::make_constructor(create_edf))
+        .def("get_model", &EDF::get_model)
         ;
 
     bind_typed_entity_vector<EDF>("EDFContainer");

--- a/src/appleseed.python/bind_entity.cpp
+++ b/src/appleseed.python/bind_entity.cpp
@@ -51,7 +51,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     Entity* get_entity_vec_item(EntityVector& vec, const int relative_index)
     {
@@ -97,35 +97,35 @@ void bind_entity()
         .def("get_name", &Entity::get_name)
         .def("set_name", &Entity::set_name)
 
-        .def("get_parameters", detail::entity_get_parameters)
-        .def("set_parameters", detail::entity_set_parameters)
+        .def("get_parameters", entity_get_parameters)
+        .def("set_parameters", entity_set_parameters)
 
         .def("set_render_layer_index", &Entity::set_render_layer_index)
-        .def("get_render_layer_index", &Entity::get_render_layer_index);
+        .def("get_render_layer_index", &Entity::get_render_layer_index)
+        ;
 
     bpy::class_<ConnectableEntity, auto_release_ptr<ConnectableEntity>, bpy::bases<Entity>, boost::noncopyable>("ConnectableEntity", bpy::no_init);
 
     bpy::class_<EntityVector, boost::noncopyable>("EntityVector")
         .def("clear", &EntityVector::clear)
         .def("__len__", &EntityVector::size)
-        .def("__getitem__", detail::get_entity_vec_item, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("__getitem__", get_entity_vec_item, bpy::return_value_policy<bpy::reference_existing_object>())
 
         .def("insert", &EntityVector::insert)
         .def("remove", &EntityVector::remove)
 
-        .def("__iter__", bpy::iterator<EntityVector>());
+        .def("__iter__", bpy::iterator<EntityVector>())
+        ;
 
     bpy::class_<EntityMap, boost::noncopyable>("EntityMap")
         .def("clear", &EntityMap::clear)
         .def("__len__", &EntityMap::size)
-        .def("__getitem__", detail::get_entity_map_item, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("__getitem__", get_entity_map_item, bpy::return_value_policy<bpy::reference_existing_object>())
 
         .def("insert", &EntityMap::insert)
         .def("remove", &EntityMap::remove)
 
         .def("get_by_uid", &EntityMap::get_by_uid, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("get_by_name", &EntityMap::get_by_name, bpy::return_value_policy<bpy::reference_existing_object>())
-
-        //.def("__iter__", bpy::iterator<EntityMap>())
         ;
 }

--- a/src/appleseed.python/bind_environment.cpp
+++ b/src/appleseed.python/bind_environment.cpp
@@ -43,7 +43,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     auto_release_ptr<EnvironmentEDF> create_environment_edf(const std::string env_type,
                                                             const std::string& name,
@@ -91,21 +91,24 @@ void bind_environment()
 {
     bpy::class_<EnvironmentEDF, auto_release_ptr<EnvironmentEDF>, bpy::bases<ConnectableEntity>, boost::noncopyable >("EnvironmentEDF", bpy::no_init)
         .def("get_input_metadata", &detail::get_entity_input_metadata<EnvironmentEDFFactoryRegistrar>).staticmethod("get_input_metadata")
-        .def("__init__", bpy::make_constructor(detail::create_environment_edf))
+        .def("__init__", bpy::make_constructor(create_environment_edf))
+        .def("get_model", &EnvironmentEDF::get_model)
         ;
 
     bind_typed_entity_vector<EnvironmentEDF>("EnvironmentEDFContainer");
 
     bpy::class_<EnvironmentShader, auto_release_ptr<EnvironmentShader>, bpy::bases<ConnectableEntity>, boost::noncopyable >("EnvironmentShader", bpy::no_init)
         .def("get_input_metadata", &detail::get_entity_input_metadata<EnvironmentShaderFactoryRegistrar>).staticmethod("get_input_metadata")
-        .def("__init__", bpy::make_constructor(detail::create_environment_shader))
+        .def("__init__", bpy::make_constructor(create_environment_shader))
+        .def("get_model", &EnvironmentShader::get_model)
         ;
 
     bind_typed_entity_vector<EnvironmentShader>("EnvironmentShaderContainer");
 
     bpy::class_<Environment, auto_release_ptr<Environment>, bpy::bases<Entity>, boost::noncopyable >("Environment", bpy::no_init)
-        .def("__init__", bpy::make_constructor(detail::create_environment))
+        .def("__init__", bpy::make_constructor(create_environment))
         .def("get_environment_edf", &Environment::get_environment_edf, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("get_environment_shader", &Environment::get_environment_shader, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("get_model", &Environment::get_model)
         ;
 }

--- a/src/appleseed.python/bind_frame.cpp
+++ b/src/appleseed.python/bind_frame.cpp
@@ -45,9 +45,11 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
-    auto_release_ptr<Frame> create_frame(const std::string& name, const bpy::dict& params)
+    auto_release_ptr<Frame> create_frame(
+        const std::string&  name,
+        const bpy::dict&    params)
     {
         return FrameFactory::create(name.c_str(), bpy_dict_to_param_array(params));
     }
@@ -81,16 +83,17 @@ namespace detail
 void bind_frame()
 {
     bpy::class_<Frame, auto_release_ptr<Frame>, bpy::bases<Entity>, boost::noncopyable>("Frame", bpy::no_init)
-        .def("__init__", bpy::make_constructor(detail::create_frame))
+        .def("__init__", bpy::make_constructor(create_frame))
 
         .def("image", &Frame::image, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("aov_images", &Frame::aov_images, bpy::return_value_policy<bpy::reference_existing_object>())
 
-        .def("transform_tile_to_output_color_space", detail::transform_tile_to_output_color_space)
-        .def("transform_image_to_output_color_space", detail::transform_image_to_output_color_space)
+        .def("transform_tile_to_output_color_space", transform_tile_to_output_color_space)
+        .def("transform_image_to_output_color_space", transform_image_to_output_color_space)
 
         .def("clear_main_image", &Frame::clear_main_image)
         .def("write_main_image", &Frame::write_main_image)
         .def("write_aov_images", &Frame::write_aov_images)
-        .def("archive", detail::archive_frame);
+        .def("archive", archive_frame)
+        ;
 }

--- a/src/appleseed.python/bind_image.cpp
+++ b/src/appleseed.python/bind_image.cpp
@@ -50,7 +50,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     Tile* copy_tile(const Tile* source)
     {
@@ -110,7 +110,8 @@ void bind_image()
         .value("UInt32", PixelFormatUInt32)
         .value("Half",   PixelFormatHalf)
         .value("Float",  PixelFormatFloat)
-        .value("Double", PixelFormatDouble);
+        .value("Double", PixelFormatDouble)
+        ;
 
     bpy::class_<CanvasProperties, boost::noncopyable>("CanvasProperties", bpy::no_init)
         .def_readonly("canvas_width", &CanvasProperties::m_canvas_width)
@@ -129,32 +130,36 @@ void bind_image()
         .def_readonly("pixel_count", &CanvasProperties::m_pixel_count)
         .def_readonly("pixel_size", &CanvasProperties::m_pixel_size)
         .def("get_tile_width", &CanvasProperties::get_tile_width)
-        .def("get_tile_height", &CanvasProperties::get_tile_height);
+        .def("get_tile_height", &CanvasProperties::get_tile_height)
+        ;
 
     bpy::class_<Tile, boost::noncopyable>("Tile", bpy::init<size_t, size_t, size_t, PixelFormat>())
-        .def("__copy__", detail::copy_tile, bpy::return_value_policy<bpy::manage_new_object>())
-        .def("__deepcopy__", detail::deepcopy_tile, bpy::return_value_policy<bpy::manage_new_object>())
+        .def("__copy__", copy_tile, bpy::return_value_policy<bpy::manage_new_object>())
+        .def("__deepcopy__", deepcopy_tile, bpy::return_value_policy<bpy::manage_new_object>())
         .def("get_pixel_format", &Tile::get_pixel_format)
         .def("get_width", &Tile::get_width)
         .def("get_height", &Tile::get_height)
         .def("get_channel_count", &Tile::get_channel_count)
         .def("get_pixel_count", &Tile::get_pixel_count)
         .def("get_size", &Tile::get_size)
-        .def("copy_data_to", detail::copy_tile_data_to_py_array);   // todo: maybe this needs a better name
+        .def("copy_data_to", copy_tile_data_to_py_array)   // todo: maybe this needs a better name
+        ;
 
     const Tile& (Image::*image_get_tile)(const size_t, const size_t) const = &Image::tile;
 
     bpy::class_<Image, boost::noncopyable>("Image", bpy::no_init)
-        .def("__copy__", detail::copy_image, bpy::return_value_policy<bpy::manage_new_object>())
-        .def("__deepcopy__", detail::copy_image, bpy::return_value_policy<bpy::manage_new_object>())
+        .def("__copy__", copy_image, bpy::return_value_policy<bpy::manage_new_object>())
+        .def("__deepcopy__", copy_image, bpy::return_value_policy<bpy::manage_new_object>())
         .def("properties", &Image::properties, bpy::return_value_policy<bpy::reference_existing_object>())
-        .def("tile", image_get_tile, bpy::return_value_policy<bpy::reference_existing_object>());
+        .def("tile", image_get_tile, bpy::return_value_policy<bpy::reference_existing_object>())
+        ;
 
     const Image& (ImageStack::*image_stack_get_image)(const size_t) const = &ImageStack::get_image;
 
     bpy::class_<ImageStack, boost::noncopyable>("ImageStack", bpy::no_init)
         .def("empty", &ImageStack::empty)
         .def("size", &ImageStack::size)
-        .def("get_name", detail::image_stack_get_name)
-        .def("get_image", image_stack_get_image, bpy::return_value_policy<bpy::reference_existing_object>());
+        .def("get_name", image_stack_get_name)
+        .def("get_image", image_stack_get_image, bpy::return_value_policy<bpy::reference_existing_object>())
+        ;
 }

--- a/src/appleseed.python/bind_light.cpp
+++ b/src/appleseed.python/bind_light.cpp
@@ -43,11 +43,11 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     auto_release_ptr<Light> create_light(const std::string& light_type,
                                          const std::string& name,
-                                         const bpy::dict& params)
+                                         const bpy::dict&   params)
     {
         LightFactoryRegistrar factories;
         const ILightFactory* factory = factories.lookup(light_type.c_str());
@@ -78,9 +78,11 @@ void bind_light()
 {
     bpy::class_<Light, auto_release_ptr<Light>, bpy::bases<ConnectableEntity>, boost::noncopyable>("Light", bpy::no_init)
         .def("get_input_metadata", &detail::get_entity_input_metadata<LightFactoryRegistrar>).staticmethod("get_input_metadata")
-        .def("__init__", bpy::make_constructor(detail::create_light))
-        .def("set_transform", &detail::light_set_transform)
-        .def("get_transform", &detail::light_get_transform);
+        .def("__init__", bpy::make_constructor(create_light))
+        .def("get_model", &Light::get_model)
+        .def("set_transform", &light_set_transform)
+        .def("get_transform", &light_get_transform)
+        ;
 
     bind_typed_entity_vector<Light>("LightContainer");
 }

--- a/src/appleseed.python/bind_logger.cpp
+++ b/src/appleseed.python/bind_logger.cpp
@@ -50,7 +50,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     struct ILogTargetWrap
       : public ILogTarget
@@ -120,25 +120,28 @@ namespace detail
 
 void bind_logger()
 {
-    bpy::class_<detail::ILogTargetWrap, boost::shared_ptr<detail::ILogTargetWrap>, boost::noncopyable>("ILogTarget")
-        .def("write", bpy::pure_virtual(&ILogTarget::write));
+    bpy::class_<ILogTargetWrap, boost::shared_ptr<ILogTargetWrap>, boost::noncopyable>("ILogTarget")
+        .def("write", bpy::pure_virtual(&ILogTarget::write))
+        ;
 
     bpy::enum_<LogMessage::Category>("LogMessageCategory")
         .value("Info", LogMessage::Info)
         .value("Debug", LogMessage::Debug)
         .value("Warning", LogMessage::Warning)
         .value("Error", LogMessage::Error)
-        .value("Fatal", LogMessage::Fatal);
+        .value("Fatal", LogMessage::Fatal)
+        ;
 
     bpy::class_<Logger, boost::noncopyable>("Logger", bpy::no_init)
         .def("set_enabled", &Logger::set_enabled)
         .def("reset_all_formats", &Logger::reset_all_formats)
         .def("reset_format", &Logger::reset_format)
-        .def("set_all_formats", detail::logger_set_all_formats)
-        .def("set_format", detail::logger_set_format)
+        .def("set_all_formats", logger_set_all_formats)
+        .def("set_format", logger_set_format)
         .def("get_format", &Logger::get_format)
-        .def("add_target", detail::logger_add_target)
-        .def("remove_target", detail::logger_remove_target);
+        .def("add_target", logger_add_target)
+        .def("remove_target", logger_remove_target)
+        ;
 
-    bpy::def("global_logger", &detail::get_global_logger, bpy::return_value_policy<bpy::reference_existing_object>());
+    bpy::def("global_logger", &get_global_logger, bpy::return_value_policy<bpy::reference_existing_object>());
 }

--- a/src/appleseed.python/bind_master_renderer.cpp
+++ b/src/appleseed.python/bind_master_renderer.cpp
@@ -48,7 +48,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     std::auto_ptr<MasterRenderer> create_master_renderer(
         Project*                project,
@@ -101,9 +101,10 @@ namespace detail
 void bind_master_renderer()
 {
     bpy::class_<MasterRenderer, std::auto_ptr<MasterRenderer>, boost::noncopyable>("MasterRenderer", bpy::no_init)
-        .def("__init__", bpy::make_constructor(detail::create_master_renderer))
-        .def("__init__", bpy::make_constructor(detail::create_master_renderer_with_tile_callback))
-        .def("get_parameters", detail::master_renderer_get_parameters)
-        .def("set_parameters", detail::master_renderer_set_parameters)
-        .def("render", detail::master_renderer_render);
+        .def("__init__", bpy::make_constructor(create_master_renderer))
+        .def("__init__", bpy::make_constructor(create_master_renderer_with_tile_callback))
+        .def("get_parameters", master_renderer_get_parameters)
+        .def("set_parameters", master_renderer_set_parameters)
+        .def("render", master_renderer_render)
+        ;
 }

--- a/src/appleseed.python/bind_material.cpp
+++ b/src/appleseed.python/bind_material.cpp
@@ -44,9 +44,11 @@ using namespace foundation;
 using namespace renderer;
 using namespace std;
 
-namespace detail
+namespace
 {
-    auto_release_ptr<Material> create_material(const string& name, const bpy::dict& params)
+    auto_release_ptr<Material> create_material(
+        const string&   name,
+        const bpy::dict& params)
     {
         return GenericMaterialFactory().create(name.c_str(), bpy_dict_to_param_array(params));
     }
@@ -56,7 +58,9 @@ void bind_material()
 {
     bpy::class_<Material, auto_release_ptr<Material>, bpy::bases<ConnectableEntity>, boost::noncopyable>("Material", bpy::no_init)
         .def("get_input_metadata", &detail::get_entity_input_metadata<MaterialFactoryRegistrar>).staticmethod("get_input_metadata")
-        .def("__init__", bpy::make_constructor(detail::create_material));
+        .def("__init__", bpy::make_constructor(create_material))
+        .def("get_model", &Material::get_model)
+        ;
 
     bind_typed_entity_vector<Material>("MaterialContainer");
 }

--- a/src/appleseed.python/bind_matrix.cpp
+++ b/src/appleseed.python/bind_matrix.cpp
@@ -42,7 +42,7 @@
 namespace bpy = boost::python;
 using namespace foundation;
 
-namespace detail
+namespace
 {
     template <typename T>
     UnalignedMatrix44<T>* construct_matrix_from_list(bpy::list l)
@@ -159,13 +159,13 @@ namespace detail
         }
     };
 
-    template <class T>
+    template <typename T>
     UnalignedMatrix44<T> transpose_matrix(const UnalignedMatrix44<T>& mat)
     {
         return UnalignedMatrix44<T>(transpose(mat.as_foundation_matrix()));
     }
 
-    template <class T>
+    template <typename T>
     bpy::tuple matrix_extract_euler_angles(const UnalignedMatrix44<T>& mat)
     {
         T yaw, pitch, roll;
@@ -183,7 +183,7 @@ namespace detail
         X.def(bpy::init<UnalignedMatrix44<float> >());
     }
 
-    template <class T>
+    template <typename T>
     void bind_typed_matrix4(const char* class_name)
     {
         UnalignedMatrix44<T>(*rot1)(T, T, T) = &UnalignedMatrix44<T>::rotation;
@@ -219,7 +219,8 @@ namespace detail
             .def(bpy::self_ns::repr(bpy::self))
 
             .def("extract_matrix3", &UnalignedMatrix44<T>::extract_matrix3)
-            .def("extract_translation", &UnalignedMatrix44<T>::extract_translation);
+            .def("extract_translation", &UnalignedMatrix44<T>::extract_translation)
+            ;
 
         bind_typed_matrix4_extra(X);
     }
@@ -227,8 +228,8 @@ namespace detail
 
 void bind_matrix()
 {
-    detail::bind_typed_matrix4<float>("Matrix4f");
-    detail::bind_typed_matrix4<double>("Matrix4d");
+    bind_typed_matrix4<float>("Matrix4f");
+    bind_typed_matrix4<double>("Matrix4d");
 
 #ifdef APPLESEED_ENABLE_IMATH_INTEROP
     bpy::implicitly_convertible<UnalignedMatrix44<float>, Imath::M44f>();
@@ -237,5 +238,4 @@ void bind_matrix()
     bpy::implicitly_convertible<UnalignedMatrix44<double>, Imath::M44d>();
     bpy::implicitly_convertible<Imath::M44d, UnalignedMatrix44<double> >();
 #endif
-
 }

--- a/src/appleseed.python/bind_mesh_object.cpp
+++ b/src/appleseed.python/bind_mesh_object.cpp
@@ -49,7 +49,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     auto_release_ptr<MeshObject> create_mesh_obj(
         const std::string&  name,
@@ -126,10 +126,11 @@ void bind_mesh_object()
         .def_readwrite("a0", &Triangle::m_a0)
         .def_readwrite("a1", &Triangle::m_a1)
         .def_readwrite("a2", &Triangle::m_a2)
-        .def_readwrite("pa", &Triangle::m_pa);
+        .def_readwrite("pa", &Triangle::m_pa)
+        ;
 
     bpy::class_<MeshObject, auto_release_ptr<MeshObject>, bpy::bases<Object>, boost::noncopyable>("MeshObject", bpy::no_init)
-        .def("__init__", bpy::make_constructor(detail::create_mesh_obj))
+        .def("__init__", bpy::make_constructor(create_mesh_obj))
 
         .def("reserve_vertices", &MeshObject::reserve_vertices)
         .def("push_vertex", &MeshObject::push_vertex)
@@ -155,13 +156,16 @@ void bind_mesh_object()
 
         .def("set_vertex_pose", &MeshObject::set_vertex_pose)
         .def("get_vertex_pose", &MeshObject::get_vertex_pose)
-        .def("clear_vertex_poses", &MeshObject::clear_vertex_poses);
+        .def("clear_vertex_poses", &MeshObject::clear_vertex_poses)
+        ;
 
     boost::python::implicitly_convertible<auto_release_ptr<MeshObject>, auto_release_ptr<Object> >();
 
     bpy::class_<MeshObjectReader>("MeshObjectReader", bpy::no_init)
-        .def("read", detail::read_mesh_objects).staticmethod("read");
+        .def("read", read_mesh_objects).staticmethod("read")
+        ;
 
     bpy::class_<MeshObjectWriter>("MeshObjectWriter", bpy::no_init)
-        .def("write", detail::write_mesh_object).staticmethod("write");
+        .def("write", write_mesh_object).staticmethod("write")
+        ;
 }

--- a/src/appleseed.python/bind_object.cpp
+++ b/src/appleseed.python/bind_object.cpp
@@ -46,7 +46,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     void bpy_list_to_string_array(const bpy::list& l, StringArray& strings)
     {
@@ -63,6 +63,16 @@ namespace detail
 
             strings.push_back(ex());
         }
+    }
+
+    bpy::list obj_material_slots(const Object* obj)
+    {
+        bpy::list result;
+
+        for (size_t i = 0, e = obj->get_material_slot_count(); i < e; ++i)
+            result.append(obj->get_material_slot(i));
+
+        return result;
     }
 
     auto_release_ptr<ObjectInstance> create_obj_instance_with_back_mat(
@@ -109,16 +119,20 @@ namespace detail
 void bind_object()
 {
     bpy::class_<Object, auto_release_ptr<Object>, bpy::bases<Entity>, boost::noncopyable>("Object", bpy::no_init)
-        .def("compute_local_bbox", &Object::compute_local_bbox);
+        .def("get_model", &Object::get_model)
+        .def("compute_local_bbox", &Object::compute_local_bbox)
+        .def("material_slots", &obj_material_slots)
+        ;
 
     bind_typed_entity_vector<Object>("ObjectContainer");
 
     bpy::class_<ObjectInstance, auto_release_ptr<ObjectInstance>, bpy::bases<Entity>, boost::noncopyable>("ObjectInstance", bpy::no_init)
-        .def("__init__", bpy::make_constructor(detail::create_obj_instance))
-        .def("__init__", bpy::make_constructor(detail::create_obj_instance_with_back_mat))
+        .def("__init__", bpy::make_constructor(create_obj_instance))
+        .def("__init__", bpy::make_constructor(create_obj_instance_with_back_mat))
         .def("get_object", &ObjectInstance::get_object, bpy::return_value_policy<bpy::reference_existing_object>())
-        .def("get_transform", &detail::obj_inst_get_transform)
-        .def("compute_parent_bbox", &ObjectInstance::compute_parent_bbox);
+        .def("get_transform", &obj_inst_get_transform)
+        .def("compute_parent_bbox", &ObjectInstance::compute_parent_bbox)
+        ;
 
     bind_typed_entity_vector<ObjectInstance>("ObjectInstanceContainer");
 }

--- a/src/appleseed.python/bind_project.cpp
+++ b/src/appleseed.python/bind_project.cpp
@@ -52,7 +52,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     auto_release_ptr<Project> create_project(const std::string& name)
     {
@@ -171,23 +171,24 @@ namespace detail
 void bind_project()
 {
     bpy::class_<Configuration, auto_release_ptr<Configuration>, bpy::bases<Entity>, boost::noncopyable>("Configuration", bpy::no_init)
-        .def("create_base_final", detail::create_base_final_config).staticmethod("create_base_final")
-        .def("create_base_interactive", detail::create_base_interactive_config).staticmethod("create_base_interactive")
+        .def("create_base_final", create_base_final_config).staticmethod("create_base_final")
+        .def("create_base_interactive", create_base_interactive_config).staticmethod("create_base_interactive")
 
-        .def("__init__", bpy::make_constructor(detail::create_config))
-        .def("__init__", bpy::make_constructor(detail::create_config_with_params))
+        .def("__init__", bpy::make_constructor(create_config))
+        .def("__init__", bpy::make_constructor(create_config_with_params))
 
         .def("set_base", &Configuration::set_base)
         .def("get_base", &Configuration::get_base, bpy::return_value_policy<bpy::reference_existing_object>())
-        .def("get_inherited_parameters", detail::config_get_inherited_parameters);
+        .def("get_inherited_parameters", config_get_inherited_parameters)
+        ;
 
     bind_typed_entity_map<Configuration>("ConfigurationContainer");
 
     bpy::class_<Project, auto_release_ptr<Project>, bpy::bases<Entity>, boost::noncopyable>("Project", bpy::no_init)
-        .def("create_default", detail::create_default_project).staticmethod("create_default")
-        .def("create_cornell_box", detail::create_cornell_box_project).staticmethod("create_cornell_box")
+        .def("create_default", create_default_project).staticmethod("create_default")
+        .def("create_cornell_box", create_cornell_box_project).staticmethod("create_cornell_box")
 
-        .def("__init__", bpy::make_constructor(detail::create_project))
+        .def("__init__", bpy::make_constructor(create_project))
 
         .def("add_default_configurations", &Project::add_default_configurations)
 
@@ -195,8 +196,8 @@ void bind_project()
         .def("set_path", &Project::set_path)
         .def("get_path", &Project::get_path)
 
-        .def("get_search_paths", detail::project_get_search_paths)
-        .def("set_search_paths", detail::project_set_search_paths)
+        .def("get_search_paths", project_get_search_paths)
+        .def("set_search_paths", project_set_search_paths)
 
         .def("set_scene", &Project::set_scene)
         .def("get_scene", &Project::get_scene, bpy::return_value_policy<bpy::reference_existing_object>())
@@ -206,24 +207,28 @@ void bind_project()
 
         .def("set_display", &Project::set_display)
 
-        .def("configurations", detail::project_get_configs, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("configurations", project_get_configs, bpy::return_value_policy<bpy::reference_existing_object>())
 
-        .def("create_aov_images", &Project::create_aov_images);
+        .def("create_aov_images", &Project::create_aov_images)
+        ;
 
     bpy::class_<ProjectFileReader>("ProjectFileReader")
-        .def("read", &detail::project_file_reader_read)
-        .def("load_builtin", &detail::project_file_reader_load_builtin);
+        .def("read", &project_file_reader_read)
+        .def("load_builtin", &project_file_reader_load_builtin)
+        ;
 
     bpy::enum_<ProjectFileWriter::Options>("ProjectFileWriterOptions")
         .value("Defaults", ProjectFileWriter::Defaults)
         .value("OmitHeaderComment", ProjectFileWriter::OmitHeaderComment)
         .value("OmitWritingGeometryFiles", ProjectFileWriter::OmitWritingGeometryFiles)
         .value("OmitBringingAssets", ProjectFileWriter::OmitBringingAssets)
-        .value("OmitSearchPaths", ProjectFileWriter::OmitSearchPaths);
+        .value("OmitSearchPaths", ProjectFileWriter::OmitSearchPaths)
+        ;
 
     bpy::class_<ProjectFileWriter>("ProjectFileWriter")
         // These methods are static, but for symmetry with
         // ProjectFileReader we're wrapping them non-static.
-        .def("write", detail::write_project_default_opts)
-        .def("write", detail::write_project_with_opts);
+        .def("write", write_project_default_opts)
+        .def("write", write_project_with_opts)
+        ;
 }

--- a/src/appleseed.python/bind_quaternion.cpp
+++ b/src/appleseed.python/bind_quaternion.cpp
@@ -41,7 +41,7 @@
 namespace bpy = boost::python;
 using namespace foundation;
 
-namespace detail
+namespace
 {
     template <class T>
     T quat_dot_prod(const Quaternion<T>& a, const Quaternion<T>& b)
@@ -157,8 +157,8 @@ namespace detail
 
 void bind_quaternion()
 {
-    detail::do_bind_quaternion<float>("Quaternionf");
-    detail::do_bind_quaternion<double>("Quaterniond");
+    do_bind_quaternion<float>("Quaternionf");
+    do_bind_quaternion<double>("Quaterniond");
 
 #ifdef APPLESEED_ENABLE_IMATH_INTEROP
     bpy::implicitly_convertible<Quaternionf, Imath::Quatf>();

--- a/src/appleseed.python/bind_renderer_controller.cpp
+++ b/src/appleseed.python/bind_renderer_controller.cpp
@@ -45,7 +45,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     class IRendererControllerWrapper
       : public IRendererController
@@ -179,16 +179,18 @@ void bind_renderer_controller()
         .value("TerminateRendering", IRendererController::TerminateRendering)
         .value("AbortRendering", IRendererController::AbortRendering)
         .value("RestartRendering", IRendererController::RestartRendering)
-        .value("ReinitializeRendering", IRendererController::ReinitializeRendering);
+        .value("ReinitializeRendering", IRendererController::ReinitializeRendering)
+        ;
 
-    bpy::class_<detail::IRendererControllerWrapper, boost::noncopyable>("IRendererController")
+    bpy::class_<IRendererControllerWrapper, boost::noncopyable>("IRendererController")
         .def("on_rendering_begin", bpy::pure_virtual(&IRendererController::on_rendering_begin))
         .def("on_rendering_success", bpy::pure_virtual(&IRendererController::on_rendering_success))
         .def("on_rendering_abort", bpy::pure_virtual(&IRendererController::on_rendering_abort))
         .def("on_frame_begin", bpy::pure_virtual(&IRendererController::on_frame_begin))
         .def("on_frame_end", bpy::pure_virtual(&IRendererController::on_frame_end))
         .def("on_progress", bpy::pure_virtual(&IRendererController::on_progress))
-        .def("get_status", bpy::pure_virtual(&IRendererController::get_status));
+        .def("get_status", bpy::pure_virtual(&IRendererController::get_status))
+        ;
 
     bpy::class_<DefaultRendererController, boost::noncopyable>("DefaultRendererController");
 }

--- a/src/appleseed.python/bind_scene.cpp
+++ b/src/appleseed.python/bind_scene.cpp
@@ -37,7 +37,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     auto_release_ptr<Scene> create_scene()
     {
@@ -48,7 +48,7 @@ namespace detail
 void bind_scene()
 {
     bpy::class_<Scene, auto_release_ptr<Scene>, bpy::bases<Entity, BaseGroup>, boost::noncopyable>("Scene", bpy::no_init)
-        .def("__init__", bpy::make_constructor(detail::create_scene))
+        .def("__init__", bpy::make_constructor(create_scene))
         .def("get_uid", &Identifiable::get_uid)
         .def("set_camera", &Scene::set_camera)
         .def("get_camera", &Scene::get_camera, bpy::return_value_policy<bpy::reference_existing_object>())

--- a/src/appleseed.python/bind_shadergroup.cpp
+++ b/src/appleseed.python/bind_shadergroup.cpp
@@ -45,7 +45,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     auto_release_ptr<ShaderGroup> create_shader_group(const std::string& name)
     {
@@ -66,9 +66,10 @@ namespace detail
 void bind_shader_group()
 {
     bpy::class_<ShaderGroup, auto_release_ptr<ShaderGroup>, bpy::bases<Entity>, boost::noncopyable>("ShaderGroup", bpy::no_init)
-        .def("__init__", bpy::make_constructor(detail::create_shader_group))
-        .def("add_shader", detail::add_shader)
-        .def("add_connection", &ShaderGroup::add_connection);
+        .def("__init__", bpy::make_constructor(create_shader_group))
+        .def("add_shader", add_shader)
+        .def("add_connection", &ShaderGroup::add_connection)
+        ;
 
     bind_typed_entity_vector<ShaderGroup>("ShaderGroupContainer");
 }

--- a/src/appleseed.python/bind_surface_shader.cpp
+++ b/src/appleseed.python/bind_surface_shader.cpp
@@ -41,13 +41,14 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
-    auto_release_ptr<SurfaceShader> create_surface_shader(const std::string& surf_type,
-                                                          const std::string& name)
+    auto_release_ptr<SurfaceShader> create_surface_shader(
+        const std::string& model,
+        const std::string& name)
     {
         SurfaceShaderFactoryRegistrar factories;
-        const ISurfaceShaderFactory* factory = factories.lookup(surf_type.c_str());
+        const ISurfaceShaderFactory* factory = factories.lookup(model.c_str());
 
         if (factory)
             return factory->create(name.c_str(), ParamArray());
@@ -60,12 +61,13 @@ namespace detail
         return auto_release_ptr<SurfaceShader>();
     }
 
-    auto_release_ptr<SurfaceShader> create_surface_shader_with_params(const std::string& surf_type,
-                                                                      const std::string& name,
-                                                                      const bpy::dict& params)
+    auto_release_ptr<SurfaceShader> create_surface_shader_with_params(
+        const std::string&    model,
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         SurfaceShaderFactoryRegistrar factories;
-        const ISurfaceShaderFactory* factory = factories.lookup(surf_type.c_str());
+        const ISurfaceShaderFactory* factory = factories.lookup(model.c_str());
 
         if (factory)
             return factory->create(name.c_str(), bpy_dict_to_param_array(params));
@@ -83,8 +85,9 @@ void bind_surface_shader()
 {
     bpy::class_<SurfaceShader, auto_release_ptr<SurfaceShader>, bpy::bases<ConnectableEntity>, boost::noncopyable>("SurfaceShader", bpy::no_init)
         .def("get_input_metadata", &detail::get_entity_input_metadata<SurfaceShaderFactoryRegistrar>).staticmethod("get_input_metadata")
-        .def("__init__", bpy::make_constructor(detail::create_surface_shader))
-        .def("__init__", bpy::make_constructor(detail::create_surface_shader_with_params))
+        .def("__init__", bpy::make_constructor(create_surface_shader))
+        .def("__init__", bpy::make_constructor(create_surface_shader_with_params))
+        .def("get_model", &SurfaceShader::get_model)
         ;
 
     bind_typed_entity_vector<SurfaceShader>("SurfaceShaderContainer");

--- a/src/appleseed.python/bind_texture.cpp
+++ b/src/appleseed.python/bind_texture.cpp
@@ -46,7 +46,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     auto_release_ptr<Texture> create_texture(
         const std::string&              texture_type,
@@ -97,18 +97,27 @@ namespace detail
                 texture_name.c_str(),
                 transform.as_foundation_transform());
     }
+
+    UnalignedTransformd44 texture_inst_get_transform(const TextureInstance* tx)
+    {
+        return UnalignedTransformd44(tx->get_transform());
+    }
 }
 
 void bind_texture()
 {
     bpy::class_<Texture, auto_release_ptr<Texture>, bpy::bases<Entity>, boost::noncopyable>("Texture", bpy::no_init)
         .def("get_input_metadata", &detail::get_entity_input_metadata<TextureFactoryRegistrar>).staticmethod("get_input_metadata")
-        .def("__init__", bpy::make_constructor(detail::create_texture));
+        .def("__init__", bpy::make_constructor(create_texture))
+        .def("get_model", &Texture::get_model)
+        ;
 
     bind_typed_entity_vector<Texture>("TextureContainer");
 
     bpy::class_<TextureInstance, auto_release_ptr<TextureInstance>, bpy::bases<Entity>, boost::noncopyable>("TextureInstance", bpy::no_init)
-        .def("__init__", bpy::make_constructor(detail::create_texture_instance));
+        .def("__init__", bpy::make_constructor(create_texture_instance))
+        .def("get_transform", &texture_inst_get_transform)
+        ;
 
     bind_typed_entity_vector<TextureInstance>("TextureInstanceContainer");
 }

--- a/src/appleseed.python/bind_tile_callback.cpp
+++ b/src/appleseed.python/bind_tile_callback.cpp
@@ -45,7 +45,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     class ITileCallbackWrapper
       : public ITileCallback
@@ -109,7 +109,7 @@ namespace detail
 
 void bind_tile_callback()
 {
-    bpy::class_<detail::ITileCallbackWrapper, boost::noncopyable>("ITileCallback")
+    bpy::class_<ITileCallbackWrapper, boost::noncopyable>("ITileCallback")
         .def("pre_render", bpy::pure_virtual(&ITileCallback::pre_render))
         .def("post_render_tile", bpy::pure_virtual(&ITileCallback::post_render_tile))
         .def("post_render", bpy::pure_virtual(&ITileCallback::post_render));

--- a/src/appleseed.python/bind_transform.cpp
+++ b/src/appleseed.python/bind_transform.cpp
@@ -43,7 +43,7 @@ namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
 
-namespace detail
+namespace
 {
     void transform_seq_set_transform(
         TransformSequence*              seq,
@@ -65,6 +65,22 @@ namespace detail
         Transformd xform;
         seq->get_transform(index, time, xform);
         return bpy::make_tuple(time, UnalignedTransformd44(xform));
+    }
+
+    bpy::list transform_seq_as_list(const TransformSequence* seq)
+    {
+        bpy::list result;
+
+        for (size_t i = 0, e = seq->size(); i < e; ++i)
+        {
+            double time;
+            Transformd xform;
+            seq->get_transform(i, time, xform);
+            bpy::tuple t = bpy::make_tuple(time, UnalignedTransformd44(xform));
+            result.append(t);
+        }
+
+        return result;
     }
 
     UnalignedTransformd44 transform_seq_get_earliest(const TransformSequence* seq)
@@ -131,11 +147,14 @@ void bind_transform()
         .def(bpy::self_ns::repr(bpy::self));
 
     bpy::class_<TransformSequence, boost::noncopyable>("TransformSequence", bpy::no_init)
-        .def("set_transform", &detail::transform_seq_set_transform)
-        .def("get_transform", &detail::transform_seq_get_transform)
-        .def("get_earliest_transform", &detail::transform_seq_get_earliest)
+        .def("set_transform", &transform_seq_set_transform)
+        .def("get_transform", &transform_seq_get_transform)
+        .def("get_earliest_transform", &transform_seq_get_earliest)
 
         .def("empty", &TransformSequence::empty)
         .def("size", &TransformSequence::size)
-        .def("clear", &TransformSequence::clear);
+        .def("clear", &TransformSequence::clear)
+
+        .def("transforms", &transform_seq_as_list)
+        ;
 }

--- a/src/appleseed.python/bind_utility.cpp
+++ b/src/appleseed.python/bind_utility.cpp
@@ -51,13 +51,15 @@ void bind_utility()
         .def("signal_errors", &EventCounters::signal_errors)
         .def("get_warning_count", &EventCounters::get_warning_count)
         .def("get_error_count", &EventCounters::get_error_count)
-        .def("has_errors", &EventCounters::has_errors);
+        .def("has_errors", &EventCounters::has_errors)
+        ;
 
     bpy::class_<ILogTarget, boost::noncopyable>("ILogTarget", bpy::no_init);
 
     bpy::class_<Logger, boost::noncopyable>("Logger", bpy::no_init)
         .def("set_enabled", &Logger::set_enabled)
-        .def("add_target", &Logger::add_target);
+        .def("add_target", &Logger::add_target)
+        ;
 
     bpy::def("global_logger", global_logger, bpy::return_value_policy<bpy::reference_existing_object>());
 }

--- a/src/appleseed.python/bind_vector.cpp
+++ b/src/appleseed.python/bind_vector.cpp
@@ -80,12 +80,9 @@ namespace
     {
         typedef Vector<T, 2> VectorType;
 
-        static VectorType* construct(T x, T y)
+        static VectorType* construct(const T x, const T y)
         {
-            Vector<T, 2>* r = new VectorType();
-            (*r)[0] = x;
-            (*r)[1] = y;
-            return r;
+            return new VectorType(x, y);
         }
     };
 
@@ -94,13 +91,9 @@ namespace
     {
         typedef Vector<T, 3> VectorType;
 
-        static VectorType* construct(T x, T y, T z)
+        static VectorType* construct(const T x, const T y, const T z)
         {
-            Vector<T, 3>* r = new VectorType();
-            (*r)[0] = x;
-            (*r)[1] = y;
-            (*r)[2] = z;
-            return r;
+            return new VectorType(x, y, z);
         }
     };
 
@@ -109,14 +102,9 @@ namespace
     {
         typedef Vector<T, 4> VectorType;
 
-        static VectorType* construct(T x, T y, T z, T w)
+        static VectorType* construct(const T x, const T y, const T z, const T w)
         {
-            VectorType* r = new VectorType();
-            (*r)[0] = x;
-            (*r)[1] = y;
-            (*r)[2] = z;
-            (*r)[3] = w;
-            return r;
+            return new VectorType(x, y, z, w);
         }
     };
 
@@ -186,7 +174,8 @@ namespace
 
             // Because of a bug in Boost.Python, this needs the extra self_ns qualification.
             .def(bpy::self_ns::str(bpy::self))
-            .def(bpy::self_ns::repr(bpy::self));
+            .def(bpy::self_ns::repr(bpy::self))
+            ;
     }
 }
 

--- a/src/appleseed.python/bind_vector.cpp
+++ b/src/appleseed.python/bind_vector.cpp
@@ -44,7 +44,7 @@
 namespace bpy = boost::python;
 using namespace foundation;
 
-namespace detail
+namespace
 {
     template <typename T, std::size_t N>
     Vector<T, N>* construct_vec_from_list(bpy::list l)
@@ -73,14 +73,16 @@ namespace detail
     }
 
     template <class T, std::size_t N>
-    struct vector_constructor {};
+    struct vector_helper {};
 
     template <class T>
-    struct vector_constructor<T, 2>
+    struct vector_helper<T, 2>
     {
-        static Vector<T, 2>* construct(T x, T y)
+        typedef Vector<T, 2> VectorType;
+
+        static VectorType* construct(T x, T y)
         {
-            Vector<T, 2>* r = new Vector<T, 2>();
+            Vector<T, 2>* r = new VectorType();
             (*r)[0] = x;
             (*r)[1] = y;
             return r;
@@ -88,11 +90,13 @@ namespace detail
     };
 
     template <class T>
-    struct vector_constructor<T, 3>
+    struct vector_helper<T, 3>
     {
-        static Vector<T, 3>* construct(T x, T y, T z)
+        typedef Vector<T, 3> VectorType;
+
+        static VectorType* construct(T x, T y, T z)
         {
-            Vector<T, 3>* r = new Vector<T, 3>();
+            Vector<T, 3>* r = new VectorType();
             (*r)[0] = x;
             (*r)[1] = y;
             (*r)[2] = z;
@@ -101,11 +105,13 @@ namespace detail
     };
 
     template <class T>
-    struct vector_constructor<T, 4>
+    struct vector_helper<T, 4>
     {
-        static Vector<T, 4>* construct(T x, T y, T z, T w)
+        typedef Vector<T, 4> VectorType;
+
+        static VectorType* construct(T x, T y, T z, T w)
         {
-            Vector<T, 4>* r = new Vector<T, 4>();
+            VectorType* r = new VectorType();
             (*r)[0] = x;
             (*r)[1] = y;
             (*r)[2] = z;
@@ -154,7 +160,7 @@ namespace detail
         bpy::class_<Vector<T, N> >(class_name)
             .def(bpy::init<>())
             .def(bpy::init<T>())
-            .def("__init__", bpy::make_constructor(&vector_constructor<T, N>::construct))
+            .def("__init__", bpy::make_constructor(&vector_helper<T, N>::construct))
             .def("__init__", bpy::make_constructor(&construct_vec_from_list<T, N>))
 
             // operator[]
@@ -186,15 +192,15 @@ namespace detail
 
 void bind_vector()
 {
-    detail::do_bind_vector<int, 2>("Vector2i");
-    detail::do_bind_vector<float, 2>("Vector2f");
-    detail::do_bind_vector<double, 2>("Vector2d");
+    do_bind_vector<int, 2>("Vector2i");
+    do_bind_vector<float, 2>("Vector2f");
+    do_bind_vector<double, 2>("Vector2d");
 
-    detail::do_bind_vector<int, 3>("Vector3i");
-    detail::do_bind_vector<float, 3>("Vector3f");
-    detail::do_bind_vector<double, 3>("Vector3d");
+    do_bind_vector<int, 3>("Vector3i");
+    do_bind_vector<float, 3>("Vector3f");
+    do_bind_vector<double, 3>("Vector3d");
 
-    detail::do_bind_vector<int, 4>("Vector4i");
+    do_bind_vector<int, 4>("Vector4i");
 
 #ifdef APPLESEED_ENABLE_IMATH_INTEROP
     bpy::implicitly_convertible<Vector2i, Imath::V2i>();
@@ -214,8 +220,5 @@ void bind_vector()
 
     bpy::implicitly_convertible<Vector3d, Imath::V3d>();
     bpy::implicitly_convertible<Imath::V3d, Vector3d>();
-
-    bpy::implicitly_convertible<Vector4i, Imath::V4i>();
-    bpy::implicitly_convertible<Imath::V4i, Vector4i>();
 #endif
 }


### PR DESCRIPTION
- Formatting changes to make the code style closer to the rest of appleseed's code.
- Removed the detail namespace when possible (non headers).
- Exposed some missing methods to python.
- Enabled conversions to / from imath python module.
