### PR TITLE
Ray differentials work

### DIFF
--- a/src/appleseed.studio/mainwindow/rendering/frozendisplayrenderer.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/frozendisplayrenderer.cpp
@@ -127,7 +127,7 @@ void FrozenDisplayRenderer::capture()
 
                     // Generate a world space ray going through that film point.
                     ShadingRay ray;
-                    m_camera.generate_ray(sampling_context, point, ray);
+                    m_camera.generate_ray(sampling_context, point, 0, ray);
 
                     // Retrieve pixel color.
                     Color4f pixel;

--- a/src/appleseed.studio/mainwindow/rendering/frozendisplayrenderer.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/frozendisplayrenderer.cpp
@@ -127,7 +127,7 @@ void FrozenDisplayRenderer::capture()
 
                     // Generate a world space ray going through that film point.
                     ShadingRay ray;
-                    m_camera.generate_ray(sampling_context, point, 0, ray);
+                    m_camera.generate_ray(sampling_context, Dual2d(point), ray);
 
                     // Retrieve pixel color.
                     Color4f pixel;

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -259,6 +259,7 @@ set (foundation_math_sources
     foundation/math/cdf.h
     foundation/math/combination.h
     foundation/math/distance.h
+    foundation/math/dual.h
     foundation/math/fastmath.h
     foundation/math/filter.h
     foundation/math/fp.h

--- a/src/appleseed/foundation/math/dual.h
+++ b/src/appleseed/foundation/math/dual.h
@@ -1,0 +1,101 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2015 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef APPLESEED_FOUNDATION_MATH_DUAL_H
+#define APPLESEED_FOUNDATION_MATH_DUAL_H
+
+// appleseed.foundation headers.
+#include "foundation/math/vector.h"
+
+
+namespace foundation
+{
+
+//
+// Dual holds a quantity and its partial derivatives wrt. x and y.
+//
+
+template <typename T>
+class Dual
+{
+  public:
+    // Types.
+    typedef T ValueType;
+
+    // Constructors.
+    Dual();
+    explicit Dual(const T& value);
+    Dual(const T& value, const T& dx, const T& dy);
+
+    T m_value;
+    T m_dx;
+    T m_dy;
+};
+
+//
+// Dual class implementation.
+//
+
+template <typename T>
+inline Dual<T>::Dual()
+{
+}
+
+template <typename T>
+inline Dual<T>::Dual(const T& value)
+  : m_value(value)
+  , m_dx(T(0.0))
+  , m_dy(T(0.0))
+{
+}
+
+template <typename T>
+inline Dual<T>::Dual(const T& value, const T& dx, const T& dy)
+  : m_value(value)
+  , m_dx(dx)
+  , m_dy(dy)
+{
+}
+
+
+//
+// Full specializations for scalars and vectors of type float and double.
+//
+
+typedef Dual<float>     Dual1f;
+typedef Dual<double>    Dual1d;
+
+typedef Dual<Vector2f>  Dual2f;
+typedef Dual<Vector2d>  Dual2d;
+
+typedef Dual<Vector3f>  Dual3f;
+typedef Dual<Vector3d>  Dual3d;
+
+}       // namespace foundation
+
+#endif  // !APPLESEED_FOUNDATION_MATH_DUAL_H

--- a/src/appleseed/foundation/math/dual.h
+++ b/src/appleseed/foundation/math/dual.h
@@ -83,8 +83,6 @@ template <typename T>
 inline Dual<T>::Dual(const T& value)
   : m_value(value)
   , m_has_derivatives(false)
-  , m_dx(T(0.0))
-  , m_dy(T(0.0))
 {
 }
 

--- a/src/appleseed/foundation/math/dual.h
+++ b/src/appleseed/foundation/math/dual.h
@@ -32,7 +32,7 @@
 // appleseed.foundation headers.
 #include "foundation/math/vector.h"
 
-// standard headers
+// Standard headers
 #include <cassert>
 
 namespace foundation
@@ -54,19 +54,19 @@ class Dual
     explicit Dual(const T& value);
     Dual(const T& value, const T& dx, const T& dy);
 
-    // Accessors.
+    // Value.
     const T& get_value() const;
 
+    // Derivatives.
     bool has_derivatives() const;
-
     const T& get_dx() const;
     const T& get_dy() const;
 
   private:
     T       m_value;
-    bool    m_has_derivatives;
     T       m_dx;
     T       m_dy;
+    bool    m_has_derivatives;
 };
 
 //

--- a/src/appleseed/foundation/math/dual.h
+++ b/src/appleseed/foundation/math/dual.h
@@ -32,12 +32,14 @@
 // appleseed.foundation headers.
 #include "foundation/math/vector.h"
 
+// standard headers
+#include <cassert>
 
 namespace foundation
 {
 
 //
-// Dual holds a quantity and its partial derivatives wrt. x and y.
+// Dual holds a quantity and optionally its partial derivatives wrt. X and Y.
 //
 
 template <typename T>
@@ -52,9 +54,19 @@ class Dual
     explicit Dual(const T& value);
     Dual(const T& value, const T& dx, const T& dy);
 
-    T m_value;
-    T m_dx;
-    T m_dy;
+    // Accessors.
+    const T& get_value() const;
+
+    bool has_derivatives() const;
+
+    const T& get_dx() const;
+    const T& get_dy() const;
+
+  private:
+    T       m_value;
+    bool    m_has_derivatives;
+    T       m_dx;
+    T       m_dy;
 };
 
 //
@@ -63,12 +75,14 @@ class Dual
 
 template <typename T>
 inline Dual<T>::Dual()
+  : m_has_derivatives(false)
 {
 }
 
 template <typename T>
 inline Dual<T>::Dual(const T& value)
   : m_value(value)
+  , m_has_derivatives(false)
   , m_dx(T(0.0))
   , m_dy(T(0.0))
 {
@@ -77,9 +91,38 @@ inline Dual<T>::Dual(const T& value)
 template <typename T>
 inline Dual<T>::Dual(const T& value, const T& dx, const T& dy)
   : m_value(value)
+  , m_has_derivatives(true)
   , m_dx(dx)
   , m_dy(dy)
 {
+}
+
+template <typename T>
+inline const T& Dual<T>::get_value() const
+{
+    return m_value;
+}
+
+template <typename T>
+inline bool Dual<T>::has_derivatives() const
+{
+    return m_has_derivatives;
+}
+
+template <typename T>
+const T& Dual<T>::get_dx() const
+{
+    assert(m_has_derivatives);
+
+    return m_dx;
+}
+
+template <typename T>
+const T& Dual<T>::get_dy() const
+{
+    assert(m_has_derivatives);
+
+    return m_dy;
 }
 
 

--- a/src/appleseed/foundation/math/ray.h
+++ b/src/appleseed/foundation/math/ray.h
@@ -223,7 +223,6 @@ inline Ray<T, N>::Ray(const Ray<U, N>& rhs)
 template <typename T, size_t N>
 inline typename Ray<T, N>::VectorType Ray<T, N>::point_at(const ValueType t) const
 {
-    assert(t >= 0.0);
     return m_org + t * m_dir;
 }
 

--- a/src/appleseed/renderer/kernel/intersection/intersector.cpp
+++ b/src/appleseed/renderer/kernel/intersection/intersector.cpp
@@ -240,6 +240,7 @@ bool Intersector::trace(
     ShadingPoint&                   shading_point,
     const ShadingPoint*             parent_shading_point) const
 {
+    assert(is_normalized(ray.m_dir));
     assert(shading_point.m_scene == 0);
     assert(shading_point.hit() == false);
     assert(parent_shading_point == 0 || parent_shading_point != &shading_point);
@@ -301,6 +302,7 @@ bool Intersector::trace_probe(
     const ShadingRay&               ray,
     const ShadingPoint*             parent_shading_point) const
 {
+    assert(is_normalized(ray.m_dir));
     assert(parent_shading_point == 0 || parent_shading_point->hit());
 
     // Update ray casting statistics.

--- a/src/appleseed/renderer/kernel/lighting/tracer.cpp
+++ b/src/appleseed/renderer/kernel/lighting/tracer.cpp
@@ -193,14 +193,14 @@ const ShadingPoint& Tracer::do_trace_between(
         }
 
         // Construct the visibility ray.
-        const foundation::Vector3d direction = target - point;
-        const double dist = foundation::norm(direction);
+        const Vector3d direction = target - point;
+        const double dist = norm(direction);
 
         const ShadingRay ray(
             point,
             direction / dist,
-            0.0,                // ray tmin
-            dist - 1.0e-6,      // ray tmax
+            0.0,                    // ray tmin
+            dist * (1.0 - 1.0e-6),  // ray tmax
             ray_time,
             m_ray_dtime,
             ray_flags,

--- a/src/appleseed/renderer/kernel/lighting/tracer.cpp
+++ b/src/appleseed/renderer/kernel/lighting/tracer.cpp
@@ -95,6 +95,8 @@ const ShadingPoint& Tracer::do_trace(
     double&                     transmission,
     const ShadingPoint*         parent_shading_point)
 {
+    assert(is_normalized(direction));
+
     transmission = 1.0;
 
     const ShadingPoint* shading_point_ptr = parent_shading_point;
@@ -191,11 +193,14 @@ const ShadingPoint& Tracer::do_trace_between(
         }
 
         // Construct the visibility ray.
+        const foundation::Vector3d direction = target - point;
+        const double dist = foundation::norm(direction);
+
         const ShadingRay ray(
             point,
-            target - point,
+            direction / dist,
             0.0,                // ray tmin
-            1.0 - 1.0e-6,       // ray tmax
+            dist - 1.0e-6,      // ray tmax
             ray_time,
             m_ray_dtime,
             ray_flags,

--- a/src/appleseed/renderer/kernel/lighting/tracer.h
+++ b/src/appleseed/renderer/kernel/lighting/tracer.h
@@ -338,8 +338,8 @@ inline double Tracer::trace_between(
         const ShadingRay ray(
             origin,
             direction / dist,
-            0.0,                        // ray tmin
-            dist - 1.0e-6,              // ray tmax
+            0.0,                    // ray tmin
+            dist * (1.0 - 1.0e-6),  // ray tmax
             ray_time,
             m_ray_dtime,
             ray_flags,
@@ -376,8 +376,8 @@ inline double Tracer::trace_between(
         const ShadingRay ray(
             origin.get_biased_point(direction),
             direction / dist,
-            0.0,                        // ray tmin
-            dist - 1.0e-6,              // ray tmax
+            0.0,                    // ray tmin
+            dist * (1.0 - 1.0e-6),  // ray tmax
             origin.get_time(),
             origin.get_dtime(),
             ray_flags,

--- a/src/appleseed/renderer/kernel/lighting/tracer.h
+++ b/src/appleseed/renderer/kernel/lighting/tracer.h
@@ -226,6 +226,8 @@ inline double Tracer::trace(
 {
     if (m_assume_no_alpha_mapping)
     {
+        assert(foundation::is_normalized(direction));
+
         const ShadingRay ray(
             origin,
             direction,
@@ -259,6 +261,8 @@ inline double Tracer::trace(
 {
     if (m_assume_no_alpha_mapping)
     {
+        assert(foundation::is_normalized(direction));
+
         const ShadingRay ray(
             origin.get_biased_point(direction),
             direction,
@@ -328,11 +332,14 @@ inline double Tracer::trace_between(
 {
     if (m_assume_no_alpha_mapping)
     {
+        const foundation::Vector3d direction = target - origin;
+        const double dist = foundation::norm(direction);
+
         const ShadingRay ray(
             origin,
-            target - origin,
+            direction / dist,
             0.0,                        // ray tmin
-            1.0 - 1.0e-6,               // ray tmax
+            dist - 1.0e-6,              // ray tmax
             ray_time,
             m_ray_dtime,
             ray_flags,
@@ -364,12 +371,13 @@ inline double Tracer::trace_between(
     if (m_assume_no_alpha_mapping)
     {
         const foundation::Vector3d direction = target - origin.get_point();
+        const double dist = foundation::norm(direction);
 
         const ShadingRay ray(
             origin.get_biased_point(direction),
-            direction,
+            direction / dist,
             0.0,                        // ray tmin
-            1.0 - 1.0e-6,               // ray tmax
+            dist - 1.0e-6,              // ray tmax
             origin.get_time(),
             origin.get_dtime(),
             ray_flags,

--- a/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
@@ -55,6 +55,7 @@
 // appleseed.foundation headers.
 #include "foundation/image/color.h"
 #include "foundation/image/colorspace.h"
+#include "foundation/image/image.h"
 #include "foundation/image/regularspectrum.h"
 #include "foundation/math/vector.h"
 #include "foundation/platform/types.h"
@@ -140,6 +141,10 @@ namespace
                 m_params.m_max_iterations)
           , m_shading_engine(shading_engine)
         {
+            // 1/4 of a pixel, like in prman RIS.
+            const CanvasProperties& c = frame.image().properties();
+            m_differentials_offset.x = 1.0 / (4.0 * c.m_canvas_width);
+            m_differentials_offset.y = 1.0 / (4.0 * c.m_canvas_height);
         }
 
         ~GenericSampleRenderer()
@@ -170,6 +175,7 @@ namespace
             m_scene.get_camera()->generate_ray(
                 sampling_context,
                 image_point,
+                &m_differentials_offset,
                 primary_ray);
 
             ShadingPoint shading_points[2];
@@ -319,6 +325,7 @@ namespace
         ILightingEngine*            m_lighting_engine;
         const ShadingContext        m_shading_context;
         ShadingEngine&              m_shading_engine;
+        Vector2d                    m_differentials_offset;
     };
 }
 

--- a/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
@@ -259,6 +259,13 @@ namespace
 
                 // Move the ray origin to the intersection point.
                 primary_ray.m_org = shading_point_ptr->get_point();
+
+                if (primary_ray.m_has_differentials)
+                {
+                    primary_ray.m_rx.m_org = primary_ray.m_rx.point_at(primary_ray.m_tmax);
+                    primary_ray.m_ry.m_org = primary_ray.m_ry.point_at(primary_ray.m_tmax);
+                }
+
                 primary_ray.m_tmax = numeric_limits<double>::max();
             }
 

--- a/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
@@ -143,8 +143,8 @@ namespace
         {
             // 1/4 of a pixel, like in prman RIS.
             const CanvasProperties& c = frame.image().properties();
-            m_differentials_offset.x = 1.0 / (4.0 * c.m_canvas_width);
-            m_differentials_offset.y = 1.0 / (4.0 * c.m_canvas_height);
+            m_image_point_dx = Vector2d(1.0 / (4.0 * c.m_canvas_width), 0.0);
+            m_image_point_dy = Vector2d(0.0, 1.0 / (4.0 * c.m_canvas_height));
         }
 
         ~GenericSampleRenderer()
@@ -174,8 +174,7 @@ namespace
             ShadingRay primary_ray;
             m_scene.get_camera()->generate_ray(
                 sampling_context,
-                image_point,
-                &m_differentials_offset,
+                Dual2d(image_point, m_image_point_dx, m_image_point_dy),
                 primary_ray);
 
             ShadingPoint shading_points[2];
@@ -325,7 +324,8 @@ namespace
         ILightingEngine*            m_lighting_engine;
         const ShadingContext        m_shading_context;
         ShadingEngine&              m_shading_engine;
-        Vector2d                    m_differentials_offset;
+        Vector2d                    m_image_point_dx;
+        Vector2d                    m_image_point_dy;
     };
 }
 

--- a/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
@@ -141,7 +141,7 @@ namespace
                 m_params.m_max_iterations)
           , m_shading_engine(shading_engine)
         {
-            // 1/4 of a pixel, like in prman RIS.
+            // 1/4 of a pixel, like in Renderman RIS.
             const CanvasProperties& c = frame.image().properties();
             m_image_point_dx = Vector2d(1.0 / (4.0 * c.m_canvas_width), 0.0);
             m_image_point_dy = Vector2d(0.0, 1.0 / (4.0 * c.m_canvas_height));

--- a/src/appleseed/renderer/kernel/rendering/rendererservices.cpp
+++ b/src/appleseed/renderer/kernel/rendering/rendererservices.cpp
@@ -115,6 +115,7 @@ RendererServices::RendererServices(
     m_global_attr_getters[OIIO::ustring("path:ray_depth")] = &RendererServices::get_ray_depth;
     m_global_attr_getters[OIIO::ustring("path:ray_length")] = &RendererServices::get_ray_length;
     m_global_attr_getters[OIIO::ustring("path:ray_ior")] = &RendererServices::get_ray_ior;
+    m_global_attr_getters[OIIO::ustring("path:ray_has_differentials")] = &RendererServices::get_ray_has_differentials;
     m_global_attr_getters[OIIO::ustring("appleseed:version_major")] = &RendererServices::get_appleseed_version_major;
     m_global_attr_getters[OIIO::ustring("appleseed:version_minor")] = &RendererServices::get_appleseed_version_minor;
     m_global_attr_getters[OIIO::ustring("appleseed:version_patch")] = &RendererServices::get_appleseed_version_patch;
@@ -702,6 +703,21 @@ IMPLEMENT_ATTR_GETTER(ray_ior)
     if (type == OIIO::TypeDesc::TypeFloat)
     {
         reinterpret_cast<float*>(val)[0] = 1.0f;
+        clear_attr_derivatives(derivs, type, val);
+        return true;
+    }
+
+    return false;
+}
+
+IMPLEMENT_ATTR_GETTER(ray_has_differentials)
+{
+    if (type == OIIO::TypeDesc::TypeInt)
+    {
+        const ShadingPoint* shading_point =
+            reinterpret_cast<const ShadingPoint*>(sg->renderstate);
+
+        reinterpret_cast<int*>(val)[0] = static_cast<int>(shading_point->get_ray().m_has_differentials);
         clear_attr_derivatives(derivs, type, val);
         return true;
     }

--- a/src/appleseed/renderer/kernel/rendering/rendererservices.h
+++ b/src/appleseed/renderer/kernel/rendering/rendererservices.h
@@ -306,6 +306,7 @@ class RendererServices
     DECLARE_ATTR_GETTER(ray_depth);
     DECLARE_ATTR_GETTER(ray_length);
     DECLARE_ATTR_GETTER(ray_ior);
+    DECLARE_ATTR_GETTER(ray_has_differentials);
 
     // Appleseed version attributes
     DECLARE_ATTR_GETTER(appleseed_version_major);

--- a/src/appleseed/renderer/kernel/rendering/scenepicker.cpp
+++ b/src/appleseed/renderer/kernel/rendering/scenepicker.cpp
@@ -97,6 +97,7 @@ ScenePicker::PickingResult ScenePicker::pick(const Vector2d& ndc) const
     camera->generate_ray(
         sampling_context,
         ndc,
+        0,
         ray);
 
     ShadingPoint shading_point;

--- a/src/appleseed/renderer/kernel/rendering/scenepicker.cpp
+++ b/src/appleseed/renderer/kernel/rendering/scenepicker.cpp
@@ -96,8 +96,7 @@ ScenePicker::PickingResult ScenePicker::pick(const Vector2d& ndc) const
     ShadingRay ray;
     camera->generate_ray(
         sampling_context,
-        ndc,
-        0,
+        Dual2d(ndc),
         ray);
 
     ShadingPoint shading_point;

--- a/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
@@ -40,6 +40,7 @@
 #endif
 
 // appleseed.foundation headers.
+#include "foundation/math/intersection/rayplane.h"
 #include "foundation/math/scalar.h"
 #include "foundation/utility/attributeset.h"
 #include "foundation/utility/otherwise.h"
@@ -276,7 +277,7 @@ Vector3d ShadingPoint::get_biased_point(const Vector3d& direction) const
           case ObjectInstance::RayBiasMethodIncomingDirection:
             {
                 const double bias = m_object_instance->get_ray_bias_distance();
-                m_biased_point = point + bias * normalize(m_ray.m_dir);
+                m_biased_point = point + bias * m_ray.m_dir;
                 m_members |= HasBiasedPoint;
                 return m_biased_point;
             }
@@ -294,7 +295,7 @@ Vector3d ShadingPoint::get_biased_point(const Vector3d& direction) const
     return m_biased_point;
 }
 
-void ShadingPoint::compute_partial_derivatives() const
+void ShadingPoint::compute_world_space_partial_derivatives() const
 {
     cache_source_geometry();
 
@@ -361,6 +362,79 @@ void ShadingPoint::compute_partial_derivatives() const
     }
 }
 
+void ShadingPoint::compute_screen_space_partial_derivatives() const
+{
+    const ShadingRay& ray = get_ray();
+
+    if (ray.m_has_differentials)
+    {
+        const Vector3d& n = get_shading_normal();
+        const Vector3d& p = get_point();
+        double t = intersect(ray.m_rx, p, n);
+        const Vector3d px = ray.m_rx.point_at(t);
+        m_dpdx = px - p;
+
+        t = intersect(ray.m_ry, p, n);
+        const Vector3d py = ray.m_ry.point_at(t);
+        m_dpdy = py - p;
+
+        size_t axes[2];
+        switch (max_abs_index(n))
+        {
+          case 0:
+            axes[0] = 1;
+            axes[1] = 2;
+          break;
+
+          case 1:
+            axes[0] = 0;
+            axes[1] = 2;
+          break;
+
+          case 2:
+            axes[0] = 0;
+            axes[1] = 1;
+          break;
+        }
+
+        const Vector3d& dpdu = get_dpdu(0);
+        const Vector3d& dpdv = get_dpdv(0);
+
+        const Vector2d a0(dpdu[axes[0]], dpdu[axes[1]]);
+        const Vector2d a1(dpdv[axes[0]], dpdv[axes[1]]);
+
+        const double d = det(a0, a1);
+
+        if (d == 0.0)
+        {
+            m_duvdx = Vector2d(0.0);
+            m_duvdy = Vector2d(0.0);
+            return;
+        }
+
+        const Vector2d bx(
+            px[axes[0]] - p[axes[0]],
+            px[axes[1]] - p[axes[1]]);
+
+        m_duvdx[0] = (a1[1] * bx[0] - a0[1] * bx[1]) / d;
+        m_duvdx[1] = (a0[0] * bx[1] - a1[0] * bx[0]) / d;
+
+        const Vector2d by(
+            py[axes[0]] - p[axes[0]],
+            py[axes[1]] - p[axes[1]]);
+
+        m_duvdy[0] = (a1[1] * by[0] - a0[1] * by[1]) / d;
+        m_duvdy[1] = (a0[0] * by[1] - a1[0] * by[0]) / d;
+    }
+    else
+    {
+        m_dpdx = Vector3d(0.0);
+        m_dpdy = Vector3d(0.0);
+        m_duvdx = Vector2d(0.0);
+        m_duvdy = Vector2d(0.0);
+    }
+}
+
 void ShadingPoint::compute_geometric_normal() const
 {
     if (m_primitive_type == PrimitiveTriangle)
@@ -409,7 +483,7 @@ void ShadingPoint::compute_geometric_normal() const
         assert(m_primitive_type == PrimitiveCurve1 || m_primitive_type == PrimitiveCurve3);
 
         // We assume flat ribbons facing incoming rays.
-        m_geometric_normal = -normalize(m_ray.m_dir);
+        m_geometric_normal = -m_ray.m_dir;
         m_side = ObjectInstance::FrontSide;
     }
 }
@@ -439,7 +513,7 @@ void ShadingPoint::compute_original_shading_normal() const
         assert(m_primitive_type == PrimitiveCurve1 || m_primitive_type == PrimitiveCurve3);
 
         // We assume flat ribbons facing incoming rays.
-        m_original_shading_normal = -normalize(m_ray.m_dir);
+        m_original_shading_normal = -m_ray.m_dir;
     }
 }
 
@@ -622,7 +696,9 @@ void ShadingPoint::initialize_osl_shader_globals(
         const ShadingRay& ray(get_ray());
 
         m_shader_globals.P = Vector3f(get_point());
-        m_shader_globals.I = Vector3f(normalize(ray.m_dir));
+
+        assert(is_normalized(ray.m_dir));
+        m_shader_globals.I = Vector3f(ray.m_dir);
 
         m_shader_globals.N = get_side() == ObjectInstance::FrontSide
             ?  Vector3f(get_original_shading_normal())
@@ -637,6 +713,26 @@ void ShadingPoint::initialize_osl_shader_globals(
 
         m_shader_globals.dPdu = Vector3f(get_dpdu(0));
         m_shader_globals.dPdv = Vector3f(get_dpdv(0));
+
+        if (ray.m_has_differentials)
+        {
+            assert(is_normalized(ray.m_rx.m_dir));
+            m_shader_globals.dIdx = Vector3f(ray.m_rx.m_dir);
+
+            assert(is_normalized(ray.m_ry.m_dir));
+            m_shader_globals.dIdy = Vector3f(ray.m_ry.m_dir);
+
+            m_shader_globals.dPdx = Vector3f(get_dpdx());
+            m_shader_globals.dPdy = Vector3f(get_dpdy());
+
+            Vector2d duv = get_duvdx(0);
+            m_shader_globals.dudx = duv[0];
+            m_shader_globals.dvdx = duv[1];
+
+            duv = get_duvdy(0);
+            m_shader_globals.dudy = duv[0];
+            m_shader_globals.dvdy = duv[1];
+        }
 
         m_shader_globals.time = static_cast<float>(ray.m_time);
         m_shader_globals.dtime = static_cast<float>(get_dtime());

--- a/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
@@ -338,6 +338,15 @@ void ShadingPoint::compute_world_space_partial_derivatives() const
 
             m_dndu = (dv1 * dn0 - dv0 * dn1) * rcp_det;
             m_dndv = (du0 * dn1 - du1 * dn0) * rcp_det;
+
+            // Transform the normal derivatives to world space.
+            m_dndu =
+                m_assembly_instance_transform.normal_to_parent(
+                    m_object_instance->get_transform().normal_to_parent(m_dndu));
+
+            m_dndv =
+                m_assembly_instance_transform.normal_to_parent(
+                    m_object_instance->get_transform().normal_to_parent(m_dndv));
         }
     }
     else if (m_primitive_type == PrimitiveCurve1)

--- a/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
@@ -707,6 +707,8 @@ void ShadingPoint::initialize_osl_shader_globals(
         const ShadingRay& ray(get_ray());
 
         m_shader_globals.P = Vector3f(get_point());
+
+        assert(is_normalized(ray.m_dir));
         m_shader_globals.I = Vector3f(ray.m_dir);
 
         m_shader_globals.N = get_side() == ObjectInstance::FrontSide

--- a/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
@@ -320,16 +320,24 @@ void ShadingPoint::compute_world_space_partial_derivatives() const
 
             m_dpdu = basis.get_tangent_u();
             m_dpdv = basis.get_tangent_v();
+            m_dndu = m_dndv = Vector3d(0.0);
         }
         else
         {
             const Vector3d& v2 = get_vertex(2);
             const Vector3d dp0 = get_vertex(0) - v2;
             const Vector3d dp1 = get_vertex(1) - v2;
+
             const double rcp_det = 1.0 / det;
 
             m_dpdu = (dv1 * dp0 - dv0 * dp1) * rcp_det;
             m_dpdv = (du0 * dp1 - du1 * dp0) * rcp_det;
+
+            const Vector3d dn0 = m_n0 - m_n2;
+            const Vector3d dn1 = m_n1 - m_n2;
+
+            m_dndu = (dv1 * dn0 - dv0 * dn1) * rcp_det;
+            m_dndv = (du0 * dn1 - du1 * dn0) * rcp_det;
         }
     }
     else if (m_primitive_type == PrimitiveCurve1)
@@ -345,6 +353,7 @@ void ShadingPoint::compute_world_space_partial_derivatives() const
 
         m_dpdu = normalize(Vector3d(tangent));
         m_dpdv = normalize(cross(sn, m_dpdu));
+        m_dndu = m_dndv = Vector3d(0.0);
     }
     else
     {
@@ -359,6 +368,7 @@ void ShadingPoint::compute_world_space_partial_derivatives() const
 
         m_dpdu = normalize(Vector3d(tangent));
         m_dpdv = normalize(cross(sn, m_dpdu));
+        m_dndu = m_dndv = Vector3d(0.0);
     }
 }
 

--- a/src/appleseed/renderer/kernel/shading/shadingpoint.h
+++ b/src/appleseed/renderer/kernel/shading/shadingpoint.h
@@ -149,6 +149,10 @@ class ShadingPoint
     const foundation::Vector3d& get_dpdu(const size_t uvset) const;
     const foundation::Vector3d& get_dpdv(const size_t uvset) const;
 
+    // Return the world space partial derivatives of the intersection normal wrt. a given UV set.
+    const foundation::Vector3d& get_dndu(const size_t uvset) const;
+    const foundation::Vector3d& get_dndv(const size_t uvset) const;
+
     // Return the screen space partial derivatives of the intersection point.
     const foundation::Vector3d& get_dpdx() const;
     const foundation::Vector3d& get_dpdy() const;
@@ -316,6 +320,8 @@ class ShadingPoint
     mutable foundation::Vector3d        m_biased_point;                 // world space intersection point with per-object-instance bias applied
     mutable foundation::Vector3d        m_dpdu;                         // world space partial derivative of the intersection point wrt. U
     mutable foundation::Vector3d        m_dpdv;                         // world space partial derivative of the intersection point wrt. V
+    mutable foundation::Vector3d        m_dndu;                         // world space partial derivative of the intersection normal wrt. U
+    mutable foundation::Vector3d        m_dndv;                         // world space partial derivative of the intersection normal wrt. V
     mutable foundation::Vector3d        m_dpdx;                         // screen space partial derivative of the intersection point wrt. X
     mutable foundation::Vector3d        m_dpdy;                         // screen space partial derivative of the intersection point wrt. Y
     mutable foundation::Vector3d        m_geometric_normal;             // world space geometric normal, unit-length
@@ -569,6 +575,34 @@ inline const foundation::Vector3d& ShadingPoint::get_dpdv(const size_t uvset) co
     }
 
     return m_dpdv;
+}
+
+inline const foundation::Vector3d& ShadingPoint::get_dndu(const size_t uvset) const
+{
+    assert(hit());
+    assert(uvset == 0);     // todo: support multiple UV sets
+
+    if (!(m_members & HasWorldSpacePartialDerivatives))
+    {
+        compute_world_space_partial_derivatives();
+        m_members |= HasWorldSpacePartialDerivatives;
+    }
+
+    return m_dndu;
+}
+
+inline const foundation::Vector3d& ShadingPoint::get_dndv(const size_t uvset) const
+{
+    assert(hit());
+    assert(uvset == 0);     // todo: support multiple UV sets
+
+    if (!(m_members & HasWorldSpacePartialDerivatives))
+    {
+        compute_world_space_partial_derivatives();
+        m_members |= HasWorldSpacePartialDerivatives;
+    }
+
+    return m_dndv;
 }
 
 inline const foundation::Vector3d& ShadingPoint::get_dpdx() const

--- a/src/appleseed/renderer/kernel/shading/shadingpoint.h
+++ b/src/appleseed/renderer/kernel/shading/shadingpoint.h
@@ -132,6 +132,10 @@ class ShadingPoint
     // Return the texture coordinates from a given UV set at the intersection point.
     const foundation::Vector2d& get_uv(const size_t uvset) const;
 
+    // Return the screen space partial derivatives of the texture coordinates from a given UV set.
+    const foundation::Vector2d& get_duvdx(const size_t uvset) const;
+    const foundation::Vector2d& get_duvdy(const size_t uvset) const;
+
     // Return the intersection point in world space.
     const foundation::Vector3d& get_point() const;
 
@@ -144,6 +148,10 @@ class ShadingPoint
     // Return the world space partial derivatives of the intersection point wrt. a given UV set.
     const foundation::Vector3d& get_dpdu(const size_t uvset) const;
     const foundation::Vector3d& get_dpdv(const size_t uvset) const;
+
+    // Return the screen space partial derivatives of the intersection point.
+    const foundation::Vector3d& get_dpdx() const;
+    const foundation::Vector3d& get_dpdy() const;
 
     // Return the world space geometric normal at the intersection point. The geometric normal
     // always faces the incoming ray, i.e. dot(ray_dir, geometric_normal) is always positive or null.
@@ -269,22 +277,23 @@ class ShadingPoint
     // Flags to keep track of which on-demand results have been computed and cached.
     enum Members
     {
-        HasSourceGeometry               = 1 << 0,
-        HasUV0                          = 1 << 1,
-        HasPoint                        = 1 << 2,
-        HasBiasedPoint                  = 1 << 3,
-        HasRefinedPoints                = 1 << 4,
-        HasPartialDerivatives           = 1 << 5,
-        HasGeometricNormal              = 1 << 6,
-        HasOriginalShadingNormal        = 1 << 7,
-        HasShadingBasis                 = 1 << 8,
-        HasWorldSpaceTriangleVertices   = 1 << 9,
-        HasMaterial                     = 1 << 10,
-        HasTriangleVertexTangents       = 1 << 11,
-        HasPointVelocity                = 1 << 12,
-        HasAlpha                        = 1 << 13
+        HasSourceGeometry                = 1 << 0,
+        HasUV0                           = 1 << 1,
+        HasPoint                         = 1 << 2,
+        HasBiasedPoint                   = 1 << 3,
+        HasRefinedPoints                 = 1 << 4,
+        HasWorldSpacePartialDerivatives  = 1 << 5,
+        HasGeometricNormal               = 1 << 6,
+        HasOriginalShadingNormal         = 1 << 7,
+        HasShadingBasis                  = 1 << 8,
+        HasWorldSpaceTriangleVertices    = 1 << 9,
+        HasMaterial                      = 1 << 10,
+        HasTriangleVertexTangents        = 1 << 11,
+        HasPointVelocity                 = 1 << 12,
+        HasAlpha                         = 1 << 13,
+        HasScreenSpacePartialDerivatives = 1 << 14
 #ifdef APPLESEED_WITH_OSL
-        , HasOSLShaderGlobals           = 1 << 14
+        , HasOSLShaderGlobals            = 1 << 15
 #endif
     };
     mutable foundation::uint32          m_members;
@@ -301,10 +310,14 @@ class ShadingPoint
 
     // Additional intersection results, computed on demand.
     mutable foundation::Vector2d        m_uv;                           // texture coordinates from UV set #0
+    mutable foundation::Vector2d        m_duvdx;                        // screen space partial derivative of the texture coords wrt. X
+    mutable foundation::Vector2d        m_duvdy;                        // screen space partial derivative of the texture coords wrt. Y
     mutable foundation::Vector3d        m_point;                        // world space intersection point
     mutable foundation::Vector3d        m_biased_point;                 // world space intersection point with per-object-instance bias applied
     mutable foundation::Vector3d        m_dpdu;                         // world space partial derivative of the intersection point wrt. U
     mutable foundation::Vector3d        m_dpdv;                         // world space partial derivative of the intersection point wrt. V
+    mutable foundation::Vector3d        m_dpdx;                         // screen space partial derivative of the intersection point wrt. X
+    mutable foundation::Vector3d        m_dpdy;                         // screen space partial derivative of the intersection point wrt. Y
     mutable foundation::Vector3d        m_geometric_normal;             // world space geometric normal, unit-length
     mutable foundation::Vector3d        m_original_shading_normal;      // original world space shading normal, unit-length
     mutable foundation::Basis3d         m_shading_basis;                // world space orthonormal basis around shading normal
@@ -337,7 +350,8 @@ class ShadingPoint
     // Refine and offset the intersection point.
     void refine_and_offset() const;
 
-    void compute_partial_derivatives() const;
+    void compute_world_space_partial_derivatives() const;
+    void compute_screen_space_partial_derivatives() const;
     void compute_geometric_normal() const;
     void compute_shading_normal() const;
     void compute_original_shading_normal() const;
@@ -403,6 +417,7 @@ inline const Scene& ShadingPoint::get_scene() const
 
 inline void ShadingPoint::set_ray(const ShadingRay& ray)
 {
+    assert(foundation::is_normalized(ray.m_dir));
     m_ray = ray;
 }
 
@@ -476,6 +491,34 @@ inline const foundation::Vector2d& ShadingPoint::get_uv(const size_t uvset) cons
     return m_uv;
 }
 
+inline const foundation::Vector2d& ShadingPoint::get_duvdx(const size_t uvset) const
+{
+    assert(hit());
+    assert(uvset == 0);     // todo: support multiple UV sets
+
+    if (!(m_members & HasScreenSpacePartialDerivatives))
+    {
+        compute_screen_space_partial_derivatives();
+        m_members |= HasScreenSpacePartialDerivatives;
+    }
+
+    return m_duvdx;
+}
+
+inline const foundation::Vector2d& ShadingPoint::get_duvdy(const size_t uvset) const
+{
+    assert(hit());
+    assert(uvset == 0);     // todo: support multiple UV sets
+
+    if (!(m_members & HasScreenSpacePartialDerivatives))
+    {
+        compute_screen_space_partial_derivatives();
+        m_members |= HasScreenSpacePartialDerivatives;
+    }
+
+    return m_duvdy;
+}
+
 inline const foundation::Vector3d& ShadingPoint::get_point() const
 {
     assert(hit());
@@ -505,10 +548,10 @@ inline const foundation::Vector3d& ShadingPoint::get_dpdu(const size_t uvset) co
     assert(hit());
     assert(uvset == 0);     // todo: support multiple UV sets
 
-    if (!(m_members & HasPartialDerivatives))
+    if (!(m_members & HasWorldSpacePartialDerivatives))
     {
-        compute_partial_derivatives();
-        m_members |= HasPartialDerivatives;
+        compute_world_space_partial_derivatives();
+        m_members |= HasWorldSpacePartialDerivatives;
     }
 
     return m_dpdu;
@@ -519,13 +562,39 @@ inline const foundation::Vector3d& ShadingPoint::get_dpdv(const size_t uvset) co
     assert(hit());
     assert(uvset == 0);     // todo: support multiple UV sets
 
-    if (!(m_members & HasPartialDerivatives))
+    if (!(m_members & HasWorldSpacePartialDerivatives))
     {
-        compute_partial_derivatives();
-        m_members |= HasPartialDerivatives;
+        compute_world_space_partial_derivatives();
+        m_members |= HasWorldSpacePartialDerivatives;
     }
 
     return m_dpdv;
+}
+
+inline const foundation::Vector3d& ShadingPoint::get_dpdx() const
+{
+    assert(hit());
+
+    if (!(m_members & HasScreenSpacePartialDerivatives))
+    {
+        compute_screen_space_partial_derivatives();
+        m_members |= HasScreenSpacePartialDerivatives;
+    }
+
+    return m_dpdx;
+}
+
+inline const foundation::Vector3d& ShadingPoint::get_dpdy() const
+{
+    assert(hit());
+
+    if (!(m_members & HasScreenSpacePartialDerivatives))
+    {
+        compute_screen_space_partial_derivatives();
+        m_members |= HasScreenSpacePartialDerivatives;
+    }
+
+    return m_dpdy;
 }
 
 inline const foundation::Vector3d& ShadingPoint::get_geometric_normal() const

--- a/src/appleseed/renderer/kernel/shading/shadingpoint.h
+++ b/src/appleseed/renderer/kernel/shading/shadingpoint.h
@@ -424,6 +424,7 @@ inline const Scene& ShadingPoint::get_scene() const
 inline void ShadingPoint::set_ray(const ShadingRay& ray)
 {
     assert(foundation::is_normalized(ray.m_dir));
+
     m_ray = ray;
 }
 

--- a/src/appleseed/renderer/kernel/shading/shadingray.h
+++ b/src/appleseed/renderer/kernel/shading/shadingray.h
@@ -196,6 +196,7 @@ inline ShadingRay transform_to_local(
     const ShadingRay&               ray)
 {
     if (ray.m_has_differentials)
+    {
         return
             ShadingRay(
                 transform.transform_to_local(ray),
@@ -205,7 +206,9 @@ inline ShadingRay transform_to_local(
                 ray.m_depth,
                 transform.transform_to_local(ray.m_rx),
                 transform.transform_to_local(ray.m_ry));
+    }
     else
+    {
         return
             ShadingRay(
                 transform.transform_to_local(ray),
@@ -213,6 +216,7 @@ inline ShadingRay transform_to_local(
                 ray.m_dtime,
                 ray.m_flags,
                 ray.m_depth);
+    }
 }
 
 template <typename U>
@@ -221,6 +225,7 @@ inline ShadingRay transform_to_parent(
     const ShadingRay&               ray)
 {
     if (ray.m_has_differentials)
+    {
         return
             ShadingRay(
                 transform.transform_to_parent(ray),
@@ -230,7 +235,9 @@ inline ShadingRay transform_to_parent(
                 ray.m_depth,
                 transform.transform_to_parent(ray.m_rx),
                 transform.transform_to_parent(ray.m_ry));
+    }
     else
+    {
         return
             ShadingRay(
                 transform.transform_to_parent(ray),
@@ -238,6 +245,7 @@ inline ShadingRay transform_to_parent(
                 ray.m_dtime,
                 ray.m_flags,
                 ray.m_depth);
+    }
 }
 
 }       // namespace renderer

--- a/src/appleseed/renderer/meta/tests/test_sphericalcamera.cpp
+++ b/src/appleseed/renderer/meta/tests/test_sphericalcamera.cpp
@@ -59,7 +59,7 @@ TEST_SUITE(Renderer_Modeling_Camera_SphericalCamera)
         SamplingContext sampling_context(rng, SamplingContext::QMCMode);
 
         ShadingRay ray;
-        camera->generate_ray(sampling_context, Vector2d(1.0, 1.0), ray);
+        camera->generate_ray(sampling_context, Vector2d(1.0, 1.0), 0, ray);
 
         const Vector3d hit_point = ray.m_org + 3.0 * normalize(ray.m_dir);
 

--- a/src/appleseed/renderer/meta/tests/test_sphericalcamera.cpp
+++ b/src/appleseed/renderer/meta/tests/test_sphericalcamera.cpp
@@ -59,7 +59,7 @@ TEST_SUITE(Renderer_Modeling_Camera_SphericalCamera)
         SamplingContext sampling_context(rng, SamplingContext::QMCMode);
 
         ShadingRay ray;
-        camera->generate_ray(sampling_context, Vector2d(1.0, 1.0), 0, ray);
+        camera->generate_ray(sampling_context, Dual2d(Vector2d(1.0, 1.0)), ray);
 
         const Vector3d hit_point = ray.m_org + 3.0 * normalize(ray.m_dir);
 

--- a/src/appleseed/renderer/modeling/camera/camera.h
+++ b/src/appleseed/renderer/modeling/camera/camera.h
@@ -36,6 +36,7 @@
 #include "renderer/utility/transformsequence.h"
 
 // appleseed.foundation headers.
+#include "foundation/math/dual.h"
 #include "foundation/math/frustum.h"
 #include "foundation/math/vector.h"
 #include "foundation/utility/uid.h"
@@ -103,8 +104,7 @@ class APPLESEED_DLLSYMBOL Camera
     // The generated ray is expressed in world space.
     virtual void generate_ray(
         SamplingContext&                sampling_context,
-        const foundation::Vector2d&     point,
-        const foundation::Vector2d*     point_differential,
+        const foundation::Dual2d&       point,
         ShadingRay&                     ray) const = 0;
 
     // Project a 3D point back to the film plane. The input point is expressed in

--- a/src/appleseed/renderer/modeling/camera/camera.h
+++ b/src/appleseed/renderer/modeling/camera/camera.h
@@ -104,6 +104,7 @@ class APPLESEED_DLLSYMBOL Camera
     virtual void generate_ray(
         SamplingContext&                sampling_context,
         const foundation::Vector2d&     point,
+        const foundation::Vector2d*     point_differential,
         ShadingRay&                     ray) const = 0;
 
     // Project a 3D point back to the film plane. The input point is expressed in

--- a/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
@@ -40,6 +40,7 @@
 
 // appleseed.foundation headers.
 #include "foundation/image/canvasproperties.h"
+#include "foundation/math/dual.h"
 #include "foundation/image/image.h"
 #include "foundation/math/intersection/frustumsegment.h"
 #include "foundation/math/frustum.h"
@@ -122,10 +123,9 @@ namespace
         }
 
         virtual void generate_ray(
-            SamplingContext&        sampling_context,
-            const Vector2d&         point,
-            const Vector2d*         point_differential,
-            ShadingRay&             ray) const APPLESEED_OVERRIDE
+            SamplingContext&            sampling_context,
+            const foundation::Dual2d&   point,
+            ShadingRay&                 ray) const APPLESEED_OVERRIDE
         {
             // Initialize the ray.
             initialize_ray(sampling_context, ray);
@@ -141,19 +141,16 @@ namespace
                     : transform.get_local_to_parent().extract_translation();
 
             // Compute the direction of the ray.
-            ray.m_dir = transform.vector_to_parent(ndc_to_camera(point));
+            ray.m_dir = transform.vector_to_parent(ndc_to_camera(point.m_value));
 
-            if (point_differential)
-            {
-                ray.m_has_differentials = true;
-                ray.m_rx.m_org = ray.m_org;
-                const Vector2d px(point.x + point_differential->x, point.y);
-                ray.m_rx.m_dir = transform.vector_to_parent(ndc_to_camera(px));
+            ray.m_has_differentials = true;
+            ray.m_rx.m_org = ray.m_org;
+            const Vector2d px(point.m_value + point.m_dx);
+            ray.m_rx.m_dir = transform.vector_to_parent(ndc_to_camera(px));
 
-                ray.m_ry.m_org = ray.m_org;
-                const Vector2d py(point.x, point.y + point_differential->y);
-                ray.m_ry.m_dir = transform.vector_to_parent(ndc_to_camera(py));
-            }
+            ray.m_ry.m_org = ray.m_org;
+            const Vector2d py(point.m_value + point.m_dy);
+            ray.m_ry.m_dir = transform.vector_to_parent(ndc_to_camera(py));
         }
 
         virtual bool project_camera_space_point(

--- a/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
@@ -40,8 +40,8 @@
 
 // appleseed.foundation headers.
 #include "foundation/image/canvasproperties.h"
-#include "foundation/math/dual.h"
 #include "foundation/image/image.h"
+#include "foundation/math/dual.h"
 #include "foundation/math/intersection/frustumsegment.h"
 #include "foundation/math/frustum.h"
 #include "foundation/math/matrix.h"
@@ -124,7 +124,7 @@ namespace
 
         virtual void generate_ray(
             SamplingContext&            sampling_context,
-            const foundation::Dual2d&   point,
+            const Dual2d&               point,
             ShadingRay&                 ray) const APPLESEED_OVERRIDE
         {
             // Initialize the ray.
@@ -146,12 +146,14 @@ namespace
             if (point.has_derivatives())
             {
                 ray.m_has_differentials = true;
-                ray.m_rx.m_org = ray.m_org;
-                const Vector2d px(point.get_value() + point.get_dx());
-                ray.m_rx.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(px)));
 
+                ray.m_rx.m_org = ray.m_org;
                 ray.m_ry.m_org = ray.m_org;
+
+                const Vector2d px(point.get_value() + point.get_dx());
                 const Vector2d py(point.get_value() + point.get_dy());
+
+                ray.m_rx.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(px)));
                 ray.m_ry.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(py)));
             }
         }

--- a/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
@@ -141,16 +141,19 @@ namespace
                     : transform.get_local_to_parent().extract_translation();
 
             // Compute the direction of the ray.
-            ray.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(point.m_value)));
+            ray.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(point.get_value())));
 
-            ray.m_has_differentials = true;
-            ray.m_rx.m_org = ray.m_org;
-            const Vector2d px(point.m_value + point.m_dx);
-            ray.m_rx.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(px)));
+            if (point.has_derivatives())
+            {
+                ray.m_has_differentials = true;
+                ray.m_rx.m_org = ray.m_org;
+                const Vector2d px(point.get_value() + point.get_dx());
+                ray.m_rx.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(px)));
 
-            ray.m_ry.m_org = ray.m_org;
-            const Vector2d py(point.m_value + point.m_dy);
-            ray.m_ry.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(py)));
+                ray.m_ry.m_org = ray.m_org;
+                const Vector2d py(point.get_value() + point.get_dy());
+                ray.m_ry.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(py)));
+            }
         }
 
         virtual bool project_camera_space_point(

--- a/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
@@ -124,6 +124,7 @@ namespace
         virtual void generate_ray(
             SamplingContext&        sampling_context,
             const Vector2d&         point,
+            const Vector2d*         point_differential,
             ShadingRay&             ray) const APPLESEED_OVERRIDE
         {
             // Initialize the ray.
@@ -141,6 +142,18 @@ namespace
 
             // Compute the direction of the ray.
             ray.m_dir = transform.vector_to_parent(ndc_to_camera(point));
+
+            if (point_differential)
+            {
+                ray.m_has_differentials = true;
+                ray.m_rx.m_org = ray.m_org;
+                const Vector2d px(point.x + point_differential->x, point.y);
+                ray.m_rx.m_dir = transform.vector_to_parent(ndc_to_camera(px));
+
+                ray.m_ry.m_org = ray.m_org;
+                const Vector2d py(point.x, point.y + point_differential->y);
+                ray.m_ry.m_dir = transform.vector_to_parent(ndc_to_camera(py));
+            }
         }
 
         virtual bool project_camera_space_point(

--- a/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
@@ -141,16 +141,16 @@ namespace
                     : transform.get_local_to_parent().extract_translation();
 
             // Compute the direction of the ray.
-            ray.m_dir = transform.vector_to_parent(ndc_to_camera(point.m_value));
+            ray.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(point.m_value)));
 
             ray.m_has_differentials = true;
             ray.m_rx.m_org = ray.m_org;
             const Vector2d px(point.m_value + point.m_dx);
-            ray.m_rx.m_dir = transform.vector_to_parent(ndc_to_camera(px));
+            ray.m_rx.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(px)));
 
             ray.m_ry.m_org = ray.m_org;
             const Vector2d py(point.m_value + point.m_dy);
-            ray.m_ry.m_dir = transform.vector_to_parent(ndc_to_camera(py));
+            ray.m_ry.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(py)));
         }
 
         virtual bool project_camera_space_point(

--- a/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
@@ -124,16 +124,19 @@ namespace
                     : transform.get_local_to_parent().extract_translation();
 
             // Compute the direction of the ray.
-            ray.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(point.m_value)));
+            ray.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(point.get_value())));
 
-            ray.m_has_differentials = true;
-            ray.m_rx.m_org = ray.m_org;
-            const Vector2d px(point.m_value + point.m_dx);
-            ray.m_rx.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(px)));
+            if (point.has_derivatives())
+            {
+                ray.m_has_differentials = true;
+                ray.m_rx.m_org = ray.m_org;
+                const Vector2d px(point.get_value() + point.get_dx());
+                ray.m_rx.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(px)));
 
-            ray.m_ry.m_org = ray.m_org;
-            const Vector2d py(point.m_value + point.m_dy);
-            ray.m_ry.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(py)));
+                ray.m_ry.m_org = ray.m_org;
+                const Vector2d py(point.get_value() + point.get_dy());
+                ray.m_ry.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(py)));
+            }
         }
 
         virtual bool project_camera_space_point(

--- a/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
@@ -107,6 +107,7 @@ namespace
         virtual void generate_ray(
             SamplingContext&        sampling_context,
             const Vector2d&         point,
+            const Vector2d*         point_differential,
             ShadingRay&             ray) const APPLESEED_OVERRIDE
         {
             // Initialize the ray.
@@ -124,6 +125,18 @@ namespace
 
             // Compute the direction of the ray.
             ray.m_dir = transform.vector_to_parent(ndc_to_camera(point));
+
+            if (point_differential)
+            {
+                ray.m_has_differentials = true;
+                ray.m_rx.m_org = ray.m_org;
+                const Vector2d px(point.x + point_differential->x, point.y);
+                ray.m_rx.m_dir = transform.vector_to_parent(ndc_to_camera(px));
+
+                ray.m_ry.m_org = ray.m_org;
+                const Vector2d py(point.x, point.y + point_differential->y);
+                ray.m_ry.m_dir = transform.vector_to_parent(ndc_to_camera(py));
+            }
         }
 
         virtual bool project_camera_space_point(

--- a/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
@@ -124,16 +124,16 @@ namespace
                     : transform.get_local_to_parent().extract_translation();
 
             // Compute the direction of the ray.
-            ray.m_dir = transform.vector_to_parent(ndc_to_camera(point.m_value));
+            ray.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(point.m_value)));
 
             ray.m_has_differentials = true;
             ray.m_rx.m_org = ray.m_org;
             const Vector2d px(point.m_value + point.m_dx);
-            ray.m_rx.m_dir = transform.vector_to_parent(ndc_to_camera(px));
+            ray.m_rx.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(px)));
 
             ray.m_ry.m_org = ray.m_org;
             const Vector2d py(point.m_value + point.m_dy);
-            ray.m_ry.m_dir = transform.vector_to_parent(ndc_to_camera(py));
+            ray.m_ry.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(py)));
         }
 
         virtual bool project_camera_space_point(

--- a/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
@@ -40,6 +40,7 @@
 
 // appleseed.foundation headers.
 #include "foundation/image/canvasproperties.h"
+#include "foundation/math/dual.h"
 #include "foundation/image/image.h"
 #include "foundation/math/matrix.h"
 #include "foundation/math/scalar.h"
@@ -105,10 +106,9 @@ namespace
         }
 
         virtual void generate_ray(
-            SamplingContext&        sampling_context,
-            const Vector2d&         point,
-            const Vector2d*         point_differential,
-            ShadingRay&             ray) const APPLESEED_OVERRIDE
+            SamplingContext&            sampling_context,
+            const foundation::Dual2d&   point,
+            ShadingRay&                 ray) const APPLESEED_OVERRIDE
         {
             // Initialize the ray.
             initialize_ray(sampling_context, ray);
@@ -124,19 +124,16 @@ namespace
                     : transform.get_local_to_parent().extract_translation();
 
             // Compute the direction of the ray.
-            ray.m_dir = transform.vector_to_parent(ndc_to_camera(point));
+            ray.m_dir = transform.vector_to_parent(ndc_to_camera(point.m_value));
 
-            if (point_differential)
-            {
-                ray.m_has_differentials = true;
-                ray.m_rx.m_org = ray.m_org;
-                const Vector2d px(point.x + point_differential->x, point.y);
-                ray.m_rx.m_dir = transform.vector_to_parent(ndc_to_camera(px));
+            ray.m_has_differentials = true;
+            ray.m_rx.m_org = ray.m_org;
+            const Vector2d px(point.m_value + point.m_dx);
+            ray.m_rx.m_dir = transform.vector_to_parent(ndc_to_camera(px));
 
-                ray.m_ry.m_org = ray.m_org;
-                const Vector2d py(point.x, point.y + point_differential->y);
-                ray.m_ry.m_dir = transform.vector_to_parent(ndc_to_camera(py));
-            }
+            ray.m_ry.m_org = ray.m_org;
+            const Vector2d py(point.m_value + point.m_dy);
+            ray.m_ry.m_dir = transform.vector_to_parent(ndc_to_camera(py));
         }
 
         virtual bool project_camera_space_point(

--- a/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
@@ -107,7 +107,7 @@ namespace
 
         virtual void generate_ray(
             SamplingContext&            sampling_context,
-            const foundation::Dual2d&   point,
+            const Dual2d&               point,
             ShadingRay&                 ray) const APPLESEED_OVERRIDE
         {
             // Initialize the ray.
@@ -129,12 +129,14 @@ namespace
             if (point.has_derivatives())
             {
                 ray.m_has_differentials = true;
-                ray.m_rx.m_org = ray.m_org;
-                const Vector2d px(point.get_value() + point.get_dx());
-                ray.m_rx.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(px)));
 
+                ray.m_rx.m_org = ray.m_org;
                 ray.m_ry.m_org = ray.m_org;
+
+                const Vector2d px(point.get_value() + point.get_dx());
                 const Vector2d py(point.get_value() + point.get_dy());
+
+                ray.m_rx.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(px)));
                 ray.m_ry.m_dir = normalize(transform.vector_to_parent(ndc_to_camera(py)));
             }
         }

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -233,6 +233,7 @@ namespace
         virtual void generate_ray(
             SamplingContext&        sampling_context,
             const Vector2d&         point,
+            const Vector2d*         point_differential,
             ShadingRay&             ray) const APPLESEED_OVERRIDE
         {
             // Initialize the ray.
@@ -293,11 +294,20 @@ namespace
             if (w != 1.0)
                 ray.m_org /= w;
 
-            // Compute the direction of the ray.
-            ray.m_dir.x = (point.x - 0.5) * m_kx - lens_point.x;
-            ray.m_dir.y = (0.5 - point.y) * m_ky - lens_point.y;
-            ray.m_dir.z = -m_focal_distance;
-            ray.m_dir = transform.vector_to_parent(ray.m_dir);
+            ray.m_dir = ray_direction(point, lens_point, transform);
+
+            if (point_differential)
+            {
+                ray.m_has_differentials = true;
+
+                ray.m_rx.m_org = ray.m_org;
+                const Vector2d px(point.x + point_differential->x, point.y);
+                ray.m_rx.m_dir = ray_direction(px, lens_point, transform);
+
+                ray.m_ry.m_org = ray.m_org;
+                const Vector2d py(point.x, point.y + point_differential->y);
+                ray.m_ry.m_dir = ray_direction(py, lens_point, transform);
+            }
         }
 
         virtual bool project_camera_space_point(
@@ -521,6 +531,19 @@ namespace
                     (point.x - 0.5) * m_film_dimensions[0],
                     (0.5 - point.y) * m_film_dimensions[1],
                     -m_focal_length);
+        }
+
+        Vector3d ray_direction(
+            const Vector2d&     point,
+            const Vector2d&     lens_point,
+             const Transformd&  transform) const
+        {
+            const Vector3d dir(
+                (point.x - 0.5) * m_kx - lens_point.x,
+                (0.5 - point.y) * m_ky - lens_point.y,
+                -m_focal_distance);
+
+            return transform.vector_to_parent(dir);
         }
     };
 }

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -294,16 +294,19 @@ namespace
             if (w != 1.0)
                 ray.m_org /= w;
 
-            ray.m_dir = normalize(ray_direction(point.m_value, lens_point, transform));
+            ray.m_dir = normalize(ray_direction(point.get_value(), lens_point, transform));
 
-            ray.m_has_differentials = true;
-            ray.m_rx.m_org = ray.m_org;
-            const Vector2d px(point.m_value + point.m_dx);
-            ray.m_rx.m_dir = normalize(ray_direction(px, lens_point, transform));
+            if (point.has_derivatives())
+            {
+                ray.m_has_differentials = true;
+                ray.m_rx.m_org = ray.m_org;
+                const Vector2d px(point.get_value() + point.get_dx());
+                ray.m_rx.m_dir = normalize(ray_direction(px, lens_point, transform));
 
-            ray.m_ry.m_org = ray.m_org;
-            const Vector2d py(point.m_value + point.m_dy);
-            ray.m_ry.m_dir = normalize(ray_direction(py, lens_point, transform));
+                ray.m_ry.m_org = ray.m_org;
+                const Vector2d py(point.get_value() + point.get_dy());
+                ray.m_ry.m_dir = normalize(ray_direction(py, lens_point, transform));
+            }
         }
 
         virtual bool project_camera_space_point(

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -294,16 +294,16 @@ namespace
             if (w != 1.0)
                 ray.m_org /= w;
 
-            ray.m_dir = ray_direction(point.m_value, lens_point, transform);
+            ray.m_dir = normalize(ray_direction(point.m_value, lens_point, transform));
 
             ray.m_has_differentials = true;
             ray.m_rx.m_org = ray.m_org;
             const Vector2d px(point.m_value + point.m_dx);
-            ray.m_rx.m_dir = ray_direction(px, lens_point, transform);
+            ray.m_rx.m_dir = normalize(ray_direction(px, lens_point, transform));
 
             ray.m_ry.m_org = ray.m_org;
             const Vector2d py(point.m_value + point.m_dy);
-            ray.m_ry.m_dir = ray_direction(py, lens_point, transform);
+            ray.m_ry.m_dir = normalize(ray_direction(py, lens_point, transform));
         }
 
         virtual bool project_camera_space_point(

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -233,7 +233,7 @@ namespace
 
         virtual void generate_ray(
             SamplingContext&            sampling_context,
-            const foundation::Dual2d&   point,
+            const Dual2d&               point,
             ShadingRay&                 ray) const APPLESEED_OVERRIDE
         {
             // Initialize the ray.
@@ -294,18 +294,20 @@ namespace
             if (w != 1.0)
                 ray.m_org /= w;
 
-            ray.m_dir = normalize(ray_direction(point.get_value(), lens_point, transform));
+            ray.m_dir = normalize(compute_ray_direction(point.get_value(), lens_point, transform));
 
             if (point.has_derivatives())
             {
                 ray.m_has_differentials = true;
-                ray.m_rx.m_org = ray.m_org;
-                const Vector2d px(point.get_value() + point.get_dx());
-                ray.m_rx.m_dir = normalize(ray_direction(px, lens_point, transform));
 
+                ray.m_rx.m_org = ray.m_org;
                 ray.m_ry.m_org = ray.m_org;
+
+                const Vector2d px(point.get_value() + point.get_dx());
                 const Vector2d py(point.get_value() + point.get_dy());
-                ray.m_ry.m_dir = normalize(ray_direction(py, lens_point, transform));
+
+                ray.m_rx.m_dir = normalize(compute_ray_direction(px, lens_point, transform));
+                ray.m_ry.m_dir = normalize(compute_ray_direction(py, lens_point, transform));
             }
         }
 
@@ -532,10 +534,10 @@ namespace
                     -m_focal_length);
         }
 
-        Vector3d ray_direction(
+        Vector3d compute_ray_direction(
             const Vector2d&     point,
             const Vector2d&     lens_point,
-             const Transformd&  transform) const
+            const Transformd&   transform) const
         {
             const Vector3d dir(
                 (point.x - 0.5) * m_kx - lens_point.x,


### PR DESCRIPTION
- Added a Dual<T> class that holds a value and its derivatives wrt X and Y.
- Camera classes now generate differential rays.
- Normalize ray direction vectors and add asserts to check it.
- Advance ray differentials when dealing with alpha maps / transparency.
- Compute screen space partial derivatives in ShadingPoint.
- Compute world space normal derivatives in ShadingPoint.