### PR TITLE
appleseed.python small improvements and fixes

### DIFF
--- a/sandbox/samples/python/basic/basic.py
+++ b/sandbox/samples/python/basic/basic.py
@@ -72,7 +72,7 @@ def build_project():
     assembly.surface_shaders().insert(asr.SurfaceShader("physical_surface_shader", "physical_surface_shader"))
 
     # Create a material called "gray_material" and insert it into the assembly.
-    assembly.materials().insert(asr.Material("gray_material", { "surface_shader" : "physical_surface_shader",
+    assembly.materials().insert(asr.Material("generic_material", "gray_material", { "surface_shader" : "physical_surface_shader",
                                                                 "bsdf" : "diffuse_gray_brdf" }))
 
     #------------------------------------------------------------------------

--- a/src/appleseed.python/bindassembly.cpp
+++ b/src/appleseed.python/bindassembly.cpp
@@ -44,24 +44,25 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
-    auto_release_ptr<Assembly> create_assembly(const std::string& name)
+    auto_release_ptr<Assembly> create_assembly(const string& name)
     {
         return AssemblyFactory().create(name.c_str(), ParamArray());
     }
 
     auto_release_ptr<Assembly> create_assembly_with_params(
-        const std::string&  name,
+        const string&       name,
         const bpy::dict&    params)
     {
         return AssemblyFactory().create(name.c_str(), bpy_dict_to_param_array(params));
     }
 
     auto_release_ptr<Assembly> create_assembly_with_model_and_params(
-        const std::string&  model,
-        const std::string&  name,
+        const string&       model,
+        const string&       name,
         const bpy::dict&    params)
     {
         AssemblyFactoryRegistrar factories;
@@ -79,9 +80,9 @@ namespace
     }
 
     auto_release_ptr<AssemblyInstance> create_assembly_instance(
-        const std::string&  name,
+        const string&       name,
         const bpy::dict&    params,
-        const std::string&  assembly_name)
+        const string&       assembly_name)
     {
         return
             AssemblyInstanceFactory::create(
@@ -95,7 +96,7 @@ namespace
         return instance->transform_sequence();
     }
 
-    std::string get_assembly_name(AssemblyInstance* instance)
+    string get_assembly_name(AssemblyInstance* instance)
     {
         return instance->get_assembly_name();
     }

--- a/src/appleseed.python/bindbsdf.cpp
+++ b/src/appleseed.python/bindbsdf.cpp
@@ -42,21 +42,22 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
-    auto_release_ptr<BSDF> create_bsdf(const std::string&   bsdf_type,
-                                       const std::string&   name,
-                                       const bpy::dict&     params)
+    auto_release_ptr<BSDF> create_bsdf(const string&    model,
+                                       const string&    name,
+                                       const bpy::dict& params)
     {
         BSDFFactoryRegistrar factories;
-        const IBSDFFactory* factory = factories.lookup(bsdf_type.c_str());
+        const IBSDFFactory* factory = factories.lookup(model.c_str());
 
         if (factory)
             return factory->create(name.c_str(), bpy_dict_to_param_array(params));
         else
         {
-            PyErr_SetString(PyExc_RuntimeError, "BSDF type not found");
+            PyErr_SetString(PyExc_RuntimeError, "BSDF model not found");
             bpy::throw_error_already_set();
         }
 

--- a/src/appleseed.python/bindbssrdf.cpp
+++ b/src/appleseed.python/bindbssrdf.cpp
@@ -41,21 +41,22 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
-    auto_release_ptr<BSSRDF> create_bssrdf(const std::string&   bssrdf_type,
-                                           const std::string&   name,
-                                           const bpy::dict&     params)
+    auto_release_ptr<BSSRDF> create_bssrdf(const string&    model,
+                                           const string&    name,
+                                           const bpy::dict& params)
     {
         BSSRDFFactoryRegistrar factories;
-        const IBSSRDFFactory* factory = factories.lookup(bssrdf_type.c_str());
+        const IBSSRDFFactory* factory = factories.lookup(model.c_str());
 
         if (factory)
             return factory->create(name.c_str(), bpy_dict_to_param_array(params));
         else
         {
-            PyErr_SetString(PyExc_RuntimeError, "BSSRDF type not found");
+            PyErr_SetString(PyExc_RuntimeError, "BSSRDF model not found");
             bpy::throw_error_already_set();
         }
 

--- a/src/appleseed.python/bindcamera.cpp
+++ b/src/appleseed.python/bindcamera.cpp
@@ -38,22 +38,23 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
     auto_release_ptr<Camera> create_camera(
-        const std::string&  camera_type,
-        const std::string&  name,
+        const string&       model,
+        const string&       name,
         const bpy::dict&    params)
     {
         CameraFactoryRegistrar factories;
-        const ICameraFactory* factory = factories.lookup(camera_type.c_str());
+        const ICameraFactory* factory = factories.lookup(model.c_str());
 
         if (factory)
             return factory->create(name.c_str(), bpy_dict_to_param_array(params));
         else
         {
-            PyErr_SetString(PyExc_RuntimeError, "Camera type not found");
+            PyErr_SetString(PyExc_RuntimeError, "Camera model not found");
             bpy::throw_error_already_set();
         }
 

--- a/src/appleseed.python/bindedf.cpp
+++ b/src/appleseed.python/bindedf.cpp
@@ -39,21 +39,22 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
-    auto_release_ptr<EDF> create_edf(const std::string& edf_type,
-                                     const std::string& name,
+    auto_release_ptr<EDF> create_edf(const string&      model,
+                                     const string&      name,
                                      const bpy::dict&   params)
     {
         EDFFactoryRegistrar factories;
-        const IEDFFactory* factory = factories.lookup(edf_type.c_str());
+        const IEDFFactory* factory = factories.lookup(model.c_str());
 
         if (factory)
             return factory->create(name.c_str(), bpy_dict_to_param_array(params));
         else
         {
-            PyErr_SetString(PyExc_RuntimeError, "EDF type not found");
+            PyErr_SetString(PyExc_RuntimeError, "EDF model not found");
             bpy::throw_error_already_set();
         }
 

--- a/src/appleseed.python/bindentity.cpp
+++ b/src/appleseed.python/bindentity.cpp
@@ -47,6 +47,7 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
@@ -65,7 +66,7 @@ namespace
         return vec.get_by_index(index);
     }
 
-    Entity* get_entity_map_item(EntityMap& map, const std::string& key)
+    Entity* get_entity_map_item(EntityMap& map, const string& key)
     {
         return map.get_by_name(key.c_str());
     }

--- a/src/appleseed.python/bindenvironment.cpp
+++ b/src/appleseed.python/bindenvironment.cpp
@@ -41,21 +41,22 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
-    auto_release_ptr<EnvironmentEDF> create_environment_edf(const std::string env_type,
-                                                            const std::string& name,
+    auto_release_ptr<EnvironmentEDF> create_environment_edf(const string&    model,
+                                                            const string&    name,
                                                             const bpy::dict& params)
     {
         EnvironmentEDFFactoryRegistrar factories;
-        const IEnvironmentEDFFactory* factory = factories.lookup(env_type.c_str());
+        const IEnvironmentEDFFactory* factory = factories.lookup(model.c_str());
 
         if (factory)
             return factory->create(name.c_str(), bpy_dict_to_param_array(params));
         else
         {
-            PyErr_SetString(PyExc_RuntimeError, "EnvironmentEDF type not found");
+            PyErr_SetString(PyExc_RuntimeError, "EnvironmentEDF model not found");
             bpy::throw_error_already_set();
         }
 

--- a/src/appleseed.python/bindframe.cpp
+++ b/src/appleseed.python/bindframe.cpp
@@ -42,11 +42,12 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
     auto_release_ptr<Frame> create_frame(
-        const std::string&  name,
+        const string&       name,
         const bpy::dict&    params)
     {
         return FrameFactory::create(name.c_str(), bpy_dict_to_param_array(params));

--- a/src/appleseed.python/bindlight.cpp
+++ b/src/appleseed.python/bindlight.cpp
@@ -40,21 +40,22 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
-    auto_release_ptr<Light> create_light(const std::string& light_type,
-                                         const std::string& name,
+    auto_release_ptr<Light> create_light(const string&      model,
+                                         const string&      name,
                                          const bpy::dict&   params)
     {
         LightFactoryRegistrar factories;
-        const ILightFactory* factory = factories.lookup(light_type.c_str());
+        const ILightFactory* factory = factories.lookup(model.c_str());
 
         if (factory)
             return factory->create(name.c_str(), bpy_dict_to_param_array(params));
         else
         {
-            PyErr_SetString(PyExc_RuntimeError, "Light type not found");
+            PyErr_SetString(PyExc_RuntimeError, "Light model not found");
             bpy::throw_error_already_set();
         }
 

--- a/src/appleseed.python/bindmaterial.cpp
+++ b/src/appleseed.python/bindmaterial.cpp
@@ -47,10 +47,22 @@ using namespace std;
 namespace
 {
     auto_release_ptr<Material> create_material(
-        const string&   name,
-        const bpy::dict& params)
+        const string&       model,
+        const string&       name,
+        const bpy::dict&    params)
     {
-        return GenericMaterialFactory().create(name.c_str(), bpy_dict_to_param_array(params));
+        MaterialFactoryRegistrar factories;
+        const IMaterialFactory* factory = factories.lookup(model.c_str());
+
+        if (factory)
+            return factory->create(name.c_str(), bpy_dict_to_param_array(params));
+        else
+        {
+            PyErr_SetString(PyExc_RuntimeError, "Material model not found");
+            bpy::throw_error_already_set();
+        }
+
+        return auto_release_ptr<Material>();
     }
 }
 

--- a/src/appleseed.python/bindmeshobject.cpp
+++ b/src/appleseed.python/bindmeshobject.cpp
@@ -45,11 +45,12 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
     auto_release_ptr<MeshObject> create_mesh_obj(
-        const std::string&  name,
+        const string&       name,
         const bpy::dict&    params)
     {
         return MeshObjectFactory::create(name.c_str(), bpy_dict_to_param_array(params));
@@ -57,7 +58,7 @@ namespace
 
     bpy::list read_mesh_objects(
         const bpy::list&    search_paths,
-        const std::string&  base_object_name,
+        const string&       base_object_name,
         const bpy::dict&    params)
     {
         SearchPaths paths;
@@ -97,8 +98,8 @@ namespace
 
     bool write_mesh_object(
         const MeshObject*   object,
-        const std::string&  object_name,
-        const std::string&  filename)
+        const string&       object_name,
+        const string&       filename)
     {
         return MeshObjectWriter::write(*object, object_name.c_str(), filename.c_str());
     }

--- a/src/appleseed.python/bindobject.cpp
+++ b/src/appleseed.python/bindobject.cpp
@@ -43,6 +43,7 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
@@ -74,9 +75,9 @@ namespace
     }
 
     auto_release_ptr<ObjectInstance> create_obj_instance_with_back_mat(
-        const std::string&              name,
+        const string&                   name,
         const bpy::dict&                params,
-        const std::string&              object_name,
+        const string&                   object_name,
         const UnalignedTransformd44&    transform,
         const bpy::dict&                front_material_mappings,
         const bpy::dict&                back_material_mappings)
@@ -92,9 +93,9 @@ namespace
     }
 
     auto_release_ptr<ObjectInstance> create_obj_instance(
-        const std::string&              name,
+        const string&                   name,
         const bpy::dict&                params,
-        const std::string&              object_name,
+        const string&                   object_name,
         const UnalignedTransformd44&    transform,
         const bpy::dict&                front_material_mappings)
     {
@@ -113,7 +114,7 @@ namespace
         return UnalignedTransformd44(obj->get_transform());
     }
 
-    std::string obj_inst_get_obj_name(const ObjectInstance* obj)
+    string obj_inst_get_obj_name(const ObjectInstance* obj)
     {
         return obj->get_object_name();
     }

--- a/src/appleseed.python/bindproject.cpp
+++ b/src/appleseed.python/bindproject.cpp
@@ -48,10 +48,11 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
-    auto_release_ptr<Project> create_project(const std::string& name)
+    auto_release_ptr<Project> create_project(const string& name)
     {
         return ProjectFactory::create(name.c_str());
     }
@@ -119,13 +120,13 @@ namespace
         return ProjectFileWriter::write(*project, filepath, opts);
     }
 
-    auto_release_ptr<Configuration> create_config(const std::string& name)
+    auto_release_ptr<Configuration> create_config(const string& name)
     {
         return ConfigurationFactory::create(name.c_str());
     }
 
     auto_release_ptr<Configuration> create_config_with_params(
-        const std::string&                  name,
+        const string&                       name,
         const bpy::dict&                    params)
     {
         return ConfigurationFactory::create(name.c_str(), bpy_dict_to_param_array(params));

--- a/src/appleseed.python/bindshadergroup.cpp
+++ b/src/appleseed.python/bindshadergroup.cpp
@@ -47,20 +47,21 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
-    auto_release_ptr<ShaderGroup> create_shader_group(const std::string& name)
+    auto_release_ptr<ShaderGroup> create_shader_group(const string& name)
     {
         return ShaderGroupFactory::create(name.c_str());
     }
 
     void add_shader(
-        ShaderGroup*        sg,
-        const std::string&  type,
-        const std::string&  name,
-        const std::string&  layer,
-        bpy::dict           params)
+        ShaderGroup*   sg,
+        const string&  type,
+        const string&  name,
+        const string&  layer,
+        bpy::dict      params)
     {
         sg->add_shader(type.c_str(), name.c_str(), layer.c_str(), bpy_dict_to_param_array(params));
     }
@@ -92,12 +93,12 @@ namespace
             return m_shader_query->open(shader_name);
         }
 
-        std::string get_shader_name() const
+        string get_shader_name() const
         {
             return m_shader_query->get_shader_name();
         }
 
-        std::string get_shader_type() const
+        string get_shader_type() const
         {
             return m_shader_query->get_shader_type();
         }

--- a/src/appleseed.python/bindsurfaceshader.cpp
+++ b/src/appleseed.python/bindsurfaceshader.cpp
@@ -39,12 +39,13 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
     auto_release_ptr<SurfaceShader> create_surface_shader(
-        const std::string& model,
-        const std::string& name)
+        const string& model,
+        const string& name)
     {
         SurfaceShaderFactoryRegistrar factories;
         const ISurfaceShaderFactory* factory = factories.lookup(model.c_str());
@@ -53,7 +54,7 @@ namespace
             return factory->create(name.c_str(), ParamArray());
         else
         {
-            PyErr_SetString(PyExc_RuntimeError, "SurfaceShader type not found");
+            PyErr_SetString(PyExc_RuntimeError, "SurfaceShader model not found");
             bpy::throw_error_already_set();
         }
 
@@ -61,9 +62,9 @@ namespace
     }
 
     auto_release_ptr<SurfaceShader> create_surface_shader_with_params(
-        const std::string&    model,
-        const std::string&    name,
-        const bpy::dict&      params)
+        const string&        model,
+        const string&        name,
+        const bpy::dict&     params)
     {
         SurfaceShaderFactoryRegistrar factories;
         const ISurfaceShaderFactory* factory = factories.lookup(model.c_str());
@@ -72,7 +73,7 @@ namespace
             return factory->create(name.c_str(), bpy_dict_to_param_array(params));
         else
         {
-            PyErr_SetString(PyExc_RuntimeError, "SurfaceShader type not found");
+            PyErr_SetString(PyExc_RuntimeError, "SurfaceShader model not found");
             bpy::throw_error_already_set();
         }
 

--- a/src/appleseed.python/bindtexture.cpp
+++ b/src/appleseed.python/bindtexture.cpp
@@ -44,17 +44,18 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
     auto_release_ptr<Texture> create_texture(
-        const std::string&              texture_type,
-        const std::string&              name,
-        const bpy::dict&                params,
-        const bpy::list&                search_paths)
+        const string&              model,
+        const string&              name,
+        const bpy::dict&           params,
+        const bpy::list&           search_paths)
     {
         TextureFactoryRegistrar factories;
-        const ITextureFactory* factory = factories.lookup(texture_type.c_str());
+        const ITextureFactory* factory = factories.lookup(model.c_str());
 
         if (factory)
         {
@@ -76,7 +77,7 @@ namespace
         }
         else
         {
-            PyErr_SetString(PyExc_RuntimeError, "EDF type not found");
+            PyErr_SetString(PyExc_RuntimeError, "Texture model not found");
             bpy::throw_error_already_set();
         }
 
@@ -84,9 +85,9 @@ namespace
     }
 
     auto_release_ptr<TextureInstance> create_texture_instance(
-        const std::string&              name,
+        const string&                   name,
         const bpy::dict&                params,
-        const std::string&              texture_name,
+        const string&                   texture_name,
         const UnalignedTransformd44&    transform)
     {
         return
@@ -102,7 +103,7 @@ namespace
         return UnalignedTransformd44(tx->get_transform());
     }
 
-    std::string texture_inst_get_texture_name(const TextureInstance* tx)
+    string texture_inst_get_texture_name(const TextureInstance* tx)
     {
         return tx->get_texture_name();
     }

--- a/src/appleseed.python/dict2dict.cpp
+++ b/src/appleseed.python/dict2dict.cpp
@@ -44,6 +44,7 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
+using namespace std;
 
 namespace
 {
@@ -186,7 +187,7 @@ namespace
         return result;
     }
 
-    bpy::object obj_from_string(const std::string& str)
+    bpy::object obj_from_string(const string& str)
     {
         // try to guess the type of the value represented by str.
 


### PR DESCRIPTION
- Replace 'type' by 'model' in python constructors for consistency with the rest of appleseed.
- Removed std qualifiers.
- Fixed wrong error message.
- Allow creating OSL and DIsney materials from python.