### PR TITLE
Added compile-time and run-time appleseed version information for OSL shaders.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ endif ()
 
 
 #--------------------------------------------------------------------------------------------------
-# Auto-generate version header.
+# Auto-generate version headers.
 #--------------------------------------------------------------------------------------------------
 
 set (appleseed_version_major    1)
@@ -136,6 +136,11 @@ set (appleseed_version_maturity beta)
 
 configure_file (${PROJECT_SOURCE_DIR}/src/appleseed/foundation/core/version.h.in
                 ${PROJECT_SOURCE_DIR}/src/appleseed/foundation/core/version.h)
+
+if (WITH_OSL)
+    configure_file (${PROJECT_SOURCE_DIR}/src/appleseed/renderer/kernel/shading/stdosl.h.in
+                    ${PROJECT_SOURCE_DIR}/src/appleseed/renderer/kernel/shading/stdosl.h)
+endif ()
 
 #--------------------------------------------------------------------------------------------------
 # Boost libraries.

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -1121,7 +1121,6 @@ if (WITH_OSL)
         renderer/kernel/shading/oslshadergroupexec.cpp
         renderer/kernel/shading/oslshadergroupexec.h
         renderer/kernel/shading/oslutil.h
-        renderer/kernel/shading/stdosl.h
     )
 endif ()
 list (APPEND appleseed_sources

--- a/src/appleseed/renderer/kernel/rendering/rendererservices.cpp
+++ b/src/appleseed/renderer/kernel/rendering/rendererservices.cpp
@@ -42,6 +42,7 @@
 #include "renderer/modeling/scene/visibilityflags.h"
 
 // appleseed.foundation headers.
+#include "foundation/core/version.h"
 #include "foundation/image/image.h"
 
 // Standard headers.
@@ -114,6 +115,10 @@ RendererServices::RendererServices(
     m_global_attr_getters[OIIO::ustring("path:ray_depth")] = &RendererServices::get_ray_depth;
     m_global_attr_getters[OIIO::ustring("path:ray_length")] = &RendererServices::get_ray_length;
     m_global_attr_getters[OIIO::ustring("path:ray_ior")] = &RendererServices::get_ray_ior;
+    m_global_attr_getters[OIIO::ustring("appleseed:version_major")] = &RendererServices::get_appleseed_version_major;
+    m_global_attr_getters[OIIO::ustring("appleseed:version_minor")] = &RendererServices::get_appleseed_version_minor;
+    m_global_attr_getters[OIIO::ustring("appleseed:version_patch")] = &RendererServices::get_appleseed_version_patch;
+    m_global_attr_getters[OIIO::ustring("appleseed:version")] = &RendererServices::get_appleseed_version;
 }
 
 void RendererServices::initialize()
@@ -839,6 +844,54 @@ IMPLEMENT_ATTR_GETTER(ray_ior)
     if (type == OIIO::TypeDesc::TypeFloat)
     {
         reinterpret_cast<float*>(val)[0] = 1.0f;
+        clear_attr_derivatives(derivs, type, val);
+        return true;
+    }
+
+    return false;
+}
+
+IMPLEMENT_ATTR_GETTER(appleseed_version_major)
+{
+    if (type == OIIO::TypeDesc::TypeInt)
+    {
+        reinterpret_cast<int*>(val)[0] = APPLESEED_VERSION_MAJOR;
+        clear_attr_derivatives(derivs, type, val);
+        return true;
+    }
+
+    return false;
+}
+
+IMPLEMENT_ATTR_GETTER(appleseed_version_minor)
+{
+    if (type == OIIO::TypeDesc::TypeInt)
+    {
+        reinterpret_cast<int*>(val)[0] = APPLESEED_VERSION_MINOR;
+        clear_attr_derivatives(derivs, type, val);
+        return true;
+    }
+
+    return false;
+}
+
+IMPLEMENT_ATTR_GETTER(appleseed_version_patch)
+{
+    if (type == OIIO::TypeDesc::TypeInt)
+    {
+        reinterpret_cast<int*>(val)[0] = APPLESEED_VERSION_PATCH;
+        clear_attr_derivatives(derivs, type, val);
+        return true;
+    }
+
+    return false;
+}
+
+IMPLEMENT_ATTR_GETTER(appleseed_version)
+{
+    if (type == OIIO::TypeDesc::TypeInt)
+    {
+        reinterpret_cast<int*>(val)[0] = APPLESEED_VERSION;
         clear_attr_derivatives(derivs, type, val);
         return true;
     }

--- a/src/appleseed/renderer/kernel/rendering/rendererservices.h
+++ b/src/appleseed/renderer/kernel/rendering/rendererservices.h
@@ -392,6 +392,12 @@ class RendererServices
     DECLARE_ATTR_GETTER(ray_length);
     DECLARE_ATTR_GETTER(ray_ior);
 
+    // Appleseed version attributes
+    DECLARE_ATTR_GETTER(appleseed_version_major);
+    DECLARE_ATTR_GETTER(appleseed_version_minor);
+    DECLARE_ATTR_GETTER(appleseed_version_patch);
+    DECLARE_ATTR_GETTER(appleseed_version);
+
     #undef DECLARE_ATTR_GETTER
 
     static void clear_attr_derivatives(

--- a/src/appleseed/renderer/kernel/shading/.gitignore
+++ b/src/appleseed/renderer/kernel/shading/.gitignore
@@ -1,0 +1,1 @@
+stdosl.h

--- a/src/appleseed/renderer/kernel/shading/stdosl.h.in
+++ b/src/appleseed/renderer/kernel/shading/stdosl.h.in
@@ -34,7 +34,7 @@
 #define STDOSL_H
 
 // appleseed specific
-#define __APPLESEED_OSL__
+#define APPLESEED_OSL
 
 #define APPLESEED_VERSION_MAJOR     ${appleseed_version_major}
 #define APPLESEED_VERSION_MINOR     ${appleseed_version_minor}

--- a/src/appleseed/renderer/kernel/shading/stdosl.h.in
+++ b/src/appleseed/renderer/kernel/shading/stdosl.h.in
@@ -33,9 +33,7 @@
 #ifndef STDOSL_H
 #define STDOSL_H
 
-// appleseed specific
-#define APPLESEED_OSL
-
+// appleseed version
 #define APPLESEED_VERSION_MAJOR     ${appleseed_version_major}
 #define APPLESEED_VERSION_MINOR     ${appleseed_version_minor}
 #define APPLESEED_VERSION_PATCH     ${appleseed_version_patch}

--- a/src/appleseed/renderer/kernel/shading/stdosl.h.in
+++ b/src/appleseed/renderer/kernel/shading/stdosl.h.in
@@ -34,9 +34,16 @@
 #define STDOSL_H
 
 // appleseed specific
-#ifndef __APPLESEED_OSL__
 #define __APPLESEED_OSL__
-#endif
+
+#define APPLESEED_VERSION_MAJOR     ${appleseed_version_major}
+#define APPLESEED_VERSION_MINOR     ${appleseed_version_minor}
+#define APPLESEED_VERSION_PATCH     ${appleseed_version_patch}
+
+#define APPLESEED_VERSION               \
+    APPLESEED_VERSION_MAJOR * 10000 +   \
+    APPLESEED_VERSION_MINOR * 100 +     \
+    APPLESEED_VERSION_PATCH
 
 #ifndef M_PI
 #define M_PI       3.1415926535897932        /* pi */


### PR DESCRIPTION
OSL shaders can now check appleseed's version using the preprocessor at compile time or 
getattribute at run time.
Also removed the old __APPLESEED_OSL__ define. Checking if APPLESEED_VERSION is defined could be used instead.
