### PR TITLE
Make Material::get_uncached_edf() non-virtual

### DIFF
--- a/src/appleseed/renderer/kernel/lighting/lightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lightsampler.cpp
@@ -374,22 +374,22 @@ void LightSampler::collect_emitting_triangles(
 
                 for (size_t side = 0; side < 2; ++side)
                 {
-                    // Retrieve the material; skip sides without a material.
+                    // Retrieve the material; skip sides without a material or without emission.
                     const Material* material = side == 0 ? front_material : back_material;
-                    if (material == 0)
+                    if (material == 0 || material->has_emission() == false)
                         continue;
 
-                    // Retrieve the EDF; skip sides without a light-emitting material.
-                    const EDF* edf = material->get_uncached_edf();
-                    if (edf == 0)
-                        continue;
+                    // Retrieve the EDF and get the importance multiplier.
+                    double importance_multiplier = 1.0;
+                    if (const EDF* edf = material->get_uncached_edf())
+                        importance_multiplier = edf->get_uncached_importance_multiplier();
 
                     // Accumulate the object area for OSL shaders.
                     object_area += area;
 
                     // Compute the probability density of this triangle.
                     const double triangle_importance = m_params.m_importance_sampling ? area : 1.0;
-                    const double triangle_prob = triangle_importance * edf->get_uncached_importance_multiplier();
+                    const double triangle_prob = triangle_importance * importance_multiplier;
 
                     // Create a light-emitting triangle.
                     EmittingTriangle emitting_triangle;

--- a/src/appleseed/renderer/modeling/material/material.h
+++ b/src/appleseed/renderer/modeling/material/material.h
@@ -116,7 +116,7 @@ class APPLESEED_DLLSYMBOL Material
 
     // Return the EDF of the material, or 0 if the material doesn't have one.
     const EDF* get_edf() const;
-    virtual const EDF* get_uncached_edf() const;
+    const EDF* get_uncached_edf() const;
 
     // Return the source bound to the alpha map input, or 0 if the material doesn't have an alpha map.
     const Source* get_alpha_map() const;

--- a/src/appleseed/renderer/modeling/material/oslmaterial.cpp
+++ b/src/appleseed/renderer/modeling/material/oslmaterial.cpp
@@ -133,14 +133,6 @@ namespace
             return false;
         }
 
-        virtual const EDF* get_uncached_edf() const APPLESEED_OVERRIDE
-        {
-            if (has_emission())
-                return m_osl_edf.get();
-
-            return 0;
-        }
-
       private:
         auto_release_ptr<BSDF>  m_osl_bsdf;
         auto_release_ptr<EDF>   m_osl_edf;


### PR DESCRIPTION
Just like other Material::get_uncached_xxx() methods.
