### PR TITLE
Do not use SSE4.1 (not supported by gcc4.1)

### DIFF
--- a/src/appleseed/foundation/math/scalar.h
+++ b/src/appleseed/foundation/math/scalar.h
@@ -555,42 +555,6 @@ inline T fast_ceil(const T x)
     return std::ceil(x);
 }
 
-#ifdef APPLESEED_USE_SSE
-
-template <>
-inline float fast_floor(const float x)
-{
-    M128Fields f;
-    f.m128 = _mm_floor_ss(_mm_set1_ps(x), _mm_set1_ps(x));
-    return f.f32[0];
-}
-
-template <>
-inline double fast_floor(const double x)
-{
-    M128Fields f;
-    f.m128d = _mm_floor_sd(_mm_set1_pd(x), _mm_set1_pd(x));
-    return f.f64[0];
-}
-
-template <>
-inline float fast_ceil(const float x)
-{
-    M128Fields f;
-    f.m128 = _mm_ceil_ss(_mm_set1_ps(x), _mm_set1_ps(x));
-    return f.f32[0];
-}
-
-template <>
-inline double fast_ceil(const double x)
-{
-    M128Fields f;
-    f.m128d = _mm_ceil_sd(_mm_set1_pd(x), _mm_set1_pd(x));
-    return f.f64[0];
-}
-
-#endif
-
 template <typename Int, typename T>
 inline Int round(const T x)
 {

--- a/src/appleseed/foundation/platform/sse.h
+++ b/src/appleseed/foundation/platform/sse.h
@@ -40,7 +40,6 @@
 // Platform headers.
 #include <xmmintrin.h>      // SSE1 intrinsics
 #include <emmintrin.h>      // SSE2 intrinsics
-#include <smmintrin.h>      // SSE4 intrinsics
 
 namespace foundation
 {

--- a/src/cmake/config/linux-gcc.txt
+++ b/src/cmake/config/linux-gcc.txt
@@ -68,7 +68,7 @@ set (c_compiler_flags_common
 if (USE_SSE)
     set (c_compiler_flags_common
          ${c_compiler_flags_common}
-        -msse4.2                                        # enable SSE instruction sets up to SSE 4.2
+        -msse2                                          # enable SSE instruction sets up to SSE 2
     )
 endif ()
 set (exe_linker_flags_common

--- a/src/cmake/config/mac-clang.txt
+++ b/src/cmake/config/mac-clang.txt
@@ -67,7 +67,7 @@ set (c_compiler_flags_common
 if (USE_SSE)
     set (c_compiler_flags_common
          ${c_compiler_flags_common}
-        -msse4.2                                        # enable SSE instruction sets up to SSE 4.2
+        -msse2                                          # enable SSE instruction sets up to SSE 2
     )
 endif ()
 set (exe_linker_flags_common


### PR DESCRIPTION
Remove uses of SSE4.1 until we have a better way to optionally enable different instruction sets.