### PR TITLE
Unbreak the build when WITH_DISNEY_MATERIAL is OFF (default setting)

### DIFF
--- a/src/appleseed.studio/mainwindow/project/materialcollectionitem.cpp
+++ b/src/appleseed.studio/mainwindow/project/materialcollectionitem.cpp
@@ -94,6 +94,7 @@ MaterialCollectionItem::MaterialCollectionItem(
     add_items(materials);
 }
 
+#ifdef APPLESEED_WITH_DISNEY_MATERIAL
 const Material& MaterialCollectionItem::create_default_disney_material(const string& material_name)
 {
     auto_release_ptr<Material> material =
@@ -110,6 +111,7 @@ const Material& MaterialCollectionItem::create_default_disney_material(const str
 
     return *material_ptr;
 }
+#endif // APPLESEED_WITH_DISNEY_MATERIAL
 
 QMenu* MaterialCollectionItem::get_single_item_context_menu() const
 {

--- a/src/appleseed.studio/mainwindow/project/objectinstanceitem.cpp
+++ b/src/appleseed.studio/mainwindow/project/objectinstanceitem.cpp
@@ -124,8 +124,10 @@ QMenu* ObjectInstanceItem::get_single_item_context_menu() const
 {
     QMenu* menu = ItemBase::get_single_item_context_menu();
 
+#ifdef APPLESEED_WITH_DISNEY_MATERIAL
     menu->addSeparator();
     menu->addAction("Assign New Disney Material", this, SLOT(slot_assign_new_disney_material()));
+#endif
 
     menu->addSeparator();
     menu->addAction("Assign Materials...", this, SLOT(slot_open_material_assignment_editor()));
@@ -168,15 +170,18 @@ QMenu* ObjectInstanceItem::get_multiple_items_context_menu(const QList<ItemBase*
 
     QMenu* menu = ItemBase::get_multiple_items_context_menu(items);
 
+#ifdef APPLESEED_WITH_DISNEY_MATERIAL
     menu->addSeparator();
     menu->addAction("Assign New Disney Material", this, SLOT(slot_assign_new_disney_material()))
         ->setData(QVariant::fromValue(items));
+#endif
 
     add_material_assignment_menu_actions(menu, items);
 
     return menu;
 }
 
+#ifdef APPLESEED_WITH_DISNEY_MATERIAL
 // Friend of ObjectInstanceItem class, thus cannot be placed in anonymous namespace.
 class AssignNewDisneyMaterialAction
   : public RenderingManager::IScheduledAction
@@ -255,12 +260,15 @@ class AssignNewDisneyMaterialAction
     EntityEditorContext&    m_editor_context;
     const QList<ItemBase*>  m_items;
 };
+#endif // APPLESEED_WITH_DISNEY_MATERIAL
 
 void ObjectInstanceItem::slot_assign_new_disney_material()
 {
+#ifdef APPLESEED_WITH_DISNEY_MATERIAL
     m_editor_context.m_rendering_manager.schedule_or_execute(
         auto_ptr<RenderingManager::IScheduledAction>(
             new AssignNewDisneyMaterialAction(m_editor_context, get_action_items())));
+#endif
 }
 
 void ObjectInstanceItem::slot_open_material_assignment_editor()


### PR DESCRIPTION
We should not attempt to build or use `renderer::DisneyMaterial` or any other
Disney-related class if `APPLESEED_WITH_DISNEY_MATERIAL` is not defined; put
missing `#ifdef`'s where they're due.