### PR TITLE
Allow shader_group entities inside scenes, in project files.

### DIFF
--- a/src/appleseed/renderer/modeling/project/project.xsd
+++ b/src/appleseed/renderer/modeling/project/project.xsd
@@ -161,36 +161,7 @@
                             </xsd:complexContent>
                         </xsd:complexType>
                     </xsd:element>
-                    <xsd:element name="shader_group">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:choice minOccurs="0" maxOccurs="unbounded">
-                                    <xsd:element name="shader" minOccurs="0">
-                                        <xsd:complexType>
-                                            <xsd:complexContent>
-                                                <xsd:extension base="parameterSet">
-                                                    <xsd:attribute name="type" type="xsd:string" use="required"/>
-                                                    <xsd:attribute name="name" type="xsd:string" use="required"/>
-                                                    <xsd:attribute name="layer" type="xsd:string" use="required"/>
-                                                </xsd:extension>
-                                            </xsd:complexContent>
-                                        </xsd:complexType>
-                                    </xsd:element>
-                                </xsd:choice>
-                                <xsd:choice minOccurs="0" maxOccurs="unbounded">
-                                    <xsd:element name="connect_shaders" minOccurs="0">
-                                        <xsd:complexType>
-                                            <xsd:attribute name="src_layer" type="xsd:string" use="required"/>
-                                            <xsd:attribute name="src_param" type="xsd:string" use="required"/>
-                                            <xsd:attribute name="dst_layer" type="xsd:string" use="required"/>
-                                            <xsd:attribute name="dst_param" type="xsd:string" use="required"/>
-                                        </xsd:complexType>
-                                    </xsd:element>
-                                </xsd:choice>
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" use="required"/>
-                        </xsd:complexType>
-                    </xsd:element>
+                    <xsd:element ref="shader_group" />
                     <xsd:element name="surface_shader">
                         <xsd:complexType>
                             <xsd:complexContent>
@@ -293,6 +264,7 @@
                                     </xsd:element>
                                     <xsd:element ref="texture"/>
                                     <xsd:element ref="texture_instance"/>
+                                    <xsd:element ref="shader_group"/>
                                 </xsd:choice>
                             </xsd:extension>
                         </xsd:complexContent>
@@ -383,6 +355,36 @@
                     <xsd:attribute name="model" type="xsd:string" use="required"/>
                 </xsd:extension>
             </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="shader_group">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                    <xsd:element name="shader" minOccurs="0">
+                        <xsd:complexType>
+                            <xsd:complexContent>
+                                <xsd:extension base="parameterSet">
+                                    <xsd:attribute name="type" type="xsd:string" use="required"/>
+                                    <xsd:attribute name="name" type="xsd:string" use="required"/>
+                                    <xsd:attribute name="layer" type="xsd:string" use="required"/>
+                                </xsd:extension>
+                            </xsd:complexContent>
+                        </xsd:complexType>
+                    </xsd:element>
+                </xsd:choice>
+                <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                    <xsd:element name="connect_shaders" minOccurs="0">
+                        <xsd:complexType>
+                            <xsd:attribute name="src_layer" type="xsd:string" use="required"/>
+                            <xsd:attribute name="src_param" type="xsd:string" use="required"/>
+                            <xsd:attribute name="dst_layer" type="xsd:string" use="required"/>
+                            <xsd:attribute name="dst_param" type="xsd:string" use="required"/>
+                        </xsd:complexType>
+                    </xsd:element>
+                </xsd:choice>
+            </xsd:sequence>
+            <xsd:attribute name="name" type="xsd:string" use="required"/>
         </xsd:complexType>
     </xsd:element>
 </xsd:schema>

--- a/src/appleseed/renderer/modeling/project/projectfilereader.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilereader.cpp
@@ -2305,6 +2305,13 @@ namespace
                     static_cast<TextureInstanceElementHandler*>(handler)->get_texture_instance());
                 break;
 
+#ifdef APPLESEED_WITH_OSL
+              case ElementShaderGroup:
+                insert(
+                    m_scene->shader_groups(),
+                    static_cast<ShaderGroupElementHandler*>(handler)->get_shader_group());
+                break;
+#endif
               default:
                 ParametrizedElementHandler::end_child_element(element, handler);
                 break;

--- a/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
@@ -885,6 +885,9 @@ namespace
                 !scene.environment_edfs().empty() ||
                 !scene.environment_shaders().empty() ||
                 scene.get_environment() != 0 ||
+#ifdef APPLESEED_WITH_OSL
+                !scene.shader_groups().empty() ||
+#endif
                 !scene.assemblies().empty() ||
                 !scene.assembly_instances().empty()
                     ? XMLElement::HasChildElements
@@ -904,6 +907,9 @@ namespace
             if (scene.get_environment())
                 write(*scene.get_environment());
 
+#ifdef APPLESEED_WITH_OSL
+            write_collection(scene.shader_groups());
+#endif
             write_collection(scene.assemblies());
             write_collection(scene.assembly_instances());
         }
@@ -933,7 +939,6 @@ namespace
         }
 
 #ifdef APPLESEED_WITH_OSL
-
         // Write a <shader> parameter.
         void write(const ShaderParam& param)
         {
@@ -980,7 +985,6 @@ namespace
             for (const_each<ShaderConnectionContainer> i = shader_group.shader_connections(); i; ++i)
                 write(*i);
         }
-
 #endif
 
         // Write a <surface_shader> element.


### PR DESCRIPTION
Useful for OSL environments for example.