### PR TITLE
RendererControllers don't need a release method.

### DIFF
--- a/src/appleseed.python/bindrenderercontroller.cpp
+++ b/src/appleseed.python/bindrenderercontroller.cpp
@@ -49,11 +49,6 @@ namespace
       , public bpy::wrapper<IRendererController>
     {
       public:
-        virtual void release() APPLESEED_OVERRIDE
-        {
-            delete this;
-        }
-
         virtual void on_rendering_begin() APPLESEED_OVERRIDE
         {
             // Lock Python's global interpreter lock (GIL),

--- a/src/appleseed.studio/mainwindow/rendering/qtrenderercontroller.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/qtrenderercontroller.cpp
@@ -44,11 +44,6 @@ QtRendererController::QtRendererController()
     set_status(ContinueRendering);
 }
 
-void QtRendererController::release()
-{
-    delete this;
-}
-
 void QtRendererController::on_rendering_begin()
 {
     set_status(ContinueRendering);

--- a/src/appleseed.studio/mainwindow/rendering/qtrenderercontroller.h
+++ b/src/appleseed.studio/mainwindow/rendering/qtrenderercontroller.h
@@ -56,9 +56,6 @@ class QtRendererController
     // Constructor.
     QtRendererController();
 
-    // Delete this instance.
-    virtual void release() APPLESEED_OVERRIDE;
-
     // This method is called before rendering begins.
     virtual void on_rendering_begin() APPLESEED_OVERRIDE;
 

--- a/src/appleseed/renderer/kernel/rendering/defaultrenderercontroller.cpp
+++ b/src/appleseed/renderer/kernel/rendering/defaultrenderercontroller.cpp
@@ -37,11 +37,6 @@ namespace renderer
 // DefaultRendererController class implementation.
 //
 
-void DefaultRendererController::release()
-{
-    delete this;
-}
-
 void DefaultRendererController::on_rendering_begin()
 {
 }

--- a/src/appleseed/renderer/kernel/rendering/defaultrenderercontroller.h
+++ b/src/appleseed/renderer/kernel/rendering/defaultrenderercontroller.h
@@ -50,9 +50,6 @@ class APPLESEED_DLLSYMBOL DefaultRendererController
   : public IRendererController
 {
   public:
-    // Delete this instance.
-    virtual void release() APPLESEED_OVERRIDE;
-
     // This method is called before rendering begins.
     virtual void on_rendering_begin() APPLESEED_OVERRIDE;
 

--- a/src/appleseed/renderer/kernel/rendering/irenderercontroller.h
+++ b/src/appleseed/renderer/kernel/rendering/irenderercontroller.h
@@ -31,7 +31,7 @@
 #define APPLESEED_RENDERER_KERNEL_RENDERING_IRENDERERCONTROLLER_H
 
 // appleseed.foundation headers.
-#include "foundation/core/concepts/iunknown.h"
+#include "foundation/core/concepts/noncopyable.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
@@ -44,7 +44,7 @@ namespace renderer
 //
 
 class APPLESEED_DLLSYMBOL IRendererController
-  : public foundation::IUnknown
+  : public foundation::NonCopyable
 {
   public:
     // This method is called before rendering begins.

--- a/src/appleseed/renderer/kernel/rendering/serialrenderercontroller.cpp
+++ b/src/appleseed/renderer/kernel/rendering/serialrenderercontroller.cpp
@@ -51,11 +51,6 @@ SerialRendererController::SerialRendererController(
 {
 }
 
-void SerialRendererController::release()
-{
-    delete this;
-}
-
 void SerialRendererController::on_rendering_begin()
 {
     m_controller->on_rendering_begin();

--- a/src/appleseed/renderer/kernel/rendering/serialrenderercontroller.h
+++ b/src/appleseed/renderer/kernel/rendering/serialrenderercontroller.h
@@ -61,8 +61,6 @@ class SerialRendererController
         IRendererController*    controller,
         ITileCallback*          tile_callback);
 
-    virtual void release() APPLESEED_OVERRIDE;
-
     virtual void on_rendering_begin() APPLESEED_OVERRIDE;
     virtual void on_rendering_success() APPLESEED_OVERRIDE;
     virtual void on_rendering_abort() APPLESEED_OVERRIDE;


### PR DESCRIPTION
The release method was not being used. RendererControllers are always created and destroyed by clients of the appleseed library. Issue #730.