### PR TITLE
OSL work

### DIFF
--- a/sandbox/tests/test scenes/osl/_shaders/marble.oso
+++ b/sandbox/tests/test scenes/osl/_shaders/marble.oso
@@ -42,7 +42,7 @@ const	float	$const14	2		%read{22,22} %write{2147483647,-1}
 const	float	$const15	0.75		%read{23,23} %write{2147483647,-1}
 temp	float	$tmp11	%read{25,25} %write{23,23}
 const	float	$const16	0		%read{26,26} %write{2147483647,-1}
-const	float	$const17	1		%read{25,25} %write{2147483647,-1}
+const	float	$const17	1		%read{25,31} %write{2147483647,-1}
 const	string	$const18	"clamp"		%read{24,24} %write{2147483647,-1}
 temp	float	$tmp12	%read{26,26} %write{25,25}
 temp	color	$tmp13	%read{29,29} %write{28,28}
@@ -125,9 +125,9 @@ code ___main___
 # marble.osl:58
 #         Ks * Cs * phong(N, exponent);
 	functioncall	$const19 32 	%line{58} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:573
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:572
 # closure color as_velvet(normal N, float alpha) BUILTIN;
-	closure		$tmp15 $const23 N $const20 $const21 $const22 exponent exponent 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{573} %argrw{"wrrrrrrr"}
+	closure		$tmp15 $const23 N $const20 $const21 $const22 exponent exponent $const17 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{572} %argrw{"wrrrrrrrr"}
 # marble.osl:58
 #         Ks * Cs * phong(N, exponent);
 	mul		$tmp19 Ks Cs 	%filename{"marble.osl"} %line{58} %argrw{"wrr"}

--- a/src/appleseed/renderer/kernel/shading/closures.h
+++ b/src/appleseed/renderer/kernel/shading/closures.h
@@ -46,6 +46,7 @@
 // appleseed.foundation headers.
 #include "foundation/core/concepts/noncopyable.h"
 #include "foundation/image/color.h"
+#include "foundation/math/basis.h"
 #include "foundation/math/vector.h"
 #include "foundation/platform/compiler.h"
 
@@ -183,28 +184,27 @@ class APPLESEED_ALIGN(16) CompositeSurfaceClosure
   public:
     CompositeSurfaceClosure(
         const BSDF*                 osl_bsdf,
+        const foundation::Basis3d&  original_shading_basis,
         const OSL::ClosureColor*    ci);
 
-    const foundation::Vector3d& get_closure_normal(const size_t index) const;
-    bool closure_has_tangent(const size_t index) const;
-    const foundation::Vector3d& get_closure_tangent(const size_t index) const;
+    const foundation::Basis3d& get_closure_shading_basis(const size_t index) const;
 
     // For future layered closures.
     const BSDF* get_osl_bsdf() const;
 
   private:
-    foundation::Vector3d            m_normals[MaxClosureEntries];
-    bool                            m_has_tangent[MaxClosureEntries];
-    foundation::Vector3d            m_tangents[MaxClosureEntries];
+    foundation::Basis3d             m_bases[MaxClosureEntries];
     const BSDF*                     m_osl_bsdf;
 
     void process_closure_tree(
         const OSL::ClosureColor*    closure,
+        const foundation::Basis3d&  original_shading_basis,
         const foundation::Color3f&  weight);
 
     template <typename InputValues>
     void add_closure(
         const ClosureID             closure_type,
+        const foundation::Basis3d&  original_shading_basis,
         const foundation::Color3f&  weight,
         const foundation::Vector3d& normal,
         const InputValues&          values);
@@ -212,6 +212,7 @@ class APPLESEED_ALIGN(16) CompositeSurfaceClosure
     template <typename InputValues>
     void add_closure(
         const ClosureID             closure_type,
+        const foundation::Basis3d&  original_shading_basis,
         const foundation::Color3f&  weight,
         const foundation::Vector3d& normal,
         const foundation::Vector3d& tangent,
@@ -220,6 +221,7 @@ class APPLESEED_ALIGN(16) CompositeSurfaceClosure
     template <typename InputValues>
     void do_add_closure(
         const ClosureID             closure_type,
+        const foundation::Basis3d&  original_shading_basis,
         const foundation::Color3f&  weight,
         const foundation::Vector3d& normal,
         bool                        has_tangent,
@@ -329,23 +331,10 @@ inline size_t CompositeClosure::get_closure_input_offset(const size_t index) con
 // CompositeSurfaceClosure class implementation.
 //
 
-inline const foundation::Vector3d& CompositeSurfaceClosure::get_closure_normal(const size_t index) const
+inline const foundation::Basis3d& CompositeSurfaceClosure::get_closure_shading_basis(const size_t index) const
 {
     assert(index < get_num_closures());
-    return m_normals[index];
-}
-
-inline bool CompositeSurfaceClosure::closure_has_tangent(const size_t index) const
-{
-    assert(index < get_num_closures());
-    return m_has_tangent[index];
-}
-
-inline const foundation::Vector3d& CompositeSurfaceClosure::get_closure_tangent(const size_t index) const
-{
-    assert(index < get_num_closures());
-    assert(closure_has_tangent(index));
-    return m_tangents[index];
+    return m_bases[index];
 }
 
 inline const BSDF* CompositeSurfaceClosure::get_osl_bsdf() const

--- a/src/appleseed/renderer/kernel/shading/shadingcontext.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingcontext.cpp
@@ -130,11 +130,7 @@ void ShadingContext::execute_osl_normal(
     {
         const size_t index = c->choose_closure(s);
         shading_point.set_shading_basis(
-            Basis3d(
-                c->get_closure_normal(index),
-                c->closure_has_tangent(index)
-                    ? c->get_closure_tangent(index)
-                    : shading_point.get_shading_basis().get_tangent_u()));
+            c->get_closure_shading_basis(index));
     }
 }
 

--- a/src/appleseed/renderer/modeling/bsdf/osl/oslbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/osl/oslbsdf.cpp
@@ -47,7 +47,6 @@
 #include "renderer/utility/paramarray.h"
 
 // appleseed.foundation headers.
-#include "foundation/math/basis.h"
 #include "foundation/math/vector.h"
 #include "foundation/platform/compiler.h"
 #include "foundation/platform/types.h"
@@ -223,7 +222,10 @@ namespace
             const size_t            offset) const APPLESEED_OVERRIDE
         {
             CompositeSurfaceClosure* c = reinterpret_cast<CompositeSurfaceClosure*>(input_evaluator.data());
-            new (c) CompositeSurfaceClosure(this, shading_point.get_osl_shader_globals().Ci);
+            new (c) CompositeSurfaceClosure(
+                this,
+                shading_point.get_shading_basis(),
+                shading_point.get_osl_shader_globals().Ci);
         }
 
         FORCE_INLINE virtual void sample(
@@ -240,7 +242,7 @@ namespace
                 const double s = sample.get_sampling_context().next_double2();
 
                 const size_t closure_index = c->choose_closure(s);
-                sample.set_shading_basis(make_osl_basis(c, closure_index, sample.get_shading_basis()));
+                sample.set_shading_basis(c->get_closure_shading_basis(closure_index));
                 bsdf_to_closure_id(
                     c->get_closure_type(closure_index)).sample(
                         c->get_closure_input_values(closure_index),
@@ -271,15 +273,13 @@ namespace
             for (size_t i = 0, e = c->get_num_closures(); i < e; ++i)
             {
                 Spectrum s;
-                const Basis3d new_shading_basis = make_osl_basis(c, i, shading_basis);
-
                 const double bsdf_prob =
                     bsdf_to_closure_id(c->get_closure_type(i)).evaluate(
                         c->get_closure_input_values(i),
                         adjoint,
                         false,
                         geometric_normal,
-                        new_shading_basis,
+                        c->get_closure_shading_basis(i),
                         outgoing,
                         incoming,
                         modes,
@@ -309,13 +309,11 @@ namespace
 
             for (size_t i = 0, e = c->get_num_closures(); i < e; ++i)
             {
-                const Basis3d new_shading_basis = make_osl_basis(c, i, shading_basis);
-
                 const double bsdf_prob =
                     bsdf_to_closure_id(c->get_closure_type(i)).evaluate_pdf(
                         c->get_closure_input_values(i),
                         geometric_normal,
-                        new_shading_basis,
+                        c->get_closure_shading_basis(i),
                         outgoing,
                         incoming,
                         modes);
@@ -397,19 +395,6 @@ namespace
             BSDF* bsdf = m_all_bsdfs[cid];
             assert(bsdf);
             return *bsdf;
-        }
-
-        Basis3d make_osl_basis(
-            const CompositeSurfaceClosure* c,
-            const size_t            index,
-            const Basis3d&          original_basis) const
-        {
-            return
-                Basis3d(
-                    c->get_closure_normal(index),
-                    c->closure_has_tangent(index)
-                        ? c->get_closure_tangent(index)
-                        : original_basis.get_tangent_u());
         }
     };
 


### PR DESCRIPTION
Save OSL shading bases in CompositeSurfaceClosure, instead of storing normals and tangents and recomputing the shading bases in OSLBSDF.