### PR TITLE
Revert "Remove OSL headers from public appleseed headers."

### DIFF
--- a/src/appleseed/renderer/modeling/scene/basegroup.h
+++ b/src/appleseed/renderer/modeling/scene/basegroup.h
@@ -36,8 +36,15 @@
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
+// OSL headers.
+#ifdef APPLESEED_WITH_OSL
+#include "foundation/platform/oslheaderguards.h"
+BEGIN_OSL_INCLUDES
+#include "OSL/oslexec.h"
+END_OSL_INCLUDES
+#endif
+
 // Forward declarations.
-namespace OSL           { class ShadingSystem; }
 namespace foundation    { class IAbortSwitch; }
 namespace foundation    { class StringArray; }
 namespace foundation    { class StringDictionary; }

--- a/src/appleseed/renderer/modeling/shadergroup/shadergroup.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shadergroup.cpp
@@ -42,12 +42,6 @@
 #include "foundation/utility/job/abortswitch.h"
 #include "foundation/utility/uid.h"
 
-// OSL headers.
-#include "foundation/platform/oslheaderguards.h"
-BEGIN_OSL_INCLUDES
-#include "OSL/oslexec.h"
-END_OSL_INCLUDES
-
 // Boost headers
 #include "boost/unordered/unordered_map.hpp"
 

--- a/src/appleseed/renderer/modeling/shadergroup/shadergroup.h
+++ b/src/appleseed/renderer/modeling/shadergroup/shadergroup.h
@@ -40,23 +40,13 @@
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
-// boost headers.
-#include "boost/shared_ptr.hpp"
+// OSL headers.
+#include "foundation/platform/oslheaderguards.h"
+BEGIN_OSL_INCLUDES
+#include "OSL/oslexec.h"
+END_OSL_INCLUDES
 
 // Forward declarations.
-namespace OSL
-{
-    class ShadingSystem;
-
-    // We cannot forward declare ShaderGroupRef because it's a typedef.
-    // Instead, it's legal to define a typedef multiple times as long
-    // as the definition is the same.
-    // It's not very elegant, but it seems better than requiring API
-    // users to have OSL just for one header.
-    class ShaderGroup;
-    typedef boost::shared_ptr<ShaderGroup> ShaderGroupRef;
-}
-
 namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class Assembly; }
 namespace renderer      { class AssemblyInstance; }


### PR DESCRIPTION
There are a few other places where OSL headers leak into the public headers and 
this fix was not that nice.

I think it's better to revert this change and do it properly when we have a chance.
I added a ticket instead to keep track of this.
