### PR TITLE
compute smooth normals mesh operation

### DIFF
--- a/src/appleseed.python/bindmeshobject.cpp
+++ b/src/appleseed.python/bindmeshobject.cpp
@@ -56,6 +56,16 @@ namespace
         return MeshObjectFactory::create(name.c_str(), bpy_dict_to_param_array(params));
     }
 
+    const Triangle& get_triangle(const MeshObject* object, const size_t index)
+    {
+        return object->get_triangle(index);
+    }
+
+    void set_triangle(MeshObject* object, const size_t index, const Triangle& triangle)
+    {
+        object->get_triangle(index) = triangle;
+    }
+
     bpy::list read_mesh_objects(
         const bpy::list&    search_paths,
         const string&       base_object_name,
@@ -147,7 +157,8 @@ void bind_mesh_object()
         .def("reserve_triangles", &MeshObject::reserve_triangles)
         .def("push_triangle", &MeshObject::push_triangle)
         .def("get_triangle_count", &MeshObject::get_triangle_count)
-        .def("get_triangle", &MeshObject::get_triangle, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("get_triangle", get_triangle, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("set_triangle", set_triangle)
 
         .def("set_motion_segment_count", &MeshObject::set_motion_segment_count)
         .def("get_motion_segment_count", &MeshObject::get_motion_segment_count)
@@ -166,4 +177,7 @@ void bind_mesh_object()
     bpy::class_<MeshObjectWriter>("MeshObjectWriter", bpy::no_init)
         .def("write", write_mesh_object).staticmethod("write")
         ;
+
+    bpy::def("compute_smooth_vertex_normals", compute_smooth_vertex_normals);
+    bpy::def("compute_smooth_vertex_tangents", compute_smooth_vertex_tangents);
 }

--- a/src/appleseed/renderer/api/object.h
+++ b/src/appleseed/renderer/api/object.h
@@ -35,6 +35,7 @@
 #include "renderer/modeling/object/curveobjectreader.h"
 #include "renderer/modeling/object/curveobjectwriter.h"
 #include "renderer/modeling/object/meshobject.h"
+#include "renderer/modeling/object/meshobjectoperations.h"
 #include "renderer/modeling/object/meshobjectreader.h"
 #include "renderer/modeling/object/meshobjectwriter.h"
 #include "renderer/modeling/object/object.h"

--- a/src/appleseed/renderer/modeling/object/meshobject.cpp
+++ b/src/appleseed/renderer/modeling/object/meshobject.cpp
@@ -284,6 +284,11 @@ const Triangle& MeshObject::get_triangle(const size_t index) const
     return impl->m_tess.m_primitives[index];
 }
 
+Triangle& MeshObject::get_triangle(const size_t index)
+{
+    return impl->m_tess.m_primitives[index];
+}
+
 void MeshObject::clear_triangles()
 {
     impl->m_tess.m_primitives.clear();

--- a/src/appleseed/renderer/modeling/object/meshobject.h
+++ b/src/appleseed/renderer/modeling/object/meshobject.h
@@ -127,6 +127,7 @@ class APPLESEED_DLLSYMBOL MeshObject
     size_t push_triangle(const Triangle& triangle);
     size_t get_triangle_count() const;
     const Triangle& get_triangle(const size_t index) const;
+    Triangle& get_triangle(const size_t index);
     void clear_triangles();
 
     // Set/get the number of motion segments (the number of motion vectors per vertex).

--- a/src/appleseed/renderer/modeling/object/meshobjectoperations.h
+++ b/src/appleseed/renderer/modeling/object/meshobjectoperations.h
@@ -29,16 +29,23 @@
 #ifndef APPLESEED_RENDERER_MODELING_OBJECT_MESHOBJECTOPERATIONS_H
 #define APPLESEED_RENDERER_MODELING_OBJECT_MESHOBJECTOPERATIONS_H
 
+// appleseed.main headers.
+#include "main/dllsymbol.h"
+
 // Forward declarations.
 namespace renderer  { class MeshObject; }
 
 namespace renderer
 {
 
+// Compute smooth vertex normal vectors for a mesh object.
+// The mesh object must not already have normals.
+APPLESEED_DLLSYMBOL void compute_smooth_vertex_normals(MeshObject& object);
+
 // Compute smooth vertex tangent vectors for a mesh object.
 // The mesh object must not already have tangent vectors.
 // The mesh object must have texture coordinates.
-void compute_smooth_vertex_tangents(MeshObject& object);
+APPLESEED_DLLSYMBOL void compute_smooth_vertex_tangents(MeshObject& object);
 
 }       // namespace renderer
 

--- a/src/appleseed/renderer/modeling/object/meshobjectreader.cpp
+++ b/src/appleseed/renderer/modeling/object/meshobjectreader.cpp
@@ -773,6 +773,21 @@ namespace
         return true;
     }
 
+    void compute_smooth_normals(MeshObject& object)
+    {
+        if (object.get_vertex_normal_count() > 0)
+        {
+            RENDERER_LOG_WARNING(
+                "skipping computation of smooth normal vectors for mesh object \"%s\" because it already has normal vectors.",
+                object.get_name());
+            return;
+        }
+
+        RENDERER_LOG_INFO("computing smooth normal vectors for mesh object \"%s\"...", object.get_name());
+
+        compute_smooth_vertex_normals(object);
+    }
+
     void compute_smooth_tangents(MeshObject& object)
     {
         if (object.get_vertex_tangent_count() > 0)
@@ -898,6 +913,18 @@ bool MeshObjectReader::read(
             "\"filename\" parameter group found.",
             base_object_name);
         return false;
+    }
+
+    // Compute smooth normals.
+    if (params.strings().exist("compute_smooth_normals"))
+    {
+        const RegExFilter filter(params.get("compute_smooth_normals"));
+        for (size_t i = 0; i < objects.size(); ++i)
+        {
+            MeshObject& object = *objects[i];
+            if (filter.accepts(object.get_name()))
+                compute_smooth_normals(object);
+        }
     }
 
     // Compute smooth tangents.


### PR DESCRIPTION
- Added a compute smooth normals mesh operation, similar to compute smooth tangents.
- Exported mesh operations from the appleseed library.
- Added python bindings for mesh ops.