### PR TITLE
python: use nested dicts for entity params metadata

### DIFF
--- a/src/appleseed.python/dict2dict.cpp
+++ b/src/appleseed.python/dict2dict.cpp
@@ -227,12 +227,17 @@ bpy::dict param_array_to_bpy_dict(const ParamArray& array)
     return dictionary_to_bpy_dict(array);
 }
 
-bpy::list dictionary_array_to_bpy_list(const DictionaryArray& array)
+boost::python::dict dictionary_array_to_bpy_dict(
+    const DictionaryArray&  array,
+    const char*             key)
 {
-    bpy::list dictionaries;
+    bpy::dict dictionaries;
 
     for (size_t i = 0, e = array.size(); i < e; ++i)
-        dictionaries.append(dictionary_to_bpy_dict(array[i]));
+    {
+        bpy::dict d(dictionary_to_bpy_dict(array[i]));
+        dictionaries[d[key]] = d;
+    }
 
     return dictionaries;
 }

--- a/src/appleseed.python/dict2dict.h
+++ b/src/appleseed.python/dict2dict.h
@@ -44,6 +44,8 @@ boost::python::dict dictionary_to_bpy_dict(const foundation::Dictionary& dict);
 renderer::ParamArray bpy_dict_to_param_array(const boost::python::dict& d);
 boost::python::dict param_array_to_bpy_dict(const renderer::ParamArray& array);
 
-boost::python::list dictionary_array_to_bpy_list(const foundation::DictionaryArray& array);
+boost::python::dict dictionary_array_to_bpy_dict(
+    const foundation::DictionaryArray&  array,
+    const char*                         key);
 
 #endif  // !APPLESEED_PYTHON_DICT2DICT_H

--- a/src/appleseed.python/metadata.h
+++ b/src/appleseed.python/metadata.h
@@ -67,7 +67,7 @@ namespace detail
         for (size_t i = 0, e = factories.size(); i < e; ++i)
         {
             input_metadata[factories[i]->get_model()] =
-                dictionary_array_to_bpy_list(factories[i]->get_input_metadata());
+                dictionary_array_to_bpy_dict(factories[i]->get_input_metadata(), "name");
         }
 
         return input_metadata;


### PR DESCRIPTION
Previously lists of dictionaries were used. 
Now, metadata for entity parameters can now be accessed as a dict:

md = appleseed.Light.get_input_metadata()
md['directional_light']['irradiance']['help']

