### PR TITLE
Temporary switch dirpole to absorption and scattering inputs

### DIFF
--- a/src/appleseed/renderer/kernel/shading/closures.cpp
+++ b/src/appleseed/renderer/kernel/shading/closures.cpp
@@ -629,6 +629,7 @@ void CompositeSubsurfaceClosure::process_closure_tree(
 
             if (c->id == SubsurfaceID)
             {
+                /*
                 const SubsurfaceClosureParams* p =
                     reinterpret_cast<const SubsurfaceClosureParams*>(c->data());
 
@@ -650,6 +651,7 @@ void CompositeSubsurfaceClosure::process_closure_tree(
                 }
                 else
                     assert(false);
+                */
             }
         }
         break;

--- a/src/appleseed/renderer/modeling/bssrdf/directionaldipolebssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/directionaldipolebssrdf.cpp
@@ -83,10 +83,10 @@ namespace
             const ParamArray&       params)
           : BSSRDF(name, params)
         {
-            m_inputs.declare("reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("reflectance_multiplier", InputFormatScalar, "1.0");
-            m_inputs.declare("dmfp", InputFormatSpectralReflectance);
-            m_inputs.declare("dmfp_multiplier", InputFormatScalar, "1.0");
+            m_inputs.declare("sigma_a", InputFormatSpectralReflectance);
+            m_inputs.declare("sigma_a_multiplier", InputFormatScalar, "1.0");
+            m_inputs.declare("sigma_s", InputFormatSpectralReflectance);
+            m_inputs.declare("sigma_s_multiplier", InputFormatScalar, "1.0");
             m_inputs.declare("anisotropy", InputFormatScalar);
             m_inputs.declare("outside_ior", InputFormatScalar);
             m_inputs.declare("inside_ior", InputFormatScalar);
@@ -120,6 +120,9 @@ namespace
             DirectionalDipoleBSSRDFInputValues* values =
                 reinterpret_cast<DirectionalDipoleBSSRDFInputValues*>(ptr + offset);
 
+            assert(values->m_sigma_a.size() == values->m_sigma_s.size());
+
+            /*
             values->m_reflectance *= static_cast<float>(values->m_reflectance_multiplier);
             values->m_dmfp *= static_cast<float>(values->m_dmfp_multiplier);
 
@@ -160,6 +163,7 @@ namespace
                 // Compute absorption coefficient.
                 values->m_sigma_a[i] = static_cast<float>(sigma_t_prime) - sigma_s_prime;
             }
+            */
         }
 
         virtual void evaluate(
@@ -174,8 +178,6 @@ namespace
                 reinterpret_cast<const DirectionalDipoleBSSRDFInputValues*>(data);
 
             value.resize(values->m_sigma_a.size());
-            value.set(0.0f);
-
             bssrdf(
                 values,
                 incoming_point.get_point(),
@@ -184,19 +186,6 @@ namespace
                 outgoing_point.get_point(),
                 outgoing_point.get_shading_normal(),
                 value);
-
-#if 0
-            // Hack to make the BSSRDF reciprocal (section 6.3).
-            bssrdf(
-                values,
-                outgoing_point.get_point(),
-                outgoing_point.get_shading_normal(),
-                outgoing_dir,
-                incoming_point.get_point(),
-                incoming_point.get_shading_normal(),
-                value);
-            value *= 0.5f;
-#endif
         }
 
       private:
@@ -215,7 +204,7 @@ namespace
             const Vector3d s = sample.get_sampling_context().next_vector2<3>();
 
             // Sample a color channel uniformly.
-            const size_t channel = truncate<size_t>(s[0] * values->m_reflectance.size());
+            const size_t channel = truncate<size_t>(s[0] * values->m_sigma_a.size());
             sample.set_channel(channel);
 
             // Sample a radius, by importance sampling the attenuation.
@@ -242,7 +231,7 @@ namespace
                 reinterpret_cast<const DirectionalDipoleBSSRDFInputValues*>(data);
 
             // PDF of the sampled channel.
-            const double pdf_channel = 1.0 / values->m_reflectance.size();
+            const double pdf_channel = 1.0 / values->m_sigma_a.size();
 
             // PDF of the sampled radius.
             const double sigma_t = values->m_sigma_a[channel] + values->m_sigma_s[channel];
@@ -354,7 +343,7 @@ namespace
                     value = 0.0;
 
                 // Store result.
-                result[i] += static_cast<float>(value);
+                result[i] = static_cast<float>(value);
             }
 
             // todo: we seem to be missing the S_sigma_E term (single scattering).
@@ -387,47 +376,53 @@ DictionaryArray DirectionalDipoleBSSRDFFactory::get_input_metadata() const
 
     metadata.push_back(
         Dictionary()
-            .insert("name", "reflectance")
-            .insert("label", "Diffuse Surface Reflectance")
+            .insert("name", "sigma_a")
+            .insert("label", "Absorption")
             .insert("type", "colormap")
             .insert("entity_types",
                 Dictionary()
                     .insert("color", "Colors")
                     .insert("texture_instance", "Textures"))
             .insert("use", "required")
-            .insert("default", "0.5"));
+            .insert("default", "0.0030"));
 
+    // Since presets are usually specified in mm.,
+    // we set the multipliers so that the values are correct
+    // for scenes modelled in meters.
     metadata.push_back(
         Dictionary()
-            .insert("name", "reflectance_multiplier")
-            .insert("label", "Diffuse Surface Reflectance Multiplier")
+            .insert("name", "sigma_a_multiplier")
+            .insert("label", "Absorption Multiplier")
             .insert("type", "colormap")
             .insert("entity_types",
                 Dictionary().insert("texture_instance", "Textures"))
             .insert("use", "optional")
-            .insert("default", "1.0"));
+            .insert("default", "0.001"));
 
     metadata.push_back(
         Dictionary()
-            .insert("name", "dmfp")
-            .insert("label", "Diffuse Mean Free Path")
+            .insert("name", "sigma_s")
+            .insert("label", "Scattering")
             .insert("type", "colormap")
             .insert("entity_types",
                 Dictionary()
                     .insert("color", "Colors")
                     .insert("texture_instance", "Textures"))
             .insert("use", "required")
-            .insert("default", "0.5"));
+            .insert("default", "2.29"));
 
+    // Since presets are usually specified in mm.,
+    // we set the multipliers so that the values are correct
+    // for scenes modelled in meters.
     metadata.push_back(
         Dictionary()
-            .insert("name", "dmfp_multiplier")
-            .insert("label", "Diffuse Mean Free Path Multiplier")
+            .insert("name", "sigma_s_multiplier")
+            .insert("label", "Scattering Multiplier")
             .insert("type", "colormap")
             .insert("entity_types",
                 Dictionary().insert("texture_instance", "Textures"))
             .insert("use", "optional")
-            .insert("default", "1.0"));
+            .insert("default", "0.001"));
 
     metadata.push_back(
         Dictionary()

--- a/src/appleseed/renderer/modeling/bssrdf/directionaldipolebssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/directionaldipolebssrdf.h
@@ -55,17 +55,13 @@ namespace renderer
 
 APPLESEED_DECLARE_INPUT_VALUES(DirectionalDipoleBSSRDFInputValues)
 {
-    Spectrum    m_reflectance;
-    double      m_reflectance_multiplier;
-    Spectrum    m_dmfp;
-    double      m_dmfp_multiplier;
+    Spectrum    m_sigma_a;
+    double      m_sigma_a_multiplier;
+    Spectrum    m_sigma_s;
+    double      m_sigma_s_multiplier;
     double      m_anisotropy;
     double      m_outside_ior;
     double      m_inside_ior;
-
-    // Precomputed values.
-    Spectrum    m_sigma_a;
-    Spectrum    m_sigma_s;
 };
 
 

--- a/src/appleseed/renderer/modeling/bssrdf/directionaldipolebssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/directionaldipolebssrdf.h
@@ -55,6 +55,7 @@ namespace renderer
 
 APPLESEED_DECLARE_INPUT_VALUES(DirectionalDipoleBSSRDFInputValues)
 {
+    double      m_weight;
     Spectrum    m_sigma_a;
     double      m_sigma_a_multiplier;
     Spectrum    m_sigma_s;

--- a/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.cpp
@@ -80,6 +80,7 @@ namespace
             const ParamArray&       params)
           : BSSRDF(name, params)
         {
+            m_inputs.declare("weight", InputFormatScalar, "1.0");
             m_inputs.declare("reflectance", InputFormatSpectralReflectance);
             m_inputs.declare("reflectance_multiplier", InputFormatScalar, "1.0");
             m_inputs.declare("dmfp", InputFormatSpectralReflectance);
@@ -149,6 +150,8 @@ namespace
                 const double ld = values->m_dmfp[i];
                 value[i] = static_cast<float>(normalized_diffusion_r(dist, ld, s, a));
             }
+
+            value *= static_cast<float>(values->m_weight);
         }
 
       private:
@@ -234,6 +237,16 @@ Dictionary NormalizedDiffusionBSSRDFFactory::get_model_metadata() const
 DictionaryArray NormalizedDiffusionBSSRDFFactory::get_input_metadata() const
 {
     DictionaryArray metadata;
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "weight")
+            .insert("label", "Weight")
+            .insert("type", "colormap")
+            .insert("entity_types",
+                Dictionary().insert("texture_instance", "Textures"))
+            .insert("use", "optional")
+            .insert("default", "1.0"));
 
     metadata.push_back(
         Dictionary()

--- a/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.h
@@ -55,6 +55,7 @@ namespace renderer
 
 APPLESEED_DECLARE_INPUT_VALUES(NormalizedDiffusionBSSRDFInputValues)
 {
+    double      m_weight;
     Spectrum    m_reflectance;
     double      m_reflectance_multiplier;
     Spectrum    m_dmfp;


### PR DESCRIPTION
To simplify testing and debugging. Presets can now be used directly in the directional dipole BSSRDF.