### PR TITLE
SSS work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ option (WITH_ALEMBIC                        "Build Alembic support"             
 option (WITH_OSL                            "Build OSL support"                                     OFF)
 option (WITH_DISNEY_MATERIAL                "Build Disney material"                                 OFF)
 option (WITH_NORMALIZED_DIFFUSION_BSSRDF    "Build Normalized diffusion BSSRDF (patented)"          OFF)
+option (WITH_PARTIO                         "Build Partio support (used in unit tests)"             OFF)
 
 option (USE_STATIC_BOOST                    "Use static Boost libraries"                            ON)
 option (USE_STATIC_OIIO                     "Use static OpenImageIO libraries"                      ON)
@@ -245,6 +246,11 @@ if (WITH_NORMALIZED_DIFFUSION_BSSRDF)
     add_definitions (-DAPPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF)
 endif ()
 
+if (WITH_PARTIO)
+    add_definitions (-DAPPLESEED_WITH_PARTIO)
+    find_package (Partio REQUIRED)
+endif ()
+
 #--------------------------------------------------------------------------------------------------
 # Include paths.
 #--------------------------------------------------------------------------------------------------
@@ -328,6 +334,9 @@ if (WITH_DISNEY_MATERIAL)
     endif ()
 endif ()
 
+if (WITH_PARTIO)
+    include_directories (${PARTIO_INCLUDE_DIRS})
+endif ()
 
 #--------------------------------------------------------------------------------------------------
 # Preprocessor definitions.

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -746,6 +746,12 @@ set (foundation_utility_sources
     foundation/utility/xercesc.h
     foundation/utility/xmlelement.h
 )
+if (WITH_PARTIO)
+    list (APPEND foundation_utility_sources
+        foundation/utility/partiofile.cpp
+        foundation/utility/partiofile.h
+    )
+endif ()
 list (APPEND appleseed_sources
     ${foundation_utility_sources}
 )
@@ -1842,6 +1848,10 @@ endif ()
 
 if (WITH_DISNEY_MATERIAL)
     link_against_seexpr (appleseed)
+endif ()
+
+if (WITH_PARTIO)
+    link_against_partio (appleseed)
 endif ()
 
 target_link_libraries (appleseed

--- a/src/appleseed/foundation/math/scalar.h
+++ b/src/appleseed/foundation/math/scalar.h
@@ -79,6 +79,7 @@ static const double RcpPiSquare     =  0.1013211836423378;      // 1 / (Pi^2) = 
 static const double RcpFourPiSquare =  0.0253302959105844;      // 1 / (4 * Pi^2)
 static const double SqrtTwo         =  1.4142135623730950;      // sqrt(2)
 static const double RcpSqrtTwo      =  0.7071067811865475;      // 1 / sqrt(2) = sqrt(2) / 2
+static const double SqrtThree       =  1.7320508075688773;      // sqrt(3)
 static const double GoldenRatio     =  1.6180339887498948;      // (1 + sqrt(5)) / 2
 
 

--- a/src/appleseed/foundation/utility/partiofile.cpp
+++ b/src/appleseed/foundation/utility/partiofile.cpp
@@ -29,8 +29,6 @@
 // Interface header.
 #include "partiofile.h"
 
-// appleseed.foundation headers.
-
 // Standard headers.
 #include <cstddef>
 
@@ -53,19 +51,19 @@ PartioFile::~PartioFile()
     m_particles->release();
 }
 
-Partio::ParticleAttribute PartioFile::add_float_attribute(const std::string& name)
+Partio::ParticleAttribute PartioFile::add_float_attribute(const char* name)
 {
-    return m_particles->addAttribute(name.c_str(), Partio::FLOAT, 1);
+    return m_particles->addAttribute(name, Partio::FLOAT, 1);
 }
 
-Partio::ParticleAttribute PartioFile::add_vector_attribute(const std::string& name)
+Partio::ParticleAttribute PartioFile::add_vector_attribute(const char* name)
 {
-    return m_particles->addAttribute(name.c_str(), Partio::VECTOR, 3);
+    return m_particles->addAttribute(name, Partio::VECTOR, 3);
 }
 
-Partio::ParticleAttribute PartioFile::add_color_attribute(const string& name)
+Partio::ParticleAttribute PartioFile::add_color_attribute(const char* name)
 {
-    return m_particles->addAttribute(name.c_str(), Partio::VECTOR, 3);
+    return m_particles->addAttribute(name, Partio::VECTOR, 3);
 }
 
 Partio::ParticleIndex PartioFile::add_particle()
@@ -73,9 +71,9 @@ Partio::ParticleIndex PartioFile::add_particle()
     return m_particles->addParticle();
 }
 
-void PartioFile::write(const string& filepath) const
+void PartioFile::write(const char* filepath) const
 {
-    Partio::write(filepath.c_str(), *m_particles);
+    Partio::write(filepath, *m_particles);
 }
 
 }   // namespace foundation

--- a/src/appleseed/foundation/utility/partiofile.cpp
+++ b/src/appleseed/foundation/utility/partiofile.cpp
@@ -1,0 +1,81 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2015 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "partiofile.h"
+
+// appleseed.foundation headers.
+
+// Standard headers.
+#include <cstddef>
+
+using namespace std;
+
+namespace foundation
+{
+
+//
+// PartioFile class implementation.
+//
+
+PartioFile::PartioFile()
+{
+    m_particles = Partio::create();
+}
+
+PartioFile::~PartioFile()
+{
+    m_particles->release();
+}
+
+Partio::ParticleAttribute PartioFile::add_float_attribute(const std::string& name)
+{
+    return m_particles->addAttribute(name.c_str(), Partio::FLOAT, 1);
+}
+
+Partio::ParticleAttribute PartioFile::add_vector_attribute(const std::string& name)
+{
+    return m_particles->addAttribute(name.c_str(), Partio::VECTOR, 3);
+}
+
+Partio::ParticleAttribute PartioFile::add_color_attribute(const string& name)
+{
+    return m_particles->addAttribute(name.c_str(), Partio::VECTOR, 3);
+}
+
+Partio::ParticleIndex PartioFile::add_particle()
+{
+    return m_particles->addParticle();
+}
+
+void PartioFile::write(const string& filepath) const
+{
+    Partio::write(filepath.c_str(), *m_particles);
+}
+
+}   // namespace foundation

--- a/src/appleseed/foundation/utility/partiofile.h
+++ b/src/appleseed/foundation/utility/partiofile.h
@@ -1,0 +1,124 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2015 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef APPLESEED_FOUNDATION_UTILITY_PARTIOFILE_H
+#define APPLESEED_FOUNDATION_UTILITY_PARTIOFILE_H
+
+// appleseed.foundation headers.
+#include "foundation/core/concepts/noncopyable.h"
+#include "foundation/image/color.h"
+#include "foundation/math/vector.h"
+
+// Partio headers.
+#include <Partio.h>
+
+// Standard headers.
+#include <string>
+
+namespace foundation
+{
+
+class PartioFile
+  : public NonCopyable
+{
+  public:
+    PartioFile();
+    ~PartioFile();
+
+    Partio::ParticleAttribute add_float_attribute(const std::string& name);
+    Partio::ParticleAttribute add_vector_attribute(const std::string& name);
+    Partio::ParticleAttribute add_color_attribute(const std::string& name);
+
+    Partio::ParticleIndex add_particle();
+
+    template <typename T>
+    void set_float_attribute(
+        const Partio::ParticleIndex         particle,
+        const Partio::ParticleAttribute&    attribute,
+        const T                             value);
+
+    template <typename T>
+    void set_vector_attribute(
+        const Partio::ParticleIndex         particle,
+        const Partio::ParticleAttribute&    attribute,
+        const foundation::Vector<T,3>&      value);
+
+    template <typename T>
+    void set_color_attribute(
+        const Partio::ParticleIndex         particle,
+        const Partio::ParticleAttribute&    attribute,
+        const foundation::Color<T,3>&       value);
+
+    void write(const std::string& filepath) const;
+
+  private:
+    Partio::ParticlesDataMutable*   m_particles;
+};
+
+
+//
+// PartioFile class implementation.
+//
+
+template <typename T>
+inline void PartioFile::set_float_attribute(
+    const Partio::ParticleIndex         particle,
+    const Partio::ParticleAttribute&    attribute,
+    const T                             value)
+{
+    float* data = m_particles->dataWrite<float>(attribute, particle);
+    *data = static_cast<float>(value);
+}
+
+template <typename T>
+inline void PartioFile::set_vector_attribute(
+    const Partio::ParticleIndex         particle,
+    const Partio::ParticleAttribute&    attribute,
+    const foundation::Vector<T,3>&      value)
+{
+    float* data = m_particles->dataWrite<float>(attribute, particle);
+    data[0] = static_cast<float>(value[0]);
+    data[1] = static_cast<float>(value[1]);
+    data[2] = static_cast<float>(value[2]);
+}
+
+template <typename T>
+inline void PartioFile::set_color_attribute(
+    const Partio::ParticleIndex         particle,
+    const Partio::ParticleAttribute&    attribute,
+    const foundation::Color<T,3>&       value)
+{
+    float* data = m_particles->dataWrite<float>(attribute, particle);
+    data[0] = static_cast<float>(value[0]);
+    data[1] = static_cast<float>(value[1]);
+    data[2] = static_cast<float>(value[2]);
+}
+
+}       // namespace foundation
+
+#endif  // !APPLESEED_FOUNDATION_UTILITY_PARTIOFILE_H

--- a/src/appleseed/foundation/utility/partiofile.h
+++ b/src/appleseed/foundation/utility/partiofile.h
@@ -37,9 +37,6 @@
 // Partio headers.
 #include <Partio.h>
 
-// Standard headers.
-#include <string>
-
 namespace foundation
 {
 
@@ -50,9 +47,9 @@ class PartioFile
     PartioFile();
     ~PartioFile();
 
-    Partio::ParticleAttribute add_float_attribute(const std::string& name);
-    Partio::ParticleAttribute add_vector_attribute(const std::string& name);
-    Partio::ParticleAttribute add_color_attribute(const std::string& name);
+    Partio::ParticleAttribute add_float_attribute(const char* name);
+    Partio::ParticleAttribute add_vector_attribute(const char* name);
+    Partio::ParticleAttribute add_color_attribute(const char* name);
 
     Partio::ParticleIndex add_particle();
 
@@ -74,7 +71,7 @@ class PartioFile
         const Partio::ParticleAttribute&    attribute,
         const foundation::Color<T,3>&       value);
 
-    void write(const std::string& filepath) const;
+    void write(const char* filepath) const;
 
   private:
     Partio::ParticlesDataMutable*   m_particles;

--- a/src/appleseed/renderer/modeling/bssrdf/sss.h
+++ b/src/appleseed/renderer/modeling/bssrdf/sss.h
@@ -143,9 +143,17 @@ double gaussian_profile_pdf(
 // Dipole diffusion profile.
 //
 
-double dipole_max_radius(
-    const double        sigma_tr);
+double dipole_pdf(const double r, const double sigma_tr);
 
+double dipole_cdf(const double r, const double sigma_tr);
+
+double dipole_sample(
+    const double    u,                      // uniform random sample in [0,1)
+    const double    sigma_tr,               // effective_extinction_coefficient
+    const double    eps = 0.0001,           // root precision
+    const size_t    max_iterations = 10);   // max root refinement iterations
+
+double dipole_max_radius(const double sigma_tr);
 
 //
 // Normalized diffusion profile.
@@ -216,14 +224,11 @@ inline double compute_alpha_prime(
     const ComputeRdFun  rd_fun,
     const double        rd)
 {
-    if (rd == 0.0)
-        return 0.0;
-
     double x0 = 0.0, x1 = 1.0, xmid;
 
     // For now simple bisection.
     // todo: switch to faster algorithm.
-    for (size_t i = 0; i < 50; ++i)
+    for (size_t i = 0; i < 20; ++i)
     {
         xmid = 0.5 * (x0 + x1);
         const double x = rd_fun(xmid);
@@ -242,6 +247,9 @@ void compute_absorption_and_scattering(
     Spectrum&           sigma_a,
     Spectrum&           sigma_s)
 {
+    assert(g > -1.0);
+    assert(g < 1.0);
+
     sigma_a.resize(rd.size());
     sigma_s.resize(rd.size());
 
@@ -252,8 +260,18 @@ void compute_absorption_and_scattering(
         assert(rd[i] >= 0.0f);
         assert(rd[i] <= 1.0f);
 
+        if (rd[i] == 0.0f)
+        {
+            // rd == 0 -> alpha_prime == 0 -> sigma_s == 0
+            sigma_s[i] = 0.0f;
+            sigma_a[i] = 1.0 / (foundation::SqrtThree * dmfp);
+            continue;
+        }
+
         // Find alpha' by numerically inverting Rd(alpha').
         const double alpha_prime = compute_alpha_prime(rd_fun, rd[i]);
+        assert(alpha_prime > 0.0);
+        assert(alpha_prime < 1.0);
 
         // Compute reduced extinction coefficient.
         const double sigma_t_prime =

--- a/src/cmake/Modules/FindPartio.cmake
+++ b/src/cmake/Modules/FindPartio.cmake
@@ -1,0 +1,64 @@
+
+#
+# This source file is part of appleseed.
+# Visit http://appleseedhq.net/ for additional information and resources.
+#
+# This software is released under the MIT license.
+#
+# Copyright (c) 2015 Esteban Tovagliari, The appleseedhq Organization
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+
+#
+# Find Partio headers and libraries.
+#
+# This module defines the following variables:
+#
+#   PARTIO_FOUND            True if Partio was found
+#   PARTIO_INCLUDE_DIRS     Where to find Partio header files
+#   PARTIO_LIBRARIES        List of Partio libraries to link against
+#
+
+include (FindPackageHandleStandardArgs)
+
+find_path (PARTIO_INCLUDE_DIR NAMES Partio.h)
+
+find_library (PARTIO_LIBRARY NAMES partio)
+
+# Handle the QUIETLY and REQUIRED arguments and set PARTIO_FOUND.
+find_package_handle_standard_args (PARTIO DEFAULT_MSG
+    PARTIO_INCLUDE_DIR
+    PARTIO_LIBRARY
+)
+
+# Set the output variables.
+if (PARTIO_FOUND)
+    set (PARTIO_INCLUDE_DIRS ${PARTIO_INCLUDE_DIR})
+    set (PARTIO_LIBRARIES ${PARTIO_LIBRARY})
+else ()
+    set (PARTIO_INCLUDE_DIRS)
+    set (PARTIO_LIBRARIES)
+endif ()
+
+mark_as_advanced (
+    PARTIO_INCLUDE_DIR
+    PARTIO_LIBRARY
+)

--- a/src/cmake/config/linux-gcc.txt
+++ b/src/cmake/config/linux-gcc.txt
@@ -208,6 +208,9 @@ macro (link_against_seexpreditor target)
     target_link_libraries (${target} ${SEEXPREDITOR_LIBRARIES})
 endmacro ()
 
+macro (link_against_partio target)
+    target_link_libraries (${target} ${PARTIO_LIBRARIES})
+endmacro ()
 
 #--------------------------------------------------------------------------------------------------
 # Copy a target binary to the sandbox.

--- a/src/cmake/config/mac-clang.txt
+++ b/src/cmake/config/mac-clang.txt
@@ -187,6 +187,9 @@ macro (link_against_seexpreditor target)
     target_link_libraries (${target} ${SEEXPREDITOR_LIBRARIES})
 endmacro ()
 
+macro (link_against_partio target)
+    target_link_libraries (${target} ${PARTIO_LIBRARIES})
+endmacro ()
 
 #--------------------------------------------------------------------------------------------------
 # Copy a target binary to the sandbox.

--- a/src/cmake/config/win-vs.txt
+++ b/src/cmake/config/win-vs.txt
@@ -331,6 +331,9 @@ macro (link_against_seexpreditor target)
     endif ()
 endmacro ()
 
+macro (link_against_partio target)
+    target_link_libraries (${target} ${PARTIO_LIBRARIES})
+endmacro ()
 
 #--------------------------------------------------------------------------------------------------
 # Copy a target binary to the sandbox.


### PR DESCRIPTION
- Added Partio as an optional dependency (OFF by default). 
Used in unit tests to produce "plots" like this:

![dipole_sampling_old_new_vis1](https://cloud.githubusercontent.com/assets/409013/9657882/4a9dcd26-5245-11e5-8cb7-0cc3ef9e0301.png)

- Refactored numerical CDF inversion code.
- Reduced BSSRDF reparameterization precision.
- Added new experimental dipole sampling code (not being used).
- Handled special cases and added asserts in BSSRDF reparameterization code.
