### PR TITLE
Travis scripts cleanup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,6 @@ matrix:
     include:
         - os: linux
           compiler: gcc
-          env: GCC_VERSION=4.8 USE_CPP11=OFF
-
-        - os: linux
-          compiler: gcc
           env: GCC_VERSION= USE_CPP11=OFF
 
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,22 @@ env:
 
 matrix:
     include:
-    include:
+        - os: linux
+          compiler: gcc
+          env: GCC_VERSION=4.8 USE_CPP11=OFF
+
+        - os: linux
+          compiler: gcc
+          env: GCC_VERSION= USE_CPP11=OFF
+
         - os: linux
           compiler: gcc
           env: GCC_VERSION=5 USE_CPP11=OFF
+
         - os: linux
           compiler: gcc
           env: GCC_VERSION=4.8 USE_CPP11=ON
+
         - os: linux
           compiler: gcc
           env: GCC_VERSION=5 USE_CPP11=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,21 +31,21 @@ env:
 
 matrix:
     include:
-        - os: linux
-          compiler: gcc
-          env: GCC_VERSION= USE_CPP11=OFF
+#        - os: linux
+#          compiler: gcc
+#          env: GCC_VERSION= USE_CPP11=OFF
 
         - os: linux
           compiler: gcc
           env: GCC_VERSION=5 USE_CPP11=OFF
 
-        - os: linux
-          compiler: gcc
-          env: GCC_VERSION=4.8 USE_CPP11=ON
+#        - os: linux
+#          compiler: gcc
+#          env: GCC_VERSION=4.8 USE_CPP11=ON
 
-        - os: linux
-          compiler: gcc
-          env: GCC_VERSION=5 USE_CPP11=ON
+#        - os: linux
+#          compiler: gcc
+#          env: GCC_VERSION=5 USE_CPP11=ON
 
 script:
   - ./travis/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ env:
 
 matrix:
     include:
-#        - os: linux
-#          compiler: gcc
-#          env: GCC_VERSION= USE_CPP11=OFF
+        - os: linux
+          compiler: gcc
+          env: GCC_VERSION= USE_CPP11=OFF
 
         - os: linux
           compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 
 language: cpp
 
-compiler:
-  - gcc
+os:
+  - linux
 
 addons:
   apt:
@@ -13,5 +13,27 @@ addons:
       - libxerces-c-dev
       - gcc-4.8
       - g++-4.8
+      - gcc-5
+      - g++-5
 
-script: ./travis-ci-build.sh
+before_install:
+  - git clone https://github.com/appleseedhq/travis-linux-deps.git
+
+install:
+  - if [ -n "$GCC_VERSION" ]; then export CC="${CC}-${GCC_VERSION}"; fi
+  - if [ -n "$GCC_VERSION" ]; then export CXX="${CXX}-${GCC_VERSION}"; fi
+
+compiler:
+  - gcc
+
+env:
+    - GCC_VERSION=4.8
+
+matrix:
+    include:
+        - os: linux
+          compiler: gcc
+          env: GCC_VERSION=5
+
+script:
+  - ./travis/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,20 @@ compiler:
   - gcc
 
 env:
-    - GCC_VERSION=4.8
+    - GCC_VERSION=4.8 USE_CPP11=OFF
 
 matrix:
     include:
+    include:
         - os: linux
           compiler: gcc
-          env: GCC_VERSION=5
+          env: GCC_VERSION=5 USE_CPP11=OFF
+        - os: linux
+          compiler: gcc
+          env: GCC_VERSION=4.8 USE_CPP11=ON
+        - os: linux
+          compiler: gcc
+          env: GCC_VERSION=5 USE_CPP11=ON
 
 script:
   - ./travis/build.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ endif ()
 
 if (USE_CPP11)
     message ("Building in C++11 mode.")
+    add_definitions (-DAPPLESEED_USE_CPP11)
 else ()
     message ("Building in C++03 mode.")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ option (WITH_DISNEY_MATERIAL                "Build Disney material"             
 option (WITH_NORMALIZED_DIFFUSION_BSSRDF    "Build Normalized Diffusion BSSRDF (patented)"          OFF)
 option (WITH_PARTIO                         "Build Partio support (used in unit tests)"             OFF)
 
+option (USE_CPP11                           "Use C++ 11"                                            OFF)
 option (USE_STATIC_BOOST                    "Use static Boost libraries"                            ON)
 option (USE_STATIC_OIIO                     "Use static OpenImageIO libraries"                      ON)
 option (USE_STATIC_OSL                      "Use static OpenShadingLanguage libraries"              ON)
@@ -141,6 +142,11 @@ else ()
     # Unknown architecture: No SIMD.
 endif ()
 
+if (USE_CPP11)
+    message ("Building in C++11 mode.")
+else ()
+    message ("Building in C++03 mode.")
+endif ()
 
 #--------------------------------------------------------------------------------------------------
 # Common settings.

--- a/src/appleseed/foundation/math/bvh/bvh_intersector.h
+++ b/src/appleseed/foundation/math/bvh/bvh_intersector.h
@@ -125,7 +125,7 @@ class Intersector
 // Intersector class implementation.
 //
 
-#ifndef __clang__
+#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
@@ -258,7 +258,7 @@ void Intersector<Tree, Visitor, Ray, StackSize, N>::intersect_no_motion(
     FOUNDATION_BVH_TRAVERSAL_STATS(stats.m_discarded_nodes.insert(discarded_nodes));
 }
 
-#ifndef __clang__
+#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/appleseed/foundation/platform/compiler.h
+++ b/src/appleseed/foundation/platform/compiler.h
@@ -219,7 +219,7 @@ namespace foundation
 //  A macro to mark a variable as unused. Useful in unit tests.
 //
 
-#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))
+#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 6)))
     #define APPLESEED_UNUSED   __attribute__((unused))
 #elif defined(__clang__)
     #define APPLESEED_UNUSED   __attribute__((unused))

--- a/src/appleseed/renderer/meta/tests/test_sss.cpp
+++ b/src/appleseed/renderer/meta/tests/test_sss.cpp
@@ -794,7 +794,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
 
         for (size_t i = 0; i < CircleCount; ++i)
         {
-            const float phi = fit<size_t, float>(i, 0, CircleCount - 1, 0.0f, TwoPi);
+            const float phi = fit<size_t, float>(i, 0, CircleCount - 1, 0.0f, TwoPi<float>());
             const Vector3d c(max_radius * cos(phi), 0.0f, max_radius * sin(phi));
 
             Partio::ParticleIndex p = particles.add_particle();

--- a/src/cmake/config/linux-gcc.txt
+++ b/src/cmake/config/linux-gcc.txt
@@ -77,6 +77,13 @@ if (WARNINGS_AS_ERRORS)
     )
 endif ()
 
+if (USE_CPP11)
+    set (cxx_compiler_flags_common
+        ${cxx_compiler_flags_common}
+        -std=c++11                                      # enable C++ 11
+    )
+endif ()
+
 # SIMD compiler flags.
 if (is_x86)
     if (USE_SSE)

--- a/src/cmake/config/linux-gcc.txt
+++ b/src/cmake/config/linux-gcc.txt
@@ -82,8 +82,8 @@ endif ()
 if (USE_CPP11)
     set (cxx_compiler_flags_common
         ${cxx_compiler_flags_common}
-        -std=c++11                                      # enable C++ 11
-        -Wno-deprecated-declarations                    # remove when C++ 11 support improves.
+        -std=c++11                                      # enable C++11
+        -Wno-deprecated-declarations                    # remove when C++11 support improves.
     )
 endif ()
 

--- a/src/cmake/config/linux-gcc.txt
+++ b/src/cmake/config/linux-gcc.txt
@@ -83,6 +83,7 @@ if (USE_CPP11)
     set (cxx_compiler_flags_common
         ${cxx_compiler_flags_common}
         -std=c++11                                      # enable C++ 11
+        -Wno-deprecated-declarations                    # remove when C++ 11 support improves.
     )
 endif ()
 

--- a/src/cmake/config/linux-gcc.txt
+++ b/src/cmake/config/linux-gcc.txt
@@ -65,10 +65,12 @@ set (c_compiler_flags_common
     -Wno-unknown-pragmas
     -Wno-sign-compare
     -Wno-unused-function
-    -Wno-reorder
     -Wno-strict-aliasing
     -fno-math-errno                                     # ignore errno when calling math functions
     -fPIC                                               # emit position-independent code
+)
+set (cxx_compiler_flags_common
+    -Wno-reorder
 )
 if (WARNINGS_AS_ERRORS)
     set (c_compiler_flags_common

--- a/src/cmake/config/mac-clang.txt
+++ b/src/cmake/config/mac-clang.txt
@@ -72,8 +72,8 @@ endif ()
 if (USE_CPP11)
     set (cxx_compiler_flags_common
         ${cxx_compiler_flags_common}
-        -std=c++11                                      # enable C++ 11
-        -Wno-deprecated-declarations                    # remove when C++ 11 support improves.
+        -std=c++11                                      # enable C++11
+        -Wno-deprecated-declarations                    # remove when C++11 support improves.
     )
 endif ()
 if (USE_SSE)

--- a/src/cmake/config/mac-clang.txt
+++ b/src/cmake/config/mac-clang.txt
@@ -69,6 +69,12 @@ if (WARNINGS_AS_ERRORS)
         -Werror                                         # treat Warnings As Errors
     )
 endif ()
+if (USE_CPP11)
+    set (cxx_compiler_flags_common
+        ${cxx_compiler_flags_common}
+        -std=c++11                                      # enable C++ 11
+    )
+endif ()
 if (USE_SSE)
     set (c_compiler_flags_common
         ${c_compiler_flags_common}

--- a/src/cmake/config/mac-clang.txt
+++ b/src/cmake/config/mac-clang.txt
@@ -73,6 +73,7 @@ if (USE_CPP11)
     set (cxx_compiler_flags_common
         ${cxx_compiler_flags_common}
         -std=c++11                                      # enable C++ 11
+        -Wno-deprecated-declarations                    # remove when C++ 11 support improves.
     )
 endif ()
 if (USE_SSE)

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -5,10 +5,11 @@ set -e
 THISDIR=`pwd`
 DEPSDIR=$THISDIR/travis-linux-deps
 
-mkdir build-$GCC_VERSION
-cd build-$GCC_VERSION
+mkdir build
+cd build
 
 cmake \
+    -D USE_CPP11=$USE_CPP11 \
     -D WITH_CLI=ON \
     -D WITH_STUDIO=OFF \
     -D WITH_TOOLS=OFF \

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -3,15 +3,10 @@
 set -e
 
 THISDIR=`pwd`
-
-git clone https://github.com/appleseedhq/travis-linux-deps.git
 DEPSDIR=$THISDIR/travis-linux-deps
 
-mkdir build
-cd build
-
-export CC=gcc-4.8
-export CXX=g++-4.8
+mkdir build-$GCC_VERSION
+cd build-$GCC_VERSION
 
 cmake \
     -D WITH_CLI=ON \
@@ -47,7 +42,7 @@ cmake \
     -D SEEXPR_LIBRARY=$DEPSDIR/lib/libSeExpr.so \
     -D USE_EXTERNAL_OIIO=ON \
     -D OPENIMAGEIO_INCLUDE_DIR=$DEPSDIR/include \
-    -D OPENIMAGEIO_LIBRARY=$DEPSDIR/lib/libOpenImageIO.so.1.5 \
+    -D OPENIMAGEIO_LIBRARY=$DEPSDIR/lib/libOpenImageIO.so.1.7 \
     -D USE_EXTERNAL_OSL=ON \
     -D OSL_INCLUDE_DIR=$DEPSDIR/include \
     -D OSL_COMP_LIBRARY=$DEPSDIR/lib/liboslcomp.so \


### PR DESCRIPTION
- Added build option to enable C++ 11.
- Simplified and improved Travis build scripts.
- Add gcc 4.6, gcc 4.8 and 5.0 in C++03 and C++11 modes to build matrix.
- Fix compile error when USE_PARTIO was enabled.
