### PR TITLE
Bumped appleseed version after release.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ endif ()
 
 set (appleseed_version_major    1)
 set (appleseed_version_minor    1)
-set (appleseed_version_patch    0)
+set (appleseed_version_patch    1)
 set (appleseed_version_maturity beta)
 
 configure_file (${PROJECT_SOURCE_DIR}/src/appleseed/foundation/core/version.h.in


### PR DESCRIPTION
The real version number can be decided when the next release is done,
but for now, it has to be greater than the previous release.
