### PR TITLE
Started adding metadata to Configurations

### DIFF
--- a/src/appleseed.python/bindproject.cpp
+++ b/src/appleseed.python/bindproject.cpp
@@ -149,6 +149,11 @@ namespace
         return param_array_to_bpy_dict(params);
     }
 
+    bpy::dict config_get_metadata()
+    {
+        return dictionary_to_bpy_dict(Configuration::get_metadata());
+    }
+
     bpy::object project_file_reader_read_default_opts(
         ProjectFileReader*                  reader,
         const char*                         project_filename,
@@ -187,6 +192,7 @@ void bind_project()
         .def("set_base", &Configuration::set_base)
         .def("get_base", &Configuration::get_base, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("get_inherited_parameters", config_get_inherited_parameters)
+        .def("get_metadata", config_get_metadata).staticmethod("get_metadata")
         ;
 
     bind_typed_entity_map<Configuration>("ConfigurationContainer");

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -944,6 +944,7 @@ source_group ("renderer\\kernel\\lighting\\sppm" FILES
 set (renderer_kernel_lighting_sources
     renderer/kernel/lighting/directlightingintegrator.cpp
     renderer/kernel/lighting/directlightingintegrator.h
+    renderer/kernel/lighting/ilightingengine.cpp
     renderer/kernel/lighting/ilightingengine.h
     renderer/kernel/lighting/imagebasedlighting.cpp
     renderer/kernel/lighting/imagebasedlighting.h

--- a/src/appleseed/renderer/kernel/lighting/drt/drtlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/drt/drtlightingengine.cpp
@@ -53,6 +53,7 @@
 #include "foundation/math/population.h"
 #include "foundation/math/vector.h"
 #include "foundation/platform/types.h"
+#include "foundation/utility/containers/dictionary.h"
 #include "foundation/utility/statistics.h"
 #include "foundation/utility/string.h"
 
@@ -458,6 +459,31 @@ void DRTLightingEngineFactory::release()
 ILightingEngine* DRTLightingEngineFactory::create()
 {
     return new DRTLightingEngine(m_light_sampler, m_params);
+}
+
+Dictionary DRTLightingEngineFactory::get_params_metadata()
+{
+    Dictionary metadata;
+    add_common_params_metadata(metadata, true);
+
+    metadata.dictionaries().insert(
+        "max_path_length",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "8")
+            .insert("unlimited", "true")
+            .insert("min", "1")
+            .insert("help", "Maximum ray trace depth"));
+
+    metadata.dictionaries().insert(
+        "rr_min_path_length",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "3")
+            .insert("min", "1")
+            .insert("help", "Consider pruning low contribution paths starting with this bounce"));
+
+    return metadata;
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/kernel/lighting/ilightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/ilightingengine.cpp
@@ -5,8 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2010-2013 Francois Beaune, Jupiter Jazz Limited
-// Copyright (c) 2014-2015 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2015 Esteban Tovagliari, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -27,51 +26,44 @@
 // THE SOFTWARE.
 //
 
-#ifndef APPLESEED_RENDERER_KERNEL_LIGHTING_DRT_DRTLIGHTINGENGINE_H
-#define APPLESEED_RENDERER_KERNEL_LIGHTING_DRT_DRTLIGHTINGENGINE_H
-
-// appleseed.renderer headers.
-#include "renderer/kernel/lighting/ilightingengine.h"
-#include "renderer/utility/paramarray.h"
+// Interface header.
+#include "ilightingengine.h"
 
 // appleseed.foundation headers.
-#include "foundation/platform/compiler.h"
+#include "foundation/utility/containers/dictionary.h"
 
-// Forward declarations.
-namespace foundation    { class Dictionary; }
-namespace renderer      { class LightSampler; }
+using namespace foundation;
 
 namespace renderer
 {
 
-//
-// Distribution Ray Tracing (DRT) lighting engine factory.
-//
-
-class DRTLightingEngineFactory
-  : public ILightingEngineFactory
+void ILightingEngineFactory::add_common_params_metadata(
+    Dictionary& metadata,
+    const bool  add_lighting_samples)
 {
-  public:
-    // Constructor.
-    DRTLightingEngineFactory(
-        const LightSampler& light_sampler,
-        const ParamArray&   params);
+    metadata.dictionaries().insert(
+        "enable_ibl",
+        Dictionary()
+            .insert("type", "bool")
+            .insert("default", "on")
+            .insert("help", "Enable image-based lighting"));
 
-    // Delete this instance.
-    virtual void release() APPLESEED_OVERRIDE;
+    if (add_lighting_samples)
+    {
+        metadata.dictionaries().insert(
+            "dl_light_samples",
+            Dictionary()
+                .insert("type", "float")
+                .insert("default", "1.0")
+                .insert("help", "Number of samples used to estimate direct lighting"));
 
-    // Return a new DRT lighting engine instance.
-    virtual ILightingEngine* create() APPLESEED_OVERRIDE;
-
-    // Get the metadata dictionary describing
-    // the DRT lighting engine params.
-    static foundation::Dictionary get_params_metadata();
-
-  private:
-    const LightSampler&     m_light_sampler;
-    ParamArray              m_params;
-};
+        metadata.dictionaries().insert(
+            "ibl_env_samples",
+            Dictionary()
+                .insert("type", "float")
+                .insert("default", "1.0")
+                .insert("help", "Number of samples used to estimate environment lighting"));
+    }
+}
 
 }       // namespace renderer
-
-#endif  // !APPLESEED_RENDERER_KERNEL_LIGHTING_DRT_DRTLIGHTINGENGINE_H

--- a/src/appleseed/renderer/kernel/lighting/ilightingengine.h
+++ b/src/appleseed/renderer/kernel/lighting/ilightingengine.h
@@ -37,6 +37,7 @@
 #include "foundation/core/concepts/iunknown.h"
 
 // Forward declarations.
+namespace foundation    { class Dictionary; }
 namespace foundation    { class StatisticsVector; }
 namespace renderer      { class PixelContext; }
 namespace renderer      { class ShadingContext; }
@@ -78,6 +79,11 @@ class ILightingEngineFactory
   public:
     // Return a new sample lighting engine instance.
     virtual ILightingEngine* create() = 0;
+
+  protected:
+    static void add_common_params_metadata(
+        foundation::Dictionary& metadata,
+        const bool              add_lighting_samples);
 };
 
 }       // namespace renderer

--- a/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.cpp
@@ -710,4 +710,52 @@ ILightingEngine* PTLightingEngineFactory::create()
     return new PTLightingEngine(m_light_sampler, m_params);
 }
 
+Dictionary PTLightingEngineFactory::get_params_metadata()
+{
+    Dictionary metadata;
+    add_common_params_metadata(metadata, true);
+
+    metadata.dictionaries().insert(
+        "enable_dl",
+        Dictionary()
+            .insert("type", "bool")
+            .insert("default", "true")
+            .insert("help", "Enable direct lighting"));
+
+    metadata.dictionaries().insert(
+        "enable_caustics",
+        Dictionary()
+            .insert("type", "bool")
+            .insert("default", "false")
+            .insert("help", "Enable caustics"));
+
+    metadata.dictionaries().insert(
+        "max_path_length",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "8")
+            .insert("unlimited", "true")
+            .insert("min", "1")
+            .insert("help", "Maximum number of path bounces"));
+
+    metadata.dictionaries().insert(
+        "rr_min_path_length",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "3")
+            .insert("min", "1")
+            .insert("help", "Consider pruning low contribution paths starting with this bounce"));
+
+    metadata.dictionaries().insert(
+        "max_ray_intensity",
+        Dictionary()
+            .insert("type", "float")
+            .insert("default", "1.0")
+            .insert("unlimited", "true")
+            .insert("min", "0.0")
+            .insert("help", "Clamp intensity of rays (after the first bounce) to this value to reduce fireflies"));
+
+    return metadata;
+}
+
 }   // namespace renderer

--- a/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.h
+++ b/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.h
@@ -38,7 +38,8 @@
 #include "foundation/platform/compiler.h"
 
 // Forward declarations.
-namespace renderer  { class LightSampler; }
+namespace foundation    { class Dictionary; }
+namespace renderer      { class LightSampler; }
 
 namespace renderer
 {
@@ -61,6 +62,10 @@ class PTLightingEngineFactory
 
     // Return a new path tracing lighting engine instance.
     virtual ILightingEngine* create() APPLESEED_OVERRIDE;
+
+    // Get the metadata dictionary describing
+    // the PT lighting engine params.
+    static foundation::Dictionary get_params_metadata();
 
   private:
     const LightSampler&     m_light_sampler;

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmlightingengine.cpp
@@ -55,6 +55,7 @@
 #include "foundation/math/scalar.h"
 #include "foundation/math/vector.h"
 #include "foundation/platform/types.h"
+#include "foundation/utility/containers/dictionary.h"
 #include "foundation/utility/statistics.h"
 
 // Standard headers.
@@ -662,6 +663,142 @@ ILightingEngine* SPPMLightingEngineFactory::create()
             m_pass_callback,
             m_light_sampler,
             m_params);
+}
+
+Dictionary SPPMLightingEngineFactory::get_params_metadata()
+{
+    Dictionary metadata;
+    add_common_params_metadata(metadata, false);
+
+    metadata.dictionaries().insert(
+        "enable_caustics",
+        Dictionary()
+            .insert("type", "bool")
+            .insert("default", "false")
+            .insert("help", "Enable caustics"));
+
+    metadata.dictionaries().insert(
+        "photon_type",
+        Dictionary()
+            .insert("type", "enum")
+            .insert("values", "mono|poly")
+            .insert("default", "poly")
+            .insert("help", "TODO: Not documented yet")
+            .insert(
+                "options",
+                Dictionary()
+                    .insert(
+                        "mono",
+                        Dictionary()
+                            .insert(
+                                "help",
+                                "TODO: Not documented yet"))
+                    .insert(
+                        "poly",
+                        Dictionary()
+                            .insert(
+                                "help",
+                                "TODO: Not documented yet"))));
+
+    metadata.dictionaries().insert(
+        "dl_type",
+        Dictionary()
+            .insert("type", "enum")
+            .insert("values", "rt|sppm|off")
+            .insert("default", "rt")
+            .insert("help", "Method used to estimate direct lighting")
+            .insert(
+                "options",
+                Dictionary()
+                    .insert(
+                        "rt",
+                        Dictionary()
+                            .insert(
+                                "help",
+                                "Use ray tracing to estimate direct lighting"))
+                    .insert(
+                        "sppm",
+                        Dictionary()
+                            .insert(
+                                "help",
+                                "Use photon maps to estimate direct lighting"))
+                    .insert(
+                        "off",
+                        Dictionary()
+                            .insert(
+                                "help",
+                                "Do not estimate direct lighting"))));
+
+    metadata.dictionaries().insert(
+        "photon_tracing_max_path_length",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "8")
+            .insert("unlimited", "true")
+            .insert("help", "Maximum number of photon bounces"));
+
+    metadata.dictionaries().insert(
+        "photon_tracing_rr_min_path_length",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "3")
+            .insert("help", "Consider pruning low contribution photons starting with this bounce"));
+
+    metadata.dictionaries().insert(
+        "path_tracing_max_path_length",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "8")
+            .insert("unlimited", "true")
+            .insert("help", "Maximum number of path bounces"));
+
+    metadata.dictionaries().insert(
+        "path_tracing_rr_min_path_length",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "3")
+            .insert("help", "Consider pruning low contribution paths starting with this bounce"));
+
+    metadata.dictionaries().insert(
+        "light_photons_per_pass",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "1000000")
+            .insert("help", "Number of photons per render pass"));
+
+    metadata.dictionaries().insert(
+        "env_photons_per_pass",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "1000000")
+            .insert("help", "Number of environment photons per render pass"));
+
+    metadata.dictionaries().insert(
+        "initial_radius",
+        Dictionary()
+            .insert("type", "float")
+            .insert("default", "1.0")
+            .insert("unit", "percent")
+            .insert("min", "0.0")
+            .insert("max", "100.0")
+            .insert("help", "Initial photon gathering radius in percent of the scene diameter."));
+
+    metadata.dictionaries().insert(
+        "max_photons_per_estimate",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "100")
+            .insert("min", "1")
+            .insert("help", "Maximum number of photons used to estimate radiance"));
+
+    metadata.dictionaries().insert(
+        "alpha",
+        Dictionary()
+            .insert("type", "float")
+            .insert("default", "0.7")
+            .insert("help", "Evolution rate of photon gathering radius"));
+
+    return metadata;
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmlightingengine.h
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmlightingengine.h
@@ -38,8 +38,9 @@
 #include "foundation/platform/compiler.h"
 
 // Forward declarations.
-namespace renderer  { class LightSampler; }
-namespace renderer  { class SPPMPassCallback; }
+namespace foundation    { class Dictionary; }
+namespace renderer      { class LightSampler; }
+namespace renderer      { class SPPMPassCallback; }
 
 namespace renderer
 {
@@ -63,6 +64,10 @@ class SPPMLightingEngineFactory
 
     // Return a new SPPM lighting engine instance.
     virtual ILightingEngine* create() APPLESEED_OVERRIDE;
+
+    // Get the metadata dictionary describing
+    // the SPPM lighting engine params.
+    static foundation::Dictionary get_params_metadata();
 
   private:
     const SPPMParameters            m_params;

--- a/src/appleseed/renderer/kernel/rendering/final/uniformpixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/uniformpixelrenderer.cpp
@@ -53,6 +53,7 @@
 #include "foundation/math/vector.h"
 #include "foundation/platform/types.h"
 #include "foundation/utility/autoreleaseptr.h"
+#include "foundation/utility/containers/dictionary.h"
 #include "foundation/utility/statistics.h"
 
 // Standard headers.
@@ -273,6 +274,28 @@ IPixelRenderer* UniformPixelRendererFactory::create(
     const size_t                thread_index)
 {
     return new UniformPixelRenderer(m_factory, m_params, thread_index);
+}
+
+Dictionary UniformPixelRendererFactory::get_params_metadata()
+{
+    Dictionary metadata;
+    metadata.dictionaries().insert(
+        "samples",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "64")
+            .insert("help", "Number of anti-aliasing samples"));
+
+    metadata.dictionaries().insert(
+        "force_antialiasing",
+        Dictionary()
+            .insert("type", "bool")
+            .insert("default", "false")
+            .insert(
+                "help",
+                "When using 1 sample/pixel and force_antialiasing is disabled, samples are placed in the middle of the pixels"));
+
+    return metadata;
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/kernel/rendering/final/uniformpixelrenderer.h
+++ b/src/appleseed/renderer/kernel/rendering/final/uniformpixelrenderer.h
@@ -41,7 +41,8 @@
 #include <cstddef>
 
 // Forward declarations.
-namespace renderer  { class ISampleRendererFactory; }
+namespace foundation    { class Dictionary; }
+namespace renderer      { class ISampleRendererFactory; }
 
 namespace renderer
 {
@@ -65,6 +66,9 @@ class UniformPixelRendererFactory
     // Return a new uniform pixel renderer instance.
     virtual IPixelRenderer* create(
         const size_t                thread_index) APPLESEED_OVERRIDE;
+
+    // Get the metadata dictionary describing the uniform pixel renderer params.
+    static foundation::Dictionary get_params_metadata();
 
   private:
     ISampleRendererFactory*         m_factory;

--- a/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
@@ -44,6 +44,7 @@
 #include "foundation/math/hash.h"
 #include "foundation/platform/thread.h"
 #include "foundation/platform/types.h"
+#include "foundation/utility/containers/dictionary.h"
 #include "foundation/utility/foreach.h"
 #include "foundation/utility/job.h"
 #include "foundation/utility/statistics.h"
@@ -416,6 +417,54 @@ IFrameRenderer* GenericFrameRendererFactory::create(
             tile_callback_factory,
             pass_callback,
             params);
+}
+
+Dictionary GenericFrameRendererFactory::get_params_metadata()
+{
+    Dictionary metadata;
+    metadata.dictionaries().insert(
+        "passes",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "1")
+            .insert("help", "Number of render passes"));
+
+    metadata.dictionaries().insert(
+        "tile_ordering",
+        Dictionary()
+            .insert("type", "enum")
+            .insert("values", "linear|spiral|hilbert|random")
+            .insert("default", "hilbert")
+            .insert("help", "Tile rendering order")
+            .insert(
+                "options",
+                Dictionary()
+                    .insert(
+                        "linear",
+                        Dictionary()
+                            .insert(
+                                "help",
+                                "Linear tile ordering"))
+                    .insert(
+                        "spiral",
+                        Dictionary()
+                            .insert(
+                                "help",
+                                "Spiral tile ordering"))
+                    .insert(
+                        "hilbert",
+                        Dictionary()
+                            .insert(
+                                "help",
+                                "Hilbert tile ordering"))
+                    .insert(
+                        "random",
+                        Dictionary()
+                            .insert(
+                                "help",
+                                "Random tile ordering"))));
+
+    return metadata;
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.h
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.h
@@ -38,10 +38,11 @@
 #include "foundation/platform/compiler.h"
 
 // Forward declarations.
-namespace renderer  { class Frame; }
-namespace renderer  { class IPassCallback; }
-namespace renderer  { class ITileCallbackFactory; }
-namespace renderer  { class ITileRendererFactory; }
+namespace foundation    { class Dictionary; }
+namespace renderer      { class Frame; }
+namespace renderer      { class IPassCallback; }
+namespace renderer      { class ITileCallbackFactory; }
+namespace renderer      { class ITileRendererFactory; }
 
 namespace renderer
 {
@@ -75,6 +76,9 @@ class GenericFrameRendererFactory
         ITileCallbackFactory*   tile_callback_factory,      // may be 0
         IPassCallback*          pass_callback,              // may be 0
         const ParamArray&       params);
+
+    // Get the metadata dictionary describing the generic frame renderer params.
+    static foundation::Dictionary get_params_metadata();
 
   private:
     const Frame&                m_frame;

--- a/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
@@ -55,6 +55,7 @@
 #include "foundation/platform/thread.h"
 #include "foundation/platform/timers.h"
 #include "foundation/platform/types.h"
+#include "foundation/utility/containers/dictionary.h"
 #include "foundation/utility/foreach.h"
 #include "foundation/utility/gnuplotfile.h"
 #include "foundation/utility/job.h"
@@ -655,6 +656,25 @@ IFrameRenderer* ProgressiveFrameRendererFactory::create(
             generator_factory,
             callback_factory,
             params);
+}
+
+Dictionary ProgressiveFrameRendererFactory::get_params_metadata()
+{
+    Dictionary metadata;
+    metadata.dictionaries().insert(
+        "max_fps",
+        Dictionary()
+            .insert("type", "float")
+            .insert("default", "30.0")
+            .insert("help", "Maximum progressive rendering update rate in frames per second"));
+
+    metadata.dictionaries().insert(
+        "max_samples",
+        Dictionary()
+            .insert("type", "int")
+            .insert("help", "Maximum number of samples per pixel"));
+
+    return metadata;
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.h
+++ b/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.h
@@ -38,9 +38,10 @@
 #include "foundation/platform/compiler.h"
 
 // Forward declarations.
-namespace renderer  { class ISampleGeneratorFactory; }
-namespace renderer  { class ITileCallbackFactory; }
-namespace renderer  { class Project; }
+namespace foundation    { class Dictionary; }
+namespace renderer      { class ISampleGeneratorFactory; }
+namespace renderer      { class ITileCallbackFactory; }
+namespace renderer      { class Project; }
 
 namespace renderer
 {
@@ -72,6 +73,10 @@ class ProgressiveFrameRendererFactory
         ISampleGeneratorFactory*    generator_factory,
         ITileCallbackFactory*       callback_factory,       // may be 0
         const ParamArray&           params);
+
+    // Get the metadata dictionary describing
+    // the progressive frame renderer params.
+    static foundation::Dictionary get_params_metadata();
 
   private:
     const Project&                  m_project;

--- a/src/appleseed/renderer/kernel/texturing/texturestore.cpp
+++ b/src/appleseed/renderer/kernel/texturing/texturestore.cpp
@@ -42,6 +42,7 @@
 #include "foundation/image/colorspace.h"
 #include "foundation/image/tile.h"
 #include "foundation/platform/types.h"
+#include "foundation/utility/containers/dictionary.h"
 #include "foundation/utility/foreach.h"
 #include "foundation/utility/memory.h"
 #include "foundation/utility/statistics.h"
@@ -75,6 +76,19 @@ StatisticsVector TextureStore::get_statistics() const
     stats.insert_size("peak size", m_tile_swapper.get_peak_memory_size());
 
     return StatisticsVector::make("texture store statistics", stats);
+}
+
+Dictionary TextureStore::get_params_metadata()
+{
+    Dictionary metadata;
+    metadata.dictionaries().insert(
+        "max_size",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "268435456")
+            .insert("help", "Texture cache size in bytes"));
+
+    return metadata;
 }
 
 

--- a/src/appleseed/renderer/kernel/texturing/texturestore.h
+++ b/src/appleseed/renderer/kernel/texturing/texturestore.h
@@ -49,6 +49,7 @@
 #include <map>
 
 // Forward declarations.
+namespace foundation    { class Dictionary; }
 namespace foundation    { class Statistics; }
 namespace foundation    { class Tile; }
 namespace renderer      { class Assemblies; }
@@ -119,6 +120,9 @@ class TextureStore
 
     // Retrieve performance statistics.
     foundation::StatisticsVector get_statistics() const;
+
+    // Get the metadata dictionary describing the texture store params.
+    static foundation::Dictionary get_params_metadata();
 
   private:
     class TileSwapper

--- a/src/appleseed/renderer/modeling/project/configuration.cpp
+++ b/src/appleseed/renderer/modeling/project/configuration.cpp
@@ -31,7 +31,17 @@
 #include "configuration.h"
 
 // appleseed.renderer headers.
+#include "renderer/kernel/lighting/drt/drtlightingengine.h"
+#include "renderer/kernel/lighting/pt/ptlightingengine.h"
+#include "renderer/kernel/lighting/sppm/sppmlightingengine.h"
+#include "renderer/kernel/rendering/final/uniformpixelrenderer.h"
+#include "renderer/kernel/rendering/generic/genericframerenderer.h"
+#include "renderer/kernel/rendering/progressive/progressiveframerenderer.h"
+#include "renderer/kernel/texturing/texturestore.h"
 #include "renderer/utility/paramarray.h"
+
+// appleseed.foundation headers.
+#include "foundation/utility/containers/dictionary.h"
 
 // Standard headers.
 #include <cassert>
@@ -91,6 +101,95 @@ ParamArray Configuration::get_inherited_parameters() const
     {
         return m_params;
     }
+}
+
+Dictionary Configuration::get_metadata()
+{
+    ParamArray metadata;
+
+    metadata.insert(
+        "sampling_mode",
+        Dictionary()
+            .insert("type", "enum")
+            .insert("values", "rng|qmc")
+            .insert("default", "rng")
+            .insert(
+                "help",
+                "Sampler to use when generating samples")
+            .insert(
+                "options",
+                Dictionary()
+                    .insert(
+                        "rng",
+                        Dictionary()
+                            .insert(
+                                "help",
+                                "Random sampler"))
+                        .insert(
+                        "qmc",
+                        Dictionary()
+                            .insert(
+                                "help",
+                                "Quasi monte carlo sampler"))));
+
+    metadata.insert(
+        "lighting_engine",
+        Dictionary()
+            .insert("type", "enum")
+            .insert("values", "drt|pt|sppm")
+            .insert("default", "pt")
+            .insert(
+                "help",
+                "Lighting engine used when rendering.")
+            .insert(
+                "options",
+                Dictionary()
+                    .insert(
+                        "drt",
+                        Dictionary()
+                            .insert(
+                                "help",
+                                "Distribution ray tracing"))
+                    .insert(
+                        "pt",
+                        Dictionary()
+                            .insert(
+                                "help",
+                                "Unidirectional path tracing"))
+                    .insert(
+                        "sppm",
+                        Dictionary()
+                            .insert(
+                                "help",
+                                "Stochastic progressive photon mapping"))));
+
+    metadata.insert(
+        "rendering_threads",
+        Dictionary()
+            .insert("type", "int")
+            .insert("help", "Number of threads to use for rendering"));
+
+    metadata.dictionaries().insert(
+        "texture_store",
+        TextureStore::get_params_metadata());
+
+    metadata.dictionaries().insert(
+        "uniform_pixel_renderer",
+        UniformPixelRendererFactory::get_params_metadata());
+
+    metadata.dictionaries().insert(
+        "generic_frame_renderer",
+        GenericFrameRendererFactory::get_params_metadata());
+
+    metadata.dictionaries().insert(
+        "progressive_frame_renderer",
+        ProgressiveFrameRendererFactory::get_params_metadata());
+
+    metadata.dictionaries().insert("drt", DRTLightingEngineFactory::get_params_metadata());
+    metadata.dictionaries().insert("pt", PTLightingEngineFactory::get_params_metadata());
+    metadata.dictionaries().insert("sppm", SPPMLightingEngineFactory::get_params_metadata());
+
+    return metadata;
 }
 
 

--- a/src/appleseed/renderer/modeling/project/configuration.h
+++ b/src/appleseed/renderer/modeling/project/configuration.h
@@ -42,7 +42,8 @@
 #include "main/dllsymbol.h"
 
 // Forward declarations.
-namespace renderer  { class ParamArray; }
+namespace foundation    { class Dictionary; }
+namespace renderer      { class ParamArray; }
 
 namespace renderer
 {
@@ -73,6 +74,9 @@ class APPLESEED_DLLSYMBOL Configuration
     // Construct a set of parameters from the parameters inherited
     // from the base configuration and the ones of this configuration.
     ParamArray get_inherited_parameters() const;
+
+    // Get the metadata dictionary describing the configuration settings.
+    static foundation::Dictionary get_metadata();
 
   private:
     friend class BaseConfigurationFactory;


### PR DESCRIPTION
This PR add some basic metadata to Configurations (render settings). Ticket #746
Metadata can be useful in DCC plugins, to generate automatic documentation, ...

Metadata is accesible from C++ and from appleseed.python as nested dictionaries.

I only added metadata for the settings used in GafferAppleseed for now.
Some help strings are missing and many others can certainly be improved.

But I think we can merge the PR if the implementation is ok and improve things as needed.
