### PR TITLE
Small cmake SIMD changes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,9 +123,9 @@ option (HIDE_SYMBOLS                        "When using gcc, hide symbols not on
 # SIMD options.
 if (is_x86)
     option (USE_SSE                         "Use SSE instruction sets up to version 2"              ON)
-    option (USE_SSE42                       "Use SSE instruction sets up to version 4.2"            OFF)
 
     if (TARGET_ARCH MATCHES "x86_64")
+       option (USE_SSE42                    "Use SSE instruction sets up to version 4.2"            OFF)
        option (USE_AVX                      "Use AVX instruction set"                               OFF)
     endif ()
 elseif (TARGET_ARCH MATCHES "ARM")
@@ -385,9 +385,20 @@ if (UNIX AND NOT APPLE)
     set (USE_RPATH_ORIGIN TRUE)
 endif ()
 
-# SSE.
+# SIMD.
+if (USE_AVX)
+    set (USE_SSE42 TRUE)
+    set (preprocessor_definitions_common
+        ${preprocessor_definitions_common}
+        APPLESEED_USE_AVX
+    )
+endif ()
 if (USE_SSE42)
    set (USE_SSE TRUE)
+   set (preprocessor_definitions_common
+       ${preprocessor_definitions_common}
+       APPLESEED_USE_SSE42
+   )
 endif ()
 if (USE_SSE)
    if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SIZEOF_VOID_P MATCHES 4)
@@ -397,12 +408,6 @@ if (USE_SSE)
            ${preprocessor_definitions_common}
            APPLESEED_USE_SSE
        )
-       if (USE_SSE42)
-           set (preprocessor_definitions_common
-               ${preprocessor_definitions_common}
-               APPLESEED_USE_SSE42
-           )
-       endif ()
    endif ()
 endif ()
 

--- a/src/cmake/config/linux-gcc.txt
+++ b/src/cmake/config/linux-gcc.txt
@@ -77,6 +77,12 @@ if (USE_SSE42)
         -msse4.2                                        # enable SSE instruction sets up to SSE 4.2
     )
 endif ()
+if (USE_AVX)
+    set (c_compiler_flags_common
+         ${c_compiler_flags_common}
+        -mavx                                           # enable AVX instruction sets
+    )
+endif ()
 set (exe_linker_flags_common
     -Werror                                             # Treat Warnings As Errors
 )

--- a/src/cmake/config/mac-clang.txt
+++ b/src/cmake/config/mac-clang.txt
@@ -76,6 +76,12 @@ if (USE_SSE42)
         -msse4.2                                        # enable SSE instruction sets up to SSE 4.2
     )
 endif ()
+if (USE_AVX)
+    set (c_compiler_flags_common
+         ${c_compiler_flags_common}
+        -mavx                                           # enable AVX instruction sets
+    )
+endif ()
 set (exe_linker_flags_common
     -Werror                                             # Treat Warnings As Errors
     -bind_at_load


### PR DESCRIPTION
- Show SSE4.2 option only on 64 bit Intel (SSE4.2 was introduced in the Corei7 CPU).
- Add AVX preproc. symbol and enable it in gcc and clang if selected.
