### PR TITLE
Add support for optional studio and cli user settings files.

### DIFF
--- a/src/appleseed.cli/main.cpp
+++ b/src/appleseed.cli/main.cpp
@@ -90,14 +90,36 @@ namespace
     void load_settings()
     {
         const filesystem::path root_path(Application::get_root_path());
-        const filesystem::path settings_file_path = root_path / "settings" / "appleseed.cli.xml";
         const filesystem::path schema_file_path = root_path / "schemas" / "settings.xsd";
 
         SettingsFileReader reader(g_logger);
-        reader.read(
-            settings_file_path.string().c_str(),
-            schema_file_path.string().c_str(),
-            g_settings);
+
+        // First try to read the settings from the user path.
+        if (const char* p = Application::get_user_settings_path())
+        {
+            const filesystem::path user_settings_path(p);
+            const filesystem::path user_settings_file_path = user_settings_path / "appleseed.cli.xml";
+
+            if (reader.read(
+                    user_settings_file_path.string().c_str(),
+                    schema_file_path.string().c_str(),
+                    g_settings))
+            {
+                RENDERER_LOG_INFO("successfully loaded settings from %s.", user_settings_file_path.string().c_str());
+                return;
+            }
+        }
+
+        // As a fallback, try to read the settings from the appleseed install.
+        const filesystem::path settings_file_path = root_path / "settings" / "appleseed.cli.xml";
+
+        if (reader.read(
+                settings_file_path.string().c_str(),
+                schema_file_path.string().c_str(),
+                g_settings))
+        {
+            RENDERER_LOG_INFO("successfully loaded settings from %s.", settings_file_path.string().c_str());
+        }
     }
 
     void apply_settings()

--- a/src/appleseed.shared/application/application.cpp
+++ b/src/appleseed.shared/application/application.cpp
@@ -137,6 +137,40 @@ const char* Application::get_root_path()
     return root_path_buffer;
 }
 
+const char* Application::get_user_settings_path()
+{
+    static char user_settings_buffer[FOUNDATION_MAX_PATH_LENGTH + 1];
+    static bool user_settings_initialized = false;
+
+    if (!user_settings_initialized)
+    {
+// Windows.
+#if defined _WIN32
+
+        return 0;
+
+// OS X.
+#elif defined __APPLE__
+
+        return 0;
+
+#elif defined __linux__ || defined __FreeBSD__
+
+        filesystem::path p(get_home_directory());
+        p /= ".appleseed/settings";
+        copy_directory_path_to_buffer(p, user_settings_buffer);
+
+#else
+
+        #error Unsupported platform.
+
+#endif
+        user_settings_initialized = true;
+    }
+
+    return user_settings_buffer;
+}
+
 const char* Application::get_tests_root_path()
 {
     static char tests_root_path_buffer[FOUNDATION_MAX_PATH_LENGTH + 1];

--- a/src/appleseed.shared/application/application.h
+++ b/src/appleseed.shared/application/application.h
@@ -64,6 +64,9 @@ class SHAREDDLL Application
     // an empty string if the application is not correctly installed.
     static const char* get_root_path();
 
+    // Return the user settings path.
+    static const char* get_user_settings_path();
+
     // Return the root path of the application's tests.
     static const char* get_tests_root_path();
 

--- a/src/appleseed/foundation/platform/path.h
+++ b/src/appleseed/foundation/platform/path.h
@@ -83,6 +83,8 @@ APPLESEED_DLLSYMBOL const char* get_executable_path();
 // Return the path to the directory containing the application's executable. NOT thread-safe.
 APPLESEED_DLLSYMBOL const char* get_executable_directory();
 
+// Return the path to the user's home directory.
+APPLESEED_DLLSYMBOL const char* get_home_directory();
 
 //
 // Operations on boost::filesystem::path objects.


### PR DESCRIPTION
Suggested by @danfe on the dev mailing list.

On linux, appleseed.cli and appleseed.studio now try to read and save settings files first to $HOME/.appleseed/settings and if not possible, use the default install settings path.

Useful for system installs, where appleseed_install_dir/settings may not be writeable.
