### PR TITLE
Added support for OSL array parameters.

### DIFF
--- a/src/appleseed/renderer/meta/tests/test_shaderparamparser.cpp
+++ b/src/appleseed/renderer/meta/tests/test_shaderparamparser.cpp
@@ -72,6 +72,46 @@ TEST_SUITE(Renderer_Modeling_ShaderParamParser)
         EXPECT_EQ("test_string", parser.parse_string_value());
     }
 
+    TEST_CASE(ShaderParamParserFloatArray)
+    {
+        ShaderParamParser parser("float[] 1.0 2.0 3.0 4.0 5.0 6.0 7.0");
+        EXPECT_EQ(OSLParamTypeFloatArray, parser.param_type());
+        std::vector<float> values;
+        parser.parse_float_array(values);
+        EXPECT_EQ(7, values.size());
+    }
+
+    TEST_CASE(ShaderParamParserEmptyFloatArray)
+    {
+        ShaderParamParser parser("float[] ");
+        std::vector<float> values;
+
+        EXPECT_EXCEPTION(ExceptionOSLParamParseError,
+        {
+            parser.parse_float_array(values);
+        });
+    }
+
+    TEST_CASE(ShaderParamParserColorArray)
+    {
+        ShaderParamParser parser("color[] 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0");
+        EXPECT_EQ(OSLParamTypeColorArray, parser.param_type());
+        std::vector<float> values;
+        parser.parse_float3_array(values);
+        EXPECT_EQ(9, values.size());
+    }
+
+    TEST_CASE(ShaderParamParserVectorArrayWrongLenght)
+    {
+        ShaderParamParser parser("vector[] 1.0 2.0 3.0 4.0 5.0");
+        std::vector<float> values;
+
+        EXPECT_EXCEPTION(ExceptionOSLParamParseError,
+        {
+            parser.parse_float3_array(values);
+        });
+    }
+
     TEST_CASE(ShaderParamParserUnknownType)
     {
         EXPECT_EXCEPTION(ExceptionOSLParamParseError,

--- a/src/appleseed/renderer/modeling/shadergroup/shader.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shader.cpp
@@ -85,12 +85,28 @@ struct Shader::Impl
                     }
                     break;
 
+                case OSLParamTypeColorArray:
+                  {
+                      vector<float> values;
+                      parser.parse_float3_array(values);
+                      m_params.insert(ShaderParam::create_color_array_param(i.it().key(), values));
+                  }
+                  break;
+
                   case OSLParamTypeFloat:
                     {
                         const float val = parser.parse_one_value<float>();
                         m_params.insert(ShaderParam::create_float_param(i.it().key(), val));
                     }
                     break;
+
+                case OSLParamTypeFloatArray:
+                  {
+                      vector<float> values;
+                      parser.parse_float_array(values);
+                      m_params.insert(ShaderParam::create_float_array_param(i.it().key(), values));
+                  }
+                  break;
 
                   case OSLParamTypeInt:
                     {
@@ -115,6 +131,14 @@ struct Shader::Impl
                     }
                     break;
 
+                case OSLParamTypeNormalArray:
+                  {
+                      vector<float> values;
+                      parser.parse_float3_array(values);
+                      m_params.insert(ShaderParam::create_normal_array_param(i.it().key(), values));
+                  }
+                  break;
+
                   case OSLParamTypePoint:
                     {
                         float x, y, z;
@@ -122,6 +146,14 @@ struct Shader::Impl
                         m_params.insert(ShaderParam::create_point_param(i.it().key(), x, y, z));
                     }
                     break;
+
+                case OSLParamTypePointArray:
+                  {
+                      vector<float> values;
+                      parser.parse_float3_array(values);
+                      m_params.insert(ShaderParam::create_point_array_param(i.it().key(), values));
+                  }
+                  break;
 
                   case OSLParamTypeString:
                     {
@@ -139,6 +171,14 @@ struct Shader::Impl
                         m_params.insert(ShaderParam::create_vector_param(i.it().key(), x, y, z));
                     }
                     break;
+
+                case OSLParamTypeVectorArray:
+                  {
+                      vector<float> values;
+                      parser.parse_float3_array(values);
+                      m_params.insert(ShaderParam::create_vector_array_param(i.it().key(), values));
+                  }
+                  break;
 
                   default:
                     RENDERER_LOG_ERROR(

--- a/src/appleseed/renderer/modeling/shadergroup/shaderparam.h
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderparam.h
@@ -62,13 +62,18 @@ namespace renderer
 enum OSLParamType
 {
     OSLParamTypeColor,
+    OSLParamTypeColorArray,
     OSLParamTypeFloat,
+    OSLParamTypeFloatArray,
     OSLParamTypeInt,
     OSLParamTypeMatrix,
     OSLParamTypeNormal,
+    OSLParamTypeNormalArray,
     OSLParamTypePoint,
+    OSLParamTypePointArray,
     OSLParamTypeString,
-    OSLParamTypeVector
+    OSLParamTypeVector,
+    OSLParamTypeVectorArray
 };
 
 
@@ -100,51 +105,76 @@ class APPLESEED_DLLSYMBOL ShaderParam
 
     // Create an int param.
     static foundation::auto_release_ptr<ShaderParam> create_int_param(
-        const char*     name,
-        const int       value);
+        const char*         name,
+        const int           value);
 
     // Create a float param.
     static foundation::auto_release_ptr<ShaderParam> create_float_param(
-        const char*     name,
-        const float     value);
+        const char*         name,
+        const float         value);
+
+    // Create a float array param.
+    static foundation::auto_release_ptr<ShaderParam> create_float_array_param(
+        const char*         name,
+        std::vector<float>& value);
 
     // Create a vector param.
     static foundation::auto_release_ptr<ShaderParam> create_vector_param(
-        const char*     name,
-        const float     vx,
-        const float     vy,
-        const float     vz);
+        const char*         name,
+        const float         vx,
+        const float         vy,
+        const float         vz);
+
+    // Create a vector array param.
+    static foundation::auto_release_ptr<ShaderParam> create_vector_array_param(
+        const char*         name,
+        std::vector<float>& value);
 
     // Create a normal param.
     static foundation::auto_release_ptr<ShaderParam> create_normal_param(
-        const char*     name,
-        const float     nx,
-        const float     ny,
-        const float     nz);
+        const char*         name,
+        const float         nx,
+        const float         ny,
+        const float         nz);
+
+    // Create a normal array param.
+    static foundation::auto_release_ptr<ShaderParam> create_normal_array_param(
+        const char*         name,
+        std::vector<float>& value);
 
     // Create a point param.
     static foundation::auto_release_ptr<ShaderParam> create_point_param(
-        const char*     name,
-        const float     vx,
-        const float     vy,
-        const float     vz);
+        const char*         name,
+        const float         vx,
+        const float         vy,
+        const float         vz);
+
+    // Create a point array param.
+    static foundation::auto_release_ptr<ShaderParam> create_point_array_param(
+        const char*         name,
+        std::vector<float>& value);
 
     // Create a color param.
     static foundation::auto_release_ptr<ShaderParam> create_color_param(
-        const char*     name,
-        const float     vx,
-        const float     vy,
-        const float     vz);
+        const char*         name,
+        const float         vx,
+        const float         vy,
+        const float         vz);
+
+    // Create a color array param.
+    static foundation::auto_release_ptr<ShaderParam> create_color_array_param(
+        const char*         name,
+        std::vector<float>& value);
 
     // Create a matrix param.
     static foundation::auto_release_ptr<ShaderParam> create_matrix_param(
-        const char*     name,
-        const float*    values);
+        const char*         name,
+        const float*        values);
 
     // Create a string param.
     static foundation::auto_release_ptr<ShaderParam> create_string_param(
-        const char*     name,
-        const char*     value);
+        const char*         name,
+        const char*         value);
 
     // Return a const void pointer to this param value.
     const void* get_value() const;

--- a/src/appleseed/renderer/modeling/shadergroup/shaderparamparser.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderparamparser.cpp
@@ -53,24 +53,53 @@ ShaderParamParser::ShaderParamParser(const string& s)
 
     if (tok == "color")
         m_param_type = OSLParamTypeColor;
+    else if (tok == "color[]")
+        m_param_type = OSLParamTypeColorArray;
     else if (tok == "float")
         m_param_type = OSLParamTypeFloat;
+    else if (tok == "float[]")
+        m_param_type = OSLParamTypeFloatArray;
     else if (tok == "int")
         m_param_type = OSLParamTypeInt;
     else if (tok == "matrix")
         m_param_type = OSLParamTypeMatrix;
     else if (tok == "normal")
         m_param_type = OSLParamTypeNormal;
+    else if (tok == "normal[]")
+        m_param_type = OSLParamTypeNormalArray;
     else if (tok == "point")
         m_param_type = OSLParamTypePoint;
+    else if (tok == "point[]")
+        m_param_type = OSLParamTypePointArray;
     else if (tok == "string")
         m_param_type = OSLParamTypeString;
     else if (tok == "vector")
         m_param_type = OSLParamTypeVector;
+    else if (tok == "vector[]")
+        m_param_type = OSLParamTypeVectorArray;
     else
         throw ExceptionOSLParamParseError();
 
     ++m_tok_it;
+}
+
+void ShaderParamParser::parse_float_array(std::vector<float>& values)
+{
+    values.clear();
+
+    while (m_tok_it != m_tok_end)
+        values.push_back(parse_one_value<float>(false));
+
+    if (values.empty())
+        throw ExceptionOSLParamParseError();
+}
+
+void ShaderParamParser::parse_float3_array(std::vector<float>& values)
+{
+    parse_float_array(values);
+
+    if (values.size() % 3 != 0)
+        throw ExceptionOSLParamParseError();
 }
 
 string ShaderParamParser::parse_string_value()

--- a/src/appleseed/renderer/modeling/shadergroup/shaderparamparser.h
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderparamparser.h
@@ -78,6 +78,9 @@ class ShaderParamParser
     template <typename T>
     void parse_n_values(size_t n, T* values);
 
+    void parse_float_array(std::vector<float>& values);
+    void parse_float3_array(std::vector<float>& values);
+
     std::string parse_string_value();
 
   private:


### PR DESCRIPTION
Added support for OSL float, vector, point, normal and color array params in projects.
Syntax is "float[] 1.0 2.0 3.0 4.0 ...", "vector[] 1.0 2.0 3.0 1.0 2.0 3.0 ..."
For vectors, colors, points and normals, the number of floats after the type[], must be a multiple of 3.

Closes #1061 
