### PR TITLE
SearchPaths improvements

### DIFF
--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -441,6 +441,7 @@ set (foundation_meta_tests_sources
     foundation/meta/tests/test_rng.cpp
     foundation/meta/tests/test_sampling.cpp
     foundation/meta/tests/test_scalar.cpp
+    foundation/meta/tests/test_searchpaths.cpp
     foundation/meta/tests/test_settings.cpp
     foundation/meta/tests/test_sharedlibrary.cpp
     foundation/meta/tests/test_siphash.cpp

--- a/src/appleseed/foundation/meta/tests/test_searchpaths.cpp
+++ b/src/appleseed/foundation/meta/tests/test_searchpaths.cpp
@@ -1,0 +1,99 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2016 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// appleseed.foundation headers.
+#include "foundation/utility/searchpaths.h"
+#include "foundation/utility/test.h"
+
+// Standard headers.
+#include <cassert>
+#include <cstdlib>
+#include <string>
+
+using namespace foundation;
+using namespace std;
+
+TEST_SUITE(Foundation_Utility_SearchPaths)
+{
+    static const char* TestEnvironmentName = "APPLESEED_TEST_SEARCHPATH_SEARCHPATH";
+
+    TEST_CASE(InitializeFromEnvironmentVariableUnixSeparator)
+    {
+        const char* TestEnvironmentValue = "/tmp:/usr/tmp:/var/local/tmp";
+        const char TestSeparator = ':';
+
+#if defined _WIN32
+        _putenv_s(TestEnvironmentName, TestEnvironmentValue);
+#else
+        setenv(TestEnvironmentName, TestEnvironmentValue, 1);
+#endif
+        SearchPaths searchpaths(TestEnvironmentName, TestSeparator);
+        EXPECT_EQ(searchpaths.to_string(TestSeparator, false), TestEnvironmentValue);
+    }
+
+    TEST_CASE(InitializeFromEnvironmentVariableWindowsSeparator)
+    {
+        const char* TestEnvironmentValue = "/tmp;/usr/tmp;/var/local/tmp";
+        const char TestSeparator = ';';
+
+#if defined _WIN32
+        _putenv_s(TestEnvironmentName, TestEnvironmentValue);
+#else
+        setenv(TestEnvironmentName, TestEnvironmentValue, 1);
+#endif
+        SearchPaths searchpaths(TestEnvironmentName, TestSeparator);
+        EXPECT_EQ(searchpaths.to_string(TestSeparator, false), TestEnvironmentValue);
+    }
+
+    TEST_CASE(SearchPathReset)
+    {
+        const char* TestEnvironmentValue = "/tmp:/usr/tmp:/var/local/tmp";
+        const char TestSeparator = ':';
+
+#if defined _WIN32
+        _putenv_s(TestEnvironmentName, TestEnvironmentValue);
+#else
+        setenv(TestEnvironmentName, TestEnvironmentValue, 1);
+#endif
+        SearchPaths searchpaths(TestEnvironmentName, TestSeparator);
+        searchpaths.push_back("/home/username/appleseed");
+        searchpaths.reset();
+        EXPECT_EQ(searchpaths.to_string(TestSeparator, false), TestEnvironmentValue);
+    }
+
+    TEST_CASE(SearchPathSplitAndPushBack)
+    {
+        const char* TestPaths = "/tmp:/usr/tmp:/var/local/tmp";
+        const char TestSeparator = ':';
+
+        SearchPaths searchpaths;
+        searchpaths.split_and_push_back(TestPaths, TestSeparator);
+        EXPECT_EQ(searchpaths.to_string(TestSeparator, false), TestPaths);
+    }
+}
+

--- a/src/appleseed/foundation/utility/searchpaths.cpp
+++ b/src/appleseed/foundation/utility/searchpaths.cpp
@@ -61,6 +61,7 @@ struct SearchPathsImpl::Impl
 
     filesystem::path    m_root_path;
     PathCollection      m_explicit_paths;
+    PathCollection      m_environment_paths;
     PathCollection      m_all_paths;
 };
 
@@ -69,13 +70,13 @@ SearchPathsImpl::SearchPathsImpl()
 {
 }
 
-SearchPathsImpl::SearchPathsImpl(const char* envvar)
+SearchPathsImpl::SearchPathsImpl(const char* envvar, const char separator)
   : impl(new Impl())
 {
     if (const char* value = getenv(envvar))
     {
         vector<string> paths;
-        split(value, ":", paths);
+        split(value, string(&separator, 1), paths);
 
         for (const_each<vector<string> > i = paths; i; ++i)
         {
@@ -86,7 +87,10 @@ SearchPathsImpl::SearchPathsImpl(const char* envvar)
                 continue;
 
             if (!i->empty())
+            {
+                impl->m_environment_paths.push_back(i->c_str());
                 impl->m_all_paths.push_back(i->c_str());
+            }
         }
     }
 }
@@ -100,7 +104,14 @@ void SearchPathsImpl::clear()
 {
     impl->m_root_path.clear();
     impl->m_explicit_paths.clear();
+    impl->m_environment_paths.clear();
     impl->m_all_paths.clear();
+}
+
+void SearchPathsImpl::reset()
+{
+    impl->m_explicit_paths.clear();
+    impl->m_all_paths = impl->m_environment_paths;
 }
 
 bool SearchPathsImpl::empty() const
@@ -139,6 +150,17 @@ void SearchPathsImpl::do_push_back(const char* path)
     assert(path);
     impl->m_explicit_paths.push_back(path);
     impl->m_all_paths.push_back(path);
+}
+
+void SearchPathsImpl::do_split_and_push_back(const char* paths, const char separator)
+{
+    assert(paths);
+
+    vector<string> path_list;
+    split(paths, string(&separator, 1), path_list);
+
+    for (const_each<vector<string> > i = path_list; i; ++i)
+        do_push_back(i->c_str());
 }
 
 bool SearchPathsImpl::do_exist(const char* filepath) const
@@ -247,6 +269,15 @@ char* SearchPathsImpl::do_to_string(const char separator, const bool reversed) c
     }
 
     return duplicate_string(paths_str.c_str());
+}
+
+const char SearchPaths::platform_separator()
+{
+#if defined _WIN32
+    return ';';
+#else
+    return ':';
+#endif
 }
 
 }   // namespace foundation

--- a/src/appleseed/foundation/utility/searchpaths.cpp
+++ b/src/appleseed/foundation/utility/searchpaths.cpp
@@ -271,13 +271,18 @@ char* SearchPathsImpl::do_to_string(const char separator, const bool reversed) c
     return duplicate_string(paths_str.c_str());
 }
 
-const char SearchPaths::platform_separator()
+const char SearchPaths::environment_path_separator()
 {
 #if defined _WIN32
     return ';';
 #else
     return ':';
 #endif
+}
+
+const char SearchPaths::osl_path_separator()
+{
+    return ':';
 }
 
 }   // namespace foundation

--- a/src/appleseed/foundation/utility/searchpaths.h
+++ b/src/appleseed/foundation/utility/searchpaths.h
@@ -131,12 +131,18 @@ class SearchPaths
     // this file is returned. Otherwise the input path is returned.
     std::string qualify(const std::string& filepath) const;
 
-    // Return a string with all the search paths separated by the specified separator,
-    // optionally making them absolute and/or listing them in reverse order.
-    std::string to_string(const char separator, const bool reversed) const;
+    // Return a string with all the search paths separated by the specified separator.
+    std::string to_string(const char separator) const;
 
-    // Return the default separator character for platform.
-    static const char platform_separator();
+    // Return a string with all the search paths in reverse order,
+    // separated by the specified separator.
+    std::string to_string_reversed(const char separator) const;
+
+    // Return the default environment path separator character for the platform.
+    static const char environment_path_separator();
+
+    // Return the path separator used by OSL (and OpenImageIO).
+    static const char osl_path_separator();
 };
 
 
@@ -203,11 +209,14 @@ inline std::string SearchPaths::qualify(const std::string& filepath) const
     return convert_to_std_string(do_qualify(filepath.c_str()));
 }
 
-inline std::string SearchPaths::to_string(
-    const char separator,
-    const bool reversed) const
+inline std::string SearchPaths::to_string(const char separator) const
 {
-    return convert_to_std_string(do_to_string(separator, reversed));
+    return convert_to_std_string(do_to_string(separator, false));
+}
+
+inline std::string SearchPaths::to_string_reversed(const char separator) const
+{
+    return convert_to_std_string(do_to_string(separator, true));
 }
 
 }       // namespace foundation

--- a/src/appleseed/foundation/utility/searchpaths.h
+++ b/src/appleseed/foundation/utility/searchpaths.h
@@ -59,13 +59,17 @@ class APPLESEED_DLLSYMBOL SearchPathsImpl
     SearchPathsImpl();
 
     // Constructor.
-    explicit SearchPathsImpl(const char* envvar);
+    SearchPathsImpl(const char* envvar, const char separator);
 
     // Destructor.
     ~SearchPathsImpl();
 
     // Remove all search paths and clears the root path.
     void clear();
+
+    // Remove all search paths except the root path and
+    // paths added from environment variables.
+    void reset();
 
     // Return true if empty.
     bool empty() const;
@@ -86,6 +90,7 @@ class APPLESEED_DLLSYMBOL SearchPathsImpl
     void do_set_root_path(const char* path);
     char* do_get_root_path() const;
     void do_push_back(const char* path);
+    void do_split_and_push_back(const char* paths, const char separator);
     bool do_exist(const char* filepath) const;
     char* do_qualify(const char* filepath) const;
     char* do_to_string(const char separator, const bool reversed) const;
@@ -100,7 +105,7 @@ class SearchPaths
 
     // Constructor. Initializes search paths with the contents of the specified
     // environment variable.
-    explicit SearchPaths(const char* envvar);
+    SearchPaths(const char* envvar, const char separator);
 
     // Set the root path that is used to resolve relative paths.
     void set_root_path(const char* path);
@@ -112,6 +117,9 @@ class SearchPaths
     // Insert a search path at the end of the collection.
     void push_back(const char* path);
     void push_back(const std::string& path);
+
+    void split_and_push_back(const char* paths, const char separator);
+    void split_and_push_back(const std::string& paths, const char separator);
 
     // Return true if a given file exists, that is, if the argument is the absolute
     // path to a file that exists, or it is the name of a file that exists in one of
@@ -125,9 +133,10 @@ class SearchPaths
 
     // Return a string with all the search paths separated by the specified separator,
     // optionally making them absolute and/or listing them in reverse order.
-    std::string to_string(
-        const char separator = ':',
-        const bool reversed = false) const;
+    std::string to_string(const char separator, const bool reversed) const;
+
+    // Return the default separator character for platform.
+    static const char platform_separator();
 };
 
 
@@ -139,8 +148,8 @@ inline SearchPaths::SearchPaths()
 {
 }
 
-inline SearchPaths::SearchPaths(const char* envvar)
-  : SearchPathsImpl(envvar)
+inline SearchPaths::SearchPaths(const char* envvar, const char separator)
+  : SearchPathsImpl(envvar, separator)
 {
 }
 
@@ -162,6 +171,16 @@ inline void SearchPaths::push_back(const char* path)
 inline void SearchPaths::push_back(const std::string& path)
 {
     do_push_back(path.c_str());
+}
+
+inline void SearchPaths::split_and_push_back(const char* paths, const char separator)
+{
+    do_split_and_push_back(paths, separator);
+}
+
+inline void SearchPaths::split_and_push_back(const std::string& paths, const char separator)
+{
+    do_split_and_push_back(paths.c_str(), separator);
 }
 
 inline std::string SearchPaths::get_root_path() const

--- a/src/appleseed/renderer/modeling/project/project.cpp
+++ b/src/appleseed/renderer/modeling/project/project.cpp
@@ -104,7 +104,7 @@ struct Project::Impl
 
     Impl()
       : m_format_revision(ProjectFormatRevision)
-      , m_search_paths("APPLESEED_SEARCHPATH")
+      , m_search_paths("APPLESEED_SEARCHPATH", SearchPaths::platform_separator())
     {
     }
 };

--- a/src/appleseed/renderer/modeling/project/project.cpp
+++ b/src/appleseed/renderer/modeling/project/project.cpp
@@ -104,7 +104,7 @@ struct Project::Impl
 
     Impl()
       : m_format_revision(ProjectFormatRevision)
-      , m_search_paths("APPLESEED_SEARCHPATH", SearchPaths::platform_separator())
+      , m_search_paths("APPLESEED_SEARCHPATH", SearchPaths::environment_path_separator())
     {
     }
 };
@@ -160,7 +160,7 @@ SearchPaths& Project::search_paths() const
 
 string Project::make_search_path_string() const
 {
-    return impl->m_search_paths.to_string(';', true);
+    return impl->m_search_paths.to_string_reversed(SearchPaths::osl_path_separator());
 }
 
 void Project::set_scene(auto_release_ptr<Scene> scene)

--- a/src/appleseed/renderer/modeling/shadergroup/shaderquery.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderquery.cpp
@@ -203,7 +203,7 @@ ShaderQuery::ShaderQuery(const char* search_path)
 ShaderQuery::ShaderQuery(const SearchPaths& search_paths)
   : impl(new Impl())
 {
-    impl->m_search_path = search_paths.to_string(':', false);
+    impl->m_search_path = search_paths.to_string_reversed(SearchPaths::osl_path_separator());
 }
 
 ShaderQuery::~ShaderQuery()

--- a/src/appleseed/renderer/modeling/shadergroup/shaderquery.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderquery.cpp
@@ -203,7 +203,7 @@ ShaderQuery::ShaderQuery(const char* search_path)
 ShaderQuery::ShaderQuery(const SearchPaths& search_paths)
   : impl(new Impl())
 {
-    impl->m_search_path = search_paths.to_string();
+    impl->m_search_path = search_paths.to_string(':', false);
 }
 
 ShaderQuery::~ShaderQuery()


### PR DESCRIPTION
- Remove default arguments from SearchPaths.
- Use the default platform separator when initializing SearchPaths from environment variables.
- Added reset method (needed by Gafferseed).
- Added method to split and push back paths separated by a separator (needed by Gafferseed).
- Added unit tests.
