### PR TITLE
Unbreak the build when WITH_OSL is OFF (default setting)

### DIFF
--- a/src/appleseed/renderer/kernel/shading/shadingcontext.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingcontext.cpp
@@ -31,10 +31,10 @@
 #include "shadingcontext.h"
 
 // appleseed.renderer headers.
-#include "renderer/kernel/shading/closures.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/modeling/input/inputevaluator.h"
 #ifdef APPLESEED_WITH_OSL
+#include "renderer/kernel/shading/closures.h"
 #include "renderer/modeling/shadergroup/shadergroup.h"
 #endif
 


### PR DESCRIPTION
Inclusion of `renderer/kernel/shading/closures.h` should be guarded by `APPLESEED_WITH_OSL` macro because that header file includes OSL headers.

Lest us forget to test the builds against default settings. ;-)