### PR TITLE
Build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,7 +434,7 @@ if (is_x86)
             APPLESEED_USE_SSE
        )
        if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SIZEOF_VOID_P MATCHES 4)
-           message (WARNING "Building appleseed with SSE/SSE2 instruction sets on 32-bit Linux is not supported; continuing without SSE/SSE2.")
+           message (WARNING "Building appleseed with SSE/SSE2 instruction sets on 32-bit Linux is not recommended.")
        endif ()
     endif ()
 elseif (TARGET_ARCH MATCHES "ARM")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,10 +121,6 @@ option (USE_STATIC_OSL                      "Use static OpenShadingLanguage libr
 option (WARNINGS_AS_ERRORS                  "Treat compiler warnings as errors"                     ON)
 option (HIDE_SYMBOLS                        "When using gcc, hide symbols not on the public API"    ON)
 
-if (CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD")
-    option (USE_VISIBILITY_MAP              "When using gcc, hide symbols not on the public API"    OFF)
-endif ()
-
 # SIMD options.
 if (is_x86)
     option (USE_SSE                         "Use SSE instruction sets up to version 2"              ON)
@@ -132,6 +128,9 @@ if (is_x86)
     if (TARGET_ARCH MATCHES "x86_64")
        option (USE_SSE42                    "Use SSE instruction sets up to version 4.2"            OFF)
        option (USE_AVX                      "Use AVX instruction set"                               OFF)
+       option (USE_AVX2                     "Use AVX2 instruction set"                              OFF)
+       option (USE_FMA                      "Use FMA instruction set"                               OFF)
+       option (USE_F16C                     "Use F16C instruction set"                              OFF)
     endif ()
 elseif (TARGET_ARCH MATCHES "ARM")
     option (USE_NEON                        "Use NEON instruction set"                              OFF)
@@ -391,29 +390,64 @@ if (UNIX AND NOT APPLE)
 endif ()
 
 # SIMD.
-if (USE_AVX)
-    set (USE_SSE42 TRUE)
-    set (preprocessor_definitions_common
-        ${preprocessor_definitions_common}
-        APPLESEED_USE_AVX
-    )
-endif ()
-if (USE_SSE42)
-   set (USE_SSE TRUE)
-   set (preprocessor_definitions_common
-       ${preprocessor_definitions_common}
-       APPLESEED_USE_SSE42
-   )
-endif ()
-if (USE_SSE)
-   if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SIZEOF_VOID_P MATCHES 4)
-       message (WARNING "Building appleseed with SSE/SSE2 instruction sets on 32-bit Linux is not supported; continuing without SSE/SSE2.")
-   else ()
+if (is_x86)
+    if (USE_F16C)
+        set (preprocessor_definitions_common
+            ${preprocessor_definitions_common}
+            APPLESEED_USE_F16C
+        )
+    endif ()
+    if (USE_FMA)
+        set (preprocessor_definitions_common
+            ${preprocessor_definitions_common}
+            APPLESEED_USE_FMA
+        )
+    endif ()
+    if (USE_AVX2)
+        set (USE_AVX TRUE)
+        set (preprocessor_definitions_common
+            ${preprocessor_definitions_common}
+            APPLESEED_USE_AVX2
+        )
+    endif ()
+    if (USE_AVX)
+        set (USE_SSE42 TRUE)
+        set (preprocessor_definitions_common
+            ${preprocessor_definitions_common}
+            APPLESEED_USE_AVX
+        )
+    endif ()
+    if (USE_SSE42)
+       set (USE_SSE TRUE)
        set (preprocessor_definitions_common
            ${preprocessor_definitions_common}
-           APPLESEED_USE_SSE
+           APPLESEED_USE_SSE42
        )
-   endif ()
+    endif ()
+    if (USE_SSE)
+       if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SIZEOF_VOID_P MATCHES 4)
+           message (WARNING "Building appleseed with SSE/SSE2 instruction sets on 32-bit Linux is not supported; continuing without SSE/SSE2.")
+       else ()
+           set (preprocessor_definitions_common
+               ${preprocessor_definitions_common}
+               APPLESEED_USE_SSE
+           )
+       endif ()
+    endif ()
+elseif (TARGET_ARCH MATCHES "ARM")
+    if (USE_NEON)
+        set (preprocessor_definitions_common
+            ${preprocessor_definitions_common}
+            APPLESEED_USE_NEON
+        )
+    endif ()
+elseif (TARGET_ARCH MATCHES "PPC")
+    if (USE_ALTIVEC)
+        set (preprocessor_definitions_common
+            ${preprocessor_definitions_common}
+            APPLESEED_USE_ALTIVEC
+        )
+    endif ()
 endif ()
 
 # Debug configuration.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,10 @@ option (USE_STATIC_OSL                      "Use static OpenShadingLanguage libr
 option (WARNINGS_AS_ERRORS                  "Treat compiler warnings as errors"                     ON)
 option (HIDE_SYMBOLS                        "When using gcc, hide symbols not on the public API"    ON)
 
+if (CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD")
+    option (USE_VISIBILITY_MAP              "When using gcc, hide symbols not on the public API"    OFF)
+endif ()
+
 # SIMD options.
 if (is_x86)
     option (USE_SSE                         "Use SSE instruction sets up to version 2"              ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,10 @@ option (USE_STATIC_OSL                      "Use static OpenShadingLanguage libr
 option (WARNINGS_AS_ERRORS                  "Treat compiler warnings as errors"                     ON)
 option (HIDE_SYMBOLS                        "When using gcc, hide symbols not on the public API"    ON)
 
+if (CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD")
+    option (USE_VISIBILITY_MAP              "Use GNU export map for libappleseed.so (experimental)" OFF)
+endif ()
+
 # SIMD options.
 if (is_x86)
     option (USE_SSE                         "Use SSE instruction sets up to version 2"              ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -429,13 +429,12 @@ if (is_x86)
        )
     endif ()
     if (USE_SSE)
+       set (preprocessor_definitions_common
+            ${preprocessor_definitions_common}
+            APPLESEED_USE_SSE
+       )
        if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SIZEOF_VOID_P MATCHES 4)
            message (WARNING "Building appleseed with SSE/SSE2 instruction sets on 32-bit Linux is not supported; continuing without SSE/SSE2.")
-       else ()
-           set (preprocessor_definitions_common
-               ${preprocessor_definitions_common}
-               APPLESEED_USE_SSE
-           )
        endif ()
     endif ()
 elseif (TARGET_ARCH MATCHES "ARM")

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -1869,6 +1869,11 @@ append_custom_preprocessor_definitions (appleseed
     APPLESEED_ENABLE_IMATH_INTEROP
 )
 
+if (USE_VISIBILITY_MAP)
+    set_target_properties (appleseed PROPERTIES
+        LINK_FLAGS "-Wl,--version-script=${PROJECT_SOURCE_DIR}/src/appleseed/libappleseed.map"
+    )
+endif ()
 
 #--------------------------------------------------------------------------------------------------
 # Static libraries.

--- a/src/appleseed/foundation/image/colorspace.h
+++ b/src/appleseed/foundation/image/colorspace.h
@@ -165,7 +165,7 @@ extern const RegularSpectrum31f RGBToSpectrumBlueIlluminance;
 class LightingConditions
 {
   public:
-    APPLESEED_SSE_ALIGN Color4f     m_cmf[32];                  // precomputed values of (cmf[0], cmf[1], cmf[2]) * illuminant
+    APPLESEED_SIMD4_ALIGN Color4f   m_cmf[32];                  // precomputed values of (cmf[0], cmf[1], cmf[2]) * illuminant
 
     LightingConditions();                                       // leaves the object uninitialized
 
@@ -697,7 +697,7 @@ inline __m128 fast_linear_rgb_to_srgb(const __m128 linear_rgb)
 
 inline Color3f fast_linear_rgb_to_srgb(const Color3f& linear_rgb)
 {
-    APPLESEED_SSE_ALIGN float transfer[4] =
+    APPLESEED_SIMD4_ALIGN float transfer[4] =
     {
         linear_rgb[0],
         linear_rgb[1],
@@ -762,7 +762,7 @@ inline __m128 faster_linear_rgb_to_srgb(const __m128 linear_rgb)
 
 inline Color3f faster_linear_rgb_to_srgb(const Color3f& linear_rgb)
 {
-    APPLESEED_SSE_ALIGN float transfer[4] =
+    APPLESEED_SIMD4_ALIGN float transfer[4] =
     {
         linear_rgb[0],
         linear_rgb[1],
@@ -860,7 +860,7 @@ inline Color3f spectrum_to_ciexyz<float, RegularSpectrum31f>(
     xyz3 = _mm_add_ps(xyz3, xyz4);
     xyz1 = _mm_add_ps(xyz1, xyz3);
 
-    APPLESEED_SSE_ALIGN float transfer[4];
+    APPLESEED_SIMD4_ALIGN float transfer[4];
     _mm_store_ps(transfer, xyz1);
 
     return Color3f(transfer[0], transfer[1], transfer[2]);

--- a/src/appleseed/foundation/image/regularspectrum.h
+++ b/src/appleseed/foundation/image/regularspectrum.h
@@ -78,7 +78,7 @@ class RegularSpectrum
     const ValueType& operator[](const size_t i) const;
 
   private:
-    APPLESEED_SSE_ALIGN ValueType m_samples[StoredSamples];
+    APPLESEED_SIMD4_ALIGN ValueType m_samples[StoredSamples];
 };
 
 // Exact inequality and equality tests.

--- a/src/appleseed/foundation/math/bvh/bvh_intersector.h
+++ b/src/appleseed/foundation/math/bvh/bvh_intersector.h
@@ -724,7 +724,7 @@ void Intersector<Tree, Visitor, Ray3d, StackSize, 3>::intersect_motion(
             }
             else
             {
-                APPLESEED_SSE_ALIGN double bbox_data[12];
+                APPLESEED_SIMD4_ALIGN double bbox_data[12];
 
                 // Fetch the left bounding box.
                 if (left_motion_segment_count > 0)

--- a/src/appleseed/foundation/math/bvh/bvh_node.h
+++ b/src/appleseed/foundation/math/bvh/bvh_node.h
@@ -108,7 +108,7 @@ class APPLESEED_ALIGN(64) Node
     uint32                          m_right_bbox_index;
     uint32                          m_right_bbox_count;
 
-    APPLESEED_SSE_ALIGN ValueType   m_bbox_data[4 * Dimension];
+    APPLESEED_SIMD4_ALIGN ValueType m_bbox_data[4 * Dimension];
 };
 
 

--- a/src/appleseed/foundation/math/intersection/raytrianglessk.h
+++ b/src/appleseed/foundation/math/intersection/raytrianglessk.h
@@ -222,7 +222,7 @@ APPLESEED_FORCE_INLINE bool TriangleSSK<float>::intersect(
 
     // Check that the intersection point lies inside the triangle.
 #ifdef APPLESEED_USE_SSE
-    APPLESEED_SSE_ALIGN float detarray[4] = { uprime, uprime, vprime, wprime };
+    APPLESEED_SIMD4_ALIGN float detarray[4] = { uprime, uprime, vprime, wprime };
     const __m128 mu = _mm_load_ps(detarray);
     const __m128 mv = _mm_shuffle_ps(mu, mu, _MM_SHUFFLE(2, 3, 3, 2));
     const __m128 product = _mm_mul_ps(mu, mv);
@@ -338,7 +338,7 @@ APPLESEED_FORCE_INLINE bool TriangleSSK<float>::intersect(const RayType& ray) co
 
     // Check that the intersection point lies inside the triangle.
 #ifdef APPLESEED_USE_SSE
-    APPLESEED_SSE_ALIGN float detarray[4] = { uprime, uprime, vprime, wprime };
+    APPLESEED_SIMD4_ALIGN float detarray[4] = { uprime, uprime, vprime, wprime };
     const __m128 mu = _mm_load_ps(detarray);
     const __m128 mv = _mm_shuffle_ps(mu, mu, _MM_SHUFFLE(2, 3, 3, 2));
     const __m128 product = _mm_mul_ps(mu, mv);

--- a/src/appleseed/foundation/math/matrix.h
+++ b/src/appleseed/foundation/math/matrix.h
@@ -444,7 +444,7 @@ class Matrix<T, 4, 4>
         Vector<T, 3>&           translation) const;
 
   private:
-    APPLESEED_SSE_ALIGN ValueType m_comp[Components];
+    APPLESEED_SIMD4_ALIGN ValueType m_comp[Components];
 
     // The identity matrix returned by identity().
     static const MatrixType m_identity;

--- a/src/appleseed/foundation/math/ray.h
+++ b/src/appleseed/foundation/math/ray.h
@@ -157,12 +157,12 @@ class RayInfo<double, 3>
     static const size_t Dimension = 3;
 
     // Reciprocal of the ray direction.
-    APPLESEED_SSE_ALIGN VectorType m_rcp_dir;
+    APPLESEED_SIMD4_ALIGN VectorType m_rcp_dir;
 
     // Sign of the ray direction (for the i'th component, the sign value
     // is 1 if the component is positive or null, and 0 if the component
     // is strictly negative).
-    APPLESEED_SSE_ALIGN Vector<uint32, 4> m_sgn_dir;
+    APPLESEED_SIMD4_ALIGN Vector<uint32, 4> m_sgn_dir;
 
     // Constructors.
     RayInfo();                              // leave all fields uninitialized

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_fastmath.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_fastmath.cpp
@@ -48,8 +48,8 @@ BENCHMARK_SUITE(Foundation_Math_FastMath)
 
     struct Fixture
     {
-        APPLESEED_SSE_ALIGN float m_values[N];
-        APPLESEED_SSE_ALIGN float m_output[N];
+        APPLESEED_SIMD4_ALIGN float m_values[N];
+        APPLESEED_SIMD4_ALIGN float m_output[N];
 
         Fixture()
         {

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_samesign.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_samesign.cpp
@@ -145,7 +145,7 @@ BENCHMARK_SUITE(SameSign)
 
     APPLESEED_NO_INLINE bool same_sign_multiplication_sse(const float a, const float b, const float c)
     {
-        APPLESEED_SSE_ALIGN float u[4] = { a, a, b, c };
+        APPLESEED_SIMD4_ALIGN float u[4] = { a, a, b, c };
 
         const __m128 mu = _mm_load_ps(u);
         const __m128 mv = _mm_shuffle_ps(mu, mu, _MM_SHUFFLE(2, 3, 3, 2));

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_voxelgrid.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_voxelgrid.cpp
@@ -88,7 +88,7 @@ BENCHMARK_SUITE(Foundation_Math_VoxelGrid3)
     {
         for (size_t i = 0; i < LookupPointCount; ++i)
         {
-            APPLESEED_SSE_ALIGN float values[ChannelCount];
+            APPLESEED_SIMD4_ALIGN float values[ChannelCount];
             m_grid.nearest_lookup(m_lookup_points[i], values);
 
             for (size_t j = 0; j < ChannelCount; ++j)
@@ -100,7 +100,7 @@ BENCHMARK_SUITE(Foundation_Math_VoxelGrid3)
     {
         for (size_t i = 0; i < LookupPointCount; ++i)
         {
-            APPLESEED_SSE_ALIGN float values[ChannelCount];
+            APPLESEED_SIMD4_ALIGN float values[ChannelCount];
             m_grid.linear_lookup(m_lookup_points[i], values);
 
             for (size_t j = 0; j < ChannelCount; ++j)
@@ -112,7 +112,7 @@ BENCHMARK_SUITE(Foundation_Math_VoxelGrid3)
     {
         for (size_t i = 0; i < LookupPointCount; ++i)
         {
-            APPLESEED_SSE_ALIGN float values[ChannelCount];
+            APPLESEED_SIMD4_ALIGN float values[ChannelCount];
             m_grid.quadratic_lookup(m_lookup_points[i], values);
 
             for (size_t j = 0; j < ChannelCount; ++j)

--- a/src/appleseed/foundation/meta/tests/test_fastmath.cpp
+++ b/src/appleseed/foundation/meta/tests/test_fastmath.cpp
@@ -94,15 +94,15 @@ TEST_SUITE(Foundation_Math_FastMath)
 
         for (size_t i = 0; i < step_count; i += 4)
         {
-            APPLESEED_SSE_ALIGN T x[4];
+            APPLESEED_SIMD4_ALIGN T x[4];
 
             for (size_t j = 0; j < 4; ++j)
                 x[j] = fit<size_t, T>(i + j, 0, step_count - 1, low, high);
 
-            APPLESEED_SSE_ALIGN T ref_values[4] = { x[0], x[1], x[2], x[3] };
+            APPLESEED_SIMD4_ALIGN T ref_values[4] = { x[0], x[1], x[2], x[3] };
             ref(ref_values);
 
-            APPLESEED_SSE_ALIGN T values[4] = { x[0], x[1], x[2], x[3] };
+            APPLESEED_SIMD4_ALIGN T values[4] = { x[0], x[1], x[2], x[3] };
             func(values);
 
             for (size_t j = 0; j < 4; ++j)
@@ -594,7 +594,7 @@ TEST_SUITE(Foundation_Math_FastMath)
 
     //
     // Rcp(x).
-    // 
+    //
 
     TEST_CASE(ScalarFastRcp)
     {
@@ -628,7 +628,7 @@ TEST_SUITE(Foundation_Math_FastMath)
 
     //
     // Sqrt(x).
-    // 
+    //
 
     TEST_CASE(ScalarFastSqrt)
     {
@@ -662,7 +662,7 @@ TEST_SUITE(Foundation_Math_FastMath)
 
     //
     // RcpSqrt(x).
-    // 
+    //
 
     float rcp_sqrt(const float x)
     {

--- a/src/appleseed/foundation/platform/compiler.h
+++ b/src/appleseed/foundation/platform/compiler.h
@@ -92,25 +92,28 @@ namespace foundation
 
 
 //
-// A qualifier to specify the alignment of a variable, a structure member or a structure.
+// Qualifiers to specify the alignment of a variable, a structure member or a structure.
 //
-// APPLESEED_SSE_ALIGN aligns on a 16-byte boundary as required by SSE load/store instructions.
+// APPLESEED_SIMD4_ALIGN aligns on a 16-byte boundary as required by SSE load/store instructions.
+// APPLESEED_SIMD8_ALIGN aligns on a 32-byte boundary as required by AVX load/store instructions.
 //
-// Note that APPLESEED_SSE_ALIGN *always* performs the alignment, regardless of whether or not
+// Note that APPLESEED_SIMDX_ALIGN *always* performs the alignment, regardless of whether or not
 // SSE is enabled in the build configuration.
 //
 
 // Visual C++.
 #if defined _MSC_VER
     #define APPLESEED_ALIGN(n) __declspec(align(n))
-    #define APPLESEED_SSE_ALIGN APPLESEED_ALIGN(16)
+    #define APPLESEED_SIMD4_ALIGN APPLESEED_ALIGN(16)
+    #define APPLESEED_SIMD8_ALIGN APPLESEED_ALIGN(32)
 
 // gcc.
 #elif defined __GNUC__
     #define APPLESEED_ALIGN(n) __attribute__((aligned(n)))
-    #define APPLESEED_SSE_ALIGN APPLESEED_ALIGN(16)
+    #define APPLESEED_SIMD4_ALIGN APPLESEED_ALIGN(16)
+    #define APPLESEED_SIMD8_ALIGN APPLESEED_ALIGN(32)
 
-// Other compilers: ignore the qualifier, and leave APPLESEED_SSE_ALIGN undefined.
+// Other compilers: ignore the qualifier, and leave APPLESEED_SIMDX_ALIGN undefined.
 #else
     #define APPLESEED_ALIGN(n)
 #endif

--- a/src/appleseed/foundation/platform/sse.h
+++ b/src/appleseed/foundation/platform/sse.h
@@ -38,10 +38,10 @@
 #include "foundation/platform/types.h"
 
 // Platform headers.
-#include <xmmintrin.h>      // SSE1 intrinsics
-#include <emmintrin.h>      // SSE2 intrinsics
-#ifdef APPLESEED_USE_SSE42
-#include <smmintrin.h>      // SSE4.2 intrinsics
+#if defined _MSC_VER
+#include <intrin.h>
+#else
+#include <x86intrin.h>
 #endif
 
 namespace foundation

--- a/src/appleseed/libappleseed.map
+++ b/src/appleseed/libappleseed.map
@@ -1,9 +1,0 @@
-{
-global: *;
-local:
-    extern "C++"
-    {
-        OSL*;
-        boost*;
-    };
-};

--- a/src/appleseed/libappleseed.map
+++ b/src/appleseed/libappleseed.map
@@ -1,0 +1,9 @@
+{
+global: *;
+local:
+    extern "C++"
+    {
+        OSL*;
+        boost*;
+    };
+};

--- a/src/appleseed/renderer/kernel/intersection/triangleitemhandler.cpp
+++ b/src/appleseed/renderer/kernel/intersection/triangleitemhandler.cpp
@@ -87,9 +87,9 @@ AABB3d TriangleItemHandler::clip(
 
 #ifdef APPLESEED_USE_SSE
 
-    APPLESEED_SSE_ALIGN const Vector3d v0(m_triangle_vertices[vertex_info.m_vertex_index + 0]);
-    APPLESEED_SSE_ALIGN const Vector3d v1(m_triangle_vertices[vertex_info.m_vertex_index + 1]);
-    APPLESEED_SSE_ALIGN const Vector3d v2(m_triangle_vertices[vertex_info.m_vertex_index + 2]);
+    APPLESEED_SIMD4_ALIGN const Vector3d v0(m_triangle_vertices[vertex_info.m_vertex_index + 0]);
+    APPLESEED_SIMD4_ALIGN const Vector3d v1(m_triangle_vertices[vertex_info.m_vertex_index + 1]);
+    APPLESEED_SIMD4_ALIGN const Vector3d v2(m_triangle_vertices[vertex_info.m_vertex_index + 2]);
 
     const double v0d = v0[dimension];
     const double v1d = v1[dimension];
@@ -256,7 +256,7 @@ AABB3d TriangleItemHandler::clip(
         }
     }
 
-    APPLESEED_SSE_ALIGN AABB3d bbox;
+    APPLESEED_SIMD4_ALIGN AABB3d bbox;
 
     _mm_store_pd(&bbox.min.x, bbox_min_xy);
     _mm_store_sd(&bbox.min.z, bbox_min_zz);

--- a/src/appleseed/renderer/modeling/bsdf/ashikhminbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/ashikhminbrdf.cpp
@@ -221,8 +221,7 @@ namespace
             const double den = cos_oh * (cos_in + cos_on - cos_in * cos_on);
             Spectrum glossy;
             fresnel_reflectance_dielectric_schlick(glossy, rval.m_scaled_rg, cos_oh, values->m_fr_multiplier);
-            glossy *= static_cast<float>(num / den);
-            sample.m_value += glossy;
+            madd(sample.m_value, glossy, static_cast<float>(num / den));
 
             // Evaluate the PDF of the glossy component (equation 8).
             const double pdf_glossy = num / cos_oh;     // omit division by 4 since num = pdf(h) / 4
@@ -302,8 +301,7 @@ namespace
                 const double den = cos_oh * (cos_in + cos_on - cos_in * cos_on);
                 Spectrum glossy;
                 fresnel_reflectance_dielectric_schlick(glossy, rval.m_scaled_rg, cos_oh, values->m_fr_multiplier);
-                glossy *= static_cast<float>(num / den);
-                value += glossy;
+                madd(value, glossy, static_cast<float>(num / den));
 
                 // Evaluate the PDF of the glossy component (equation 8).
                 const double pdf_glossy = num / cos_oh;     // omit division by 4 since num = pdf(h) / 4

--- a/src/appleseed/renderer/modeling/bsdf/bsdfblend.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfblend.cpp
@@ -240,15 +240,9 @@ namespace
             // Blend BSDF values.
             value.set(0.0f);
             if (bsdf0_prob > 0.0)
-            {
-                bsdf0_value *= static_cast<float>(w0);
-                value += bsdf0_value;
-            }
+                madd(value, bsdf0_value, static_cast<float>(w0));
             if (bsdf1_prob > 0.0)
-            {
-                bsdf1_value *= static_cast<float>(w1);
-                value += bsdf1_value;
-            }
+                madd(value, bsdf1_value, static_cast<float>(w1));
 
             // Blend PDF values.
             return bsdf0_prob * w0 + bsdf1_prob * w1;

--- a/src/appleseed/renderer/modeling/bsdf/bsdfmix.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfmix.cpp
@@ -257,15 +257,9 @@ namespace
             // Blend BSDF values.
             value.set(0.0f);
             if (bsdf0_prob > 0.0)
-            {
-                bsdf0_value *= static_cast<float>(w0);
-                value += bsdf0_value;
-            }
+                madd(value, bsdf0_value, static_cast<float>(w0));
             if (bsdf1_prob > 0.0)
-            {
-                bsdf1_value *= static_cast<float>(w1);
-                value += bsdf1_value;
-            }
+                madd(value, bsdf1_value, static_cast<float>(w1));
 
             // Blend PDF values.
             return bsdf0_prob * w0 + bsdf1_prob * w1;

--- a/src/appleseed/renderer/modeling/bsdf/oslbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/oslbsdf.cpp
@@ -253,8 +253,7 @@ namespace
 
                 if (bsdf_prob > 0.0)
                 {
-                    s *= c->get_closure_weight(i);
-                    value += s;
+                    madd(value, s, c->get_closure_weight(i));
                     prob += bsdf_prob * c->get_closure_pdf_weight(i);
                 }
             }

--- a/src/appleseed/renderer/modeling/bssrdf/oslbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/oslbssrdf.cpp
@@ -202,8 +202,7 @@ namespace
                     incoming_dir,
                     s);
 
-                s *= c->get_closure_weight(i);
-                value += s;
+                madd(value, s, c->get_closure_weight(i));
             }
         }
 

--- a/src/appleseed/renderer/modeling/frame/frame.cpp
+++ b/src/appleseed/renderer/modeling/frame/frame.cpp
@@ -260,7 +260,7 @@ namespace
         {
             // Load the pixel color.
 #ifdef APPLESEED_USE_SSE
-            APPLESEED_SSE_ALIGN Color4f color;
+            APPLESEED_SIMD4_ALIGN Color4f color;
 #else
             Color4f color;
 #endif

--- a/src/appleseed/renderer/modeling/input/inputevaluator.h
+++ b/src/appleseed/renderer/modeling/input/inputevaluator.h
@@ -75,7 +75,7 @@ class InputEvaluator
     enum { DataSize = 32 * 1024 };  // bytes
 
   private:
-    APPLESEED_SSE_ALIGN foundation::uint8   m_data[DataSize];
+    APPLESEED_SIMD4_ALIGN foundation::uint8 m_data[DataSize];
     TextureCache&                           m_texture_cache;
 };
 

--- a/src/appleseed/renderer/modeling/input/uniforminputevaluator.h
+++ b/src/appleseed/renderer/modeling/input/uniforminputevaluator.h
@@ -57,7 +57,7 @@ class UniformInputEvaluator
   private:
     static const size_t ScratchSize = 16 * 1024;    // bytes
 
-    APPLESEED_SSE_ALIGN foundation::uint8 m_scratch[ScratchSize];
+    APPLESEED_SIMD4_ALIGN foundation::uint8 m_scratch[ScratchSize];
 };
 
 

--- a/src/appleseed/renderer/utility/dynamicspectrum.h
+++ b/src/appleseed/renderer/utility/dynamicspectrum.h
@@ -120,7 +120,7 @@ class DynamicSpectrum
         DynamicSpectrum&                        dest);
 
   private:
-    APPLESEED_SSE_ALIGN ValueType   m_samples[StoredSamples];
+    APPLESEED_SIMD4_ALIGN ValueType m_samples[StoredSamples];
     foundation::uint32              m_size;
 };
 

--- a/src/appleseed/renderer/utility/dynamicspectrum.h
+++ b/src/appleseed/renderer/utility/dynamicspectrum.h
@@ -907,7 +907,7 @@ inline void madd(
     const DynamicSpectrum<T, N>&    b,
     const DynamicSpectrum<T, N>&    c)
 {
-    assert(a.size() == b.size() == c.size());
+    assert(a.size() == b.size() && a.size() == c.size());
 
     for (size_t i = 0, e = a.size(); i < e; ++i)
         a[i] += b[i] * c[i];
@@ -932,7 +932,7 @@ APPLESEED_FORCE_INLINE void madd(
     const DynamicSpectrum<float, 31>&   b,
     const DynamicSpectrum<float, 31>&   c)
 {
-    assert(a.size() == b.size() == c.size());
+    assert(a.size() == b.size() && a.size() == c.size());
 
     _mm_store_ps(&a[0], _mm_add_ps(_mm_load_ps(&a[0]), _mm_mul_ps(_mm_load_ps(&b[0]), _mm_load_ps(&c[0]))));
 

--- a/src/appleseed/renderer/utility/dynamicspectrum.h
+++ b/src/appleseed/renderer/utility/dynamicspectrum.h
@@ -144,6 +144,13 @@ template <typename T, size_t N> DynamicSpectrum<T, N>& operator*=(DynamicSpectru
 template <typename T, size_t N> DynamicSpectrum<T, N>& operator/=(DynamicSpectrum<T, N>& lhs, const T rhs);
 template <typename T, size_t N> DynamicSpectrum<T, N>& operator/=(DynamicSpectrum<T, N>& lhs, const DynamicSpectrum<T, N>& rhs);
 
+// Multiply-Add, a = a + b * c.
+template <typename T, size_t N>
+void madd(DynamicSpectrum<T, N>& a, const DynamicSpectrum<T, N>& b, const DynamicSpectrum<T, N>& c);
+
+template <typename T, size_t N>
+void madd(DynamicSpectrum<T, N>& a, const DynamicSpectrum<T, N>& b, const T c);
+
 
 //
 // Full specializations for spectra of type float and double.
@@ -893,6 +900,78 @@ inline DynamicSpectrum<T, N>& operator/=(DynamicSpectrum<T, N>& lhs, const Dynam
 
     return lhs;
 }
+
+template <typename T, size_t N>
+inline void madd(
+    DynamicSpectrum<T, N>&          a,
+    const DynamicSpectrum<T, N>&    b,
+    const DynamicSpectrum<T, N>&    c)
+{
+    assert(a.size() == b.size() == c.size());
+
+    for (size_t i = 0, e = a.size(); i < e; ++i)
+        a[i] += b[i] * c[i];
+}
+
+template <typename T, size_t N>
+inline void madd(
+    DynamicSpectrum<T, N>&          a,
+    const DynamicSpectrum<T, N>&    b,
+    const T                         c)
+{
+    assert(a.size() == b.size());
+
+    for (size_t i = 0, e = a.size(); i < e; ++i)
+        a[i] += b[i] * c;
+}
+
+#ifdef APPLESEED_USE_SSE
+template <>
+APPLESEED_FORCE_INLINE void madd(
+    DynamicSpectrum<float, 31>&         a,
+    const DynamicSpectrum<float, 31>&   b,
+    const DynamicSpectrum<float, 31>&   c)
+{
+    assert(a.size() == b.size() == c.size());
+
+    _mm_store_ps(&a[0], _mm_add_ps(_mm_load_ps(&a[0]), _mm_mul_ps(_mm_load_ps(&b[0]), _mm_load_ps(&c[0]))));
+
+    if (a.size() > 3)
+    {
+        _mm_store_ps(&a[ 4], _mm_add_ps(_mm_load_ps(&a[ 4]), _mm_mul_ps(_mm_load_ps(&b[ 4]), _mm_load_ps(&c[ 4]))));
+        _mm_store_ps(&a[ 8], _mm_add_ps(_mm_load_ps(&a[ 8]), _mm_mul_ps(_mm_load_ps(&b[ 8]), _mm_load_ps(&c[ 8]))));
+        _mm_store_ps(&a[12], _mm_add_ps(_mm_load_ps(&a[12]), _mm_mul_ps(_mm_load_ps(&b[12]), _mm_load_ps(&c[12]))));
+        _mm_store_ps(&a[16], _mm_add_ps(_mm_load_ps(&a[16]), _mm_mul_ps(_mm_load_ps(&b[16]), _mm_load_ps(&c[16]))));
+        _mm_store_ps(&a[20], _mm_add_ps(_mm_load_ps(&a[20]), _mm_mul_ps(_mm_load_ps(&b[20]), _mm_load_ps(&c[20]))));
+        _mm_store_ps(&a[24], _mm_add_ps(_mm_load_ps(&a[24]), _mm_mul_ps(_mm_load_ps(&b[24]), _mm_load_ps(&c[24]))));
+        _mm_store_ps(&a[28], _mm_add_ps(_mm_load_ps(&a[28]), _mm_mul_ps(_mm_load_ps(&b[28]), _mm_load_ps(&c[28]))));
+    }
+}
+
+template <>
+APPLESEED_FORCE_INLINE void madd(
+    DynamicSpectrum<float, 31>&         a,
+    const DynamicSpectrum<float, 31>&   b,
+    const float                         c)
+{
+    assert(a.size() == b.size());
+
+    const __m128 k = _mm_set_ps1(c);
+
+    _mm_store_ps(&a[0], _mm_add_ps(_mm_load_ps(&a[0]), _mm_mul_ps(_mm_load_ps(&b[0]), k)));
+
+    if (a.size() > 3)
+    {
+        _mm_store_ps(&a[ 4], _mm_add_ps(_mm_load_ps(&a[ 4]), _mm_mul_ps(_mm_load_ps(&b[ 4]), k)));
+        _mm_store_ps(&a[ 8], _mm_add_ps(_mm_load_ps(&a[ 8]), _mm_mul_ps(_mm_load_ps(&b[ 8]), k)));
+        _mm_store_ps(&a[12], _mm_add_ps(_mm_load_ps(&a[12]), _mm_mul_ps(_mm_load_ps(&b[12]), k)));
+        _mm_store_ps(&a[16], _mm_add_ps(_mm_load_ps(&a[16]), _mm_mul_ps(_mm_load_ps(&b[16]), k)));
+        _mm_store_ps(&a[20], _mm_add_ps(_mm_load_ps(&a[20]), _mm_mul_ps(_mm_load_ps(&b[20]), k)));
+        _mm_store_ps(&a[24], _mm_add_ps(_mm_load_ps(&a[24]), _mm_mul_ps(_mm_load_ps(&b[24]), k)));
+        _mm_store_ps(&a[28], _mm_add_ps(_mm_load_ps(&a[28]), _mm_mul_ps(_mm_load_ps(&b[28]), k)));
+    }
+}
+#endif
 
 }   // namespace renderer
 

--- a/src/cmake/config/linux-gcc.txt
+++ b/src/cmake/config/linux-gcc.txt
@@ -83,38 +83,38 @@ if (is_x86)
     if (USE_SSE)
         set (c_compiler_flags_common
              ${c_compiler_flags_common}
-            -msse2                                          # enable SSE instruction sets up to SSE 2
+            -msse2                                      # enable SSE instruction sets up to SSE 2
         )
     endif ()
     if (USE_SSE42)
         set (c_compiler_flags_common
              ${c_compiler_flags_common}
-            -msse4.2                                        # enable SSE instruction sets up to SSE 4.2
+            -msse4.2                                    # enable SSE instruction sets up to SSE 4.2
         )
     endif ()
     if (USE_AVX)
         set (c_compiler_flags_common
              ${c_compiler_flags_common}
-            -mavx                                           # enable AVX instruction sets
+            -mavx                                       # enable AVX instruction sets
         )
     endif ()
     if (USE_AVX2)
         set (c_compiler_flags_common
              ${c_compiler_flags_common}
-            -mavx2                                          # enable AVX2 instruction sets
+            -mavx2                                      # enable AVX2 instruction sets
         )
     endif ()
     if (USE_FMA)
         set (c_compiler_flags_common
              ${c_compiler_flags_common}
-            -mfma                                          # enable FMA instruction sets
-            -ffp-contract=off                              # for now only explicit fmadd
+            -mfma                                       # enable FMA instruction sets
+            -ffp-contract=off                           # for now only explicit fmadd
         )
     endif ()
     if (USE_F16C)
         set (c_compiler_flags_common
              ${c_compiler_flags_common}
-            -mf16c                                         # enable F16C instruction sets
+            -mf16c                                      # enable F16C instruction sets
         )
     endif ()
 elseif (TARGET_ARCH MATCHES "ARM")

--- a/src/cmake/config/linux-gcc.txt
+++ b/src/cmake/config/linux-gcc.txt
@@ -76,24 +76,64 @@ if (WARNINGS_AS_ERRORS)
         -Werror                                         # treat Warnings As Errors
     )
 endif ()
-if (USE_SSE)
-    set (c_compiler_flags_common
-         ${c_compiler_flags_common}
-        -msse2                                          # enable SSE instruction sets up to SSE 2
-    )
+
+# SIMD compiler flags
+
+if (is_x86)
+    if (USE_SSE)
+        set (c_compiler_flags_common
+             ${c_compiler_flags_common}
+            -msse2                                          # enable SSE instruction sets up to SSE 2
+        )
+    endif ()
+    if (USE_SSE42)
+        set (c_compiler_flags_common
+             ${c_compiler_flags_common}
+            -msse4.2                                        # enable SSE instruction sets up to SSE 4.2
+        )
+    endif ()
+    if (USE_AVX)
+        set (c_compiler_flags_common
+             ${c_compiler_flags_common}
+            -mavx                                           # enable AVX instruction sets
+        )
+    endif ()
+    if (USE_AVX2)
+        set (c_compiler_flags_common
+             ${c_compiler_flags_common}
+            -mavx2                                          # enable AVX2 instruction sets
+        )
+    endif ()
+    if (USE_FMA)
+        set (c_compiler_flags_common
+             ${c_compiler_flags_common}
+            -mfma                                          # enable FMA instruction sets
+            -ffp-contract=off                              # for now only explicit fmadd
+        )
+    endif ()
+    if (USE_F16C)
+        set (c_compiler_flags_common
+             ${c_compiler_flags_common}
+            -mf16c                                         # enable F16C instruction sets
+        )
+    endif ()
+elseif (TARGET_ARCH MATCHES "ARM")
+    if (USE_NEON)
+        set (c_compiler_flags_common
+             ${c_compiler_flags_common}
+             -mfpu=neon
+        )
+    endif ()
+elseif (TARGET_ARCH MATCHES "PPC")
+    if (USE_ALTIVEC)
+        set (c_compiler_flags_common
+             ${c_compiler_flags_common}
+             -maltivec
+             -mabi=altivec
+        )
+    endif ()
 endif ()
-if (USE_SSE42)
-    set (c_compiler_flags_common
-         ${c_compiler_flags_common}
-        -msse4.2                                        # enable SSE instruction sets up to SSE 4.2
-    )
-endif ()
-if (USE_AVX)
-    set (c_compiler_flags_common
-         ${c_compiler_flags_common}
-        -mavx                                           # enable AVX instruction sets
-    )
-endif ()
+
 set (exe_linker_flags_common
     -Werror                                             # Treat Warnings As Errors
 )

--- a/src/cmake/config/mac-clang.txt
+++ b/src/cmake/config/mac-clang.txt
@@ -87,6 +87,25 @@ if (USE_AVX)
         -mavx                                           # enable AVX instruction sets
     )
 endif ()
+if (USE_AVX2)
+    set (c_compiler_flags_common
+         ${c_compiler_flags_common}
+        -mavx2                                          # enable AVX2 instruction sets
+    )
+endif ()
+if (USE_FMA)
+    set (c_compiler_flags_common
+         ${c_compiler_flags_common}
+        -mfma                                          # enable FMA instruction sets
+        -ffp-contract=off                              # for now only explicit fmadd
+    )
+endif ()
+if (USE_F16C)
+    set (c_compiler_flags_common
+         ${c_compiler_flags_common}
+        -mf16c                                         # enable F16C instruction sets
+    )
+endif ()
 set (exe_linker_flags_common
     -Werror                                             # Treat Warnings As Errors
     -bind_at_load

--- a/src/cmake/config/mac-clang.txt
+++ b/src/cmake/config/mac-clang.txt
@@ -96,14 +96,14 @@ endif ()
 if (USE_FMA)
     set (c_compiler_flags_common
          ${c_compiler_flags_common}
-        -mfma                                          # enable FMA instruction sets
-        -ffp-contract=off                              # for now only explicit fmadd
+        -mfma                                           # enable FMA instruction sets
+        -ffp-contract=off                               # for now only explicit fmadd
     )
 endif ()
 if (USE_F16C)
     set (c_compiler_flags_common
          ${c_compiler_flags_common}
-        -mf16c                                         # enable F16C instruction sets
+        -mf16c                                          # enable F16C instruction sets
     )
 endif ()
 set (exe_linker_flags_common

--- a/src/cmake/config/win-vs.txt
+++ b/src/cmake/config/win-vs.txt
@@ -148,6 +148,25 @@ if (USE_AVX)
         /arch:AVX                           # Advanced Vector Extensions
     )
 endif ()
+if (USE_AVX2)
+    set (c_compiler_flags_release
+        ${c_compiler_flags_release}
+        /arch:AVX2                          # Advanced Vector Extensions 2
+    )
+endif ()
+if (USE_FMA)
+    set (c_compiler_flags_release
+        ${c_compiler_flags_release}
+        /arch:FMA                           # FMA SIMD Extensions
+    )
+endif ()
+if (USE_F16C)
+    set (c_compiler_flags_release
+        ${c_compiler_flags_release}
+        /arch:F16C                          # F16C SIMD Extensions
+    )
+endif ()
+
 set (exe_linker_flags_release
     /DEBUG                                  # Generate Debug Info
     /OPT:REF                                # Eliminate Unreferenced Data


### PR DESCRIPTION
- Added options for missing SIMD instruction sets.
- Renamed APPLESEED_SSE_ALIGN to APPLESEED_SIMD4_ALIGN.
- Added APPLESEED_SIMD8_ALIGN (currently unused).
- Use compiler intrinsics wrapper header instead of including individual SIMD headers.
- Added DynamicSpectrum multiply-add function (for now using SSE).
- Added experimental GNU visibility map for libappleseed.so (disabled by default).
