### PR TITLE
fixed BezierCurveBase<T, N>::compute_recursion_depth() about z component.

### DIFF
--- a/src/appleseed/foundation/math/beziercurve.h
+++ b/src/appleseed/foundation/math/beziercurve.h
@@ -365,7 +365,8 @@ size_t BezierCurveBase<T, N>::compute_recursion_depth(const ValueType epsilon) c
             max(
                 l0,
                 std::abs(m_ctrl_pts[i].x - ValueType(2.0) * m_ctrl_pts[i + 1].x + m_ctrl_pts[i + 2].x),
-                std::abs(m_ctrl_pts[i].y - ValueType(2.0) * m_ctrl_pts[i + 1].y + m_ctrl_pts[i + 2].y));
+                std::abs(m_ctrl_pts[i].y - ValueType(2.0) * m_ctrl_pts[i + 1].y + m_ctrl_pts[i + 2].y),
+                std::abs(m_ctrl_pts[i].z - ValueType(2.0) * m_ctrl_pts[i + 1].z + m_ctrl_pts[i + 2].z));
     }
 
     const ValueType value = (ValueType(SqrtTwo) * N * (N - 1) * l0) / (ValueType(8.0) * epsilon);


### PR DESCRIPTION
This fix introduces a subexpression about z as described in Errata (http://eaflux.com/index.html.en):

> Page 2, bottom right: If control points are placed non-uniformly in ray direction, the resulting v parameter may have a large margin of error because the algorithm computes v in 2D space. To compensate this, we should add a subexpression about z in the maximum depth computation. (Thanks to Emil Kirichev)

Anyway, thank you very much for implementing the algorithm!
