### PR TITLE
Fixed OSL searchpaths for Projects constructed using the API

### DIFF
--- a/src/appleseed/foundation/utility/searchpaths.cpp
+++ b/src/appleseed/foundation/utility/searchpaths.cpp
@@ -211,17 +211,13 @@ char* SearchPathsImpl::do_qualify(const char* filepath) const
     return duplicate_string(fp.string().c_str());
 }
 
-char* SearchPathsImpl::do_to_string(
-    const char separator,
-    const bool make_paths_absolute,
-    const bool reversed) const
+char* SearchPathsImpl::do_to_string(const char separator, const bool reversed) const
 {
-    if (make_paths_absolute)
-        assert(has_root_path());
-
     Impl::PathCollection paths;
 
-    if (has_root_path())
+    const bool root_path = has_root_path();
+
+    if (root_path)
         paths.push_back(impl->m_root_path.string().c_str());
 
     copy(impl->m_all_paths.begin(), impl->m_all_paths.end(), back_inserter(paths));
@@ -233,13 +229,19 @@ char* SearchPathsImpl::do_to_string(
 
     for (size_t i = 0, e = paths.size(); i < e; ++i)
     {
-        if (i != 0)
-            paths_str.append(1, separator);
-
         filesystem::path p(paths[i]);
 
-        if (make_paths_absolute && p.is_relative())
+        if (p.is_relative())
+        {
+            // Ignore relative paths.
+            if (!root_path)
+                continue;
+
             p = impl->m_root_path / p;
+        }
+
+        if (!paths_str.empty())
+            paths_str.append(1, separator);
 
         paths_str.append(p.string());
     }

--- a/src/appleseed/foundation/utility/searchpaths.h
+++ b/src/appleseed/foundation/utility/searchpaths.h
@@ -88,11 +88,7 @@ class APPLESEED_DLLSYMBOL SearchPathsImpl
     void do_push_back(const char* path);
     bool do_exist(const char* filepath) const;
     char* do_qualify(const char* filepath) const;
-    char* do_to_string(
-        const char separator,
-        const bool make_paths_absolute,
-        const bool reversed) const;
-
+    char* do_to_string(const char separator, const bool reversed) const;
 };
 
 class SearchPaths
@@ -131,7 +127,6 @@ class SearchPaths
     // optionally making them absolute and/or listing them in reverse order.
     std::string to_string(
         const char separator = ':',
-        const bool make_paths_absolute = true,
         const bool reversed = false) const;
 };
 
@@ -191,10 +186,9 @@ inline std::string SearchPaths::qualify(const std::string& filepath) const
 
 inline std::string SearchPaths::to_string(
     const char separator,
-    const bool make_paths_absolute,
     const bool reversed) const
 {
-    return convert_to_std_string(do_to_string(separator, make_paths_absolute, reversed));
+    return convert_to_std_string(do_to_string(separator, reversed));
 }
 
 }       // namespace foundation

--- a/src/appleseed/renderer/modeling/project/project.cpp
+++ b/src/appleseed/renderer/modeling/project/project.cpp
@@ -165,10 +165,7 @@ SearchPaths& Project::search_paths() const
 
 string Project::make_search_path_string() const
 {
-    return
-        impl->m_search_paths.has_root_path()
-            ? impl->m_search_paths.to_string(';', true, true)
-            : string();
+    return impl->m_search_paths.to_string(';', true);
 }
 
 void Project::set_scene(auto_release_ptr<Scene> scene)


### PR DESCRIPTION
Projects constructed using the API do not have a root path so Project::make_search_path_string 
was always returning an empty string.
Also removed the make_absolute option that has never been used.
