### PR TITLE
ShaderQuery fixes.

### DIFF
--- a/src/appleseed/renderer/modeling/shadergroup/shaderquery.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderquery.cpp
@@ -44,8 +44,12 @@ BEGIN_OSL_INCLUDES
 #include "OSL/oslquery.h"
 END_OSL_INCLUDES
 
+// Boost headers.
+#include "boost/optional.hpp"
+
 // Standard headers.
 #include <string>
+#include <vector>
 
 using namespace foundation;
 using namespace std;
@@ -59,8 +63,12 @@ namespace renderer
 
 struct ShaderQuery::Impl
 {
-    std::string m_search_path;
-    OSL::OSLQuery m_query;
+    typedef boost::optional<Dictionary> OptionalDictionary;
+
+    std::string                              m_search_path;
+    OSL::OSLQuery                            m_query;
+    mutable OptionalDictionary               m_metadata;
+    mutable std::vector<OptionalDictionary>  m_param_info;
 
     static bool copy_value_to_dict(
         const OSL::OSLQuery::Parameter& param,
@@ -164,13 +172,33 @@ struct ShaderQuery::Impl
 
         return dictionary;
     }
+
+    bool open(const char* shader_name)
+    {
+        m_metadata = OptionalDictionary();
+        m_param_info.clear();
+
+        m_query = OSL::OSLQuery();
+        const bool ok = m_query.open(shader_name, m_search_path);
+
+        if (ok)
+            m_param_info.assign(m_query.nparams(), OptionalDictionary());
+
+        return ok;
+    }
 };
+
+ShaderQuery::ShaderQuery()
+  : impl(new Impl())
+{
+}
 
 ShaderQuery::ShaderQuery(const char* search_path)
   : impl(new Impl())
 {
-    if (search_path)
-        impl->m_search_path = search_path;
+    assert(search_path);
+
+    impl->m_search_path = search_path;
 }
 
 ShaderQuery::ShaderQuery(const SearchPaths& search_paths)
@@ -191,7 +219,7 @@ void ShaderQuery::release()
 
 bool ShaderQuery::open(const char* shader_name)
 {
-    return impl->m_query.open(shader_name, impl->m_search_path);
+    return impl->open(shader_name);
 }
 
 const char* ShaderQuery::get_shader_name() const
@@ -209,26 +237,36 @@ size_t ShaderQuery::get_num_params() const
     return impl->m_query.nparams();
 }
 
-Dictionary ShaderQuery::get_param_info(const size_t param_index) const
+const Dictionary& ShaderQuery::get_param_info(const size_t param_index) const
 {
     assert(param_index < get_num_params());
 
-    return Impl::param_to_dict(
-                *impl->m_query.getparam(param_index));
-}
-
-Dictionary ShaderQuery::get_metadata() const
-{
-    Dictionary metadata;
-
-    for (size_t i = 0, e = impl->m_query.metadata().size(); i < e; ++i)
+    if (!impl->m_param_info[param_index])
     {
-        metadata.insert(
-            impl->m_query.metadata()[i].name.c_str(),
-            Impl::metadata_param_to_dict(impl->m_query.metadata()[i]));
+        impl->m_param_info[param_index] =
+            Impl::param_to_dict(*impl->m_query.getparam(param_index));
     }
 
-    return metadata;
+    return impl->m_param_info[param_index].get();
+}
+
+const Dictionary& ShaderQuery::get_metadata() const
+{
+    if (!impl->m_metadata)
+    {
+        Dictionary metadata;
+
+        for (size_t i = 0, e = impl->m_query.metadata().size(); i < e; ++i)
+        {
+            metadata.insert(
+                impl->m_query.metadata()[i].name.c_str(),
+                Impl::metadata_param_to_dict(impl->m_query.metadata()[i]));
+        }
+
+        impl->m_metadata = metadata;
+    }
+
+    return impl->m_metadata.get();
 }
 
 
@@ -236,8 +274,12 @@ Dictionary ShaderQuery::get_metadata() const
 // ShaderQueryFactory class implementation.
 //
 
-auto_release_ptr<ShaderQuery> ShaderQueryFactory::create(
-    const char* search_path)
+auto_release_ptr<ShaderQuery> ShaderQueryFactory::create()
+{
+    return auto_release_ptr<ShaderQuery>(new ShaderQuery());
+}
+
+auto_release_ptr<ShaderQuery> ShaderQueryFactory::create(const char* search_path)
 {
     return auto_release_ptr<ShaderQuery>(new ShaderQuery(search_path));
 }

--- a/src/appleseed/renderer/modeling/shadergroup/shaderquery.h
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderquery.h
@@ -74,10 +74,10 @@ class APPLESEED_DLLSYMBOL ShaderQuery
     size_t get_num_params() const;
 
     // Return shader parameter information.
-    foundation::Dictionary get_param_info(const size_t param_index) const;
+    const foundation::Dictionary& get_param_info(const size_t param_index) const;
 
     // Return the shader metadata.
-    foundation::Dictionary get_metadata() const;
+    const foundation::Dictionary& get_metadata() const;
 
   private:
     friend class ShaderQueryFactory;
@@ -85,7 +85,8 @@ class APPLESEED_DLLSYMBOL ShaderQuery
     struct Impl;
     Impl* impl;
 
-    explicit ShaderQuery(const char* search_path = 0);
+    explicit ShaderQuery();
+    explicit ShaderQuery(const char* search_path);
     explicit ShaderQuery(const foundation::SearchPaths& search_paths);
 
     ~ShaderQuery();
@@ -99,11 +100,12 @@ class APPLESEED_DLLSYMBOL ShaderQuery
 class APPLESEED_DLLSYMBOL ShaderQueryFactory
 {
   public:
-    // Create a new shader query with a single optional search path.
-    // If the search path is not passed, shaders can only be queried
-    // using absolute paths.
-    static foundation::auto_release_ptr<ShaderQuery> create(
-        const char* search_path = 0);
+    // Create a new shader query without a search path.
+    // Shaders can only be queried using absolute paths.
+    static foundation::auto_release_ptr<ShaderQuery> create();
+
+    // Create a new shader query with a single search path.
+    static foundation::auto_release_ptr<ShaderQuery> create(const char* search_path);
 
     // Create a new shader query with multiple search paths.
     static foundation::auto_release_ptr<ShaderQuery> create(


### PR DESCRIPTION
- Reset the query when opening a new shader. Workaround for an OSL bug?
- Do not return dictionaries by value, important if ShaderQuery is used across shared library boundaries.
- Do no use default parameters in the public API.
