### PR TITLE
Script to convert RFM Disney BRDF presets to appleseed materials

### DIFF
--- a/scripts/rfmdisneypresets2appleseed.py
+++ b/scripts/rfmdisneypresets2appleseed.py
@@ -1,0 +1,134 @@
+#!/usr/bin/python
+
+#
+# This source file is part of appleseed.
+# Visit http://appleseedhq.net/ for additional information and resources.
+#
+# This software is released under the MIT license.
+#
+# Copyright (c) 2015 Esteban Tovagliari, The appleseedhq Organization
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import argparse
+import os
+import sys
+
+
+#--------------------------------------------------------------------------------------------------
+# Constants.
+#--------------------------------------------------------------------------------------------------
+
+DISNEY_BRDF_KEYS = set([ "anisotropic", "baseColorB", "baseColorG", "baseColorR", "clearcoat", "clearcoatGloss", "metallic", "roughness", "sheen", "sheenTint", "specular", "specularTint", "subsurface", "subsurfaceColorB", "subsurfaceColorG", "subsurfaceColorR"])
+
+
+#--------------------------------------------------------------------------------------------------
+# Entry point.
+#--------------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Converts RFM Disney BRDF presets to appleseed Disney Materials.")
+    parser.add_argument("-s", "--stop-error", dest="stop_error", action="store_true", help="stop on errors")
+    parser.add_argument("-o" ,"--output", metavar="output-directory", dest="output_directory",
+                        required=True, help="directory where appleseed materials will be stored.")
+    parser.add_argument("directory", help="directory to scan for RFM Disney BRDF preset files.")
+    args = parser.parse_args()
+
+    for root, dirname, files in os.walk(args.directory):
+        for filename in files:
+            if filename.endswith(".mel"):
+                print "Processing file: " + os.path.join(root, filename)
+
+                material_name = filename.replace(".mel", "")
+
+                in_file = open(os.path.join(root, filename), "r")
+                lines = in_file.readlines()
+
+                params = {}
+
+                for line in lines:
+                    l = line.strip()
+
+                    if l.startswith("blendAttr"):
+                        tokens = l.split()
+                        param_name = tokens[1].replace('"', "")
+                        value = tokens[2].replace(";", "")
+                        params[param_name] = value
+
+                # Check if the material is a Disney BRDF
+                if not DISNEY_BRDF_KEYS.issubset(set(params.keys())):
+                    print "Error: material preset %s is not a Disney BRDF." % material_name
+
+                    if args.stop_error:
+                        sys.exit(1)
+                    else:
+                        continue
+
+                # Check the material for possible incompatibilities
+                if params["emitColorR"] != "0.0" or params["emitColorG"] != "0.0" or params["emitColorB"] != "0.0":
+                    print "Error: material %s preset uses emision." % material_name
+
+                    if args.stop_error:
+                        sys.exit(1)
+
+                # Subsurface color is missing in appleseed"s Disney BRDF implementation.
+                if params["subsurface"] != "0.0":
+                    if params["subsurfaceColorR"] != params["baseColorR"] or params["subsurfaceColorG"] != params["baseColorG"] or params["subsurfaceColorB"] != params["baseColorB"]:
+                        print "Error: material preset %s uses subsurface color." % material_name
+
+                        if args.stop_error:
+                            sys.exit(-1)
+
+                out_filename = os.path.join(args.output_directory, material_name + ".dmt")
+                print "Generating file: " + out_filename
+
+                out_file = open(out_filename, "w")
+
+                out_file.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+                out_file.write('<settings>\n')
+                out_file.write('    <parameter name="__model" value="disney_material" />\n')
+                out_file.write('    <parameter name="__name" value="%s" />\n' % material_name)
+                out_file.write('    <parameter name="bump_amplitude" value="1.0" />\n')
+                out_file.write('    <parameter name="displacement_method" value="bump" />\n')
+                out_file.write('    <parameter name="normal_map_up" value="z" />\n')
+                out_file.write('    <parameter name="shade_alpha_cutouts" value="false" />\n')
+                out_file.write('    <parameters name="layer1">\n')
+                out_file.write('        <parameter name="layer_folded" value="false" />\n')
+                out_file.write('        <parameter name="layer_name" value="layer1" />\n')
+                out_file.write('        <parameter name="layer_number" value="0" />\n')
+                out_file.write('        <parameter name="mask" value="1.0" />\n')
+
+                base_color = (params['baseColorR'], params['baseColorG'], params['baseColorB'])
+                out_file.write('        <parameter name="base_color" value="[%s, %s, %s]" />\n' % base_color)
+                out_file.write('        <parameter name="anisotropic" value="%s" />\n' % params['anisotropic'])
+                out_file.write('        <parameter name="clearcoat" value="%s" />\n' % params['clearcoat'])
+                out_file.write('        <parameter name="clearcoat_gloss" value="%s" />\n' % params['clearcoatGloss'])
+                out_file.write('        <parameter name="metallic" value="%s" />\n' % params['metallic'])
+                out_file.write('        <parameter name="roughness" value="%s" />\n' % params['roughness'])
+                out_file.write('        <parameter name="sheen" value="%s" />\n' % params['sheen'])
+                out_file.write('        <parameter name="sheen_tint" value="%s" />\n' % params['sheenTint'])
+                out_file.write('        <parameter name="specular" value="%s" />\n' % params['specular'])
+                out_file.write('        <parameter name="specular_tint" value="%s" />\n' % params['specularTint'])
+                out_file.write('        <parameter name="subsurface" value="%s" />\n' % params['subsurface'])
+                out_file.write('    </parameters>\n')
+                out_file.write('</settings>\n')
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
First version of a script to convert RenderMan for Maya Disney BRDF presets to appleseed Disney materials for use in appleseed.studio.

The script can also be used to convert the presets in LollipopShaders' RIS100 for DisneyBRDF:
http://lollipopshaders.myshopify.com/products/ris100

The RenderMan and appleseed implementations of the Disney BRDF are not 100% compatible.
appleseed's Disney BRDF does not have a subsurface color parameter for example (ticket #740).

![ris100_alum_bronze](https://cloud.githubusercontent.com/assets/409013/7812165/2883c4ea-03b0-11e5-80d7-b6c9e6bf4049.png)

RIS100 for DisneyBRDF alum bronze preset in appleseed.studio.