### PR TITLE
Added exposure parameter to some appleseed lights and latlong environment

### DIFF
--- a/src/appleseed/renderer/modeling/light/directionallight.cpp
+++ b/src/appleseed/renderer/modeling/light/directionallight.cpp
@@ -48,6 +48,7 @@
 #include "foundation/utility/containers/specializedarrays.h"
 
 // Standard headers.
+#include <cmath>
 #include <cstddef>
 
 // Forward declarations.
@@ -79,6 +80,7 @@ namespace
         {
             m_inputs.declare("irradiance", InputFormatSpectralIlluminance);
             m_inputs.declare("irradiance_multiplier", InputFormatScalar, "1.0");
+            m_inputs.declare("exposure", InputFormatScalar, "0.0");
         }
 
         virtual void release() APPLESEED_OVERRIDE
@@ -99,8 +101,13 @@ namespace
             if (!Light::on_frame_begin(project, assembly, abort_switch))
                 return false;
 
-            if (!check_uniform("irradiance") || !check_uniform("irradiance_multiplier"))
+            if (
+                !check_uniform("irradiance") ||
+                !check_uniform("irradiance_multiplier") ||
+                !check_uniform("exposure"))
+            {
                 return false;
+            }
 
             check_non_zero_emission("irradiance", "irradiance_multiplier");
 
@@ -110,7 +117,9 @@ namespace
             m_safe_scene_diameter = scene_data.m_safe_diameter;
 
             m_inputs.evaluate_uniforms(&m_values);
-            m_values.m_irradiance *= static_cast<float>(m_values.m_irradiance_multiplier);
+            m_values.m_irradiance *=
+                static_cast<float>(
+                    m_values.m_irradiance_multiplier * pow(2.0, m_values.m_exposure));
 
             return true;
         }
@@ -203,6 +212,7 @@ namespace
         {
             Spectrum    m_irradiance;               // emitted irradiance in W.m^-2
             double      m_irradiance_multiplier;    // emitted irradiance multiplier
+            double      m_exposure;                 // emitted irradiance multiplier in f-stops
         };
 
         Vector3d        m_scene_center;             // world space
@@ -284,6 +294,17 @@ DictionaryArray DirectionalLightFactory::get_input_metadata() const
             .insert("use", "optional")
             .insert("default", "1.0")
             .insert("help", "Light intensity multiplier"));
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "exposure")
+            .insert("label", "Exposure")
+            .insert("type", "numeric")
+            .insert("use", "optional")
+            .insert("default", "0.0")
+            .insert("min_value", "-64.0")
+            .insert("max_value", "64.0")
+            .insert("help", "Light exposure"));
 
     add_common_input_metadata(metadata);
 

--- a/src/appleseed/renderer/modeling/light/pointlight.cpp
+++ b/src/appleseed/renderer/modeling/light/pointlight.cpp
@@ -43,12 +43,16 @@
 #include "foundation/utility/containers/dictionary.h"
 #include "foundation/utility/containers/specializedarrays.h"
 
+// Standard headers.
+#include <cmath>
+
 // Forward declarations.
 namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class Assembly; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
+using namespace std;
 
 namespace renderer
 {
@@ -72,6 +76,7 @@ namespace
         {
             m_inputs.declare("intensity", InputFormatSpectralIlluminance);
             m_inputs.declare("intensity_multiplier", InputFormatScalar, "1.0");
+            m_inputs.declare("exposure", InputFormatScalar, "0.0");
         }
 
         virtual void release() APPLESEED_OVERRIDE
@@ -92,13 +97,20 @@ namespace
             if (!Light::on_frame_begin(project, assembly, abort_switch))
                 return false;
 
-            if (!check_uniform("intensity") || !check_uniform("intensity_multiplier"))
+            if (
+                !check_uniform("intensity") ||
+                !check_uniform("intensity_multiplier") ||
+                !check_uniform("exposure"))
+            {
                 return false;
+            }
 
             check_non_zero_emission("intensity", "intensity_multiplier");
 
             m_inputs.evaluate_uniforms(&m_values);
-            m_values.m_intensity *= static_cast<float>(m_values.m_intensity_multiplier);
+            m_values.m_intensity *=
+                static_cast<float>(
+                    m_values.m_intensity_multiplier * pow(2.0, m_values.m_exposure));
 
             return true;
         }
@@ -143,6 +155,7 @@ namespace
         {
             Spectrum    m_intensity;                // emitted intensity in W.sr^-1
             double      m_intensity_multiplier;     // emitted intensity multiplier
+            double      m_exposure;                 // emitted intensity multiplier in f-stops
         };
 
         InputValues     m_values;
@@ -195,6 +208,17 @@ DictionaryArray PointLightFactory::get_input_metadata() const
             .insert("use", "optional")
             .insert("default", "1.0")
             .insert("help", "Light intensity multiplier"));
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "exposure")
+            .insert("label", "Exposure")
+            .insert("type", "numeric")
+            .insert("use", "optional")
+            .insert("default", "0.0")
+            .insert("min_value", "-64.0")
+            .insert("max_value", "64.0")
+            .insert("help", "Light exposure"));
 
     add_common_input_metadata(metadata);
 

--- a/src/appleseed/renderer/modeling/light/spotlight.cpp
+++ b/src/appleseed/renderer/modeling/light/spotlight.cpp
@@ -80,6 +80,7 @@ namespace
         {
             m_inputs.declare("intensity", InputFormatSpectralIlluminance);
             m_inputs.declare("intensity_multiplier", InputFormatScalar, "1.0");
+            m_inputs.declare("exposure", InputFormatScalar, "0.0");
         }
 
         virtual void release() APPLESEED_OVERRIDE
@@ -102,6 +103,7 @@ namespace
 
             m_intensity_source = m_inputs.source("intensity");
             m_intensity_multiplier_source = m_inputs.source("intensity_multiplier");
+            m_exposure_source = m_inputs.source("exposure");
             check_non_zero_emission(m_intensity_source, m_intensity_multiplier_source);
 
             const double inner_half_angle = deg_to_rad(m_params.get_required<double>("inner_angle", 20.0) / 2.0);
@@ -164,10 +166,12 @@ namespace
         {
             Spectrum    m_intensity;                // emitted intensity in W.sr^-1
             double      m_intensity_multiplier;     // emitted intensity multiplier
+            double      m_exposure;                 // emitted intensity multiplier in f-stops
         };
 
         const Source*   m_intensity_source;
         const Source*   m_intensity_multiplier_source;
+        const Source*   m_exposure_source;
 
         double          m_cos_inner_half_angle;
         double          m_cos_outer_half_angle;
@@ -202,7 +206,8 @@ namespace
 
             const InputValues* values = input_evaluator.evaluate<InputValues>(m_inputs, uv);
             radiance = values->m_intensity;
-            radiance *= static_cast<float>(values->m_intensity_multiplier);
+            radiance *=
+                static_cast<float>(values->m_intensity_multiplier * pow(2.0, values->m_exposure));
 
             if (cos_theta < m_cos_inner_half_angle)
             {
@@ -260,6 +265,17 @@ DictionaryArray SpotLightFactory::get_input_metadata() const
             .insert("use", "optional")
             .insert("default", "1.0")
             .insert("help", "Light intensity multiplier"));
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "exposure")
+            .insert("label", "Exposure")
+            .insert("type", "numeric")
+            .insert("use", "optional")
+            .insert("default", "0.0")
+            .insert("min_value", "-64.0")
+            .insert("max_value", "64.0")
+            .insert("help", "Light exposure"));
 
     metadata.push_back(
         Dictionary()


### PR DESCRIPTION
An alternative way to specify intensity multipliers.
Mostly for Gaffer ImageEngine/gaffer#1590, but could be useful for other plugins.
