### PR TITLE
SSS work:

### DIFF
--- a/src/appleseed/renderer/kernel/lighting/subsurfacesampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/subsurfacesampler.cpp
@@ -154,12 +154,12 @@ size_t SubsurfaceSampler::sample(
 
     // Sample the diffusion profile.
     BSSRDFSample bssrdf_sample(outgoing_point, sampling_context);
-    Vector2d point; // todo: should be part of BSSRDFSample
-    if (!bssrdf.sample(bssrdf_data, bssrdf_sample, point))
+    if (!bssrdf.sample(bssrdf_data, bssrdf_sample))
         return 0;
 
     // Reject points too far away.
     // This introduces negligible bias in comparison to the other approximations.
+    const Vector2d& point(bssrdf_sample.get_point());
     const double radius2 = square_norm(point);
     const double rmax2 = bssrdf_sample.get_rmax2();
     if (radius2 > rmax2)

--- a/src/appleseed/renderer/meta/tests/test_sss.cpp
+++ b/src/appleseed/renderer/meta/tests/test_sss.cpp
@@ -283,6 +283,42 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         plotfile.write("unit tests/outputs/test_sss_normalized_diffusion_cdf.gnuplot");
     }
 
+    void init_dirpole_bssrdf_values(
+        const double                        sigma_a,
+        const double                        sigma_s,
+        const double                        eta,
+        const double                        g,
+        DirectionalDipoleBSSRDFInputValues& values)
+    {
+        values.m_weight = 1.0;
+        values.m_inside_ior = eta;
+        values.m_outside_ior = 1.0;
+        values.m_anisotropy = g;
+        values.m_sigma_a = Color3f(static_cast<float>(sigma_a));
+        values.m_sigma_s = Color3f(static_cast<float>(sigma_s));
+    }
+
+    void init_dirpole_bssrdf_values_rd_dmfp(
+        const double                        rd,
+        const double                        dmfp,
+        const double                        eta,
+        const double                        g,
+        DirectionalDipoleBSSRDFInputValues& values)
+    {
+        values.m_weight = 1.0;
+        values.m_inside_ior = eta;
+        values.m_outside_ior = 1.0;
+        values.m_anisotropy = g;
+
+        compute_absorption_and_scattering(
+            Spectrum(Color3f(rd)),
+            Spectrum(Color3f(dmfp)),
+            values.m_inside_ior / values.m_outside_ior,
+            values.m_anisotropy,
+            values.m_sigma_a,
+            values.m_sigma_s);
+    }
+
     void plot_dirpole_rd(
         const char*     filename,
         const char*     title,
@@ -302,11 +338,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
             DirectionalDipoleBSSRDFFactory().create("dirpole", ParamArray()));
 
         DirectionalDipoleBSSRDFInputValues values;
-        values.m_inside_ior = 1.0;
-        values.m_outside_ior = 1.0;
-        values.m_anisotropy = 0.0;
-        values.m_sigma_a = Color3f(static_cast<float>(sigma_a));
-        values.m_sigma_s = Color3f(1.0f);
+        init_dirpole_bssrdf_values(sigma_a, 1.0, 1.0, 0.0, values);
 
         const Vector3d normal(0.0, 1.0, 0.0);
 

--- a/src/appleseed/renderer/modeling/bssrdf/bssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/bssrdf.h
@@ -124,8 +124,7 @@ class APPLESEED_DLLSYMBOL BSSRDF
     // Sample the BSSRDF.
     virtual bool sample(
         const void*                 data,
-        BSSRDFSample&               sample,
-        foundation::Vector2d&       point) const = 0;
+        BSSRDFSample&               sample) const = 0;
 
     // Evaluate the BSSRDF for a given pair of points and directions.
     virtual void evaluate(

--- a/src/appleseed/renderer/modeling/bssrdf/bssrdfsample.h
+++ b/src/appleseed/renderer/modeling/bssrdf/bssrdfsample.h
@@ -69,6 +69,9 @@ class BSSRDFSample
     size_t get_channel() const;
     void set_channel(const size_t channel);
 
+    const foundation::Vector2d& get_point() const;
+    void set_point(const foundation::Vector2d& point);
+
     double get_rmax2() const;
     void set_rmax2(const double rmax2);
 
@@ -78,6 +81,7 @@ class BSSRDFSample
     bool                    m_is_directional;
     double                  m_eta;
     size_t                  m_channel;
+    foundation::Vector2d    m_point;
     double                  m_rmax2;
 };
 
@@ -132,6 +136,16 @@ inline size_t BSSRDFSample::get_channel() const
 inline void BSSRDFSample::set_channel(const size_t channel)
 {
     m_channel = channel;
+}
+
+inline const foundation::Vector2d& BSSRDFSample::get_point() const
+{
+    return m_point;
+}
+
+inline void BSSRDFSample::set_point(const foundation::Vector2d& point)
+{
+    m_point = point;
 }
 
 inline double BSSRDFSample::get_rmax2() const

--- a/src/appleseed/renderer/modeling/bssrdf/directionaldipolebssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/directionaldipolebssrdf.h
@@ -56,13 +56,17 @@ namespace renderer
 APPLESEED_DECLARE_INPUT_VALUES(DirectionalDipoleBSSRDFInputValues)
 {
     double      m_weight;
-    Spectrum    m_sigma_a;
-    double      m_sigma_a_multiplier;
-    Spectrum    m_sigma_s;
-    double      m_sigma_s_multiplier;
+    Spectrum    m_reflectance;
+    double      m_reflectance_multiplier;
+    Spectrum    m_dmfp;
+    double      m_dmfp_multiplier;
     double      m_anisotropy;
     double      m_outside_ior;
     double      m_inside_ior;
+
+    // precomputed values.
+    Spectrum    m_sigma_a;
+    Spectrum    m_sigma_s;
 };
 
 

--- a/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
@@ -159,8 +159,7 @@ namespace
 
         virtual bool sample(
             const void*             data,
-            BSSRDFSample&           sample,
-            Vector2d&               point) const APPLESEED_OVERRIDE
+            BSSRDFSample&           sample) const APPLESEED_OVERRIDE
         {
             const GaussianBSSRDFInputValues* values =
                 reinterpret_cast<const GaussianBSSRDFInputValues*>(data);
@@ -183,7 +182,8 @@ namespace
                 sqrt(-2.0 * v * log(1.0 - s[0] * (1.0 - exp(-rmax2 / (2.0 * v)))));
             const double phi = TwoPi * s[1];
 
-            point = Vector2d(radius * cos(phi), radius * sin(phi));
+            // Set the sampled point.
+            sample.set_point(Vector2d(radius * cos(phi), radius * sin(phi)));
             return true;
         }
 

--- a/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.cpp
@@ -84,7 +84,7 @@ namespace
             m_inputs.declare("reflectance", InputFormatSpectralReflectance);
             m_inputs.declare("reflectance_multiplier", InputFormatScalar, "1.0");
             m_inputs.declare("dmfp", InputFormatSpectralReflectance);
-            m_inputs.declare("dmfp_multiplier", InputFormatScalar, "1.0");
+            m_inputs.declare("dmfp_multiplier", InputFormatScalar, "0.1");
             m_inputs.declare("outside_ior", InputFormatScalar);
             m_inputs.declare("inside_ior", InputFormatScalar);
         }
@@ -125,8 +125,7 @@ namespace
 
         virtual bool sample(
             const void*             data,
-            BSSRDFSample&           sample,
-            Vector2d&               point) const APPLESEED_OVERRIDE
+            BSSRDFSample&           sample) const APPLESEED_OVERRIDE
         {
             const NormalizedDiffusionBSSRDFInputValues* values =
                 reinterpret_cast<const NormalizedDiffusionBSSRDFInputValues*>(data);
@@ -162,8 +161,8 @@ namespace
                 normalized_diffusion_max_distance(values->m_dmfp[channel], nd_s);
             sample.set_rmax2(rmax * rmax);
 
-            // Return point on disk.
-            point = Vector2d(radius * cos(phi), radius * sin(phi));
+            // Set the sampled point.
+            sample.set_point(Vector2d(radius * cos(phi), radius * sin(phi)));
 
             return true;
         }
@@ -282,7 +281,7 @@ DictionaryArray NormalizedDiffusionBSSRDFFactory::get_input_metadata() const
                     .insert("color", "Colors")
                     .insert("texture_instance", "Textures"))
             .insert("use", "required")
-            .insert("default", "0.5"));
+            .insert("default", "5"));
 
     metadata.push_back(
         Dictionary()
@@ -292,7 +291,7 @@ DictionaryArray NormalizedDiffusionBSSRDFFactory::get_input_metadata() const
             .insert("entity_types",
                 Dictionary().insert("texture_instance", "Textures"))
             .insert("use", "optional")
-            .insert("default", "1.0"));
+            .insert("default", "0.1"));
 
     metadata.push_back(
         Dictionary()

--- a/src/appleseed/renderer/modeling/bssrdf/oslbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/oslbssrdf.cpp
@@ -134,8 +134,7 @@ namespace
 
         virtual bool sample(
             const void*                 data,
-            BSSRDFSample&               sample,
-            Vector2d&                   point) const APPLESEED_OVERRIDE
+            BSSRDFSample&               sample) const APPLESEED_OVERRIDE
         {
             const CompositeSubsurfaceClosure* c =
                 reinterpret_cast<const CompositeSubsurfaceClosure*>(data);

--- a/src/appleseed/renderer/modeling/bssrdf/sss.h
+++ b/src/appleseed/renderer/modeling/bssrdf/sss.h
@@ -29,6 +29,9 @@
 #ifndef APPLESEED_RENDERER_MODELING_BSSRDF_SSS_H
 #define APPLESEED_RENDERER_MODELING_BSSRDF_SSS_H
 
+// appleseed.renderer headers.
+#include "renderer/global/globaltypes.h"
+
 // Standard headers.
 #include <cstddef>
 
@@ -82,8 +85,16 @@ double diffusion_coefficient(const double sigma_a, const double sigma_t);
 double diffuse_mean_free_path(const double sigma_a, const double sigma_t);
 
 double reduced_extinction_coefficient(
-    const double diffuse_mean_free_path,
-    const double alpha_prime);
+    const double    diffuse_mean_free_path,
+    const double    alpha_prime);
+
+void compute_absorption_and_scattering(
+    const Spectrum& rd,                     // surface albedo
+    const Spectrum& dmfp,                   // diffuse mean free path
+    const double    eta,                    // relative index of refraction
+    const double    g,                      // anisotropy
+    Spectrum&       sigma_a,                // absorption coefficient
+    Spectrum&       sigma_s);               // scattering coefficient
 
 //
 // Normalized diffusion profile.
@@ -141,6 +152,26 @@ double normalized_diffusion_sample(
 double normalized_diffusion_max_distance(
     const double    l,                      // mean free path length or diffuse mean free path length
     const double    s);                     // scaling factor
+
+//
+// Sampling.
+//
+// References:
+//
+//   Volumetric Path Tracing, Steve Marschner, section 3.
+//   http://www.cs.cornell.edu/courses/cs6630/2012sp/notes/09volpath.pdf
+//
+
+// Sample a distance by importance sampling the attenuation.
+double sample_attenuation(
+    const double    sigma_t,
+    const double    s);
+
+double pdf_attenuation(
+    const double    sigma_t,
+    const double    dist);
+
+double max_attenuation_distance(const double sigma_t);
 
 //
 // BSSRDF reparameterization implementation.


### PR DESCRIPTION
- Moved point BSSRDF::sample() argument to BSSRDFSample.
- Dirpole BSSRDF now uses reflectance and dmfp inputs.
- Refactored code to compute absorption and scattering from Rd and dmfp.
- Refactored attenuation sampling code and moved to sss.
- For BSSRDFs that use dmfp, by default values are specified in mm.
- Set the default dmfp multipliers to convert from mm to cm.