### PR TITLE
Split inputs evaluation and inputs precomputations for both BSDFs and BSSRDFs.

### DIFF
--- a/src/appleseed/renderer/kernel/shading/closures.cpp
+++ b/src/appleseed/renderer/kernel/shading/closures.cpp
@@ -306,7 +306,6 @@ void CompositeSurfaceClosure::process_closure_tree(
                     values.m_sheen_tint = saturate(p->sheen_tint);
                     values.m_clearcoat = max(p->clearcoat, 0.0f);
                     values.m_clearcoat_gloss = clamp(p->clearcoat_gloss, 0.0001f, 1.0f);
-                    values.precompute_tint_color();
 
                     add_closure<DisneyBRDFInputValues>(
                         static_cast<ClosureID>(c->id),

--- a/src/appleseed/renderer/meta/tests/test_sss.cpp
+++ b/src/appleseed/renderer/meta/tests/test_sss.cpp
@@ -66,30 +66,6 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
     // Utilities.
     //
 
-    void init_dipole_bssrdf_values_rd_dmfp(
-        const double             rd,
-        const double             dmfp,
-        const double             eta,
-        const double             g,
-        DipoleBSSRDFInputValues& values)
-    {
-        values.m_weight = 1.0;
-        values.m_reflectance.set(static_cast<float>(rd));
-        values.m_dmfp = dmfp;
-        values.m_inside_ior = eta;
-        values.m_outside_ior = 1.0;
-        values.m_anisotropy = g;
-
-        const ComputeRdBetterDipole rd_fun(1.0 / eta);
-        compute_absorption_and_scattering(
-            rd_fun,
-            values.m_reflectance,
-            values.m_dmfp,
-            values.m_anisotropy,
-            values.m_sigma_a,
-            values.m_sigma_s);
-    }
-
     template <typename BSSRDFFactory>
     class DipoleBSSRDFEvaluator
     {
@@ -130,7 +106,15 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
             const double    eta,
             const double    g)
         {
-            init_dipole_bssrdf_values_rd_dmfp(rd, dmfp, eta, g, m_values);
+            m_values.m_weight = 1.0;
+            m_values.m_reflectance.set(static_cast<float>(rd));
+            m_values.m_reflectance_multiplier = 1.0;
+            m_values.m_dmfp = dmfp;
+            m_values.m_dmfp_multiplier = 1.0;
+            m_values.m_inside_ior = eta;
+            m_values.m_outside_ior = 1.0;
+            m_values.m_anisotropy = g;
+            m_bssrdf->prepare_inputs(&m_values);
         }
 
         void set_incoming_distance(const double d)
@@ -743,7 +727,15 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
             DirectionalDipoleBSSRDFFactory().create("dirpole", ParamArray()));
 
         DipoleBSSRDFInputValues dp_values;
-        init_dipole_bssrdf_values_rd_dmfp(rd, dmfp, 1.0, 0.0, dp_values);
+        dp_values.m_weight = 1.0;
+        dp_values.m_reflectance.set(static_cast<float>(rd));
+        dp_values.m_reflectance_multiplier = 1.0;
+        dp_values.m_dmfp = dmfp;
+        dp_values.m_dmfp_multiplier = 1.0;
+        dp_values.m_inside_ior = 1.0;
+        dp_values.m_outside_ior = 1.0;
+        dp_values.m_anisotropy = 0.0;
+        dp_bssrdf->prepare_inputs(&dp_values);
 
         auto_release_ptr<BSSRDF> nd_bssrdf(
             NormalizedDiffusionBSSRDFFactory().create("norm_diff", ParamArray()));
@@ -756,7 +748,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         nd_values.m_dmfp_multiplier = 1.0;
         nd_values.m_inside_ior = 1.0;
         nd_values.m_outside_ior = 1.0;
-        nd_values.m_s.set(static_cast<float>(normalized_diffusion_s(rd)));
+        nd_bssrdf->prepare_inputs(&nd_values);
 
         const Vector3d normal(0.0, 1.0, 0.0);
 

--- a/src/appleseed/renderer/modeling/bsdf/bsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdf.cpp
@@ -94,7 +94,7 @@ void BSDF::evaluate_inputs(
     const size_t            offset) const
 {
     input_evaluator.evaluate(get_inputs(), shading_point.get_uv(0), offset);
-    prepare_inputs(reinterpret_cast<uint8*>(input_evaluator.data()) + offset);
+    prepare_inputs(input_evaluator.data() + offset);
 }
 
 void BSDF::prepare_inputs(void* data) const

--- a/src/appleseed/renderer/modeling/bsdf/bsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdf.cpp
@@ -94,6 +94,11 @@ void BSDF::evaluate_inputs(
     const size_t            offset) const
 {
     input_evaluator.evaluate(get_inputs(), shading_point.get_uv(0), offset);
+    prepare_inputs(reinterpret_cast<uint8*>(input_evaluator.data()) + offset);
+}
+
+void BSDF::prepare_inputs(void* data) const
+{
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/bsdf/bsdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdf.h
@@ -149,6 +149,9 @@ class APPLESEED_DLLSYMBOL BSDF
         const ShadingPoint&         shading_point,
         const size_t                offset = 0) const;
 
+    // Performs any precomputation needed for this BSDF input values.
+    virtual void prepare_inputs(void* data) const;
+
     // Given an outgoing direction, sample the BSDF and compute the incoming
     // direction, its probability density and the value of the BSDF for this
     // pair of directions. Return the scattering mode. If the scattering mode

--- a/src/appleseed/renderer/modeling/bsdf/disneybrdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/disneybrdf.h
@@ -71,8 +71,6 @@ APPLESEED_DECLARE_INPUT_VALUES(DisneyBRDFInputValues)
     // Instead, they are used to hold some temporary values.
     Spectrum    m_tint_color;
     double      m_base_color_luminance;
-
-    void precompute_tint_color();
 };
 
 

--- a/src/appleseed/renderer/modeling/bsdf/disneylayeredbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/disneylayeredbrdf.cpp
@@ -133,7 +133,7 @@ void DisneyLayeredBRDF::evaluate_inputs(
     // Colors in SeExpr are always in the sRGB color space.
     base_color = srgb_to_linear_rgb(base_color);
     values->m_base_color = Color3f(base_color);
-    values->precompute_tint_color();
+    m_brdf->prepare_inputs(values);
 }
 
 void DisneyLayeredBRDF::sample(

--- a/src/appleseed/renderer/modeling/bsdf/osl/oslbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/osl/oslbsdf.cpp
@@ -229,8 +229,8 @@ namespace
 
             for (size_t i = 0, e = c->get_num_closures(); i < e; ++i)
             {
-               bsdf_from_closure_id(c->get_closure_type(i)).prepare_inputs(
-                c->get_closure_input_values(i));
+                bsdf_from_closure_id(c->get_closure_type(i)).prepare_inputs(
+                    c->get_closure_input_values(i));
             }
         }
 

--- a/src/appleseed/renderer/modeling/bsdf/osl/oslbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/osl/oslbsdf.cpp
@@ -226,6 +226,12 @@ namespace
                 this,
                 shading_point.get_shading_basis(),
                 shading_point.get_osl_shader_globals().Ci);
+
+            for (size_t i = 0, e = c->get_num_closures(); i < e; ++i)
+            {
+               bsdf_from_closure_id(c->get_closure_type(i)).prepare_inputs(
+                c->get_closure_input_values(i));
+            }
         }
 
         FORCE_INLINE virtual void sample(

--- a/src/appleseed/renderer/modeling/bssrdf/betterdipolebssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/betterdipolebssrdf.cpp
@@ -89,12 +89,10 @@ namespace
             return Model;
         }
 
-        virtual void evaluate_inputs(
-            uint8*                  data,
-            const size_t            offset) const APPLESEED_OVERRIDE
+        virtual void prepare_inputs(void* data) const APPLESEED_OVERRIDE
         {
             DipoleBSSRDFInputValues* values =
-                reinterpret_cast<DipoleBSSRDFInputValues*>(data + offset);
+                reinterpret_cast<DipoleBSSRDFInputValues*>(data);
 
             // Apply multipliers.
             values->m_reflectance *= static_cast<float>(values->m_reflectance_multiplier);

--- a/src/appleseed/renderer/modeling/bssrdf/bssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/bssrdf.cpp
@@ -87,7 +87,7 @@ void BSSRDF::evaluate_inputs(
     const size_t            offset) const
 {
     input_evaluator.evaluate(get_inputs(), shading_point.get_uv(0), offset);
-    prepare_inputs(reinterpret_cast<uint8*>(input_evaluator.data()) + offset);
+    prepare_inputs(input_evaluator.data() + offset);
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/bssrdf/bssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/bssrdf.cpp
@@ -87,7 +87,7 @@ void BSSRDF::evaluate_inputs(
     const size_t            offset) const
 {
     input_evaluator.evaluate(get_inputs(), shading_point.get_uv(0), offset);
-    evaluate_inputs(input_evaluator.data(), offset);
+    prepare_inputs(reinterpret_cast<uint8*>(input_evaluator.data()) + offset);
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/bssrdf/bssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/bssrdf.h
@@ -120,11 +120,8 @@ class APPLESEED_DLLSYMBOL BSSRDF
         const ShadingPoint&         shading_point,
         const size_t                offset = 0) const;
 
-    // Evaluate the inputs of this BSSRDF and of its child BSSRDFs, if any.
-    // This method is called once per shading point and pair of incoming/outgoing directions.
-    virtual void evaluate_inputs(
-        foundation::uint8*          data,
-        const size_t                offset = 0) const = 0;
+    // Performs any precomputation needed for this BSSRDF input values.
+    virtual void prepare_inputs(void* data) const = 0;
 
     // Sample r * R(r).
     virtual bool sample(

--- a/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.cpp
@@ -72,12 +72,10 @@ size_t DipoleBSSRDF::compute_input_data_size(
     return align(sizeof(DipoleBSSRDFInputValues), 16);
 }
 
-void DipoleBSSRDF::evaluate_inputs(
-    uint8*                  data,
-    const size_t            offset) const
+void DipoleBSSRDF::prepare_inputs(void* data) const
 {
     DipoleBSSRDFInputValues* values =
-        reinterpret_cast<DipoleBSSRDFInputValues*>(data + offset);
+        reinterpret_cast<DipoleBSSRDFInputValues*>(data);
 
     // Apply multipliers.
     values->m_reflectance *= static_cast<float>(values->m_reflectance_multiplier);

--- a/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.h
@@ -91,9 +91,7 @@ class DipoleBSSRDF
     virtual size_t compute_input_data_size(
         const Assembly&         assembly) const APPLESEED_OVERRIDE;
 
-    virtual void evaluate_inputs(
-        foundation::uint8*      data,
-        const size_t            offset = 0) const APPLESEED_OVERRIDE;
+    virtual void prepare_inputs(void* data) const APPLESEED_OVERRIDE;
 
     virtual bool sample(
         const void*             data,

--- a/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
@@ -146,12 +146,10 @@ namespace
             return align(sizeof(GaussianBSSRDFInputValues), 16);
         }
 
-        virtual void evaluate_inputs(
-            uint8*                  data,
-            const size_t            offset = 0) const APPLESEED_OVERRIDE
+        virtual void prepare_inputs(void* data) const APPLESEED_OVERRIDE
         {
             GaussianBSSRDFInputValues* values =
-                reinterpret_cast<GaussianBSSRDFInputValues*>(data + offset);
+                reinterpret_cast<GaussianBSSRDFInputValues*>(data);
 
             values->m_rmax2 = values->m_v * RMax2Constant;
         }

--- a/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.cpp
@@ -106,12 +106,10 @@ namespace
             return align(sizeof(NormalizedDiffusionBSSRDFInputValues), 16);
         }
 
-        virtual void evaluate_inputs(
-            uint8*                  data,
-            const size_t            offset = 0) const APPLESEED_OVERRIDE
+        virtual void prepare_inputs(void* data) const APPLESEED_OVERRIDE
         {
             NormalizedDiffusionBSSRDFInputValues* values =
-                reinterpret_cast<NormalizedDiffusionBSSRDFInputValues*>(data + offset);
+                reinterpret_cast<NormalizedDiffusionBSSRDFInputValues*>(data);
 
             // Apply multipliers.
             values->m_reflectance *= static_cast<float>(values->m_reflectance_multiplier);

--- a/src/appleseed/renderer/modeling/bssrdf/oslbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/oslbssrdf.cpp
@@ -158,16 +158,19 @@ namespace
         {
             CompositeSubsurfaceClosure* c = reinterpret_cast<CompositeSubsurfaceClosure*>(input_evaluator.data());
             new (c) CompositeSubsurfaceClosure(shading_point.get_osl_shader_globals().Ci);
-
-            for (size_t i = 0, e = c->get_num_closures(); i < e; ++i)
-            {
-                bssrdf_from_closure_id(c->get_closure_type(i)).prepare_inputs(
-                    reinterpret_cast<uint8*>(c->get_closure_input_values(i)));
-            }
+            prepare_inputs(input_evaluator.data());
         }
 
         virtual void prepare_inputs(void* data) const APPLESEED_OVERRIDE
         {
+            const CompositeSubsurfaceClosure* c =
+                reinterpret_cast<const CompositeSubsurfaceClosure*>(data);
+
+            for (size_t i = 0, e = c->get_num_closures(); i < e; ++i)
+            {
+                bssrdf_from_closure_id(c->get_closure_type(i)).prepare_inputs(
+                    c->get_closure_input_values(i));
+            }
         }
 
         virtual bool sample(

--- a/src/appleseed/renderer/modeling/bssrdf/oslbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/oslbssrdf.cpp
@@ -161,14 +161,12 @@ namespace
 
             for (size_t i = 0, e = c->get_num_closures(); i < e; ++i)
             {
-                bssrdf_from_closure_id(c->get_closure_type(i)).evaluate_inputs(
+                bssrdf_from_closure_id(c->get_closure_type(i)).prepare_inputs(
                     reinterpret_cast<uint8*>(c->get_closure_input_values(i)));
             }
         }
 
-        virtual void evaluate_inputs(
-            uint8*                      data,
-            const size_t                offset = 0) const APPLESEED_OVERRIDE
+        virtual void prepare_inputs(void* data) const APPLESEED_OVERRIDE
         {
         }
 


### PR DESCRIPTION
This is needed when using BSSRDFs as OSL closures.
In that case, we don't need evaluation. Input values are initialized with the arguments of OSL closures 
and prepare_inputs can now be called to perform precomputations needed on input values.

For consistency, do the same with BSDFs.
