### PR TITLE
OSX fixes, gcc 4.2

### DIFF
--- a/src/appleseed.python/bindentity.cpp
+++ b/src/appleseed.python/bindentity.cpp
@@ -66,9 +66,19 @@ namespace
         return vec.get_by_index(index);
     }
 
+    void remove_entity_vec_item(EntityVector& vec, Entity* e)
+    {
+        vec.remove(e);
+    }
+
     Entity* get_entity_map_item(EntityMap& map, const string& key)
     {
         return map.get_by_name(key.c_str());
+    }
+
+    void remove_entity_map_item(EntityMap& map, Entity* e)
+    {
+        map.remove(e->get_uid());
     }
 
     bpy::dict entity_get_parameters(const Entity* e)
@@ -110,7 +120,7 @@ void bind_entity()
         .def("__getitem__", get_entity_vec_item, bpy::return_value_policy<bpy::reference_existing_object>())
 
         .def("insert", &EntityVector::insert)
-        .def("remove", &EntityVector::remove)
+        .def("remove", &remove_entity_vec_item)
 
         .def("__iter__", bpy::iterator<EntityVector>())
         ;
@@ -121,7 +131,7 @@ void bind_entity()
         .def("__getitem__", get_entity_map_item, bpy::return_value_policy<bpy::reference_existing_object>())
 
         .def("insert", &EntityMap::insert)
-        .def("remove", &EntityMap::remove)
+        .def("remove", &remove_entity_map_item)
 
         .def("get_by_uid", &EntityMap::get_by_uid, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("get_by_name", &EntityMap::get_by_name, bpy::return_value_policy<bpy::reference_existing_object>())

--- a/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
@@ -177,9 +177,10 @@ namespace
 
             if (m_mdf == GGX)
             {
+                const GGXMDF<double> mdf;
                 MicrofacetBRDFHelper<double>::sample(
                     sampling_context,
-                    GGXMDF<double>(),
+                    mdf,
                     alpha_x,
                     alpha_y,
                     f,
@@ -188,9 +189,10 @@ namespace
             }
             else
             {
+                const BeckmannMDF<double> mdf;
                 MicrofacetBRDFHelper<double>::sample(
                     sampling_context,
-                    BeckmannMDF<double>(),
+                    mdf,
                     alpha_x,
                     alpha_y,
                     f,
@@ -236,8 +238,9 @@ namespace
 
             if (m_mdf == GGX)
             {
+                const GGXMDF<double> mdf;
                 return MicrofacetBRDFHelper<double>::evaluate(
-                    GGXMDF<double>(),
+                    mdf,
                     alpha_x,
                     alpha_y,
                     shading_basis,
@@ -250,8 +253,9 @@ namespace
             }
             else
             {
+                const BeckmannMDF<double> mdf;
                 return MicrofacetBRDFHelper<double>::evaluate(
-                    BeckmannMDF<double>(),
+                    mdf,
                     alpha_x,
                     alpha_y,
                     shading_basis,
@@ -293,8 +297,9 @@ namespace
 
             if (m_mdf == GGX)
             {
+                const GGXMDF<double> mdf;
                 return MicrofacetBRDFHelper<double>::pdf(
-                    GGXMDF<double>(),
+                    mdf,
                     alpha_x,
                     alpha_y,
                     shading_basis,
@@ -303,8 +308,9 @@ namespace
             }
             else
             {
+                const BeckmannMDF<double> mdf;
                 return MicrofacetBRDFHelper<double>::pdf(
-                    BeckmannMDF<double>(),
+                    mdf,
                     alpha_x,
                     alpha_y,
                     shading_basis,

--- a/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
@@ -201,9 +201,10 @@ namespace
 
             if (m_mdf == GGX)
             {
+                const GGXMDF<double> mdf;
                 MicrofacetBRDFHelper<double>::sample(
                     sampling_context,
-                    GGXMDF<double>(),
+                    mdf,
                     alpha_x,
                     alpha_y,
                     f,
@@ -212,9 +213,10 @@ namespace
             }
             else
             {
+                const BeckmannMDF<double> mdf;
                 MicrofacetBRDFHelper<double>::sample(
                     sampling_context,
-                    BeckmannMDF<double>(),
+                    mdf,
                     alpha_x,
                     alpha_y,
                     f,
@@ -260,8 +262,9 @@ namespace
 
             if (m_mdf == GGX)
             {
+                const GGXMDF<double> mdf;
                 return MicrofacetBRDFHelper<double>::evaluate(
-                    GGXMDF<double>(),
+                    mdf,
                     alpha_x,
                     alpha_y,
                     shading_basis,
@@ -274,8 +277,9 @@ namespace
             }
             else
             {
+                const BeckmannMDF<double> mdf;
                 return MicrofacetBRDFHelper<double>::evaluate(
-                    BeckmannMDF<double>(),
+                    mdf,
                     alpha_x,
                     alpha_y,
                     shading_basis,
@@ -317,8 +321,9 @@ namespace
 
             if (m_mdf == GGX)
             {
+                const GGXMDF<double> mdf;
                 return MicrofacetBRDFHelper<double>::pdf(
-                    GGXMDF<double>(),
+                    mdf,
                     alpha_x,
                     alpha_y,
                     shading_basis,
@@ -327,8 +332,9 @@ namespace
             }
             else
             {
+                const BeckmannMDF<double> mdf;
                 return MicrofacetBRDFHelper<double>::pdf(
-                    BeckmannMDF<double>(),
+                    mdf,
                     alpha_x,
                     alpha_y,
                     shading_basis,


### PR DESCRIPTION
- Fixed the new BRDFs. (apply the same changes as PR #723 to glossy and metal).

- Temporary workaround for python's EntityVector and EntityMap remove method:
Since remove is not very useful in python as it is right now, we can have a proper fix when 
the code is reviewed / improved.
 
Reported by John.
