### PR TITLE
Misc work

### DIFF
--- a/src/appleseed/foundation/math/cdf.h
+++ b/src/appleseed/foundation/math/cdf.h
@@ -110,6 +110,12 @@ size_t sample_cdf(
     RandomAccessIter    end,
     const Weight        x);
 
+template <typename T>
+size_t sample_cdf_linear_search(
+    const T*            cdf,
+    const size_t        size,
+    const T             x);
+
 // Numerically invert the CDF function cdf, with corresponding PDF pdf,
 // using a combination of bisection and Newton's method.
 template <typename CDF, typename PDF, typename T>
@@ -234,6 +240,21 @@ inline size_t sample_cdf(
     assert(i < end);
 
     return i - begin;
+}
+
+template <typename T>
+inline size_t sample_cdf_linear_search(
+    const T*            cdf,
+    const T             x)
+{
+    assert(x >= T(0.0));
+    assert(x < T(1.0));
+
+    size_t i = 0;
+    while (cdf[i] < x)
+        i++;
+
+    return i;
 }
 
 template <typename CDF, typename PDF, typename T>

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_cdf.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_cdf.cpp
@@ -69,6 +69,12 @@ BENCHMARK_SUITE(Foundation_Math_CDF)
             m_x += m_cdf.sample(rand_double2(m_rng)).second;
     }
 
+    BENCHMARK_CASE_F(DoublePrecisionSampling_30Elements, Fixture<30>)
+    {
+        for (size_t i = 0; i < 100; ++i)
+            m_x += m_cdf.sample(rand_double2(m_rng)).second;
+    }
+
     BENCHMARK_CASE_F(DoublePrecisionSampling_1000Elements, Fixture<1000>)
     {
         for (size_t i = 0; i < 100; ++i)
@@ -79,5 +85,79 @@ BENCHMARK_SUITE(Foundation_Math_CDF)
     {
         for (size_t i = 0; i < 100; ++i)
             m_x += m_cdf.sample(rand_double2(m_rng)).second;
+    }
+}
+
+BENCHMARK_SUITE(Foundation_Math_CDF_Linear_Search)
+{
+    template <size_t Size>
+    struct Fixture
+    {
+        double              m_weights[Size];
+        Xorshift            m_rng;
+        double              m_x;
+
+        Fixture()
+          : m_x(0.0)
+        {
+            CDF<size_t, double> cdf;
+
+            for (size_t i = 0; i < Size; ++i)
+                cdf.insert(i, rand_double1(m_rng));
+
+            assert(cdf.valid());
+            cdf.prepare();
+
+            for (size_t i = 0; i < Size; ++i)
+                m_weights[i] = cdf[i].second;
+        }
+    };
+
+    BENCHMARK_CASE_F(DoublePrecisionSampling_1Elements, Fixture<1>)
+    {
+        for (size_t i = 0; i < 100; ++i)
+            m_x += sample_cdf_linear_search(m_weights, rand_double2(m_rng));
+    }
+
+    BENCHMARK_CASE_F(DoublePrecisionSampling_3Elements, Fixture<3>)
+    {
+        for (size_t i = 0; i < 100; ++i)
+            m_x += sample_cdf_linear_search(m_weights, rand_double2(m_rng));
+    }
+
+    BENCHMARK_CASE_F(DoublePrecisionSampling_5Elements, Fixture<5>)
+    {
+        for (size_t i = 0; i < 100; ++i)
+            m_x += sample_cdf_linear_search(m_weights, rand_double2(m_rng));
+    }
+
+    BENCHMARK_CASE_F(DoublePrecisionSampling_10Elements, Fixture<10>)
+    {
+        for (size_t i = 0; i < 100; ++i)
+            m_x += sample_cdf_linear_search(m_weights, rand_double2(m_rng));
+    }
+
+    BENCHMARK_CASE_F(DoublePrecisionSampling_15Elements, Fixture<15>)
+    {
+        for (size_t i = 0; i < 100; ++i)
+            m_x += sample_cdf_linear_search(m_weights, rand_double2(m_rng));
+    }
+
+    BENCHMARK_CASE_F(DoublePrecisionSampling_20Elements, Fixture<20>)
+    {
+        for (size_t i = 0; i < 100; ++i)
+            m_x += sample_cdf_linear_search(m_weights, rand_double2(m_rng));
+    }
+
+    BENCHMARK_CASE_F(DoublePrecisionSampling_30Elements, Fixture<30>)
+    {
+        for (size_t i = 0; i < 100; ++i)
+            m_x += sample_cdf_linear_search(m_weights, rand_double2(m_rng));
+    }
+
+    BENCHMARK_CASE_F(DoublePrecisionSampling_50Elements, Fixture<50>)
+    {
+        for (size_t i = 0; i < 100; ++i)
+            m_x += sample_cdf_linear_search(m_weights, rand_double2(m_rng));
     }
 }

--- a/src/appleseed/foundation/meta/tests/test_cdf.cpp
+++ b/src/appleseed/foundation/meta/tests/test_cdf.cpp
@@ -205,4 +205,25 @@ TEST_SUITE(Foundation_Math_CDF)
         for (size_t i = 0, e = countof(Result); i < e; ++i)
             EXPECT_EQ(Result[i], sample_cdf(begin, end, Weights[i]));
     }
+
+    TEST_CASE(SampleCDFLinearSearch)
+    {
+        static const double Cdf[] =
+        {
+            0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0
+        };
+
+        static const double Weights[] =
+        {
+            0.0, 0.07, 0.15, 0.23, 0.41, 0.77, 0.98
+        };
+
+        static const size_t Result[] =
+        {
+            0, 1, 2, 3, 5, 8, 10
+        };
+
+        for (size_t i = 0, e = countof(Result); i < e; ++i)
+            EXPECT_EQ(Result[i], sample_cdf_linear_search(Cdf, Weights[i]));
+    }
 }

--- a/src/appleseed/renderer/kernel/shading/closures.cpp
+++ b/src/appleseed/renderer/kernel/shading/closures.cpp
@@ -303,7 +303,7 @@ namespace
             values->m_metallic = saturate(p->metallic);
             values->m_specular = max(p->specular, 0.0f);
             values->m_specular_tint = saturate(p->specular_tint);
-            values->m_anisotropic = saturate(p->anisotropic);
+            values->m_anisotropic = clamp(p->anisotropic, -1.0f, 1.0f);
             values->m_roughness = clamp(p->roughness, 0.0001f, 1.0f);
             values->m_sheen = saturate(p->sheen);
             values->m_sheen_tint = saturate(p->sheen_tint);

--- a/src/appleseed/renderer/kernel/shading/closures.cpp
+++ b/src/appleseed/renderer/kernel/shading/closures.cpp
@@ -1002,7 +1002,7 @@ void CompositeClosure::compute_cdf()
 
 size_t CompositeClosure::choose_closure(const double w) const
 {
-    return sample_cdf(m_cdf, m_cdf + get_num_closures(), w);
+    return sample_cdf_linear_search(m_cdf, w);
 }
 
 void CompositeClosure::compute_closure_shading_basis(
@@ -1196,7 +1196,7 @@ double CompositeSurfaceClosure::choose_ior(const double w) const
     if APPLESEED_LIKELY(m_num_iors == 1)
         return m_iors[0];
 
-    const size_t index = sample_cdf(m_ior_cdf, m_ior_cdf + m_num_iors, w);
+    const size_t index = sample_cdf_linear_search(m_ior_cdf, w);
     return m_iors[index];
 }
 


### PR DESCRIPTION
- Allow negative anisotropy values for Disney brdf OSL closure.
- Added fast linear search CDF sample function:

./bin/Ship/appleseed.cli --run-unit-benchmarks Foundation_Math_CDF*
Foundation_Math_CDF:
  DoublePrecisionSampling_10Elements: 3,514 clock ticks (634.036K calls/s at 2228.001 MHz)
  DoublePrecisionSampling_30Elements: 5,196 clock ticks (427.486K calls/s at 2221.219 MHz)
  DoublePrecisionSampling_1000Elements: 12,124 clock ticks (183.404K calls/s at 2223.595 MHz)
  DoublePrecisionSampling_1000000Elements: 41,420 clock ticks (53.638K calls/s at 2221.705 MHz)
Foundation_Math_CDF_Linear_Search:
  DoublePrecisionSampling_1Elements: 472.0 clock ticks (4.687M calls/s at 2212.255 MHz)
  DoublePrecisionSampling_3Elements: 1,600 clock ticks (1.388M calls/s at 2221.442 MHz)
  DoublePrecisionSampling_5Elements: 1,518 clock ticks (1.465M calls/s at 2223.272 MHz)
  DoublePrecisionSampling_10Elements: 1,728 clock ticks (1.287M calls/s at 2224.741 MHz)
  DoublePrecisionSampling_15Elements: 2,014 clock ticks (1.104M calls/s at 2223.692 MHz)
  DoublePrecisionSampling_20Elements: 2,368 clock ticks (939.214K calls/s at 2224.058 MHz)
  DoublePrecisionSampling_30Elements: 3,044 clock ticks (729.722K calls/s at 2221.274 MHz)
  DoublePrecisionSampling_50Elements: 4,838 clock ticks (459.159K calls/s at 2221.410 MHz)
