### PR TITLE
Enable more warnings when using gcc.

### DIFF
--- a/src/appleseed.studio/utility/widgetzoomhandler.cpp
+++ b/src/appleseed.studio/utility/widgetzoomhandler.cpp
@@ -227,9 +227,6 @@ void WidgetZoomHandler::apply_scale_factor()
     if (m_scroll_area->widget()->layout())
         m_scroll_area->widget()->layout()->activate();
 
-    const int new_widget_width = m_scroll_area->widget()->width();
-    const int new_widget_height = m_scroll_area->widget()->height();
-
     const double actual_h_multiplier = static_cast<double>(m_scroll_area->widget()->width()) / old_widget_width;
     const double actual_v_multiplier = static_cast<double>(m_scroll_area->widget()->height()) / old_widget_height;
 

--- a/src/appleseed/foundation/math/bezier.h
+++ b/src/appleseed/foundation/math/bezier.h
@@ -130,11 +130,6 @@ inline V evaluate_bezier3_derivative(const V v0, const V v1, const V v2, const V
     const T t2 = t * t;             // t^2
     const T u2 = u * u;             // (1-t)^2
 
-    const T a = u2 * u;             // (1-t)^3
-    const T b = u2 * t;             // (1-t)^2*t
-    const T c = u * t2;             // (1-t)*t^2
-    const T d = t2 * t;             // t^3
-
     return T(3.0) * (u2 * (v1 - v0) + t2 * (v3 - v2)) + T(6.0) * u * t * (v2 - v1);
 }
 

--- a/src/appleseed/foundation/math/fresnel.h
+++ b/src/appleseed/foundation/math/fresnel.h
@@ -519,8 +519,6 @@ inline void artist_friendly_fresnel_conductor_inverse_reparameterization(
     SpectrumType&           normal_reflectance,
     SpectrumType&           edge_tint)
 {
-    typedef typename impl::GetValueType<SpectrumType>::ValueType ValueType;
-
     const SpectrumType one(1.0);
 
     SpectrumType square_n_plus_one(n + one);

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_knn.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_knn.cpp
@@ -135,8 +135,8 @@ BENCHMARK_SUITE(Foundation_Math_Knn_Query)
         vector<Vector3f>    m_query_points;
 
         FixtureBase(const string& name)
-          : m_accumulator(0)
-          , m_answer(AnswerSize)
+          : m_answer(AnswerSize)
+          , m_accumulator(0)
         {
             configure_logger(name);
         }

--- a/src/appleseed/foundation/meta/tests/test_dictionary.cpp
+++ b/src/appleseed/foundation/meta/tests/test_dictionary.cpp
@@ -110,7 +110,7 @@ TEST_SUITE(Foundation_Utility_StringDictionary)
 
         EXPECT_EXCEPTION(ExceptionDictionaryItemNotFound,
         {
-            const char* item = sd.get("key");
+            APPLESEED_UNUSED const char* item = sd.get("key");
         });
     }
 
@@ -120,7 +120,7 @@ TEST_SUITE(Foundation_Utility_StringDictionary)
 
         EXPECT_EXCEPTION(ExceptionDictionaryItemNotFound,
         {
-            const int item = sd.get<int>("key");
+            APPLESEED_UNUSED const int item = sd.get<int>("key");
         });
     }
 
@@ -130,7 +130,7 @@ TEST_SUITE(Foundation_Utility_StringDictionary)
 
         EXPECT_EXCEPTION(ExceptionDictionaryItemNotFound,
         {
-            const int item = sd.get<int>(string("key"));
+            APPLESEED_UNUSED const int item = sd.get<int>(string("key"));
         });
     }
 
@@ -358,7 +358,7 @@ TEST_SUITE(Foundation_Utility_Dictionary)
 
         EXPECT_EXCEPTION(ExceptionDictionaryItemNotFound,
         {
-            const int item = dic.get<int>("key");
+            APPLESEED_UNUSED const int item = dic.get<int>("key");
         });
     }
 
@@ -368,7 +368,7 @@ TEST_SUITE(Foundation_Utility_Dictionary)
 
         EXPECT_EXCEPTION(ExceptionDictionaryItemNotFound,
         {
-            const int item = dic.get<int>(string("key"));
+            APPLESEED_UNUSED const int item = dic.get<int>(string("key"));
         });
     }
 

--- a/src/appleseed/foundation/meta/tests/test_snprintf.cpp
+++ b/src/appleseed/foundation/meta/tests/test_snprintf.cpp
@@ -99,7 +99,7 @@ TEST_SUITE(Foundation_Platform_Snprintf)
     TEST_CASE(PortableSnprintf_GivenLargeSizeTValue_UsingC99FormatString_ReturnsProperlyFormattedString)
     {
         char buf[100];
-        const int result = portable_snprintf(buf, sizeof(buf), "%zu", MaxSizeTValue);
+        portable_snprintf(buf, sizeof(buf), "%zu", MaxSizeTValue);
 
         EXPECT_EQ(MaxSizeTValueString, string(buf));
     }

--- a/src/appleseed/foundation/platform/compiler.h
+++ b/src/appleseed/foundation/platform/compiler.h
@@ -196,6 +196,8 @@ namespace foundation
 
 #if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))
     #define APPLESEED_UNUSED   __attribute__((unused))
+#elif defined(__clang__)
+    #define APPLESEED_UNUSED   __attribute__((unused))
 #else
     #define APPLESEED_UNUSED
 #endif

--- a/src/appleseed/foundation/platform/compiler.h
+++ b/src/appleseed/foundation/platform/compiler.h
@@ -191,6 +191,17 @@ namespace foundation
 
 
 //
+//  A macro to mark a variable as unused. Useful in unit tests.
+//
+
+#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))
+    #define APPLESEED_UNUSED   __attribute__((unused))
+#else
+    #define APPLESEED_UNUSED
+#endif
+
+
+//
 // Utility macros converting their argument to a string literal:
 //   APPLESEED_TO_STRING_EVAL first expands the argument definition.
 //   APPLESEED_TO_STRING_NOEVAL does not expand the argument definition.

--- a/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
@@ -260,8 +260,6 @@ namespace
 
             // Merge the scratch framebuffer into the output framebuffer.
             const float rcp_sample_count = 1.0f / trackers[0].get_size();
-            const size_t width = m_scratch_fb->get_width();
-            const size_t height = m_scratch_fb->get_height();
             for (int y = -m_scratch_fb_half_height; y <= m_scratch_fb_half_height; ++y)
             {
                 for (int x = -m_scratch_fb_half_width; x <= m_scratch_fb_half_width; ++x)

--- a/src/appleseed/renderer/kernel/rendering/irenderercontroller.h
+++ b/src/appleseed/renderer/kernel/rendering/irenderercontroller.h
@@ -47,6 +47,9 @@ class APPLESEED_DLLSYMBOL IRendererController
   : public foundation::NonCopyable
 {
   public:
+    // Destructor.
+    virtual ~IRendererController() {}
+
     // This method is called before rendering begins.
     virtual void on_rendering_begin() = 0;
 

--- a/src/appleseed/renderer/meta/tests/test_paramarray.cpp
+++ b/src/appleseed/renderer/meta/tests/test_paramarray.cpp
@@ -130,7 +130,7 @@ TEST_SUITE(Renderer_Utility_ParamArray)
 
         EXPECT_EXCEPTION(ExceptionDictionaryItemNotFound,
         {
-            const char* value = params.get_path("y");
+            APPLESEED_UNUSED const char* value = params.get_path("y");
         });
     }
 
@@ -141,7 +141,7 @@ TEST_SUITE(Renderer_Utility_ParamArray)
 
         EXPECT_EXCEPTION(ExceptionDictionaryItemNotFound,
         {
-            const char* value = params.get_path("other.x");
+            APPLESEED_UNUSED const char* value = params.get_path("other.x");
         });
     }
 

--- a/src/appleseed/renderer/modeling/bssrdf/standarddipolebssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/standarddipolebssrdf.cpp
@@ -169,9 +169,6 @@ namespace
 
             for (size_t i = 0, e = value.size(); i < e; ++i)
             {
-                const double sigma_a = values->m_sigma_a[i];
-                const double sigma_s = values->m_sigma_s[i];
-                const double sigma_s_prime = values->m_sigma_s_prime[i];
                 const double sigma_t_prime = values->m_sigma_t_prime[i];
                 const double alpha_prime = values->m_alpha_prime[i];
                 const double sigma_tr = values->m_sigma_tr[i];

--- a/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
@@ -110,7 +110,6 @@ namespace renderer
 namespace
 {
     // Floating-point formatting settings.
-    const char* VectorFormat     = "%.15f";
     const char* MatrixFormat     = "%.15f";
     const char* ColorValueFormat = "%.6f";
 

--- a/src/cmake/config/linux-gcc.txt
+++ b/src/cmake/config/linux-gcc.txt
@@ -60,8 +60,13 @@ set (git_command "git")
 
 # Flags common to all configurations.
 set (c_compiler_flags_common
-    -Werror                                             # Treat Warnings As Errors
+    -Wall
     -Wno-switch                                         # don't complain about unhandled enumeration values in switch
+    -Wno-unknown-pragmas
+    -Wno-sign-compare
+    -Wno-unused-function
+    -Wno-reorder
+    -Werror                                             # treat Warnings As Errors
     -fno-math-errno                                     # ignore errno when calling math functions
     -fPIC                                               # emit position-independent code
 )

--- a/src/tools/makefluffy/main.cpp
+++ b/src/tools/makefluffy/main.cpp
@@ -138,7 +138,6 @@ namespace
             if (normal_norm == GScalar(0.0))
                 continue;
             const GScalar rcp_normal_norm = GScalar(1.0) / normal_norm;
-            const GScalar rcp_area = GScalar(2.0) * rcp_normal_norm;
             const GScalar area = GScalar(0.5) * normal_norm;
             normal *= rcp_normal_norm;
             assert(is_normalized(normal));
@@ -235,8 +234,6 @@ namespace
 
     void make_fluffy(const Assembly& assembly, const FluffParams& params)
     {
-        const ObjectContainer& objects = assembly.objects();
-
         typedef vector<const ObjectInstance*> ObjectInstanceVector;
         typedef map<const MeshObject*, ObjectInstanceVector> ObjectToInstanceMap;
 


### PR DESCRIPTION
- Added APPLESEED_UNUSED to mark unused variables.
- Removed unused variables, unused local typedefs, ...
- Added missing virtual destructor.
