### PR TITLE
Flip tangents again. Small OSL tangent fixes.

### DIFF
--- a/src/appleseed/renderer/kernel/rendering/rendererservices.cpp
+++ b/src/appleseed/renderer/kernel/rendering/rendererservices.cpp
@@ -903,9 +903,18 @@ IMPLEMENT_USER_DATA_GETTER(tn)
             reinterpret_cast<const ShadingPoint*>(sg->renderstate);
 
         const Vector3d& tn = shading_point->get_shading_basis().get_tangent_u();
-        reinterpret_cast<float*>(val)[0] = static_cast<float>(tn.x);
-        reinterpret_cast<float*>(val)[1] = static_cast<float>(tn.y);
-        reinterpret_cast<float*>(val)[2] = static_cast<float>(tn.z);
+        OSL::Vec3 v(
+            static_cast<float>(tn.x),
+            static_cast<float>(tn.y),
+            static_cast<float>(tn.z));
+
+        // Make sure Tn points in the same direction as dPdu.
+        if (v.dot(sg->dPdu) < 0.0f)
+            v = -v;
+
+        reinterpret_cast<float*>(val)[0] = v.x;
+        reinterpret_cast<float*>(val)[1] = v.y;
+        reinterpret_cast<float*>(val)[2] = v.z;
 
         if (derivatives)
             clear_derivatives(type, val);
@@ -924,9 +933,19 @@ IMPLEMENT_USER_DATA_GETTER(bn)
             reinterpret_cast<const ShadingPoint*>(sg->renderstate);
 
         const Vector3d& bn = shading_point->get_shading_basis().get_tangent_v();
-        reinterpret_cast<float*>(val)[0] = static_cast<float>(bn.x);
-        reinterpret_cast<float*>(val)[1] = static_cast<float>(bn.y);
-        reinterpret_cast<float*>(val)[2] = static_cast<float>(bn.z);
+
+        OSL::Vec3 v(
+            static_cast<float>(bn.x),
+            static_cast<float>(bn.y),
+            static_cast<float>(bn.z));
+
+        // Make sure Bn points in the same direction as dPdv.
+        if (v.dot(sg->dPdv) < 0.0f)
+            v = -v;
+
+        reinterpret_cast<float*>(val)[0] = v.x;
+        reinterpret_cast<float*>(val)[1] = v.y;
+        reinterpret_cast<float*>(val)[2] = v.z;
 
         if (derivatives)
             clear_derivatives(type, val);

--- a/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
@@ -411,6 +411,11 @@ void ShadingPoint::compute_world_space_partial_derivatives() const
             m_dpdu = (dv1 * dp0 - dv0 * dp1) * rcp_det;
             m_dpdv = (du0 * dp1 - du1 * dp0) * rcp_det;
 
+            // Make sure dPdv x dPdu points in the same direction as
+            // the original shading normal.
+            if (dot(get_original_shading_normal(), cross(m_dpdv, m_dpdu)) < 0.0)
+                m_dpdu = -m_dpdu;
+
             const Vector3d dn0 = m_n0 - m_n2;
             const Vector3d dn1 = m_n1 - m_n2;
 
@@ -466,6 +471,11 @@ void ShadingPoint::compute_screen_space_partial_derivatives() const
         const double ty = intersect(ray.m_ry, p, n);
         const Vector3d py = ray.m_ry.point_at(ty);
         m_dpdy = py - p;
+
+        // Make sure dPdy x dPdx points in the same direction as
+        // the original shading normal.
+        if (dot(get_original_shading_normal(), cross(m_dpdy, m_dpdx)) < 0.0)
+            m_dpdx = -m_dpdx;
 
         // Select the two smallest axes.
         const size_t max_index = max_abs_index(n);
@@ -814,17 +824,17 @@ void ShadingPoint::initialize_osl_shader_globals(
 
         // Handedness flip flag.
         // Currently it is unused, but we might want to enable it in the future.
-        /*
         m_shader_globals.flipHandedness =
             m_assembly_instance_transform_seq->swaps_handedness(m_assembly_instance_transform) !=
             get_object_instance().transform_swaps_handedness() ? 1 : 0;
-        */
-        m_shader_globals.flipHandedness = 0;
 
         // Surface position and incident ray direction differentials.
         if (ray.m_has_differentials)
         {
-            m_shader_globals.dPdx = Vector3f(get_dpdx());
+            m_shader_globals.dPdx =
+                m_shader_globals.flipHandedness
+                    ?  Vector3f(get_dpdx())
+                    : -Vector3f(get_dpdx());
             m_shader_globals.dPdy = Vector3f(get_dpdy());
             m_shader_globals.dPdz = Vector3f(0.0);
             m_shader_globals.dIdx = Vector3f(ray.m_rx.m_dir);
@@ -868,7 +878,11 @@ void ShadingPoint::initialize_osl_shader_globals(
         }
 
         // Surface tangents.
-        m_shader_globals.dPdu = Vector3f(get_dpdu(0));
+        m_shader_globals.dPdu =
+            m_shader_globals.flipHandedness
+                ?  Vector3f(get_dpdu(0))
+                : -Vector3f(get_dpdu(0));
+
         m_shader_globals.dPdv = Vector3f(get_dpdv(0));
 
         // Time and its derivative.


### PR DESCRIPTION
- Tangent flipping apparently improves sampling when using QMC.
- Put back OSL flip handedness.
- Make sure the smooth tangent and bitangent point in the same dir as dPdu & dPdv in OSL.
