### PR TITLE
Some minor improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ find_package (Boost 1.47 REQUIRED ${BOOST_NEEDED_LIBS})
 
 add_definitions (-DBOOST_FILESYSTEM_VERSION=3 -DBOOST_FILESYSTEM_NO_DEPRECATED)
 
-include_directories (${Boost_INCLUDE_DIRS})
+include_directories (SYSTEM ${Boost_INCLUDE_DIRS})
 link_directories (${Boost_LIBRARY_DIRS})
 
 

--- a/src/appleseed/foundation/platform/x86timer.cpp
+++ b/src/appleseed/foundation/platform/x86timer.cpp
@@ -105,16 +105,26 @@ uint64 X86Timer::read_start()
 // gcc.
 #elif defined __GNUC__
 
-    uint32 h, l;
+    uint32 h, l, _dummy;
 
+    // %ebx may be used to point to GOT for PIC on 32-bit x86, so it must be
+    // preserved (cf. src/appleseed/foundation/platform/system.cpp).
+    // We force in-order execution of the RDTSC instruction by calling CPUID
+    // first.  Reference: "Using the RDTSC Instruction for Performance
+    // Monitoring", Section 3.1, p. 3 [Intel 1997].
     asm volatile (
-        "cpuid\n\t"                         // force in-order execution of the RDTSC instruction
-        "rdtsc\n\t"
-        "mov %%edx, %0\n\t"
-        "mov %%eax, %1\n\t"
-        : "=r" (h), "=r" (l)                // outputs
-        :                                   // inputs
-        : "%rax", "%rbx", "%rcx", "%rdx"    // clobbered registers
+#if __x86_64__
+        "movq %%rbx, %q2\n\t"
+        "cpuid\n\t"
+        "xchgq %%rbx, %q2\n\t"
+#else
+        "movl %%ebx, %2\n\t"
+        "cpuid\n\t"
+        "xchgl %%ebx, %2\n\t"
+#endif
+        "rdtsc"
+        : "=d" (h), "=a" (l), "=r" (_dummy)
+      : : "ecx"
     );
 
     return (static_cast<uint64>(h) << 32) | l;
@@ -158,16 +168,27 @@ uint64 X86Timer::read_end()
 // gcc.
 #elif defined __GNUC__
 
-    uint32 h, l;
+    uint32 h, l, _dummy;
 
+    // Here we call CPUID to prevent instructions coming afterward from
+    // executing before the RDTSCP instruction.  Reference: "How to
+    // Benchmark Code Execution Times on Intel IA-32 and IA-64 Instruction
+    // Set Architectures", Section 3.2.1, p. 16 [Intel 2010].
     asm volatile (
         "rdtscp\n\t"
-        "mov %%edx, %0\n\t"
-        "mov %%eax, %1\n\t"
-        "cpuid\n\t"                         // prevent instructions coming afterward from executing before the RDTSCP instruction
-        : "=r" (h), "=r" (l)                // outputs
-        :                                   // inputs
-        : "%rax", "%rbx", "%rcx", "%rdx"    // clobbered registers
+        "movl %%edx, %0\n\t"
+        "movl %%eax, %1\n\t"
+#if __x86_64__
+        "movq %%rbx, %q2\n\t"
+        "cpuid\n\t"
+        "xchgq %%rbx, %q2\n\t"
+#else
+        "movl %%ebx, %2\n\t"
+        "cpuid\n\t"
+        "xchgl %%ebx, %2\n\t"
+#endif
+        : "=m" (h), "=m" (l), "=r" (_dummy)
+      : : "eax", "ecx", "edx"
     );
 
     return (static_cast<uint64>(h) << 32) | l;

--- a/src/appleseed/renderer/modeling/frame/frame.cpp
+++ b/src/appleseed/renderer/modeling/frame/frame.cpp
@@ -259,18 +259,26 @@ namespace
         for (size_t i = 0; i < pixel_count; ++i)
         {
             // Load the pixel color.
+#ifdef APPLESEED_USE_SSE
             SSE_ALIGN Color4f color;
+#else
+            Color4f color;
+#endif
             tile.get_pixel(i, color);
 
             // Apply color space conversion.
             switch (ColorSpace)
             {
               case ColorSpaceSRGB:
+#ifdef APPLESEED_USE_SSE
                 {
                     const float old_alpha = color[3];
                     _mm_store_ps(&color[0], fast_linear_rgb_to_srgb(_mm_load_ps(&color[0])));
                     color[3] = old_alpha;
                 }
+#else
+                color.rgb() = fast_linear_rgb_to_srgb(color.rgb());
+#endif
                 break;
 
               case ColorSpaceCIEXYZ:


### PR DESCRIPTION
1. Guard x86-specific SIMD code with `#ifdef APPLESEED_USE_SSE`.  This helps to get PowerPC port going.
2. Unbreak the build in 32-bit mode with GCC: improvements for x86 timer code as discussed earlier; GCC-only for now.
3. Declare Boost includes are "system": on modern compilers it is no-op, but 1) it fixes the build against GCC 4.2.1 which is still the default on FreeBSD 9.X, and 2) guards us from potential warnings is Boost headers in the future.  Strictly speaking, all 3rd-party headers should be marked as `SYSTEM`.