### PR TITLE
BRDF and OSL improvements.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,8 +186,8 @@ configure_file (${PROJECT_SOURCE_DIR}/src/appleseed/foundation/core/version.h.in
                 ${PROJECT_SOURCE_DIR}/src/appleseed/foundation/core/version.h)
 
 if (WITH_OSL)
-    configure_file (${PROJECT_SOURCE_DIR}/src/appleseed/renderer/kernel/shading/stdosl.h.in
-                    ${PROJECT_SOURCE_DIR}/src/appleseed/renderer/kernel/shading/stdosl.h)
+    configure_file (${PROJECT_SOURCE_DIR}/src/appleseed/renderer/kernel/shading/as_osl_extensions.h.in
+                    ${PROJECT_SOURCE_DIR}/src/appleseed/renderer/kernel/shading/as_osl_extensions.h)
 endif ()
 
 

--- a/sandbox/shaders/.gitignore
+++ b/sandbox/shaders/.gitignore
@@ -1,3 +1,4 @@
 stdosl.h
 oslutil.h
+as_osl_extensions.h
 

--- a/sandbox/shaders/color/as_color_saturation.oso
+++ b/sandbox/shaders/color/as_color_saturation.oso
@@ -5,7 +5,7 @@ shader as_color_saturation
 param	color	Color	0 0 0		%read{1,3} %write{2147483647,-1}
 param	float	Factor	1		%meta{float,min,0} %meta{float,max,1}  %read{3,3} %write{2147483647,-1}
 oparam	color	ColorOut	0 0 0		%read{2147483647,-1} %write{3,3}
-local	float	___300_lum	%read{2,2} %write{1,1}
+local	float	___320_lum	%read{2,2} %write{1,1}
 const	string	$const1	"saturate"		%read{0,0} %write{2147483647,-1}
 temp	color	$tmp1	%read{3,3} %write{2,2}
 code ___main___
@@ -14,9 +14,9 @@ code ___main___
 	functioncall	$const1 4 	%filename{"./color/as_color_saturation.osl"} %line{42} %argrw{"r"}
 # include/appleseed/color.h:34
 #     float lum = luminance(Color);
-	luminance	___300_lum Color 	%filename{"include/appleseed/color.h"} %line{34} %argrw{"wr"}
+	luminance	___320_lum Color 	%filename{"include/appleseed/color.h"} %line{34} %argrw{"wr"}
 # include/appleseed/color.h:35
 #     return mix(color(lum), Color, Factor);
-	assign		$tmp1 ___300_lum 	%line{35} %argrw{"wr"}
+	assign		$tmp1 ___320_lum 	%line{35} %argrw{"wr"}
 	mix		ColorOut $tmp1 Color Factor 	%argrw{"wrrr"}
 	end

--- a/sandbox/shaders/float/as_float_remap.oso
+++ b/sandbox/shaders/float/as_float_remap.oso
@@ -23,9 +23,9 @@ code ___main___
 	sub		$tmp2 FromHigh FromLow 	%argrw{"wrr"}
 	div		$tmp3 $tmp1 $tmp2 	%argrw{"wrr"}
 	functioncall	$const3 6 	%argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:157
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:149
 # point  log (point a,  float b) { return log(a)/log(b); }
-	min		$tmp4 $tmp3 $const2 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{157} %argrw{"wrr"}
+	min		$tmp4 $tmp3 $const2 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{149} %argrw{"wrr"}
 	max		t $tmp4 $const1 	%argrw{"wrr"}
 # ./float/as_float_remap.osl:41
 #     Result = mix(ToLow, ToHigh, t);

--- a/sandbox/shaders/normal/as_bump_map.oso
+++ b/sandbox/shaders/normal/as_bump_map.oso
@@ -17,14 +17,14 @@ local	vector	dpdx	%read{14,31} %write{6,6}
 local	vector	dpdy	%read{18,29} %write{7,7}
 local	float	dhx	%read{16,33} %write{9,9}
 local	float	dhy	%read{20,34} %write{11,11}
-local	vector	___300_new_tn	%read{22,22} %write{17,17}
-local	vector	___300_new_bn	%read{22,22} %write{21,21}
-local	int	___301_has_diffs	%read{26,26} %write{23,23}
-local	int	___301_get_attr_ok	%read{24,24} %write{23,23}
-local	vector	___302_rx	%read{31,33} %write{29,29}
-local	vector	___302_ry	%read{34,34} %write{30,30}
-local	float	___302_det	%read{32,37} %write{31,31}
-local	vector	___302_surf_grad	%read{39,39} %write{36,36}
+local	vector	___320_new_tn	%read{22,22} %write{17,17}
+local	vector	___320_new_bn	%read{22,22} %write{21,21}
+local	int	___321_has_diffs	%read{26,26} %write{23,23}
+local	int	___321_get_attr_ok	%read{24,24} %write{23,23}
+local	vector	___322_rx	%read{31,33} %write{29,29}
+local	vector	___322_ry	%read{34,34} %write{30,30}
+local	float	___322_det	%read{32,37} %write{31,31}
+local	vector	___322_surf_grad	%read{39,39} %write{36,36}
 const	float	$const1	0		%read{3,44} %write{2147483647,-1}
 temp	int	$tmp1	%read{4,4} %write{3,3}
 temp	float	$tmp2	%read{9,9} %write{8,8}
@@ -94,47 +94,47 @@ code ___main___
 	length		$tmp5 dpdx 	%line{84} %argrw{"wr"}
 	mul		$tmp6 Tn $tmp5 	%argrw{"wrr"}
 	mul		$tmp7 Normal dhx 	%argrw{"wrr"}
-	add		___300_new_tn $tmp6 $tmp7 	%argrw{"wrr"}
+	add		___320_new_tn $tmp6 $tmp7 	%argrw{"wrr"}
 # ./normal/as_bump_map.osl:85
 #         vector new_bn = Bn * length(dpdy) + Normal * dhy;
 	length		$tmp8 dpdy 	%line{85} %argrw{"wr"}
 	mul		$tmp9 Bn $tmp8 	%argrw{"wrr"}
 	mul		$tmp10 Normal dhy 	%argrw{"wrr"}
-	add		___300_new_bn $tmp9 $tmp10 	%argrw{"wrr"}
+	add		___320_new_bn $tmp9 $tmp10 	%argrw{"wrr"}
 # ./normal/as_bump_map.osl:86
 #         NormalOut = cross(new_bn, new_tn);
-	cross		NormalOut ___300_new_bn ___300_new_tn 	%line{86} %argrw{"wrr"}
+	cross		NormalOut ___320_new_bn ___320_new_tn 	%line{86} %argrw{"wrr"}
 # ./normal/as_bump_map.osl:101
 #         int get_attr_ok = getattribute("path:ray_has_differentials", has_diffs);
-	getattribute	___301_get_attr_ok $const3 ___301_has_diffs 	%line{101} %argrw{"wrw"}
+	getattribute	___321_get_attr_ok $const3 ___321_has_diffs 	%line{101} %argrw{"wrw"}
 # ./normal/as_bump_map.osl:104
 #         if (get_attr_ok && has_diffs)
-	neq		$tmp11 ___301_get_attr_ok $const4 	%line{104} %argrw{"wrr"}
+	neq		$tmp11 ___321_get_attr_ok $const4 	%line{104} %argrw{"wrr"}
 	if		$tmp11 28 28 	%argrw{"r"}
-	neq		$tmp12 ___301_has_diffs $const4 	%argrw{"wrr"}
+	neq		$tmp12 ___321_has_diffs $const4 	%argrw{"wrr"}
 	assign		$tmp11 $tmp12 	%argrw{"wr"}
 	if		$tmp11 40 40 	%argrw{"r"}
 # ./normal/as_bump_map.osl:106
 #             vector rx = cross(dpdy, Normal);
-	cross		___302_rx dpdy Normal 	%line{106} %argrw{"wrr"}
+	cross		___322_rx dpdy Normal 	%line{106} %argrw{"wrr"}
 # ./normal/as_bump_map.osl:107
 #             vector ry = cross(Normal, dpdx);
-	cross		___302_ry Normal dpdx 	%line{107} %argrw{"wrr"}
+	cross		___322_ry Normal dpdx 	%line{107} %argrw{"wrr"}
 # ./normal/as_bump_map.osl:109
 #             float det = dot(dpdx, rx);
-	dot		___302_det dpdx ___302_rx 	%line{109} %argrw{"wrr"}
+	dot		___322_det dpdx ___322_rx 	%line{109} %argrw{"wrr"}
 # ./normal/as_bump_map.osl:110
 #             vector surf_grad = sign(det) * (dhx * rx + dhy * ry);
-	sign		$tmp13 ___302_det 	%line{110} %argrw{"wr"}
-	mul		$tmp14 dhx ___302_rx 	%argrw{"wrr"}
-	mul		$tmp15 dhy ___302_ry 	%argrw{"wrr"}
+	sign		$tmp13 ___322_det 	%line{110} %argrw{"wr"}
+	mul		$tmp14 dhx ___322_rx 	%argrw{"wrr"}
+	mul		$tmp15 dhy ___322_ry 	%argrw{"wrr"}
 	add		$tmp16 $tmp14 $tmp15 	%argrw{"wrr"}
-	mul		___302_surf_grad $tmp13 $tmp16 	%argrw{"wrr"}
+	mul		___322_surf_grad $tmp13 $tmp16 	%argrw{"wrr"}
 # ./normal/as_bump_map.osl:112
 #             NormalOut = abs(det) * Normal - surf_grad;
-	abs		$tmp17 ___302_det 	%line{112} %argrw{"wr"}
+	abs		$tmp17 ___322_det 	%line{112} %argrw{"wr"}
 	mul		$tmp18 $tmp17 Normal 	%argrw{"wrr"}
-	sub		NormalOut $tmp18 ___302_surf_grad 	%argrw{"wrr"}
+	sub		NormalOut $tmp18 ___322_surf_grad 	%argrw{"wrr"}
 # ./normal/as_bump_map.osl:116
 #     NormalOut = normalize(NormalOut);
 	normalize	NormalOut NormalOut 	%line{116} %argrw{"wr"}

--- a/sandbox/shaders/normal/as_normal_map.oso
+++ b/sandbox/shaders/normal/as_normal_map.oso
@@ -12,7 +12,7 @@ oparam	vector	NormalOut	0 0 0		%read{34,34} %write{32,33}
 oparam	vector	TangentOut	0 0 0		%read{2147483647,-1} %write{35,35}
 global	normal	N	%read{0,0} %write{2147483647,-1}
 local	normal	n	%read{11,33} %write{8,28}
-local	float	___300_tmp	%read{14,14} %write{11,11}
+local	float	___320_tmp	%read{14,14} %write{11,11}
 local	vector	bn	%read{24,34} %write{15,15}
 const	float	$const2	-1		%read{1,1} %write{2147483647,-1}
 temp	normal	$tmp1	%read{8,8} %write{1,1}
@@ -58,9 +58,9 @@ code ___main___
 	assign		$tmp4 $const6 	%argrw{"wr"}
 	assign		$tmp5 $const4 	%argrw{"wr"}
 	functioncall	$const7 8 	%argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:156
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:148
 # float  degrees (float x)  { return x*(180.0/M_PI); }
-	min		$tmp6 Color $tmp5 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{156} %argrw{"wrr"}
+	min		$tmp6 Color $tmp5 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{148} %argrw{"wrr"}
 	max		$tmp3 $tmp6 $tmp4 	%argrw{"wrr"}
 # ./normal/as_normal_map.osl:60
 #     normal n = (normal) mix(-1, 1, clamp(Color, 0, 1));
@@ -71,14 +71,14 @@ code ___main___
 	if		$tmp7 15 15 	%argrw{"r"}
 # ./normal/as_normal_map.osl:64
 #         float tmp = n[2];
-	compref		___300_tmp n $const9 	%line{64} %argrw{"wrr"}
+	compref		___320_tmp n $const9 	%line{64} %argrw{"wrr"}
 # ./normal/as_normal_map.osl:65
 #         n[2] = n[1];
 	compref		$tmp8 n $const3 	%line{65} %argrw{"wrr"}
 	compassign	n $const9 $tmp8 	%argrw{"wrr"}
 # ./normal/as_normal_map.osl:66
 #         n[1] = tmp;
-	compassign	n $const3 ___300_tmp 	%line{66} %argrw{"wrr"}
+	compassign	n $const3 ___320_tmp 	%line{66} %argrw{"wrr"}
 # ./normal/as_normal_map.osl:69
 #     vector bn = cross(Tn, Normal);
 	cross		bn Tn Normal 	%line{69} %argrw{"wrr"}

--- a/sandbox/shaders/surface/as_emission_surface.oso
+++ b/sandbox/shaders/surface/as_emission_surface.oso
@@ -7,7 +7,7 @@ param	float	Emission	1		%meta{float,min,0}  %read{2,2} %write{2147483647,-1}
 param	color	Color	1 1 1		%read{2,2} %write{2147483647,-1}
 param	int	Normalize	0		%meta{string,help,"normalize light emission"} %meta{string,widget,"checkBox"}  %read{3,3} %write{2147483647,-1}
 oparam	closure color	BSDF			%read{2147483647,-1} %write{8,9}
-local	color	___300_E	%read{6,8} %write{2,6}
+local	color	___320_E	%read{6,8} %write{2,6}
 temp	int	$tmp1	%read{1,1} %write{0,0}
 const	string	$const1	"light"		%read{0,0} %write{2147483647,-1}
 temp	float	$tmp2	%read{5,5} %write{4,4}
@@ -22,7 +22,7 @@ code ___main___
 	if		$tmp1 9 10 	%argrw{"r"}
 # ./surface/as_emission_surface.osl:47
 #         color E = Emission * Color;
-	mul		___300_E Emission Color 	%line{47} %argrw{"wrr"}
+	mul		___320_E Emission Color 	%line{47} %argrw{"wrr"}
 # ./surface/as_emission_surface.osl:49
 #         if (Normalize)
 	if		Normalize 7 7 	%line{49} %argrw{"r"}
@@ -30,11 +30,11 @@ code ___main___
 #             E /= surfacearea() * M_PI;
 	surfacearea	$tmp2 	%line{50} %argrw{"w"}
 	mul		$tmp3 $tmp2 $const2 	%argrw{"wrr"}
-	div		___300_E ___300_E $tmp3 	%argrw{"wrr"}
+	div		___320_E ___320_E $tmp3 	%argrw{"wrr"}
 # ./surface/as_emission_surface.osl:52
 #         BSDF = E * emission();
 	closure		$tmp4 $const3 	%line{52} %argrw{"wr"}
-	mul		BSDF $tmp4 ___300_E 	%argrw{"wrr"}
+	mul		BSDF $tmp4 ___320_E 	%argrw{"wrr"}
 # ./surface/as_emission_surface.osl:55
 #         BSDF = BSDF1;
 	assign		BSDF BSDF1 	%line{55} %argrw{"wr"}

--- a/sandbox/shaders/surface/as_glossy_surface.oso
+++ b/sandbox/shaders/surface/as_glossy_surface.oso
@@ -13,7 +13,7 @@ param	float	RoughnessDepthScale	1		%meta{float,min,1}  %read{2,7} %write{2147483
 param	float	Anisotropic	0		%meta{string,help,"Anisotropy"} %meta{float,min,-1} %meta{float,max,1}  %read{12,12} %write{2147483647,-1}
 oparam	closure color	BRDF			%read{2147483647,-1} %write{14,14}
 global	normal	N	%read{0,0} %write{2147483647,-1}
-local	int	___301_RayDepth	%read{5,8} %write{4,4}
+local	int	___321_RayDepth	%read{5,8} %write{4,4}
 temp	closure color	$tmp1	%read{14,14} %write{12,12}
 temp	float	$tmp2	%read{12,12} %write{9,11}
 const	string	$const1	"microfacet_roughness"		%read{1,1} %write{2147483647,-1}
@@ -41,15 +41,15 @@ code ___main___
 	if		$tmp3 11 11 	%argrw{"r"}
 # include/appleseed/microfacet.h:37
 #         getattribute("path:ray_depth", RayDepth);
-	getattribute	$tmp4 $const3 ___301_RayDepth 	%line{37} %argrw{"wrw"}
+	getattribute	$tmp4 $const3 ___321_RayDepth 	%line{37} %argrw{"wrw"}
 # include/appleseed/microfacet.h:39
 #         if (RayDepth != 0)
-	neq		$tmp5 ___301_RayDepth $const4 	%line{39} %argrw{"wrr"}
+	neq		$tmp5 ___321_RayDepth $const4 	%line{39} %argrw{"wrr"}
 	if		$tmp5 11 11 	%argrw{"r"}
 # include/appleseed/microfacet.h:40
 #             return Roughness * DepthScale * RayDepth;
 	mul		$tmp6 Roughness RoughnessDepthScale 	%line{40} %argrw{"wrr"}
-	assign		$tmp7 ___301_RayDepth 	%argrw{"wr"}
+	assign		$tmp7 ___321_RayDepth 	%argrw{"wr"}
 	mul		$tmp2 $tmp6 $tmp7 	%argrw{"wrr"}
 	return
 # include/appleseed/microfacet.h:43

--- a/sandbox/shaders/surface/as_metal_surface.oso
+++ b/sandbox/shaders/surface/as_metal_surface.oso
@@ -13,7 +13,7 @@ param	float	RoughnessDepthScale	1		%meta{float,min,1}  %read{2,7} %write{2147483
 param	float	Anisotropic	0		%meta{string,help,"Anisotropy"} %meta{float,min,-1} %meta{float,max,1}  %read{12,12} %write{2147483647,-1}
 oparam	closure color	BRDF			%read{2147483647,-1} %write{13,13}
 global	normal	N	%read{0,0} %write{2147483647,-1}
-local	int	___301_RayDepth	%read{5,8} %write{4,4}
+local	int	___321_RayDepth	%read{5,8} %write{4,4}
 temp	closure color	$tmp1	%read{13,13} %write{12,12}
 temp	float	$tmp2	%read{12,12} %write{9,11}
 const	string	$const1	"microfacet_roughness"		%read{1,1} %write{2147483647,-1}
@@ -40,15 +40,15 @@ code ___main___
 	if		$tmp3 11 11 	%argrw{"r"}
 # include/appleseed/microfacet.h:37
 #         getattribute("path:ray_depth", RayDepth);
-	getattribute	$tmp4 $const3 ___301_RayDepth 	%line{37} %argrw{"wrw"}
+	getattribute	$tmp4 $const3 ___321_RayDepth 	%line{37} %argrw{"wrw"}
 # include/appleseed/microfacet.h:39
 #         if (RayDepth != 0)
-	neq		$tmp5 ___301_RayDepth $const4 	%line{39} %argrw{"wrr"}
+	neq		$tmp5 ___321_RayDepth $const4 	%line{39} %argrw{"wrr"}
 	if		$tmp5 11 11 	%argrw{"r"}
 # include/appleseed/microfacet.h:40
 #             return Roughness * DepthScale * RayDepth;
 	mul		$tmp6 Roughness RoughnessDepthScale 	%line{40} %argrw{"wrr"}
-	assign		$tmp7 ___301_RayDepth 	%argrw{"wr"}
+	assign		$tmp7 ___321_RayDepth 	%argrw{"wr"}
 	mul		$tmp2 $tmp6 $tmp7 	%argrw{"wrr"}
 	return
 # include/appleseed/microfacet.h:43

--- a/sandbox/shaders/surface/as_subsurface_surface.oso
+++ b/sandbox/shaders/surface/as_subsurface_surface.oso
@@ -46,9 +46,9 @@ code ___main___
 # ./surface/as_subsurface_surface.osl:68
 #         BSSRDF = Reflectance * Color * diffuse(Normal);
 	functioncall	$const3 9 	%line{68} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:647
-#         distribution,
-	closure		$tmp5 $const6 Normal $const5 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{647} %argrw{"wrrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:513
+#         if      (x <= -eps)                result = 0;
+	closure		$tmp5 $const6 Normal $const5 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{513} %argrw{"wrrr"}
 # ./surface/as_subsurface_surface.osl:68
 #         BSSRDF = Reflectance * Color * diffuse(Normal);
 	mul		$tmp6 Reflectance Color 	%filename{"./surface/as_subsurface_surface.osl"} %line{68} %argrw{"wrr"}

--- a/sandbox/shaders/texture2d/as_color_texture.oso
+++ b/sandbox/shaders/texture2d/as_color_texture.oso
@@ -24,9 +24,9 @@ local	string[100]	mari_filenames	%read{509,509} %write{6,501}
 local	string	tx_filename	%read{517,517} %write{502,514}
 local	float	uu	%read{517,517} %write{511,515} %derivs
 local	float	vv	%read{517,517} %write{513,516} %derivs
-local	int	___300_utile	%read{508,510} %write{505,505} %derivs
-local	int	___300_vtile	%read{507,512} %write{506,506} %derivs
-local	int	___300_offset	%read{509,509} %write{508,508}
+local	int	___320_utile	%read{508,510} %write{505,505} %derivs
+local	int	___320_vtile	%read{507,512} %write{506,506} %derivs
+local	int	___320_offset	%read{509,509} %write{508,508}
 temp	string	$tmp1	%read{6,6} %write{5,5}
 const	string	$const1	"%s%d%s"		%read{5,500} %write{2147483647,-1}
 const	int	$const2	10		%read{2,507} %write{2147483647,-1}
@@ -1064,24 +1064,24 @@ code ___main___
 	if		$tmp401 514 517 	%argrw{"r"}
 # ./texture2d/as_color_texture.osl:82
 #         int utile  = int(U); 
-	assign		___300_utile U 	%line{82} %argrw{"wr"}
+	assign		___320_utile U 	%line{82} %argrw{"wr"}
 # ./texture2d/as_color_texture.osl:83
 #         int vtile  = int(V);
-	assign		___300_vtile V 	%line{83} %argrw{"wr"}
+	assign		___320_vtile V 	%line{83} %argrw{"wr"}
 # ./texture2d/as_color_texture.osl:84
 #         int offset = 10 * vtile + utile;
-	mul		$tmp402 $const2 ___300_vtile 	%line{84} %argrw{"wrr"}
-	add		___300_offset $tmp402 ___300_utile 	%argrw{"wrr"}
+	mul		$tmp402 $const2 ___320_vtile 	%line{84} %argrw{"wrr"}
+	add		___320_offset $tmp402 ___320_utile 	%argrw{"wrr"}
 # ./texture2d/as_color_texture.osl:85
 #         tx_filename = mari_filenames[offset];
-	aref		tx_filename mari_filenames ___300_offset 	%line{85} %argrw{"wrr"}
+	aref		tx_filename mari_filenames ___320_offset 	%line{85} %argrw{"wrr"}
 # ./texture2d/as_color_texture.osl:86
 #         uu = U - utile;
-	assign		$tmp403 ___300_utile 	%line{86} %argrw{"wr"}
+	assign		$tmp403 ___320_utile 	%line{86} %argrw{"wr"}
 	sub		uu U $tmp403 	%argrw{"wrr"}
 # ./texture2d/as_color_texture.osl:87
 #         vv = V - vtile;
-	assign		$tmp404 ___300_vtile 	%line{87} %argrw{"wr"}
+	assign		$tmp404 ___320_vtile 	%line{87} %argrw{"wr"}
 	sub		vv V $tmp404 	%argrw{"wrr"}
 # ./texture2d/as_color_texture.osl:91
 #         tx_filename = Filename;

--- a/sandbox/shaders/texture2d/as_scalar_texture.oso
+++ b/sandbox/shaders/texture2d/as_scalar_texture.oso
@@ -23,9 +23,9 @@ local	string[100]	mari_filenames	%read{509,509} %write{6,501}
 local	string	tx_filename	%read{517,517} %write{502,514}
 local	float	uu	%read{517,517} %write{511,515} %derivs
 local	float	vv	%read{517,517} %write{513,516} %derivs
-local	int	___300_utile	%read{508,510} %write{505,505} %derivs
-local	int	___300_vtile	%read{507,512} %write{506,506} %derivs
-local	int	___300_offset	%read{509,509} %write{508,508}
+local	int	___320_utile	%read{508,510} %write{505,505} %derivs
+local	int	___320_vtile	%read{507,512} %write{506,506} %derivs
+local	int	___320_offset	%read{509,509} %write{508,508}
 local	color	c	%read{519,521} %write{517,517}
 temp	string	$tmp1	%read{6,6} %write{5,5}
 const	string	$const1	"%s%d%s"		%read{5,500} %write{2147483647,-1}
@@ -1064,24 +1064,24 @@ code ___main___
 	if		$tmp401 514 517 	%argrw{"r"}
 # ./texture2d/as_scalar_texture.osl:85
 #         int utile  = int(U); 
-	assign		___300_utile U 	%line{85} %argrw{"wr"}
+	assign		___320_utile U 	%line{85} %argrw{"wr"}
 # ./texture2d/as_scalar_texture.osl:86
 #         int vtile  = int(V); 
-	assign		___300_vtile V 	%line{86} %argrw{"wr"}
+	assign		___320_vtile V 	%line{86} %argrw{"wr"}
 # ./texture2d/as_scalar_texture.osl:87
 #         int offset = 10 * vtile + utile;
-	mul		$tmp402 $const2 ___300_vtile 	%line{87} %argrw{"wrr"}
-	add		___300_offset $tmp402 ___300_utile 	%argrw{"wrr"}
+	mul		$tmp402 $const2 ___320_vtile 	%line{87} %argrw{"wrr"}
+	add		___320_offset $tmp402 ___320_utile 	%argrw{"wrr"}
 # ./texture2d/as_scalar_texture.osl:88
 #         tx_filename = mari_filenames[offset];
-	aref		tx_filename mari_filenames ___300_offset 	%line{88} %argrw{"wrr"}
+	aref		tx_filename mari_filenames ___320_offset 	%line{88} %argrw{"wrr"}
 # ./texture2d/as_scalar_texture.osl:89
 #         uu = U - utile;
-	assign		$tmp403 ___300_utile 	%line{89} %argrw{"wr"}
+	assign		$tmp403 ___320_utile 	%line{89} %argrw{"wr"}
 	sub		uu U $tmp403 	%argrw{"wrr"}
 # ./texture2d/as_scalar_texture.osl:90
 #         vv = V - vtile;
-	assign		$tmp404 ___300_vtile 	%line{90} %argrw{"wr"}
+	assign		$tmp404 ___320_vtile 	%line{90} %argrw{"wr"}
 	sub		vv V $tmp404 	%argrw{"wrr"}
 # ./texture2d/as_scalar_texture.osl:94
 #         tx_filename = Filename;

--- a/sandbox/shaders/transform/as_map2d.oso
+++ b/sandbox/shaders/transform/as_map2d.oso
@@ -13,11 +13,11 @@ oparam	float	UOut	0		%read{2147483647,-1} %write{42,42}
 oparam	float	VOut	0		%read{2147483647,-1} %write{46,46}
 global	float	u	%read{0,0} %write{2147483647,-1}
 global	float	v	%read{1,1} %write{2147483647,-1}
-local	float	___301_angle_in_rad	%read{28,28} %write{27,27}
-local	float	___301_c	%read{29,33} %write{28,28}
-local	float	___301_s	%read{30,32} %write{28,28}
-local	float	___301_xx	%read{35,35} %write{31,31}
-local	float	___301_yy	%read{36,36} %write{34,34}
+local	float	___321_angle_in_rad	%read{28,28} %write{27,27}
+local	float	___321_c	%read{29,33} %write{28,28}
+local	float	___321_s	%read{30,32} %write{28,28}
+local	float	___321_xx	%read{35,35} %write{31,31}
+local	float	___321_yy	%read{36,36} %write{34,34}
 local	float	uu	%read{6,40} %write{2,37}
 local	float	vv	%read{9,44} %write{3,38}
 const	string	$const1	"U"		%read{4,4} %write{2147483647,-1}
@@ -112,29 +112,29 @@ code ___main___
 # include/appleseed/transform.h:41
 #         float angle_in_rad = radians(angle_in_degrees);
 	functioncall	$const8 28 	%line{41} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:101
-# #define M_SQRT1_2  0.7071067811865475        /* 1/sqrt(2) */
-	div		$tmp11 $const9 $const10 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{101} %argrw{"wrr"}
-	mul		___301_angle_in_rad Rotate $tmp11 	%argrw{"wrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:93
+# // Declaration of built-in functions and closures
+	div		$tmp11 $const9 $const10 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{93} %argrw{"wrr"}
+	mul		___321_angle_in_rad Rotate $tmp11 	%argrw{"wrr"}
 # include/appleseed/transform.h:43
 #         sincos(angle_in_rad, s, c);
-	sincos		___301_angle_in_rad ___301_s ___301_c 	%filename{"include/appleseed/transform.h"} %line{43} %argrw{"rww"}
+	sincos		___321_angle_in_rad ___321_s ___321_c 	%filename{"include/appleseed/transform.h"} %line{43} %argrw{"rww"}
 # include/appleseed/transform.h:44
 #         float xx = x * c - s * y;
-	mul		$tmp12 uu ___301_c 	%line{44} %argrw{"wrr"}
-	mul		$tmp13 ___301_s vv 	%argrw{"wrr"}
-	sub		___301_xx $tmp12 $tmp13 	%argrw{"wrr"}
+	mul		$tmp12 uu ___321_c 	%line{44} %argrw{"wrr"}
+	mul		$tmp13 ___321_s vv 	%argrw{"wrr"}
+	sub		___321_xx $tmp12 $tmp13 	%argrw{"wrr"}
 # include/appleseed/transform.h:45
 #         float yy = x * s + c * y;
-	mul		$tmp14 uu ___301_s 	%line{45} %argrw{"wrr"}
-	mul		$tmp15 ___301_c vv 	%argrw{"wrr"}
-	add		___301_yy $tmp14 $tmp15 	%argrw{"wrr"}
+	mul		$tmp14 uu ___321_s 	%line{45} %argrw{"wrr"}
+	mul		$tmp15 ___321_c vv 	%argrw{"wrr"}
+	add		___321_yy $tmp14 $tmp15 	%argrw{"wrr"}
 # include/appleseed/transform.h:46
 #         rx = xx;
-	assign		uu ___301_xx 	%line{46} %argrw{"wr"}
+	assign		uu ___321_xx 	%line{46} %argrw{"wr"}
 # include/appleseed/transform.h:47
 #         ry = yy;
-	assign		vv ___301_yy 	%line{47} %argrw{"wr"}
+	assign		vv ___321_yy 	%line{47} %argrw{"wr"}
 # include/appleseed/transform.h:51
 #         rx = x;
 	assign		uu uu 	%line{51} %argrw{"wr"}

--- a/sandbox/shaders/transform/as_map3d.oso
+++ b/sandbox/shaders/transform/as_map3d.oso
@@ -8,14 +8,14 @@ param	vector	Scale	1 1 1		%read{1,1} %write{2147483647,-1}
 param	vector	Rotate	0 0 0		%read{2,121} %write{2147483647,-1}
 param	vector	Translate	0 0 0		%read{177,177} %write{2147483647,-1}
 oparam	vector	Pout	0 0 0		%read{2147483647,-1} %write{177,177}
-local	vector	___233_axis	%read{14,132} %write{11,127}
-local	float	___233_cosang	%read{13,170} %write{12,128}
-local	float	___233_sinang	%read{24,165} %write{12,128}
-local	float	___233_cosang1	%read{23,164} %write{13,129}
-local	float	___233_x	%read{17,165} %write{14,130}
-local	float	___233_y	%read{22,163} %write{15,131}
-local	float	___233_z	%read{24,168} %write{16,132}
-local	matrix	___233_M	%read{58,174} %write{56,172}
+local	vector	___246_axis	%read{14,132} %write{11,127}
+local	float	___246_cosang	%read{13,170} %write{12,128}
+local	float	___246_sinang	%read{24,165} %write{12,128}
+local	float	___246_cosang1	%read{23,164} %write{13,129}
+local	float	___246_x	%read{17,165} %write{14,130}
+local	float	___246_y	%read{22,163} %write{15,131}
+local	float	___246_z	%read{24,168} %write{16,132}
+local	matrix	___246_M	%read{58,174} %write{56,172}
 local	point	p	%read{57,176} %write{1,175}
 temp	vector	$tmp1	%read{1,1} %write{0,0}
 const	int	$const1	0		%read{2,130} %write{2147483647,-1}
@@ -187,92 +187,92 @@ code ___main___
 #         p = rotate(p, radians(Rotate[0]), point(0), point(1, 0, 0));
 	compref		$tmp5 Rotate $const1 	%line{42} %argrw{"wrr"}
 	functioncall	$const3 9 	%argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:101
-# #define M_SQRT2    1.4142135623730950        /* sqrt(2) */
-	div		$tmp6 $const4 $const5 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{101} %argrw{"wrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:93
+# 
+	div		$tmp6 $const4 $const5 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{93} %argrw{"wrr"}
 	mul		$tmp4 $tmp5 $tmp6 	%argrw{"wrr"}
 # ./transform/as_map3d.osl:42
 #         p = rotate(p, radians(Rotate[0]), point(0), point(1, 0, 0));
 	functioncall	$const8 60 	%filename{"./transform/as_map3d.osl"} %line{42} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:263
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:255
 #     if (g >= 0.0) {
-	sub		$tmp9 $const7 $const6 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{263} %argrw{"wrr"}
-	normalize	___233_axis $tmp9 	%argrw{"wr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:265
+	sub		$tmp9 $const7 $const6 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{255} %argrw{"wrr"}
+	normalize	___246_axis $tmp9 	%argrw{"wr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:257
 #         float beta = g - c;
-	sincos		$tmp4 ___233_sinang ___233_cosang 	%line{265} %argrw{"rww"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:266
+	sincos		$tmp4 ___246_sinang ___246_cosang 	%line{257} %argrw{"rww"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:258
 #         float F = (c * (g+c) - 1.0) / (c * beta + 1.0);
-	sub		___233_cosang1 $const9 ___233_cosang 	%line{266} %argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:267
+	sub		___246_cosang1 $const9 ___246_cosang 	%line{258} %argrw{"wrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:259
 #         F = 0.5 * (1.0 + sqr(F));
-	compref		___233_x ___233_axis $const1 	%line{267} %argrw{"wrr"}
-	compref		___233_y ___233_axis $const10 	%argrw{"wrr"}
-	compref		___233_z ___233_axis $const11 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:268
+	compref		___246_x ___246_axis $const1 	%line{259} %argrw{"wrr"}
+	compref		___246_y ___246_axis $const10 	%argrw{"wrr"}
+	compref		___246_z ___246_axis $const11 	%argrw{"wrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:260
 #         F *= sqr (beta / (g+c));
-	mul		$tmp10 ___233_x ___233_x 	%line{268} %argrw{"wrr"}
-	mul		$tmp11 ___233_x ___233_x 	%argrw{"wrr"}
+	mul		$tmp10 ___246_x ___246_x 	%line{260} %argrw{"wrr"}
+	mul		$tmp11 ___246_x ___246_x 	%argrw{"wrr"}
 	sub		$tmp12 $const9 $tmp11 	%argrw{"wrr"}
-	mul		$tmp13 $tmp12 ___233_cosang 	%argrw{"wrr"}
+	mul		$tmp13 $tmp12 ___246_cosang 	%argrw{"wrr"}
 	add		$tmp14 $tmp10 $tmp13 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:269
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:261
 #         Kr = F;
-	mul		$tmp15 ___233_x ___233_y 	%line{269} %argrw{"wrr"}
-	mul		$tmp16 $tmp15 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp17 ___233_z ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp15 ___246_x ___246_y 	%line{261} %argrw{"wrr"}
+	mul		$tmp16 $tmp15 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp17 ___246_z ___246_sinang 	%argrw{"wrr"}
 	add		$tmp18 $tmp16 $tmp17 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:270
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:262
 #         Kt = (1.0 - Kr) * eta*eta;
-	mul		$tmp19 ___233_x ___233_z 	%line{270} %argrw{"wrr"}
-	mul		$tmp20 $tmp19 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp21 ___233_y ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp19 ___246_x ___246_z 	%line{262} %argrw{"wrr"}
+	mul		$tmp20 $tmp19 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp21 ___246_y ___246_sinang 	%argrw{"wrr"}
 	sub		$tmp22 $tmp20 $tmp21 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:272
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:264
 #         // gives us the same result as if the shader-writer called refract()
-	mul		$tmp23 ___233_x ___233_y 	%line{272} %argrw{"wrr"}
-	mul		$tmp24 $tmp23 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp25 ___233_z ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp23 ___246_x ___246_y 	%line{264} %argrw{"wrr"}
+	mul		$tmp24 $tmp23 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp25 ___246_z ___246_sinang 	%argrw{"wrr"}
 	sub		$tmp26 $tmp24 $tmp25 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:273
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:265
 #         T = refract(I, N, eta);
-	mul		$tmp27 ___233_y ___233_y 	%line{273} %argrw{"wrr"}
-	mul		$tmp28 ___233_y ___233_y 	%argrw{"wrr"}
+	mul		$tmp27 ___246_y ___246_y 	%line{265} %argrw{"wrr"}
+	mul		$tmp28 ___246_y ___246_y 	%argrw{"wrr"}
 	sub		$tmp29 $const9 $tmp28 	%argrw{"wrr"}
-	mul		$tmp30 $tmp29 ___233_cosang 	%argrw{"wrr"}
+	mul		$tmp30 $tmp29 ___246_cosang 	%argrw{"wrr"}
 	add		$tmp31 $tmp27 $tmp30 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:274
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:266
 #     } else {
-	mul		$tmp32 ___233_y ___233_z 	%line{274} %argrw{"wrr"}
-	mul		$tmp33 $tmp32 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp34 ___233_x ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp32 ___246_y ___246_z 	%line{266} %argrw{"wrr"}
+	mul		$tmp33 $tmp32 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp34 ___246_x ___246_sinang 	%argrw{"wrr"}
 	add		$tmp35 $tmp33 $tmp34 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:276
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:268
 #         Kr = 1.0;
-	mul		$tmp36 ___233_x ___233_z 	%line{276} %argrw{"wrr"}
-	mul		$tmp37 $tmp36 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp38 ___233_y ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp36 ___246_x ___246_z 	%line{268} %argrw{"wrr"}
+	mul		$tmp37 $tmp36 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp38 ___246_y ___246_sinang 	%argrw{"wrr"}
 	add		$tmp39 $tmp37 $tmp38 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:277
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:269
 #         Kt = 0.0;
-	mul		$tmp40 ___233_y ___233_z 	%line{277} %argrw{"wrr"}
-	mul		$tmp41 $tmp40 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp42 ___233_x ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp40 ___246_y ___246_z 	%line{269} %argrw{"wrr"}
+	mul		$tmp41 $tmp40 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp42 ___246_x ___246_sinang 	%argrw{"wrr"}
 	sub		$tmp43 $tmp41 $tmp42 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:278
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:270
 #         T = vector (0,0,0);
-	mul		$tmp44 ___233_z ___233_z 	%line{278} %argrw{"wrr"}
-	mul		$tmp45 ___233_z ___233_z 	%argrw{"wrr"}
+	mul		$tmp44 ___246_z ___246_z 	%line{270} %argrw{"wrr"}
+	mul		$tmp45 ___246_z ___246_z 	%argrw{"wrr"}
 	sub		$tmp46 $const9 $tmp45 	%argrw{"wrr"}
-	mul		$tmp47 $tmp46 ___233_cosang 	%argrw{"wrr"}
+	mul		$tmp47 $tmp46 ___246_cosang 	%argrw{"wrr"}
 	add		$tmp48 $tmp44 $tmp47 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:280
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:272
 # }
-	matrix		___233_M $tmp14 $tmp18 $tmp22 $const2 $tmp26 $tmp31 $tmp35 $const2 $tmp39 $tmp43 $tmp48 $const2 $const2 $const2 $const2 $const9 	%line{280} %argrw{"wrrrrrrrrrrrrrrrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:281
+	matrix		___246_M $tmp14 $tmp18 $tmp22 $const2 $tmp26 $tmp31 $tmp35 $const2 $tmp39 $tmp43 $tmp48 $const2 $const2 $const2 $const2 $const9 	%line{272} %argrw{"wrrrrrrrrrrrrrrrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:273
 # 
-	sub		$tmp50 p $const6 	%line{281} %argrw{"wrr"}
-	transformv	$tmp49 ___233_M $tmp50 	%argrw{"wrr"}
+	sub		$tmp50 p $const6 	%line{273} %argrw{"wrr"}
+	transformv	$tmp49 ___246_M $tmp50 	%argrw{"wrr"}
 	add		p $tmp49 $const6 	%argrw{"wrr"}
 # ./transform/as_map3d.osl:44
 #     if (Rotate[1] != 0.0)
@@ -283,92 +283,92 @@ code ___main___
 #         p = rotate(p, radians(Rotate[1]), point(0), point(0, 1, 0));
 	compref		$tmp54 Rotate $const10 	%line{45} %argrw{"wrr"}
 	functioncall	$const3 67 	%argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:101
-# #define M_LN10     2.3025850929940457        /* ln(10) */
-	div		$tmp55 $const4 $const5 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{101} %argrw{"wrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:93
+# #endif
+	div		$tmp55 $const4 $const5 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{93} %argrw{"wrr"}
 	mul		$tmp53 $tmp54 $tmp55 	%argrw{"wrr"}
 # ./transform/as_map3d.osl:45
 #         p = rotate(p, radians(Rotate[1]), point(0), point(0, 1, 0));
 	functioncall	$const8 118 	%filename{"./transform/as_map3d.osl"} %line{45} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:263
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:255
 #         c = -c;
-	sub		$tmp58 $const12 $const6 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{263} %argrw{"wrr"}
-	normalize	___233_axis $tmp58 	%argrw{"wr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:265
+	sub		$tmp58 $const12 $const6 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{255} %argrw{"wrr"}
+	normalize	___246_axis $tmp58 	%argrw{"wr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:257
 #     float g = 1.0 / sqr(eta) - 1.0 + c * c;
-	sincos		$tmp53 ___233_sinang ___233_cosang 	%line{265} %argrw{"rww"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:266
+	sincos		$tmp53 ___246_sinang ___246_cosang 	%line{257} %argrw{"rww"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:258
 #     if (g >= 0.0) {
-	sub		___233_cosang1 $const9 ___233_cosang 	%line{266} %argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:267
+	sub		___246_cosang1 $const9 ___246_cosang 	%line{258} %argrw{"wrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:259
 #         g = sqrt (g);
-	compref		___233_x ___233_axis $const1 	%line{267} %argrw{"wrr"}
-	compref		___233_y ___233_axis $const10 	%argrw{"wrr"}
-	compref		___233_z ___233_axis $const11 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:268
+	compref		___246_x ___246_axis $const1 	%line{259} %argrw{"wrr"}
+	compref		___246_y ___246_axis $const10 	%argrw{"wrr"}
+	compref		___246_z ___246_axis $const11 	%argrw{"wrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:260
 #         float beta = g - c;
-	mul		$tmp59 ___233_x ___233_x 	%line{268} %argrw{"wrr"}
-	mul		$tmp60 ___233_x ___233_x 	%argrw{"wrr"}
+	mul		$tmp59 ___246_x ___246_x 	%line{260} %argrw{"wrr"}
+	mul		$tmp60 ___246_x ___246_x 	%argrw{"wrr"}
 	sub		$tmp61 $const9 $tmp60 	%argrw{"wrr"}
-	mul		$tmp62 $tmp61 ___233_cosang 	%argrw{"wrr"}
+	mul		$tmp62 $tmp61 ___246_cosang 	%argrw{"wrr"}
 	add		$tmp63 $tmp59 $tmp62 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:269
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:261
 #         float F = (c * (g+c) - 1.0) / (c * beta + 1.0);
-	mul		$tmp64 ___233_x ___233_y 	%line{269} %argrw{"wrr"}
-	mul		$tmp65 $tmp64 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp66 ___233_z ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp64 ___246_x ___246_y 	%line{261} %argrw{"wrr"}
+	mul		$tmp65 $tmp64 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp66 ___246_z ___246_sinang 	%argrw{"wrr"}
 	add		$tmp67 $tmp65 $tmp66 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:270
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:262
 #         F = 0.5 * (1.0 + sqr(F));
-	mul		$tmp68 ___233_x ___233_z 	%line{270} %argrw{"wrr"}
-	mul		$tmp69 $tmp68 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp70 ___233_y ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp68 ___246_x ___246_z 	%line{262} %argrw{"wrr"}
+	mul		$tmp69 $tmp68 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp70 ___246_y ___246_sinang 	%argrw{"wrr"}
 	sub		$tmp71 $tmp69 $tmp70 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:272
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:264
 #         Kr = F;
-	mul		$tmp72 ___233_x ___233_y 	%line{272} %argrw{"wrr"}
-	mul		$tmp73 $tmp72 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp74 ___233_z ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp72 ___246_x ___246_y 	%line{264} %argrw{"wrr"}
+	mul		$tmp73 $tmp72 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp74 ___246_z ___246_sinang 	%argrw{"wrr"}
 	sub		$tmp75 $tmp73 $tmp74 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:273
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:265
 #         Kt = (1.0 - Kr) * eta*eta;
-	mul		$tmp76 ___233_y ___233_y 	%line{273} %argrw{"wrr"}
-	mul		$tmp77 ___233_y ___233_y 	%argrw{"wrr"}
+	mul		$tmp76 ___246_y ___246_y 	%line{265} %argrw{"wrr"}
+	mul		$tmp77 ___246_y ___246_y 	%argrw{"wrr"}
 	sub		$tmp78 $const9 $tmp77 	%argrw{"wrr"}
-	mul		$tmp79 $tmp78 ___233_cosang 	%argrw{"wrr"}
+	mul		$tmp79 $tmp78 ___246_cosang 	%argrw{"wrr"}
 	add		$tmp80 $tmp76 $tmp79 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:274
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:266
 #         // OPT: the following recomputes some of the above values, but it
-	mul		$tmp81 ___233_y ___233_z 	%line{274} %argrw{"wrr"}
-	mul		$tmp82 $tmp81 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp83 ___233_x ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp81 ___246_y ___246_z 	%line{266} %argrw{"wrr"}
+	mul		$tmp82 $tmp81 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp83 ___246_x ___246_sinang 	%argrw{"wrr"}
 	add		$tmp84 $tmp82 $tmp83 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:276
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:268
 #         T = refract(I, N, eta);
-	mul		$tmp85 ___233_x ___233_z 	%line{276} %argrw{"wrr"}
-	mul		$tmp86 $tmp85 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp87 ___233_y ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp85 ___246_x ___246_z 	%line{268} %argrw{"wrr"}
+	mul		$tmp86 $tmp85 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp87 ___246_y ___246_sinang 	%argrw{"wrr"}
 	add		$tmp88 $tmp86 $tmp87 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:277
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:269
 #     } else {
-	mul		$tmp89 ___233_y ___233_z 	%line{277} %argrw{"wrr"}
-	mul		$tmp90 $tmp89 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp91 ___233_x ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp89 ___246_y ___246_z 	%line{269} %argrw{"wrr"}
+	mul		$tmp90 $tmp89 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp91 ___246_x ___246_sinang 	%argrw{"wrr"}
 	sub		$tmp92 $tmp90 $tmp91 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:278
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:270
 #         // total internal reflection
-	mul		$tmp93 ___233_z ___233_z 	%line{278} %argrw{"wrr"}
-	mul		$tmp94 ___233_z ___233_z 	%argrw{"wrr"}
+	mul		$tmp93 ___246_z ___246_z 	%line{270} %argrw{"wrr"}
+	mul		$tmp94 ___246_z ___246_z 	%argrw{"wrr"}
 	sub		$tmp95 $const9 $tmp94 	%argrw{"wrr"}
-	mul		$tmp96 $tmp95 ___233_cosang 	%argrw{"wrr"}
+	mul		$tmp96 $tmp95 ___246_cosang 	%argrw{"wrr"}
 	add		$tmp97 $tmp93 $tmp96 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:280
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:272
 #         Kt = 0.0;
-	matrix		___233_M $tmp63 $tmp67 $tmp71 $const2 $tmp75 $tmp80 $tmp84 $const2 $tmp88 $tmp92 $tmp97 $const2 $const2 $const2 $const2 $const9 	%line{280} %argrw{"wrrrrrrrrrrrrrrrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:281
+	matrix		___246_M $tmp63 $tmp67 $tmp71 $const2 $tmp75 $tmp80 $tmp84 $const2 $tmp88 $tmp92 $tmp97 $const2 $const2 $const2 $const2 $const9 	%line{272} %argrw{"wrrrrrrrrrrrrrrrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:273
 #         T = vector (0,0,0);
-	sub		$tmp99 p $const6 	%line{281} %argrw{"wrr"}
-	transformv	$tmp98 ___233_M $tmp99 	%argrw{"wrr"}
+	sub		$tmp99 p $const6 	%line{273} %argrw{"wrr"}
+	transformv	$tmp98 ___246_M $tmp99 	%argrw{"wrr"}
 	add		p $tmp98 $const6 	%argrw{"wrr"}
 # ./transform/as_map3d.osl:47
 #     if (Rotate[2] != 0.0)
@@ -379,92 +379,92 @@ code ___main___
 #         p = rotate(p, radians(Rotate[2]), point(0), point(0, 0, 1));
 	compref		$tmp103 Rotate $const11 	%line{48} %argrw{"wrr"}
 	functioncall	$const3 125 	%argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:101
-# #define M_2_SQRTPI 1.1283791670955126        /* 2/sqrt(pi) */
-	div		$tmp104 $const4 $const5 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{101} %argrw{"wrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:93
+# #define M_LOG10E   0.4342944819032518        /* log_10(e) */
+	div		$tmp104 $const4 $const5 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{93} %argrw{"wrr"}
 	mul		$tmp102 $tmp103 $tmp104 	%argrw{"wrr"}
 # ./transform/as_map3d.osl:48
 #         p = rotate(p, radians(Rotate[2]), point(0), point(0, 0, 1));
 	functioncall	$const8 176 	%filename{"./transform/as_map3d.osl"} %line{48} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:263
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:255
 #     float sqr(float x) { return x*x; }
-	sub		$tmp107 $const13 $const6 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{263} %argrw{"wrr"}
-	normalize	___233_axis $tmp107 	%argrw{"wr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:265
+	sub		$tmp107 $const13 $const6 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{255} %argrw{"wrr"}
+	normalize	___246_axis $tmp107 	%argrw{"wr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:257
 #     if (c < 0)
-	sincos		$tmp102 ___233_sinang ___233_cosang 	%line{265} %argrw{"rww"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:266
+	sincos		$tmp102 ___246_sinang ___246_cosang 	%line{257} %argrw{"rww"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:258
 #         c = -c;
-	sub		___233_cosang1 $const9 ___233_cosang 	%line{266} %argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:267
+	sub		___246_cosang1 $const9 ___246_cosang 	%line{258} %argrw{"wrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:259
 #     R = reflect(I, N);
-	compref		___233_x ___233_axis $const1 	%line{267} %argrw{"wrr"}
-	compref		___233_y ___233_axis $const10 	%argrw{"wrr"}
-	compref		___233_z ___233_axis $const11 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:268
+	compref		___246_x ___246_axis $const1 	%line{259} %argrw{"wrr"}
+	compref		___246_y ___246_axis $const10 	%argrw{"wrr"}
+	compref		___246_z ___246_axis $const11 	%argrw{"wrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:260
 #     float g = 1.0 / sqr(eta) - 1.0 + c * c;
-	mul		$tmp108 ___233_x ___233_x 	%line{268} %argrw{"wrr"}
-	mul		$tmp109 ___233_x ___233_x 	%argrw{"wrr"}
+	mul		$tmp108 ___246_x ___246_x 	%line{260} %argrw{"wrr"}
+	mul		$tmp109 ___246_x ___246_x 	%argrw{"wrr"}
 	sub		$tmp110 $const9 $tmp109 	%argrw{"wrr"}
-	mul		$tmp111 $tmp110 ___233_cosang 	%argrw{"wrr"}
+	mul		$tmp111 $tmp110 ___246_cosang 	%argrw{"wrr"}
 	add		$tmp112 $tmp108 $tmp111 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:269
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:261
 #     if (g >= 0.0) {
-	mul		$tmp113 ___233_x ___233_y 	%line{269} %argrw{"wrr"}
-	mul		$tmp114 $tmp113 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp115 ___233_z ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp113 ___246_x ___246_y 	%line{261} %argrw{"wrr"}
+	mul		$tmp114 $tmp113 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp115 ___246_z ___246_sinang 	%argrw{"wrr"}
 	add		$tmp116 $tmp114 $tmp115 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:270
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:262
 #         g = sqrt (g);
-	mul		$tmp117 ___233_x ___233_z 	%line{270} %argrw{"wrr"}
-	mul		$tmp118 $tmp117 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp119 ___233_y ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp117 ___246_x ___246_z 	%line{262} %argrw{"wrr"}
+	mul		$tmp118 $tmp117 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp119 ___246_y ___246_sinang 	%argrw{"wrr"}
 	sub		$tmp120 $tmp118 $tmp119 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:272
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:264
 #         float F = (c * (g+c) - 1.0) / (c * beta + 1.0);
-	mul		$tmp121 ___233_x ___233_y 	%line{272} %argrw{"wrr"}
-	mul		$tmp122 $tmp121 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp123 ___233_z ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp121 ___246_x ___246_y 	%line{264} %argrw{"wrr"}
+	mul		$tmp122 $tmp121 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp123 ___246_z ___246_sinang 	%argrw{"wrr"}
 	sub		$tmp124 $tmp122 $tmp123 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:273
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:265
 #         F = 0.5 * (1.0 + sqr(F));
-	mul		$tmp125 ___233_y ___233_y 	%line{273} %argrw{"wrr"}
-	mul		$tmp126 ___233_y ___233_y 	%argrw{"wrr"}
+	mul		$tmp125 ___246_y ___246_y 	%line{265} %argrw{"wrr"}
+	mul		$tmp126 ___246_y ___246_y 	%argrw{"wrr"}
 	sub		$tmp127 $const9 $tmp126 	%argrw{"wrr"}
-	mul		$tmp128 $tmp127 ___233_cosang 	%argrw{"wrr"}
+	mul		$tmp128 $tmp127 ___246_cosang 	%argrw{"wrr"}
 	add		$tmp129 $tmp125 $tmp128 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:274
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:266
 #         F *= sqr (beta / (g+c));
-	mul		$tmp130 ___233_y ___233_z 	%line{274} %argrw{"wrr"}
-	mul		$tmp131 $tmp130 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp132 ___233_x ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp130 ___246_y ___246_z 	%line{266} %argrw{"wrr"}
+	mul		$tmp131 $tmp130 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp132 ___246_x ___246_sinang 	%argrw{"wrr"}
 	add		$tmp133 $tmp131 $tmp132 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:276
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:268
 #         Kt = (1.0 - Kr) * eta*eta;
-	mul		$tmp134 ___233_x ___233_z 	%line{276} %argrw{"wrr"}
-	mul		$tmp135 $tmp134 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp136 ___233_y ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp134 ___246_x ___246_z 	%line{268} %argrw{"wrr"}
+	mul		$tmp135 $tmp134 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp136 ___246_y ___246_sinang 	%argrw{"wrr"}
 	add		$tmp137 $tmp135 $tmp136 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:277
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:269
 #         // OPT: the following recomputes some of the above values, but it
-	mul		$tmp138 ___233_y ___233_z 	%line{277} %argrw{"wrr"}
-	mul		$tmp139 $tmp138 ___233_cosang1 	%argrw{"wrr"}
-	mul		$tmp140 ___233_x ___233_sinang 	%argrw{"wrr"}
+	mul		$tmp138 ___246_y ___246_z 	%line{269} %argrw{"wrr"}
+	mul		$tmp139 $tmp138 ___246_cosang1 	%argrw{"wrr"}
+	mul		$tmp140 ___246_x ___246_sinang 	%argrw{"wrr"}
 	sub		$tmp141 $tmp139 $tmp140 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:278
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:270
 #         // gives us the same result as if the shader-writer called refract()
-	mul		$tmp142 ___233_z ___233_z 	%line{278} %argrw{"wrr"}
-	mul		$tmp143 ___233_z ___233_z 	%argrw{"wrr"}
+	mul		$tmp142 ___246_z ___246_z 	%line{270} %argrw{"wrr"}
+	mul		$tmp143 ___246_z ___246_z 	%argrw{"wrr"}
 	sub		$tmp144 $const9 $tmp143 	%argrw{"wrr"}
-	mul		$tmp145 $tmp144 ___233_cosang 	%argrw{"wrr"}
+	mul		$tmp145 $tmp144 ___246_cosang 	%argrw{"wrr"}
 	add		$tmp146 $tmp142 $tmp145 	%argrw{"wrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:280
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:272
 #     } else {
-	matrix		___233_M $tmp112 $tmp116 $tmp120 $const2 $tmp124 $tmp129 $tmp133 $const2 $tmp137 $tmp141 $tmp146 $const2 $const2 $const2 $const2 $const9 	%line{280} %argrw{"wrrrrrrrrrrrrrrrr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:281
+	matrix		___246_M $tmp112 $tmp116 $tmp120 $const2 $tmp124 $tmp129 $tmp133 $const2 $tmp137 $tmp141 $tmp146 $const2 $const2 $const2 $const2 $const9 	%line{272} %argrw{"wrrrrrrrrrrrrrrrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:273
 #         // total internal reflection
-	sub		$tmp148 p $const6 	%line{281} %argrw{"wrr"}
-	transformv	$tmp147 ___233_M $tmp148 	%argrw{"wrr"}
+	sub		$tmp148 p $const6 	%line{273} %argrw{"wrr"}
+	transformv	$tmp147 ___246_M $tmp148 	%argrw{"wrr"}
 	add		p $tmp147 $const6 	%argrw{"wrr"}
 # ./transform/as_map3d.osl:50
 #     Pout = p + Center + Translate;

--- a/sandbox/shaders/vector/as_anisotropy_dir.oso
+++ b/sandbox/shaders/vector/as_anisotropy_dir.oso
@@ -8,11 +8,11 @@ param	color	Color	1 0 0		%read{1,6} %write{2147483647,-1}
 param	float	AngleOffset	0		%read{12,16} %write{2147483647,-1}
 oparam	vector	TangentOut	0 0 0		%read{2147483647,-1} %write{32,32}
 global	normal	N	%read{0,0} %write{2147483647,-1}
-local	float	___301_angle_in_rad	%read{17,17} %write{16,16}
-local	float	___301_c	%read{18,22} %write{17,17}
-local	float	___301_s	%read{19,21} %write{17,17}
-local	float	___301_xx	%read{24,24} %write{20,20}
-local	float	___301_yy	%read{25,25} %write{23,23}
+local	float	___321_angle_in_rad	%read{17,17} %write{16,16}
+local	float	___321_c	%read{18,22} %write{17,17}
+local	float	___321_s	%read{19,21} %write{17,17}
+local	float	___321_xx	%read{24,24} %write{20,20}
+local	float	___321_yy	%read{25,25} %write{23,23}
 local	float	x	%read{18,29} %write{5,26}
 local	float	z	%read{19,30} %write{10,27}
 local	vector	Bn	%read{30,30} %write{28,28}
@@ -50,9 +50,9 @@ code ___main___
 #     float x = mix(-1, 1, clamp(Color[0], 0, 1));
 	compref		$tmp2 Color $const5 	%filename{"./vector/as_anisotropy_dir.osl"} %line{45} %argrw{"wrr"}
 	functioncall	$const7 5 	%argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:157
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:149
 # PERCOMP2F (pow)
-	min		$tmp3 $tmp2 $const4 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{157} %argrw{"wrr"}
+	min		$tmp3 $tmp2 $const4 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{149} %argrw{"wrr"}
 	max		$tmp1 $tmp3 $const6 	%argrw{"wrr"}
 # ./vector/as_anisotropy_dir.osl:45
 #     float x = mix(-1, 1, clamp(Color[0], 0, 1));
@@ -61,9 +61,9 @@ code ___main___
 #     float z = mix(-1, 1, clamp(Color[2], 0, 1));
 	compref		$tmp5 Color $const8 	%line{46} %argrw{"wrr"}
 	functioncall	$const7 10 	%argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:157
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:149
 # PERCOMP1 (tanh)
-	min		$tmp6 $tmp5 $const4 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{157} %argrw{"wrr"}
+	min		$tmp6 $tmp5 $const4 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{149} %argrw{"wrr"}
 	max		$tmp4 $tmp6 $const6 	%argrw{"wrr"}
 # ./vector/as_anisotropy_dir.osl:46
 #     float z = mix(-1, 1, clamp(Color[2], 0, 1));
@@ -78,29 +78,29 @@ code ___main___
 # include/appleseed/transform.h:41
 #         float angle_in_rad = radians(angle_in_degrees);
 	functioncall	$const10 17 	%line{41} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:101
-# #define M_SQRT1_2  0.7071067811865475        /* 1/sqrt(2) */
-	div		$tmp8 $const11 $const12 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{101} %argrw{"wrr"}
-	mul		___301_angle_in_rad AngleOffset $tmp8 	%argrw{"wrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:93
+# // Declaration of built-in functions and closures
+	div		$tmp8 $const11 $const12 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{93} %argrw{"wrr"}
+	mul		___321_angle_in_rad AngleOffset $tmp8 	%argrw{"wrr"}
 # include/appleseed/transform.h:43
 #         sincos(angle_in_rad, s, c);
-	sincos		___301_angle_in_rad ___301_s ___301_c 	%filename{"include/appleseed/transform.h"} %line{43} %argrw{"rww"}
+	sincos		___321_angle_in_rad ___321_s ___321_c 	%filename{"include/appleseed/transform.h"} %line{43} %argrw{"rww"}
 # include/appleseed/transform.h:44
 #         float xx = x * c - s * y;
-	mul		$tmp9 x ___301_c 	%line{44} %argrw{"wrr"}
-	mul		$tmp10 ___301_s z 	%argrw{"wrr"}
-	sub		___301_xx $tmp9 $tmp10 	%argrw{"wrr"}
+	mul		$tmp9 x ___321_c 	%line{44} %argrw{"wrr"}
+	mul		$tmp10 ___321_s z 	%argrw{"wrr"}
+	sub		___321_xx $tmp9 $tmp10 	%argrw{"wrr"}
 # include/appleseed/transform.h:45
 #         float yy = x * s + c * y;
-	mul		$tmp11 x ___301_s 	%line{45} %argrw{"wrr"}
-	mul		$tmp12 ___301_c z 	%argrw{"wrr"}
-	add		___301_yy $tmp11 $tmp12 	%argrw{"wrr"}
+	mul		$tmp11 x ___321_s 	%line{45} %argrw{"wrr"}
+	mul		$tmp12 ___321_c z 	%argrw{"wrr"}
+	add		___321_yy $tmp11 $tmp12 	%argrw{"wrr"}
 # include/appleseed/transform.h:46
 #         rx = xx;
-	assign		x ___301_xx 	%line{46} %argrw{"wr"}
+	assign		x ___321_xx 	%line{46} %argrw{"wr"}
 # include/appleseed/transform.h:47
 #         ry = yy;
-	assign		z ___301_yy 	%line{47} %argrw{"wr"}
+	assign		z ___321_yy 	%line{47} %argrw{"wr"}
 # include/appleseed/transform.h:51
 #         rx = x;
 	assign		x x 	%line{51} %argrw{"wr"}

--- a/sandbox/tests/test scenes/bssrdf/_shaders/subsurface_multi2.oso
+++ b/sandbox/tests/test scenes/bssrdf/_shaders/subsurface_multi2.oso
@@ -62,9 +62,9 @@ code ___main___
 #     Ci = color(0.35, 0.5, 0.75) * diff + 0.65 * as_glossy("ggx", N, 0.2, 1.3);
 	mul		$tmp15 diff $const14 	%line{10} %argrw{"wrr"}
 	functioncall	$const16 15 	%argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:515
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/as_osl_extensions.h:90
 #     float   roughness,
-	closure		$tmp16 $const16 $const15 N $const17 $const10 $const18 $const5 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{515} %argrw{"wrrrrrrr"}
+	closure		$tmp16 $const16 $const15 N $const17 $const10 $const18 $const5 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/as_osl_extensions.h"} %line{90} %argrw{"wrrrrrrr"}
 # subsurface_multi2.osl:10
 #     Ci = color(0.35, 0.5, 0.75) * diff + 0.65 * as_glossy("ggx", N, 0.2, 1.3);
 	mul		$tmp18 $tmp16 $const19 	%filename{"subsurface_multi2.osl"} %line{10} %argrw{"wrr"}

--- a/sandbox/tests/test scenes/osl/_shaders/background.oso
+++ b/sandbox/tests/test scenes/osl/_shaders/background.oso
@@ -1,5 +1,6 @@
 OpenShadingLanguage 1.00
-# Compiled by oslc 1.6.9
+# Compiled by oslc 1.7.4
+# options: 
 surface background
 global	vector	I	%read{0,0} %write{2147483647,-1}
 global	closure color	Ci	%read{2147483647,-1} %write{9,9}

--- a/sandbox/tests/test scenes/osl/_shaders/diffuse_mirror_mix.oso
+++ b/sandbox/tests/test scenes/osl/_shaders/diffuse_mirror_mix.oso
@@ -1,76 +1,71 @@
 OpenShadingLanguage 1.00
-# Compiled by oslc 1.6.9
+# Compiled by oslc 1.7.4
+# options: 
 surface diffuse_mirror_mix
-param	float	Kd	1		%read{2,2} %write{2147483647,-1}
-param	color	Cs	1 1 1		%read{2,2} %write{2147483647,-1}
-param	float	Kr	0		%read{12,19} %write{2147483647,-1}
-global	point	P	%read{4,14} %write{2147483647,-1}
-global	normal	N	%read{1,18} %write{2147483647,-1}
-global	closure color	Ci	%read{13,20} %write{3,20}
-temp	closure color	$tmp1	%read{3,3} %write{1,1}
+param	float	Kd	1		%read{1,1} %write{2147483647,-1}
+param	color	Cs	1 1 1		%read{1,1} %write{2147483647,-1}
+param	float	Kr	0		%read{11,18} %write{2147483647,-1}
+global	point	P	%read{3,13} %write{2147483647,-1}
+global	normal	N	%read{0,17} %write{2147483647,-1}
+global	closure color	Ci	%read{12,19} %write{2,19}
+temp	closure color	$tmp1	%read{2,2} %write{0,0}
 const	string	$const1	"diffuse"		%read{0,0} %write{2147483647,-1}
-const	int	$const2	0		%read{7,14} %write{2147483647,-1}
-const	float	$const3	0		%read{1,18} %write{2147483647,-1}
-const	string	$const4	"oren_nayar"		%read{1,1} %write{2147483647,-1}
-temp	color	$tmp2	%read{3,3} %write{2,2}
-const	int	$const5	2		%read{4,4} %write{2147483647,-1}
-temp	float	$tmp3	%read{5,5} %write{4,4}
-temp	int	$tmp4	%read{6,6} %write{5,5}
-temp	float	$tmp5	%read{8,8} %write{7,7}
-temp	int	$tmp6	%read{9,9} %write{8,8}
-temp	closure color	$tmp7	%read{12,12} %write{11,11}
-const	string	$const6	"ggx"		%read{11,18} %write{2147483647,-1}
-const	float	$const7	0.1		%read{11,18} %write{2147483647,-1}
-const	float	$const8	1.5		%read{11,18} %write{2147483647,-1}
-const	string	$const9	"as_glossy"		%read{10,18} %write{2147483647,-1}
-const	vector	$const10	0 0 0		%read{11,18} %write{2147483647,-1}
-temp	closure color	$tmp9	%read{13,13} %write{12,12}
-temp	float	$tmp10	%read{15,15} %write{14,14}
-temp	int	$tmp11	%read{16,16} %write{15,15}
-temp	closure color	$tmp12	%read{19,19} %write{18,18}
-temp	closure color	$tmp14	%read{20,20} %write{19,19}
+temp	color	$tmp2	%read{2,2} %write{1,1}
+const	int	$const2	2		%read{3,3} %write{2147483647,-1}
+temp	float	$tmp3	%read{4,4} %write{3,3}
+const	float	$const3	0		%read{4,17} %write{2147483647,-1}
+temp	int	$tmp4	%read{5,5} %write{4,4}
+const	int	$const4	0		%read{6,13} %write{2147483647,-1}
+temp	float	$tmp5	%read{7,7} %write{6,6}
+temp	int	$tmp6	%read{8,8} %write{7,7}
+temp	closure color	$tmp7	%read{11,11} %write{10,10}
+const	string	$const5	"ggx"		%read{10,17} %write{2147483647,-1}
+const	float	$const6	0.1		%read{10,17} %write{2147483647,-1}
+const	float	$const7	1.5		%read{10,17} %write{2147483647,-1}
+const	string	$const8	"as_glossy"		%read{9,17} %write{2147483647,-1}
+const	vector	$const9	0 0 0		%read{10,17} %write{2147483647,-1}
+temp	closure color	$tmp9	%read{12,12} %write{11,11}
+temp	float	$tmp10	%read{14,14} %write{13,13}
+temp	int	$tmp11	%read{15,15} %write{14,14}
+temp	closure color	$tmp12	%read{18,18} %write{17,17}
+temp	closure color	$tmp14	%read{19,19} %write{18,18}
 code ___main___
 # diffuse_mirror_mix.osl:4
 #     Ci = Cs * Kd * diffuse(N);
-	functioncall	$const1 2 	%filename{"diffuse_mirror_mix.osl"} %line{4} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:658
-# /***************************************/
-	closure		$tmp1 $const4 N $const3 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{658} %argrw{"wrrr"}
-# diffuse_mirror_mix.osl:4
-#     Ci = Cs * Kd * diffuse(N);
-	mul		$tmp2 Cs Kd 	%filename{"diffuse_mirror_mix.osl"} %line{4} %argrw{"wrr"}
+	closure		$tmp1 $const1 N 	%filename{"diffuse_mirror_mix.osl"} %line{4} %argrw{"wrr"}
+	mul		$tmp2 Cs Kd 	%argrw{"wrr"}
 	mul		Ci $tmp1 $tmp2 	%argrw{"wrr"}
 # diffuse_mirror_mix.osl:6
 #     if (P[2] < 0.0)
-	compref		$tmp3 P $const5 	%line{6} %argrw{"wrr"}
+	compref		$tmp3 P $const2 	%line{6} %argrw{"wrr"}
 	lt		$tmp4 $tmp3 $const3 	%argrw{"wrr"}
-	if		$tmp4 14 21 	%argrw{"r"}
+	if		$tmp4 13 20 	%argrw{"r"}
 # diffuse_mirror_mix.osl:8
 # 	    if (P[0] < 0.0)
-	compref		$tmp5 P $const2 	%line{8} %argrw{"wrr"}
+	compref		$tmp5 P $const4 	%line{8} %argrw{"wrr"}
 	lt		$tmp6 $tmp5 $const3 	%argrw{"wrr"}
-	if		$tmp6 14 14 	%argrw{"r"}
+	if		$tmp6 13 13 	%argrw{"r"}
 # diffuse_mirror_mix.osl:9
 # 	    	Ci += Kr * as_glossy("ggx", N, 0.1, 1.5);
-	functioncall	$const9 12 	%line{9} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:515
+	functioncall	$const8 11 	%line{9} %argrw{"r"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/as_osl_extensions.h:90
 #     float   anisotropic,
-	closure		$tmp7 $const9 $const6 N $const10 $const7 $const3 $const8 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{515} %argrw{"wrrrrrrr"}
+	closure		$tmp7 $const8 $const5 N $const9 $const6 $const3 $const7 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/as_osl_extensions.h"} %line{90} %argrw{"wrrrrrrr"}
 # diffuse_mirror_mix.osl:9
 # 	    	Ci += Kr * as_glossy("ggx", N, 0.1, 1.5);
 	mul		$tmp9 $tmp7 Kr 	%filename{"diffuse_mirror_mix.osl"} %line{9} %argrw{"wrr"}
 	add		Ci Ci $tmp9 	%argrw{"wrr"}
 # diffuse_mirror_mix.osl:13
 # 	    if (P[0] > 0.0)
-	compref		$tmp10 P $const2 	%line{13} %argrw{"wrr"}
+	compref		$tmp10 P $const4 	%line{13} %argrw{"wrr"}
 	gt		$tmp11 $tmp10 $const3 	%argrw{"wrr"}
-	if		$tmp11 21 21 	%argrw{"r"}
+	if		$tmp11 20 20 	%argrw{"r"}
 # diffuse_mirror_mix.osl:14
 # 	    	Ci += Kr * as_glossy("ggx", N, 0.1, 1.5);
-	functioncall	$const9 19 	%line{14} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:515
+	functioncall	$const8 18 	%line{14} %argrw{"r"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/as_osl_extensions.h:90
 # closure color as_glossy(
-	closure		$tmp12 $const9 $const6 N $const10 $const7 $const3 $const8 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{515} %argrw{"wrrrrrrr"}
+	closure		$tmp12 $const8 $const5 N $const9 $const6 $const3 $const7 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/as_osl_extensions.h"} %line{90} %argrw{"wrrrrrrr"}
 # diffuse_mirror_mix.osl:14
 # 	    	Ci += Kr * as_glossy("ggx", N, 0.1, 1.5);
 	mul		$tmp14 $tmp12 Kr 	%filename{"diffuse_mirror_mix.osl"} %line{14} %argrw{"wrr"}

--- a/sandbox/tests/test scenes/osl/_shaders/gabor_noise.oso
+++ b/sandbox/tests/test scenes/osl/_shaders/gabor_noise.oso
@@ -1,5 +1,6 @@
 OpenShadingLanguage 1.00
-# Compiled by oslc 1.6.9
+# Compiled by oslc 1.7.4
+# options: 
 shader gabor_noise
 param	point	Pos	0 0 0		%read{1,1} %write{0,0} %derivs %initexpr
 param	float	frequency	1		%read{1,1} %write{2147483647,-1} %derivs

--- a/sandbox/tests/test scenes/osl/_shaders/marble.oso
+++ b/sandbox/tests/test scenes/osl/_shaders/marble.oso
@@ -1,63 +1,59 @@
 OpenShadingLanguage 1.00
-# Compiled by oslc 1.6.9
+# Compiled by oslc 1.7.4
+# options: 
 surface marble
-param	color	Color	0.5 0.5 0.5		%read{26,26} %write{0,0} %initexpr
-param	int	object_space	1		%read{1,1} %write{2147483647,-1}
-param	float	texturescale	2.5		%read{6,6} %write{2147483647,-1}
+param	color	Color	0.5 0.5 0.5		%read{25,25} %write{2147483647,-1}
+param	int	object_space	1		%read{0,0} %write{2147483647,-1}
+param	float	texturescale	2.5		%read{5,5} %write{2147483647,-1}
 param	float	exponent	1000		%read{2147483647,-1} %write{2147483647,-1}
-global	point	P	%read{4,5} %write{2147483647,-1}
-global	normal	N	%read{27,27} %write{2147483647,-1}
-global	vector	dPdu	%read{19,19} %write{2147483647,-1}
-global	closure color	Ci	%read{2147483647,-1} %write{27,27}
-local	point	q	%read{6,12} %write{4,6}
-local	float	marble	%read{11,20} %write{7,17}
-local	float	f	%read{11,17} %write{8,17}
-local	int	___301_i	%read{11,17} %write{10,17}
-local	float[13]	marble_ramp	%read{25,25} %write{18,18}
-const	color	$const1	0.5 0.5 0.5		%read{0,0} %write{2147483647,-1}
-const	int	$const2	1		%read{1,17} %write{2147483647,-1}
-temp	int	$tmp1	%read{2,2} %write{1,1}
-const	string	$const3	"object"		%read{4,4} %write{2147483647,-1}
-const	string	$const4	"transform"		%read{3,3} %write{2147483647,-1}
-const	string	$const5	"common"		%read{4,4} %write{2147483647,-1}
-const	int	$const6	0		%read{7,10} %write{2147483647,-1}
-const	int	$const7	4		%read{11,11} %write{2147483647,-1}
-temp	int	$tmp2	%read{9,17} %write{10,17}
-temp	float	$tmp3	%read{14,14} %write{13,13}
-temp	point	$tmp4	%read{13,13} %write{12,12}
-temp	float	$tmp5	%read{15,15} %write{14,14}
-const	float	$const8	2.1700001		%read{16,16} %write{2147483647,-1}
-const	float[13]	$const9	0.55000001 0.55000001 0.40000001 0.40000001 0.40000001 0.55000001 0.55000001 0.25999999 0.25999999 0.2 0.2 0.55000001 0.2 		%read{18,18} %write{2147483647,-1}
-temp	vector	$tmp6	%read{27,27} %write{19,19}
-temp	float	$tmp7	%read{26,26} %write{25,25}
-const	string	$const10	"catmull-rom"		%read{25,25} %write{2147483647,-1}
-temp	float	$tmp8	%read{25,25} %write{24,24}
-temp	float	$tmp9	%read{21,21} %write{20,20}
-const	float	$const12	2		%read{20,20} %write{2147483647,-1}
-const	float	$const13	0.75		%read{21,27} %write{2147483647,-1}
-temp	float	$tmp10	%read{23,23} %write{21,21}
-const	float	$const14	0		%read{24,27} %write{2147483647,-1}
-const	float	$const15	1		%read{23,27} %write{2147483647,-1}
-const	string	$const16	"clamp"		%read{22,22} %write{2147483647,-1}
-temp	float	$tmp11	%read{24,24} %write{23,23}
-temp	color	$tmp12	%read{27,27} %write{26,26}
-const	float	$const17	0.25		%read{27,27} %write{2147483647,-1}
-const	string	$const18	"as_disney"		%read{27,27} %write{2147483647,-1}
-code Color
-# marble.osl:15
-#     color Color = color(0.5),
-	assign		Color $const1 	%filename{"marble.osl"} %line{15} %argrw{"wr"}
+global	point	P	%read{3,4} %write{2147483647,-1}
+global	normal	N	%read{26,26} %write{2147483647,-1}
+global	vector	dPdu	%read{18,18} %write{2147483647,-1}
+global	closure color	Ci	%read{2147483647,-1} %write{26,26}
+local	point	q	%read{5,16} %write{3,5}
+local	float	marble	%read{10,19} %write{6,16}
+local	float	f	%read{10,16} %write{7,16}
+local	int	___319_i	%read{10,16} %write{9,16}
+local	float[13]	marble_ramp	%read{24,24} %write{17,17}
+const	int	$const1	1		%read{0,16} %write{2147483647,-1}
+temp	int	$tmp1	%read{1,1} %write{0,0}
+const	string	$const2	"object"		%read{3,3} %write{2147483647,-1}
+const	string	$const3	"transform"		%read{2,2} %write{2147483647,-1}
+const	string	$const4	"common"		%read{3,3} %write{2147483647,-1}
+const	int	$const5	0		%read{6,9} %write{2147483647,-1}
+const	int	$const6	4		%read{10,10} %write{2147483647,-1}
+temp	int	$tmp2	%read{8,16} %write{9,16}
+temp	float	$tmp3	%read{10,16} %write{10,16}
+temp	point	$tmp4	%read{10,16} %write{10,16}
+temp	float	$tmp5	%read{10,16} %write{10,16}
+const	float	$const7	2.1700001		%read{15,15} %write{2147483647,-1}
+const	float[13]	$const8	0.55000001 0.55000001 0.40000001 0.40000001 0.40000001 0.55000001 0.55000001 0.25999999 0.25999999 0.2 0.2 0.55000001 0.2 		%read{17,17} %write{2147483647,-1}
+temp	vector	$tmp6	%read{26,26} %write{18,18}
+temp	float	$tmp7	%read{25,25} %write{24,24}
+const	string	$const9	"catmull-rom"		%read{24,24} %write{2147483647,-1}
+temp	float	$tmp8	%read{24,24} %write{23,23}
+temp	float	$tmp9	%read{20,20} %write{19,19}
+const	float	$const11	2		%read{19,19} %write{2147483647,-1}
+const	float	$const12	0.75		%read{20,26} %write{2147483647,-1}
+temp	float	$tmp10	%read{22,22} %write{20,20}
+const	float	$const13	0		%read{23,26} %write{2147483647,-1}
+const	float	$const14	1		%read{22,26} %write{2147483647,-1}
+const	string	$const15	"clamp"		%read{21,21} %write{2147483647,-1}
+temp	float	$tmp11	%read{23,23} %write{22,22}
+temp	color	$tmp12	%read{26,26} %write{25,25}
+const	float	$const16	0.25		%read{26,26} %write{2147483647,-1}
+const	string	$const17	"as_disney"		%read{26,26} %write{2147483647,-1}
 code ___main___
 # marble.osl:22
 #     if (object_space == 1)
-	eq		$tmp1 object_space $const2 	%filename{"marble.osl"} %line{22} %argrw{"wrr"}
-	if		$tmp1 5 6 	%argrw{"r"}
+	eq		$tmp1 object_space $const1 	%filename{"marble.osl"} %line{22} %argrw{"wrr"}
+	if		$tmp1 4 5 	%argrw{"r"}
 # marble.osl:23
 #         q = transform("object", P);
-	functioncall	$const4 5 	%line{23} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:256
+	functioncall	$const3 4 	%line{23} %argrw{"r"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:248
 #         // total internal reflection
-	transform	q $const5 $const3 P 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{256} %argrw{"wrrr"}
+	transform	q $const4 $const2 P 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{248} %argrw{"wrrr"}
 # marble.osl:25
 #         q = P;
 	assign		q P 	%filename{"marble.osl"} %line{25} %argrw{"wr"}
@@ -66,15 +62,15 @@ code ___main___
 	mul		q q texturescale 	%line{27} %argrw{"wrr"}
 # marble.osl:29
 #     float marble = 0;
-	assign		marble $const6 	%line{29} %argrw{"wr"}
+	assign		marble $const5 	%line{29} %argrw{"wr"}
 # marble.osl:30
 #     float f = 1;
-	assign		f $const2 	%line{30} %argrw{"wr"}
+	assign		f $const1 	%line{30} %argrw{"wr"}
 # marble.osl:31
 #     for (int i = 0; i < NNOISE; i += 1)
-	for		$tmp2 11 12 17 18 	%line{31} %argrw{"r"}
-	assign		___301_i $const6 	%argrw{"wr"}
-	lt		$tmp2 ___301_i $const7 	%argrw{"wrr"}
+	for		$tmp2 10 11 16 17 	%line{31} %argrw{"r"}
+	assign		___319_i $const5 	%argrw{"wr"}
+	lt		$tmp2 ___319_i $const6 	%argrw{"wrr"}
 # marble.osl:33
 #         marble += snoise(q * f) / f;
 	mul		$tmp4 q f 	%line{33} %argrw{"wrr"}
@@ -83,30 +79,30 @@ code ___main___
 	add		marble marble $tmp5 	%argrw{"wrr"}
 # marble.osl:34
 #         f *= 2.17;
-	mul		f f $const8 	%line{34} %argrw{"wrr"}
+	mul		f f $const7 	%line{34} %argrw{"wrr"}
 # marble.osl:31
 #     for (int i = 0; i < NNOISE; i += 1)
-	add		___301_i ___301_i $const2 	%line{31} %argrw{"wrr"}
+	add		___319_i ___319_i $const1 	%line{31} %argrw{"wrr"}
 # marble.osl:51
 #         };
-	assign		marble_ramp $const9 	%line{51} %argrw{"wr"}
+	assign		marble_ramp $const8 	%line{51} %argrw{"wr"}
 # marble.osl:56
 #             normalize(dPdu),
 	normalize	$tmp6 dPdu 	%line{56} %argrw{"wr"}
 # marble.osl:57
 #             Color * spline("catmull-rom", clamp(2 * marble + .75, 0, 1), marble_ramp),
-	mul		$tmp9 $const12 marble 	%line{57} %argrw{"wrr"}
-	add		$tmp10 $tmp9 $const13 	%argrw{"wrr"}
-	functioncall	$const16 25 	%argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:157
+	mul		$tmp9 $const11 marble 	%line{57} %argrw{"wrr"}
+	add		$tmp10 $tmp9 $const12 	%argrw{"wrr"}
+	functioncall	$const15 24 	%argrw{"r"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:149
 # color  radians (color x)  { return x*(M_PI/180.0); }
-	min		$tmp11 $tmp10 $const15 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{157} %argrw{"wrr"}
-	max		$tmp8 $tmp11 $const14 	%argrw{"wrr"}
+	min		$tmp11 $tmp10 $const14 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{149} %argrw{"wrr"}
+	max		$tmp8 $tmp11 $const13 	%argrw{"wrr"}
 # marble.osl:57
 #             Color * spline("catmull-rom", clamp(2 * marble + .75, 0, 1), marble_ramp),
-	spline		$tmp7 $const10 $tmp8 marble_ramp 	%filename{"marble.osl"} %line{57} %argrw{"wrrr"}
+	spline		$tmp7 $const9 $tmp8 marble_ramp 	%filename{"marble.osl"} %line{57} %argrw{"wrrr"}
 	mul		$tmp12 Color $tmp7 	%argrw{"wrr"}
 # marble.osl:67
 #             0);
-	closure		Ci $const18 N $tmp6 $tmp12 $const15 $const14 $const13 $const14 $const14 $const17 $const14 $const14 $const14 $const14 	%line{67} %argrw{"wrrrrrrrrrrrrrr"}
+	closure		Ci $const17 N $tmp6 $tmp12 $const14 $const13 $const12 $const13 $const13 $const16 $const13 $const13 $const13 $const13 	%line{67} %argrw{"wrrrrrrrrrrrrrr"}
 	end

--- a/sandbox/tests/test scenes/osl/_shaders/matte.oso
+++ b/sandbox/tests/test scenes/osl/_shaders/matte.oso
@@ -1,24 +1,18 @@
 OpenShadingLanguage 1.00
-# Compiled by oslc 1.6.9
+# Compiled by oslc 1.7.4
+# options: 
 surface matte
-param	float	Kd	1		%read{2,2} %write{2147483647,-1}
-param	color	Cs	0 0 0		%read{2,2} %write{2147483647,-1}
-global	normal	N	%read{1,1} %write{2147483647,-1}
-global	closure color	Ci	%read{2147483647,-1} %write{3,3}
-temp	closure color	$tmp1	%read{3,3} %write{1,1}
+param	float	Kd	1		%read{1,1} %write{2147483647,-1}
+param	color	Cs	0 0 0		%read{1,1} %write{2147483647,-1}
+global	normal	N	%read{0,0} %write{2147483647,-1}
+global	closure color	Ci	%read{2147483647,-1} %write{2,2}
+temp	closure color	$tmp1	%read{2,2} %write{0,0}
 const	string	$const1	"diffuse"		%read{0,0} %write{2147483647,-1}
-const	float	$const3	0		%read{1,1} %write{2147483647,-1}
-const	string	$const4	"oren_nayar"		%read{1,1} %write{2147483647,-1}
-temp	color	$tmp2	%read{3,3} %write{2,2}
+temp	color	$tmp2	%read{2,2} %write{1,1}
 code ___main___
 # matte.osl:4
 #     Ci = Kd * Cs * diffuse(N);
-	functioncall	$const1 2 	%filename{"matte.osl"} %line{4} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:658
-# /***************************************/
-	closure		$tmp1 $const4 N $const3 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{658} %argrw{"wrrr"}
-# matte.osl:4
-#     Ci = Kd * Cs * diffuse(N);
-	mul		$tmp2 Kd Cs 	%filename{"matte.osl"} %line{4} %argrw{"wrr"}
+	closure		$tmp1 $const1 N 	%filename{"matte.osl"} %line{4} %argrw{"wrr"}
+	mul		$tmp2 Kd Cs 	%argrw{"wrr"}
 	mul		Ci $tmp1 $tmp2 	%argrw{"wrr"}
 	end

--- a/sandbox/tests/test scenes/osl/_shaders/noise_blocks.oso
+++ b/sandbox/tests/test scenes/osl/_shaders/noise_blocks.oso
@@ -1,19 +1,18 @@
 OpenShadingLanguage 1.00
-# Compiled by oslc 1.6.9
+# Compiled by oslc 1.7.4
+# options: 
 surface noise_blocks
-param	float	Kd	0.80000001		%read{4,4} %write{2147483647,-1}
+param	float	Kd	0.80000001		%read{3,3} %write{2147483647,-1}
 param	matrix	Xform	1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1		%read{0,0} %write{2147483647,-1}
 global	point	P	%read{0,0} %write{2147483647,-1}
-global	normal	N	%read{3,3} %write{2147483647,-1}
-global	closure color	Ci	%read{2147483647,-1} %write{5,5}
+global	normal	N	%read{2,2} %write{2147483647,-1}
+global	closure color	Ci	%read{2147483647,-1} %write{4,4}
 local	point	PP	%read{1,1} %write{0,0}
-local	color	Cs	%read{4,4} %write{1,1}
+local	color	Cs	%read{3,3} %write{1,1}
 const	string	$const1	"cell"		%read{1,1} %write{2147483647,-1}
-temp	closure color	$tmp1	%read{5,5} %write{3,3}
+temp	closure color	$tmp1	%read{4,4} %write{2,2}
 const	string	$const2	"diffuse"		%read{2,2} %write{2147483647,-1}
-const	float	$const4	0		%read{3,3} %write{2147483647,-1}
-const	string	$const5	"oren_nayar"		%read{3,3} %write{2147483647,-1}
-temp	color	$tmp2	%read{5,5} %write{4,4}
+temp	color	$tmp2	%read{4,4} %write{3,3}
 code ___main___
 # noise_blocks.osl:6
 #     point PP = transform(Xform, P);
@@ -23,12 +22,7 @@ code ___main___
 	noise		Cs $const1 PP 	%line{7} %argrw{"wrr"}
 # noise_blocks.osl:8
 #     Ci = Cs * Kd * diffuse(N);
-	functioncall	$const2 4 	%line{8} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:658
-# 
-	closure		$tmp1 $const5 N $const4 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{658} %argrw{"wrrr"}
-# noise_blocks.osl:8
-#     Ci = Cs * Kd * diffuse(N);
-	mul		$tmp2 Cs Kd 	%filename{"noise_blocks.osl"} %line{8} %argrw{"wrr"}
+	closure		$tmp1 $const2 N 	%line{8} %argrw{"wrr"}
+	mul		$tmp2 Cs Kd 	%argrw{"wrr"}
 	mul		Ci $tmp1 $tmp2 	%argrw{"wrr"}
 	end

--- a/sandbox/tests/test scenes/osl/_shaders/test_emission.oso
+++ b/sandbox/tests/test scenes/osl/_shaders/test_emission.oso
@@ -1,5 +1,6 @@
 OpenShadingLanguage 1.00
-# Compiled by oslc 1.6.9
+# Compiled by oslc 1.7.4
+# options: 
 surface test_emission
 param	float	Kl	1		%read{9,9} %write{2147483647,-1}
 param	color	Cl	1 1 1		%read{10,10} %write{2147483647,-1}

--- a/sandbox/tests/test scenes/osl/_shaders/transparent_checkers.oso
+++ b/sandbox/tests/test scenes/osl/_shaders/transparent_checkers.oso
@@ -1,18 +1,19 @@
 OpenShadingLanguage 1.00
-# Compiled by oslc 1.6.9
+# Compiled by oslc 1.7.4
+# options: 
 surface transparent_checkers
-param	float	kd	1		%read{44,44} %write{2147483647,-1}
-param	color	Cs	1 1 1		%read{44,44} %write{2147483647,-1}
+param	float	kd	1		%read{43,43} %write{2147483647,-1}
+param	color	Cs	1 1 1		%read{43,43} %write{2147483647,-1}
 param	float	scale	5		%read{7,7} %write{2147483647,-1}
 param	float	transparency	0		%read{32,32} %write{2147483647,-1}
 global	point	P	%read{7,7} %write{2147483647,-1}
-global	normal	N	%read{43,43} %write{2147483647,-1}
-global	closure color	Ci	%read{2147483647,-1} %write{41,45}
-local	point	___301_q	%read{8,28} %write{7,19}
-local	int	___301_xi	%read{33,33} %write{23,23}
-local	int	___301_yi	%read{34,34} %write{27,27}
-local	int	___301_zi	%read{36,36} %write{31,31}
-local	float	___301_transp	%read{41,41} %write{32,39}
+global	normal	N	%read{42,42} %write{2147483647,-1}
+global	closure color	Ci	%read{2147483647,-1} %write{41,44}
+local	point	___319_q	%read{8,28} %write{7,19}
+local	int	___319_xi	%read{33,33} %write{23,23}
+local	int	___319_yi	%read{34,34} %write{27,27}
+local	int	___319_zi	%read{36,36} %write{31,31}
+local	float	___319_transp	%read{41,41} %write{32,39}
 temp	int	$tmp1	%read{1,1} %write{0,0}
 const	string	$const1	"shadow"		%read{0,0} %write{2147483647,-1}
 temp	int	$tmp2	%read{2,6} %write{1,5}
@@ -50,11 +51,9 @@ temp	int	$tmp27	%read{38,38} %write{37,37}
 const	float	$const8	1		%read{39,39} %write{2147483647,-1}
 temp	closure color	$tmp28	%read{41,41} %write{40,40}
 const	string	$const9	"transparent"		%read{40,40} %write{2147483647,-1}
-temp	closure color	$tmp29	%read{45,45} %write{43,43}
+temp	closure color	$tmp29	%read{44,44} %write{42,42}
 const	string	$const10	"diffuse"		%read{42,42} %write{2147483647,-1}
-const	float	$const11	0		%read{43,43} %write{2147483647,-1}
-const	string	$const12	"oren_nayar"		%read{43,43} %write{2147483647,-1}
-temp	color	$tmp30	%read{45,45} %write{44,44}
+temp	color	$tmp30	%read{44,44} %write{43,43}
 code ___main___
 # transparent_checkers.osl:8
 #     if (raytype("shadow") || raytype("transparency"))
@@ -64,72 +63,67 @@ code ___main___
 	raytype		$tmp3 $const3 	%argrw{"wr"}
 	neq		$tmp4 $tmp3 $const2 	%argrw{"wrr"}
 	assign		$tmp2 $tmp4 	%argrw{"wr"}
-	if		$tmp2 42 46 	%argrw{"r"}
+	if		$tmp2 42 45 	%argrw{"r"}
 # transparent_checkers.osl:10
 #         point q = P * scale;
-	mul		___301_q P scale 	%line{10} %argrw{"wrr"}
+	mul		___319_q P scale 	%line{10} %argrw{"wrr"}
 # transparent_checkers.osl:11
 #         q[0] = (q[0] + 0.00001) * 0.9999;
-	compref		$tmp5 ___301_q $const2 	%line{11} %argrw{"wrr"}
+	compref		$tmp5 ___319_q $const2 	%line{11} %argrw{"wrr"}
 	add		$tmp6 $tmp5 $const4 	%argrw{"wrr"}
 	mul		$tmp7 $tmp6 $const5 	%argrw{"wrr"}
-	compassign	___301_q $const2 $tmp7 	%argrw{"wrr"}
+	compassign	___319_q $const2 $tmp7 	%argrw{"wrr"}
 # transparent_checkers.osl:12
 #         q[1] = (q[1] + 0.00001) * 0.9999;
-	compref		$tmp8 ___301_q $const6 	%line{12} %argrw{"wrr"}
+	compref		$tmp8 ___319_q $const6 	%line{12} %argrw{"wrr"}
 	add		$tmp9 $tmp8 $const4 	%argrw{"wrr"}
 	mul		$tmp10 $tmp9 $const5 	%argrw{"wrr"}
-	compassign	___301_q $const6 $tmp10 	%argrw{"wrr"}
+	compassign	___319_q $const6 $tmp10 	%argrw{"wrr"}
 # transparent_checkers.osl:13
 #         q[2] = (q[2] + 0.00001) * 0.9999;
-	compref		$tmp11 ___301_q $const7 	%line{13} %argrw{"wrr"}
+	compref		$tmp11 ___319_q $const7 	%line{13} %argrw{"wrr"}
 	add		$tmp12 $tmp11 $const4 	%argrw{"wrr"}
 	mul		$tmp13 $tmp12 $const5 	%argrw{"wrr"}
-	compassign	___301_q $const7 $tmp13 	%argrw{"wrr"}
+	compassign	___319_q $const7 $tmp13 	%argrw{"wrr"}
 # transparent_checkers.osl:15
 #         int xi = (int)fabs(floor(q[0]));
-	compref		$tmp16 ___301_q $const2 	%line{15} %argrw{"wrr"}
+	compref		$tmp16 ___319_q $const2 	%line{15} %argrw{"wrr"}
 	floor		$tmp15 $tmp16 	%argrw{"wr"}
 	fabs		$tmp14 $tmp15 	%argrw{"wr"}
-	assign		___301_xi $tmp14 	%argrw{"wr"}
+	assign		___319_xi $tmp14 	%argrw{"wr"}
 # transparent_checkers.osl:16
 #         int yi = (int)fabs(floor(q[1]));
-	compref		$tmp19 ___301_q $const6 	%line{16} %argrw{"wrr"}
+	compref		$tmp19 ___319_q $const6 	%line{16} %argrw{"wrr"}
 	floor		$tmp18 $tmp19 	%argrw{"wr"}
 	fabs		$tmp17 $tmp18 	%argrw{"wr"}
-	assign		___301_yi $tmp17 	%argrw{"wr"}
+	assign		___319_yi $tmp17 	%argrw{"wr"}
 # transparent_checkers.osl:17
 #         int zi = (int)fabs(floor(q[2]));
-	compref		$tmp22 ___301_q $const7 	%line{17} %argrw{"wrr"}
+	compref		$tmp22 ___319_q $const7 	%line{17} %argrw{"wrr"}
 	floor		$tmp21 $tmp22 	%argrw{"wr"}
 	fabs		$tmp20 $tmp21 	%argrw{"wr"}
-	assign		___301_zi $tmp20 	%argrw{"wr"}
+	assign		___319_zi $tmp20 	%argrw{"wr"}
 # transparent_checkers.osl:19
 #         float transp = transparency;
-	assign		___301_transp transparency 	%line{19} %argrw{"wr"}
+	assign		___319_transp transparency 	%line{19} %argrw{"wr"}
 # transparent_checkers.osl:21
 #         if ((xi % 2 == yi % 2) == (zi % 2))
-	mod		$tmp23 ___301_xi $const7 	%line{21} %argrw{"wrr"}
-	mod		$tmp24 ___301_yi $const7 	%argrw{"wrr"}
+	mod		$tmp23 ___319_xi $const7 	%line{21} %argrw{"wrr"}
+	mod		$tmp24 ___319_yi $const7 	%argrw{"wrr"}
 	eq		$tmp25 $tmp23 $tmp24 	%argrw{"wrr"}
-	mod		$tmp26 ___301_zi $const7 	%argrw{"wrr"}
+	mod		$tmp26 ___319_zi $const7 	%argrw{"wrr"}
 	eq		$tmp27 $tmp25 $tmp26 	%argrw{"wrr"}
 	if		$tmp27 40 40 	%argrw{"r"}
 # transparent_checkers.osl:22
 #             transp = 1.0;
-	assign		___301_transp $const8 	%line{22} %argrw{"wr"}
+	assign		___319_transp $const8 	%line{22} %argrw{"wr"}
 # transparent_checkers.osl:24
 #         Ci = transp * transparent();
 	closure		$tmp28 $const9 	%line{24} %argrw{"wr"}
-	mul		Ci $tmp28 ___301_transp 	%argrw{"wrr"}
+	mul		Ci $tmp28 ___319_transp 	%argrw{"wrr"}
 # transparent_checkers.osl:27
 #         Ci = kd * Cs * diffuse(N);
-	functioncall	$const10 44 	%line{27} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:658
-#     vector  T,
-	closure		$tmp29 $const12 N $const11 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{658} %argrw{"wrrr"}
-# transparent_checkers.osl:27
-#         Ci = kd * Cs * diffuse(N);
-	mul		$tmp30 kd Cs 	%filename{"transparent_checkers.osl"} %line{27} %argrw{"wrr"}
+	closure		$tmp29 $const10 N 	%line{27} %argrw{"wrr"}
+	mul		$tmp30 kd Cs 	%argrw{"wrr"}
 	mul		Ci $tmp29 $tmp30 	%argrw{"wrr"}
 	end

--- a/sandbox/tests/test scenes/osl/_shaders/transparent_shadow_checkers.oso
+++ b/sandbox/tests/test scenes/osl/_shaders/transparent_shadow_checkers.oso
@@ -1,18 +1,19 @@
 OpenShadingLanguage 1.00
-# Compiled by oslc 1.6.9
+# Compiled by oslc 1.7.4
+# options: 
 surface transparent_shadow_checkers
-param	float	kd	1		%read{39,39} %write{2147483647,-1}
-param	color	Cs	1 1 1		%read{39,39} %write{2147483647,-1}
+param	float	kd	1		%read{38,38} %write{2147483647,-1}
+param	color	Cs	1 1 1		%read{38,38} %write{2147483647,-1}
 param	float	scale	5		%read{2,2} %write{2147483647,-1}
 param	float	transparency	0		%read{27,27} %write{2147483647,-1}
 global	point	P	%read{2,2} %write{2147483647,-1}
-global	normal	N	%read{38,38} %write{2147483647,-1}
-global	closure color	Ci	%read{2147483647,-1} %write{36,40}
-local	point	___301_q	%read{3,23} %write{2,14}
-local	int	___301_xi	%read{28,28} %write{18,18}
-local	int	___301_yi	%read{29,29} %write{22,22}
-local	int	___301_zi	%read{31,31} %write{26,26}
-local	float	___301_transp	%read{36,36} %write{27,34}
+global	normal	N	%read{37,37} %write{2147483647,-1}
+global	closure color	Ci	%read{2147483647,-1} %write{36,39}
+local	point	___319_q	%read{3,23} %write{2,14}
+local	int	___319_xi	%read{28,28} %write{18,18}
+local	int	___319_yi	%read{29,29} %write{22,22}
+local	int	___319_zi	%read{31,31} %write{26,26}
+local	float	___319_transp	%read{36,36} %write{27,34}
 temp	int	$tmp1	%read{1,1} %write{0,0}
 const	string	$const1	"shadow"		%read{0,0} %write{2147483647,-1}
 const	int	$const2	0		%read{3,15} %write{2147483647,-1}
@@ -46,81 +47,74 @@ temp	int	$tmp24	%read{33,33} %write{32,32}
 const	float	$const7	1		%read{34,34} %write{2147483647,-1}
 temp	closure color	$tmp25	%read{36,36} %write{35,35}
 const	string	$const8	"transparent"		%read{35,35} %write{2147483647,-1}
-temp	closure color	$tmp26	%read{40,40} %write{38,38}
+temp	closure color	$tmp26	%read{39,39} %write{37,37}
 const	string	$const9	"diffuse"		%read{37,37} %write{2147483647,-1}
-const	float	$const10	0		%read{38,38} %write{2147483647,-1}
-const	string	$const11	"oren_nayar"		%read{38,38} %write{2147483647,-1}
-temp	color	$tmp27	%read{40,40} %write{39,39}
+temp	color	$tmp27	%read{39,39} %write{38,38}
 code ___main___
 # transparent_shadow_checkers.osl:8
 #     if (raytype("shadow"))
 	raytype		$tmp1 $const1 	%filename{"transparent_shadow_checkers.osl"} %line{8} %argrw{"wr"}
-	if		$tmp1 37 41 	%argrw{"r"}
+	if		$tmp1 37 40 	%argrw{"r"}
 # transparent_shadow_checkers.osl:10
 #         point q = P * scale;
-	mul		___301_q P scale 	%line{10} %argrw{"wrr"}
+	mul		___319_q P scale 	%line{10} %argrw{"wrr"}
 # transparent_shadow_checkers.osl:11
 #         q[0] = (q[0] + 0.00001) * 0.9999;
-	compref		$tmp2 ___301_q $const2 	%line{11} %argrw{"wrr"}
+	compref		$tmp2 ___319_q $const2 	%line{11} %argrw{"wrr"}
 	add		$tmp3 $tmp2 $const3 	%argrw{"wrr"}
 	mul		$tmp4 $tmp3 $const4 	%argrw{"wrr"}
-	compassign	___301_q $const2 $tmp4 	%argrw{"wrr"}
+	compassign	___319_q $const2 $tmp4 	%argrw{"wrr"}
 # transparent_shadow_checkers.osl:12
 #         q[1] = (q[1] + 0.00001) * 0.9999;
-	compref		$tmp5 ___301_q $const5 	%line{12} %argrw{"wrr"}
+	compref		$tmp5 ___319_q $const5 	%line{12} %argrw{"wrr"}
 	add		$tmp6 $tmp5 $const3 	%argrw{"wrr"}
 	mul		$tmp7 $tmp6 $const4 	%argrw{"wrr"}
-	compassign	___301_q $const5 $tmp7 	%argrw{"wrr"}
+	compassign	___319_q $const5 $tmp7 	%argrw{"wrr"}
 # transparent_shadow_checkers.osl:13
 #         q[2] = (q[2] + 0.00001) * 0.9999;
-	compref		$tmp8 ___301_q $const6 	%line{13} %argrw{"wrr"}
+	compref		$tmp8 ___319_q $const6 	%line{13} %argrw{"wrr"}
 	add		$tmp9 $tmp8 $const3 	%argrw{"wrr"}
 	mul		$tmp10 $tmp9 $const4 	%argrw{"wrr"}
-	compassign	___301_q $const6 $tmp10 	%argrw{"wrr"}
+	compassign	___319_q $const6 $tmp10 	%argrw{"wrr"}
 # transparent_shadow_checkers.osl:15
 #         int xi = (int)fabs(floor(q[0]));
-	compref		$tmp13 ___301_q $const2 	%line{15} %argrw{"wrr"}
+	compref		$tmp13 ___319_q $const2 	%line{15} %argrw{"wrr"}
 	floor		$tmp12 $tmp13 	%argrw{"wr"}
 	fabs		$tmp11 $tmp12 	%argrw{"wr"}
-	assign		___301_xi $tmp11 	%argrw{"wr"}
+	assign		___319_xi $tmp11 	%argrw{"wr"}
 # transparent_shadow_checkers.osl:16
 #         int yi = (int)fabs(floor(q[1]));
-	compref		$tmp16 ___301_q $const5 	%line{16} %argrw{"wrr"}
+	compref		$tmp16 ___319_q $const5 	%line{16} %argrw{"wrr"}
 	floor		$tmp15 $tmp16 	%argrw{"wr"}
 	fabs		$tmp14 $tmp15 	%argrw{"wr"}
-	assign		___301_yi $tmp14 	%argrw{"wr"}
+	assign		___319_yi $tmp14 	%argrw{"wr"}
 # transparent_shadow_checkers.osl:17
 #         int zi = (int)fabs(floor(q[2]));
-	compref		$tmp19 ___301_q $const6 	%line{17} %argrw{"wrr"}
+	compref		$tmp19 ___319_q $const6 	%line{17} %argrw{"wrr"}
 	floor		$tmp18 $tmp19 	%argrw{"wr"}
 	fabs		$tmp17 $tmp18 	%argrw{"wr"}
-	assign		___301_zi $tmp17 	%argrw{"wr"}
+	assign		___319_zi $tmp17 	%argrw{"wr"}
 # transparent_shadow_checkers.osl:19
 #         float transp = transparency;
-	assign		___301_transp transparency 	%line{19} %argrw{"wr"}
+	assign		___319_transp transparency 	%line{19} %argrw{"wr"}
 # transparent_shadow_checkers.osl:21
 #         if ((xi % 2 == yi % 2) == (zi % 2))
-	mod		$tmp20 ___301_xi $const6 	%line{21} %argrw{"wrr"}
-	mod		$tmp21 ___301_yi $const6 	%argrw{"wrr"}
+	mod		$tmp20 ___319_xi $const6 	%line{21} %argrw{"wrr"}
+	mod		$tmp21 ___319_yi $const6 	%argrw{"wrr"}
 	eq		$tmp22 $tmp20 $tmp21 	%argrw{"wrr"}
-	mod		$tmp23 ___301_zi $const6 	%argrw{"wrr"}
+	mod		$tmp23 ___319_zi $const6 	%argrw{"wrr"}
 	eq		$tmp24 $tmp22 $tmp23 	%argrw{"wrr"}
 	if		$tmp24 35 35 	%argrw{"r"}
 # transparent_shadow_checkers.osl:22
 #             transp = 1.0;
-	assign		___301_transp $const7 	%line{22} %argrw{"wr"}
+	assign		___319_transp $const7 	%line{22} %argrw{"wr"}
 # transparent_shadow_checkers.osl:24
 #         Ci = transp * transparent();
 	closure		$tmp25 $const8 	%line{24} %argrw{"wr"}
-	mul		Ci $tmp25 ___301_transp 	%argrw{"wrr"}
+	mul		Ci $tmp25 ___319_transp 	%argrw{"wrr"}
 # transparent_shadow_checkers.osl:27
 #         Ci = kd * Cs * diffuse(N);
-	functioncall	$const9 39 	%line{27} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:658
-#     vector  T,
-	closure		$tmp26 $const11 N $const10 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{658} %argrw{"wrrr"}
-# transparent_shadow_checkers.osl:27
-#         Ci = kd * Cs * diffuse(N);
-	mul		$tmp27 kd Cs 	%filename{"transparent_shadow_checkers.osl"} %line{27} %argrw{"wrr"}
+	closure		$tmp26 $const9 N 	%line{27} %argrw{"wrr"}
+	mul		$tmp27 kd Cs 	%argrw{"wrr"}
 	mul		Ci $tmp26 $tmp27 	%argrw{"wrr"}
 	end

--- a/sandbox/tests/test scenes/osl/_shaders/velocity_matte.oso
+++ b/sandbox/tests/test scenes/osl/_shaders/velocity_matte.oso
@@ -1,17 +1,16 @@
 OpenShadingLanguage 1.00
-# Compiled by oslc 1.6.9
+# Compiled by oslc 1.7.4
+# options: 
 surface velocity_matte
-global	normal	N	%read{4,4} %write{2147483647,-1}
-global	closure color	Ci	%read{2147483647,-1} %write{5,5}
+global	normal	N	%read{3,3} %write{2147483647,-1}
+global	closure color	Ci	%read{2147483647,-1} %write{4,4}
 global	vector	dPdtime	%read{0,0} %write{2147483647,-1}
-local	color	Cs	%read{5,5} %write{2,2}
+local	color	Cs	%read{4,4} %write{2,2}
 temp	color	$tmp1	%read{2,2} %write{1,1}
 temp	color	$tmp2	%read{1,1} %write{0,0}
 const	float	$const1	0.30000001		%read{2,2} %write{2147483647,-1}
-temp	closure color	$tmp3	%read{5,5} %write{4,4}
+temp	closure color	$tmp3	%read{4,4} %write{3,3}
 const	string	$const2	"diffuse"		%read{3,3} %write{2147483647,-1}
-const	float	$const4	0		%read{4,4} %write{2147483647,-1}
-const	string	$const5	"oren_nayar"		%read{4,4} %write{2147483647,-1}
 code ___main___
 # velocity_matte.osl:4
 #     color Cs = abs(color(dPdtime)) * 0.3;
@@ -20,11 +19,6 @@ code ___main___
 	mul		Cs $tmp1 $const1 	%argrw{"wrr"}
 # velocity_matte.osl:5
 #     Ci = Cs * diffuse(N);
-	functioncall	$const2 5 	%line{5} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:658
-# // compatibility with the OSL spec
-	closure		$tmp3 $const5 N $const4 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{658} %argrw{"wrrr"}
-# velocity_matte.osl:5
-#     Ci = Cs * diffuse(N);
-	mul		Ci $tmp3 Cs 	%filename{"velocity_matte.osl"} %line{5} %argrw{"wrr"}
+	closure		$tmp3 $const2 N 	%line{5} %argrw{"wrr"}
+	mul		Ci $tmp3 Cs 	%argrw{"wrr"}
 	end

--- a/scripts/appleseed.package.py
+++ b/scripts/appleseed.package.py
@@ -328,7 +328,7 @@ class PackageBuilder:
 
         # appleseed headers.
         safe_make_directory("appleseed/include")
-        ignore_files = shutil.ignore_patterns("*.cpp", "*.c", "*.xsd", "stdosl.h", "oslutil.h", "snprintf", "version.h.in")
+        ignore_files = shutil.ignore_patterns("*.cpp", "*.c", "*.xsd", "stdosl.h", "oslutil.h", "as_osl_extensions.h", "snprintf", "version.h.in")
         shutil.copytree(os.path.join(self.settings.appleseed_headers_path, "foundation"), "appleseed/include/foundation", ignore = ignore_files)
         shutil.copytree(os.path.join(self.settings.appleseed_headers_path, "main"), "appleseed/include/main", ignore = ignore_files)
         shutil.copytree(os.path.join(self.settings.appleseed_headers_path, "renderer"), "appleseed/include/renderer", ignore = ignore_files)
@@ -336,6 +336,7 @@ class PackageBuilder:
         # OSL headers.
         shutil.copy(os.path.join(self.settings.appleseed_headers_path, "renderer/kernel/shading/oslutil.h"), "appleseed/shaders/")
         shutil.copy(os.path.join(self.settings.appleseed_headers_path, "renderer/kernel/shading/stdosl.h"), "appleseed/shaders/")
+        shutil.copy(os.path.join(self.settings.appleseed_headers_path, "renderer/kernel/shading/as_osl_extensions.h"), "appleseed/shaders/")
 
     def add_scripts_to_stage(self):
         progress("Adding scripts to staging directory")

--- a/scripts/appleseed.package.py
+++ b/scripts/appleseed.package.py
@@ -50,7 +50,7 @@ import zipfile
 # Constants.
 #--------------------------------------------------------------------------------------------------
 
-VERSION = "2.4.3"
+VERSION = "2.4.4"
 SETTINGS_FILENAME = "appleseed.package.configuration.xml"
 
 

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -1284,6 +1284,7 @@ set (renderer_modeling_bsdf_sources
     renderer/modeling/bsdf/glassbsdf.h
     renderer/modeling/bsdf/glossybrdf.cpp
     renderer/modeling/bsdf/glossybrdf.h
+    renderer/modeling/bsdf/fresnel.h
     renderer/modeling/bsdf/ibsdffactory.h
     renderer/modeling/bsdf/kelemenbrdf.cpp
     renderer/modeling/bsdf/kelemenbrdf.h
@@ -1303,6 +1304,7 @@ set (renderer_modeling_bsdf_sources
     renderer/modeling/bsdf/specularbrdf.h
     renderer/modeling/bsdf/specularbtdf.cpp
     renderer/modeling/bsdf/specularbtdf.h
+    renderer/modeling/bsdf/specularhelper.h
     renderer/modeling/bsdf/velvetbrdf.cpp
     renderer/modeling/bsdf/velvetbrdf.h
 )

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -1161,6 +1161,7 @@ if (WITH_OSL)
         renderer/kernel/shading/oslshadergroupexec.cpp
         renderer/kernel/shading/oslshadergroupexec.h
         renderer/kernel/shading/oslutil.h
+        renderer/kernel/shading/stdosl.h
     )
 endif ()
 list (APPEND appleseed_sources

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -1281,11 +1281,11 @@ set (renderer_modeling_bsdf_sources
     renderer/modeling/bsdf/diffusebtdf.h
     renderer/modeling/bsdf/disneybrdf.cpp
     renderer/modeling/bsdf/disneybrdf.h
+    renderer/modeling/bsdf/fresnel.h
     renderer/modeling/bsdf/glassbsdf.cpp
     renderer/modeling/bsdf/glassbsdf.h
     renderer/modeling/bsdf/glossybrdf.cpp
     renderer/modeling/bsdf/glossybrdf.h
-    renderer/modeling/bsdf/fresnel.h
     renderer/modeling/bsdf/ibsdffactory.h
     renderer/modeling/bsdf/kelemenbrdf.cpp
     renderer/modeling/bsdf/kelemenbrdf.h

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -1851,7 +1851,8 @@ if (WITH_OSL)
     set (appleseed_osl_headers
         renderer/kernel/shading/oslutil.h
         renderer/kernel/shading/stdosl.h
-    )
+        renderer/kernel/shading/as_osl_extensions.h
+        )
 endif ()
 
 

--- a/src/appleseed/renderer/kernel/shading/.gitignore
+++ b/src/appleseed/renderer/kernel/shading/.gitignore
@@ -1,1 +1,1 @@
-stdosl.h
+as_osl_extensions.h

--- a/src/appleseed/renderer/kernel/shading/as_osl_extensions.h.in
+++ b/src/appleseed/renderer/kernel/shading/as_osl_extensions.h.in
@@ -1,0 +1,204 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2016 Luis Barrancos, The appleseedhq Organization
+// Copyright (c) 2016 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef AS_OSL_EXTENSIONS_H
+#define AS_OSL_EXTENSIONS_H
+
+///////////////////////////////////////////////////////////////////////////////
+
+// appleseed version
+#define APPLESEED_VERSION_MAJOR     ${appleseed_version_major}
+#define APPLESEED_VERSION_MINOR     ${appleseed_version_minor}
+#define APPLESEED_VERSION_PATCH     ${appleseed_version_patch}
+
+#define APPLESEED_VERSION               \
+    APPLESEED_VERSION_MAJOR * 10000 +   \
+    APPLESEED_VERSION_MINOR * 100 +     \
+    APPLESEED_VERSION_PATCH
+
+#ifndef M_1_PI
+#define M_1_PI      0.3183098861837907      // 1/pi
+#endif
+
+matrix inverse(matrix m) { return 1 / m; }
+
+closure color mix(closure color A, closure color B, float w)
+{
+    return (1.0 - w) * A + w * B;
+}
+
+closure color mix(closure color A, closure color B, color w)
+{
+    return (1.0 - w) * A + w * B;
+}
+
+
+/*************************************************************/
+// Custom appleseed closures
+/*************************************************************/
+
+
+/***************************************/
+// diffuse
+
+closure color as_sheen(normal N) BUILTIN;
+
+
+/***************************************/
+// glossy
+
+closure color as_glossy(
+    string  distribution,
+    normal  N,
+    vector  T,
+    float   roughness,
+    float   anisotropic,
+    float   ior) BUILTIN;
+
+closure color as_glossy(
+    string  distribution,
+    normal  N,
+    float   roughness,
+    float   ior)
+{
+    return as_glossy(distribution, N, vector(0), roughness, 0.0, ior);
+}
+
+
+/***************************************/
+// metal
+
+closure color as_metal(
+    string  distribution,
+    normal  N,
+    vector  T,
+    color   normal_reflectance,
+    color   edge_tint,
+    float   roughness,
+    float   anisotropic) BUILTIN;
+
+closure color as_metal(
+    string  distribution,
+    normal  N,
+    color   normal_reflectance,
+    color   edge_tint,
+    float   roughness)
+{
+    return as_metal(
+        distribution,
+        N,
+        vector(0),
+        normal_reflectance,
+        edge_tint,
+        roughness,
+        0.0);
+}
+
+
+/***************************************/
+// glass
+
+closure color as_glass(
+    string  distribution,
+    normal  N,
+    vector  T,
+    color   surface_transmittance,
+    color   reflection_tint,
+    color   refraction_tint,
+    float   roughness,
+    float   anisotropic,
+    float   ior,
+    color   volume_transmittance,
+    float   volume_transmittance_distance) BUILTIN;
+
+closure color as_glass(
+    string  distribution,
+    normal  N,
+    color   surface_transmittance,
+    color   reflection_tint,
+    color   refraction_tint,
+    float   roughness,
+    float   ior,
+    color   volume_transmittance,
+    float   volume_transmittance_distance)
+{
+    return as_glass(
+        distribution,
+        N,
+        vector(0),
+        surface_transmittance,
+        reflection_tint,
+        refraction_tint,
+        roughness,
+        0.0,
+        ior,
+        volume_transmittance,
+        volume_transmittance_distance);
+}
+
+
+/***************************************/
+// subsurface
+
+closure color as_subsurface(
+    string  profile,
+    normal  N,
+    color   reflectance,
+    color   mean_free_path,
+    float   ior) BUILTIN;
+
+
+/***************************************/
+// composite closures
+
+closure color as_ashikhmin_shirley(
+    normal  N,
+    vector  T,
+    color   diffuse_reflectance,
+    color   glossy_reflectance,
+    float   exponent_u,                     // Phong-like exponent in first tangent direction
+    float   exponent_v,                     // Phong-like exponent in second tangent direction
+    float   fresnel_multiplier) BUILTIN;    // Fresnel multiplier
+
+closure color as_disney(
+    normal  N,
+    vector  T,
+    color   base_color,
+    float   subsurface,
+    float   metallic,
+    float   specular,
+    float   specular_tint,
+    float   anisotropic,
+    float   roughness,
+    float   sheen,
+    float   sheen_tint,
+    float   clearcoat,
+    float   clearcoat_gloss) BUILTIN;
+
+#endif // AS_OSL_EXTENSIONS_H

--- a/src/appleseed/renderer/kernel/shading/closures.cpp
+++ b/src/appleseed/renderer/kernel/shading/closures.cpp
@@ -521,7 +521,7 @@ namespace
 
             values->m_reflectance.set(1.0f);
             values->m_reflectance_multiplier = 1.0;
-            values->m_roughness = max(p->roughness, 0.0001f);
+            values->m_roughness = max(p->roughness, 0.0f);
             values->m_anisotropic = clamp(p->anisotropic, -1.0f, 1.0f);
             values->m_ior = max(p->ior, 0.001f);
         }
@@ -638,7 +638,7 @@ namespace
             values->m_normal_reflectance = Color3f(p->normal_reflectance);
             values->m_edge_tint = Color3f(p->edge_tint);
             values->m_reflectance_multiplier = 1.0;
-            values->m_roughness = max(p->roughness, 0.0001f);
+            values->m_roughness = max(p->roughness, 0.0f);
             values->m_anisotropic = clamp(p->anisotropic, -1.0f, 1.0f);
         }
     };

--- a/src/appleseed/renderer/kernel/shading/closures.h
+++ b/src/appleseed/renderer/kernel/shading/closures.h
@@ -90,11 +90,15 @@ enum ClosureID
 {
     // BSDF closures.
     AshikhminShirleyID,
+    DiffuseID,
     DisneyID,
     OrenNayarID,
+    PhongID,
+    ReflectionID,
     SheenID,
     TranslucentID,
 
+    // Microfacet closures.
     GlassID,
     GlassBeckmannID,
     GlassGGXID,

--- a/src/appleseed/renderer/kernel/shading/oslutil.h
+++ b/src/appleseed/renderer/kernel/shading/oslutil.h
@@ -88,4 +88,48 @@ float wireframe(string edge_type, float line_width) { return wireframe(edge_type
 float wireframe(string edge_type) { return wireframe(edge_type, 1.0, 1); }
 float wireframe() { return wireframe("polygons", 1.0, 1); }
 
+float draw_string(string str, float s, float t, int wrap_s, int wrap_t, int jitter) {
+   // Glyphs from http://font.gohu.org/ (8x14 version, most common ascii characters only)
+   int glyph_pixel(int c, int x, int y) {
+      c -= 33; x--; // nudge to origin
+      if (c < 0  || x < 0 || y < 0 ) return 0;
+      if (c > 93 || x > 6 || y > 13) return 0;
+      int i = 98 * c + 7 * y + x;
+      return ((getchar("0@P01248@00120000P49B0000000000000:DXlW2UoDX@10008@h;IR4n@R<Y?48000PYDF"
+              "PP011J:U1000<T8QQQDAR4a50000@P012000000000000222448@P024@010028P0148@PP011100000"
+              "ABELDU410000000048@l7124000000000000000H`01100000000n10000000000000000006<0000@P"
+              "P011224488@00000`CXHY:=:D8?0000004<DT01248@000000l4:444444h700000`C8@Ph02D8?0000"
+              "008HX89b?8@P000000n58`7@P05b300000`CP0O25:D8?00000POPP0112248000000l4:D8?Q25b300"
+              "000`CX@Ql1244700000000H`0000<H00000000`P1000H`0110000044444@014@0000000n100PO000"
+              "0000004@014@@@@@0000h948@@@@00120000`G`l5;F\\Lf0n100000l4:DXOQ25:400000hCX@Qn4:D"
+              "X?000000?Q248@P0Ql000000N49DX@Q25i100000hGP01N48@PO00000PO124hAP012000000l4:@PLQ"
+              "25b3000008DX@Qn5:DX@000000748@P0124L00000001248@P25b3000008DT456D8AT@00000P01248"
+              "@P01n10000017G=IbP1364000008dXAU:U:E\\H000000?Q25:DX@Ql000000n4:DX?1248000000`CX"
+              "@Q2U:E4GP0000P?Q25jCR8Q2100000l4:@0?P05b300000l71248@P01200000P@Q25:DX@Ql0000002"
+              "5:D89BT`P1000004<HbT9[:BT800000P@QT8QQ49Q210000013:B4548@P000000h7888888@PO00000"
+              "7248@P01248`10P0148P0148P0148000h01248@P0124>000015A000000000000000000000000h?00"
+              "04@010000000000000000l0bGX@aL10000124XcX@Q25j300000000?Q248@8?000008@Pl5:DX@aL10"
+              "000000`CX@o24`70000`AP01N48@P0100000000l5:DX@aL12T70124XcX@Q25:40000@P0P348@P01>"
+              "00000240HP01248@P0a101248@T47B4940000HP01248@P01L00000000oBV<IbT910000000hCX@Q25"
+              ":400000000?Q25:D8?00000000j<:DX@Qn48@00000`GX@Q25c58@P0000P>S248@P000000000l48P7"
+              "@Pn0000048@`31248@030000000P@Q25:D<G0000000025:T49<H000000004<HbTE5920000000P@QT"
+              "`@BX@0000000025:DX@aL12T70000h744444h70000PS01248>P0124`1001248@P01248@P0007@P01"
+              "24`@P01R30000000S9S10000000", i / 6) - 48) >> (i % 6)) & 1;
+   }
+   int modp(int a, int b) {
+      int x = a % b;
+      return x < 0 ? x + b : x;
+   }
+   int len = strlen(str);
+   int jit = jitter ? hash(str) : 0;
+   int pix_w = len * 8;
+   int pix_h = 14;
+   int x = int(floor(s));
+   int y = int(floor(t));
+   if (wrap_s) x = modp(x + ( jitter        & 15), pix_w + pix_h);
+   if (wrap_t) y = modp(y + ((jitter >> 16) & 15), pix_h + pix_h);
+   return float(glyph_pixel(getchar(str, x / 8), x - (x / 8) * 8, y));
+}
+
+
 #endif /* OSLUTIL_H */

--- a/src/appleseed/renderer/kernel/shading/stdosl.h
+++ b/src/appleseed/renderer/kernel/shading/stdosl.h
@@ -507,23 +507,10 @@ string concat (string a, string b, string c, string d, string e, string f) {
 
 closure color emission() BUILTIN;
 closure color background() BUILTIN;
+closure color diffuse(normal N) BUILTIN;
 closure color oren_nayar (normal N, float sigma) BUILTIN;
-closure color diffuse(normal N)
-{
-    return oren_nayar(N, 0);
-}
 closure color translucent(normal N) BUILTIN;
-closure color phong(normal N, float exponent)
-{
-    return as_ashikhmin_shirley(
-        N,
-        vector(0),
-        color(0),
-        color(1),
-        exponent,
-        exponent,
-        1.0);
-}
+closure color phong(normal N, float exponent) BUILTIN;
 closure color microfacet(
     string  distribution,
     normal  N,
@@ -567,17 +554,7 @@ closure color microfacet(string distribution, normal N, float alpha, float eta,
 {
     return microfacet(distribution, N, vector(0), alpha, alpha, eta, refr);
 }
-closure color reflection(normal N, float eta)
-{
-    return as_glossy(
-        "beckmann", // MDF
-        N,
-        vector(0),  // U
-        0.0,        // roughness
-        0.0,        // anisotropy
-        eta
-        );
-}
+closure color reflection(normal N, float eta) BUILTIN;
 closure color reflection(normal N) { return reflection (N, 50.0); }
 closure color refraction(normal N, float eta)
 {

--- a/src/appleseed/renderer/kernel/shading/stdosl.h.in
+++ b/src/appleseed/renderer/kernel/shading/stdosl.h.in
@@ -659,6 +659,18 @@ closure color phong(normal N, float exponent)
         1.0);
 }
 
+closure color reflection(normal N, float eta)
+{
+    return as_glossy(
+        "beckmann", // MDF
+        N,
+        vector(0),  // U
+        0.0,        // roughness
+        0.0,        // anisotropy
+        eta
+        );
+}
+
 closure color subsurface(float eta, float g, color mfp, color albedo)
 {
     return as_subsurface("better_dipole", N, albedo, mfp, eta);

--- a/src/appleseed/renderer/modeling/bsdf/bsdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdf.h
@@ -187,7 +187,6 @@ class APPLESEED_DLLSYMBOL BSDF
         const float                 distance,
         Spectrum&                   absorption) const;
 
-  protected:
     // Force a given direction to lie above a surface described by its normal vector.
     static foundation::Vector3f force_above_surface(
         const foundation::Vector3f& direction,

--- a/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
@@ -438,7 +438,7 @@ namespace
                         alpha_y);
 
                     const GGXMDF<float> ggx_mdf;
-                    MicrofacetBRDFHelper<float>::sample(
+                    MicrofacetBRDFHelper::sample(
                         sampling_context,
                         ggx_mdf,
                         alpha_x,
@@ -451,7 +451,7 @@ namespace
                 {
                     const float alpha = clearcoat_roughness(values);
                     const BerryMDF<float> berry_mdf;
-                    MicrofacetBRDFHelper<float>::sample(
+                    MicrofacetBRDFHelper::sample(
                         sampling_context,
                         berry_mdf,
                         alpha,
@@ -530,7 +530,7 @@ namespace
                         alpha_y);
 
                     const GGXMDF<float> ggx_mdf;
-                    pdf += MicrofacetBRDFHelper<float>::evaluate(
+                    pdf += MicrofacetBRDFHelper::evaluate(
                         ggx_mdf,
                         alpha_x,
                         alpha_y,
@@ -549,7 +549,7 @@ namespace
                     Spectrum clear;
                     const float alpha = clearcoat_roughness(values);
                     const BerryMDF<float> berry_mdf;
-                    pdf += MicrofacetBRDFHelper<float>::evaluate(
+                    pdf += MicrofacetBRDFHelper::evaluate(
                         berry_mdf,
                         alpha,
                         alpha,
@@ -621,7 +621,7 @@ namespace
                         alpha_y);
 
                     const GGXMDF<float> ggx_mdf;
-                    pdf += MicrofacetBRDFHelper<float>::pdf(
+                    pdf += MicrofacetBRDFHelper::pdf(
                         ggx_mdf,
                         alpha_x,
                         alpha_y,
@@ -634,7 +634,7 @@ namespace
                 {
                     const float alpha = clearcoat_roughness(values);
                     const BerryMDF<float> berry_mdf;
-                    pdf += MicrofacetBRDFHelper<float>::pdf(
+                    pdf += MicrofacetBRDFHelper::pdf(
                         berry_mdf,
                         alpha,
                         alpha,

--- a/src/appleseed/renderer/modeling/bsdf/fresnel.h
+++ b/src/appleseed/renderer/modeling/bsdf/fresnel.h
@@ -1,0 +1,118 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2010-2013 Francois Beaune, Jupiter Jazz Limited
+// Copyright (c) 2014-2016 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2014-2016 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef APPLESEED_RENDERER_MODELING_BSDF_FRESNEL_FUNCTIONS_H
+#define APPLESEED_RENDERER_MODELING_BSDF_FRESNEL_FUNCTIONS_H
+
+// appleseed.renderer headers.
+#include "renderer/global/globaltypes.h"
+
+// appleseed.foundation headers.
+#include "foundation/math/fresnel.h"
+#include "foundation/math/scalar.h"
+#include "foundation/math/vector.h"
+
+
+namespace renderer
+{
+
+template <typename T>
+class FresnelDielectricFun
+{
+  public:
+    FresnelDielectricFun(
+        const Spectrum& reflectance,
+        const T         reflectance_multiplier,
+        const T         eta)
+      : m_reflectance(reflectance)
+      , m_reflectance_multiplier(reflectance_multiplier)
+      , m_eta(eta)
+    {
+    }
+
+    void operator()(
+        const foundation::Vector<T, 3>& o,
+        const foundation::Vector<T, 3>& h,
+        const foundation::Vector<T, 3>& n,
+        Spectrum&                       value) const
+    {
+        T f;
+        foundation::fresnel_reflectance_dielectric(
+            f,
+            m_eta,
+            foundation::clamp(foundation::dot(o, h), T(-1.0), T(1.0)));
+
+        value = m_reflectance;
+        value *= static_cast<float>(f * m_reflectance_multiplier);
+    }
+
+  private:
+    const Spectrum& m_reflectance;
+    const T         m_reflectance_multiplier;
+    const T         m_eta;
+};
+
+template <typename T>
+class FresnelFriendlyConductorFun
+{
+  public:
+    FresnelFriendlyConductorFun(
+        const Spectrum& normal_reflectance,
+        const Spectrum& edge_tint,
+        const T         reflectance_multiplier)
+      : m_r(normal_reflectance)
+      , m_g(edge_tint)
+      , m_reflectance_multiplier(reflectance_multiplier)
+    {
+    }
+
+    void operator()(
+        const foundation::Vector<T, 3>& o,
+        const foundation::Vector<T, 3>& h,
+        const foundation::Vector<T, 3>& n,
+        Spectrum&                       value) const
+    {
+        foundation::artist_friendly_fresnel_reflectance_conductor(
+            value,
+            m_r,
+            m_g,
+            foundation::dot(o, h));
+        value *= static_cast<float>(m_reflectance_multiplier);
+    }
+
+  private:
+    const Spectrum& m_r;
+    const Spectrum& m_g;
+    const float     m_reflectance_multiplier;
+};
+
+}       // namespace renderer
+
+#endif  // !APPLESEED_RENDERER_MODELING_BSDF_FRESNEL_FUNCTIONS_H

--- a/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
@@ -41,6 +41,7 @@
 
 // appleseed.foundation headers.
 #include "foundation/math/basis.h"
+#include "foundation/math/fresnel.h"
 #include "foundation/math/microfacet.h"
 #include "foundation/math/minmax.h"
 #include "foundation/math/sampling/mappings.h"

--- a/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
@@ -167,7 +167,7 @@ namespace
 
             const InputValues* values = reinterpret_cast<const InputValues*>(data);
 
-            const FresnelDielectricFun<float> f(
+            const FresnelDielectricFun f(
                 values->m_reflectance,
                 values->m_reflectance_multiplier,
                 values->m_precomputed.m_outside_ior / values->m_ior);
@@ -189,7 +189,7 @@ namespace
             if (m_mdf == GGX)
             {
                 const GGXMDF<float> mdf;
-                MicrofacetBRDFHelper<float>::sample(
+                MicrofacetBRDFHelper::sample(
                     sampling_context,
                     mdf,
                     alpha_x,
@@ -201,7 +201,7 @@ namespace
             else
             {
                 const BeckmannMDF<float> mdf;
-                MicrofacetBRDFHelper<float>::sample(
+                MicrofacetBRDFHelper::sample(
                     sampling_context,
                     mdf,
                     alpha_x,
@@ -242,7 +242,7 @@ namespace
                 alpha_x,
                 alpha_y);
 
-            FresnelDielectricFun<float> f(
+            FresnelDielectricFun f(
                 values->m_reflectance,
                 values->m_reflectance_multiplier,
                 values->m_precomputed.m_outside_ior / values->m_ior);
@@ -250,7 +250,7 @@ namespace
             if (m_mdf == GGX)
             {
                 const GGXMDF<float> mdf;
-                return MicrofacetBRDFHelper<float>::evaluate(
+                return MicrofacetBRDFHelper::evaluate(
                     mdf,
                     alpha_x,
                     alpha_y,
@@ -265,7 +265,7 @@ namespace
             else
             {
                 const BeckmannMDF<float> mdf;
-                return MicrofacetBRDFHelper<float>::evaluate(
+                return MicrofacetBRDFHelper::evaluate(
                     mdf,
                     alpha_x,
                     alpha_y,
@@ -309,7 +309,7 @@ namespace
             if (m_mdf == GGX)
             {
                 const GGXMDF<float> mdf;
-                return MicrofacetBRDFHelper<float>::pdf(
+                return MicrofacetBRDFHelper::pdf(
                     mdf,
                     alpha_x,
                     alpha_y,
@@ -320,7 +320,7 @@ namespace
             else
             {
                 const BeckmannMDF<float> mdf;
-                return MicrofacetBRDFHelper<float>::pdf(
+                return MicrofacetBRDFHelper::pdf(
                     mdf,
                     alpha_x,
                     alpha_y,

--- a/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
@@ -154,7 +154,7 @@ namespace
 
             const InputValues* values = reinterpret_cast<const InputValues*>(data);
 
-            FresnelFriendlyConductorFun<float> f(
+            FresnelFriendlyConductorFun f(
                 values->m_normal_reflectance,
                 values->m_edge_tint,
                 values->m_reflectance_multiplier);
@@ -176,7 +176,7 @@ namespace
             if (m_mdf == GGX)
             {
                 const GGXMDF<float> mdf;
-                MicrofacetBRDFHelper<float>::sample(
+                MicrofacetBRDFHelper::sample(
                     sampling_context,
                     mdf,
                     alpha_x,
@@ -188,7 +188,7 @@ namespace
             else
             {
                 const BeckmannMDF<float> mdf;
-                MicrofacetBRDFHelper<float>::sample(
+                MicrofacetBRDFHelper::sample(
                     sampling_context,
                     mdf,
                     alpha_x,
@@ -229,7 +229,7 @@ namespace
                 alpha_x,
                 alpha_y);
 
-            FresnelFriendlyConductorFun<float> f(
+            FresnelFriendlyConductorFun f(
                 values->m_normal_reflectance,
                 values->m_edge_tint,
                 values->m_reflectance_multiplier);
@@ -237,7 +237,7 @@ namespace
             if (m_mdf == GGX)
             {
                 const GGXMDF<float> mdf;
-                return MicrofacetBRDFHelper<float>::evaluate(
+                return MicrofacetBRDFHelper::evaluate(
                     mdf,
                     alpha_x,
                     alpha_y,
@@ -252,7 +252,7 @@ namespace
             else
             {
                 const BeckmannMDF<float> mdf;
-                return MicrofacetBRDFHelper<float>::evaluate(
+                return MicrofacetBRDFHelper::evaluate(
                     mdf,
                     alpha_x,
                     alpha_y,
@@ -296,7 +296,7 @@ namespace
             if (m_mdf == GGX)
             {
                 const GGXMDF<float> mdf;
-                return MicrofacetBRDFHelper<float>::pdf(
+                return MicrofacetBRDFHelper::pdf(
                     mdf,
                     alpha_x,
                     alpha_y,
@@ -307,7 +307,7 @@ namespace
             else
             {
                 const BeckmannMDF<float> mdf;
-                return MicrofacetBRDFHelper<float>::pdf(
+                return MicrofacetBRDFHelper::pdf(
                     mdf,
                     alpha_x,
                     alpha_y,

--- a/src/appleseed/renderer/modeling/bsdf/microfacetbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/microfacetbrdf.cpp
@@ -177,7 +177,7 @@ namespace
                 {
                     const float e = glossiness_to_blinn_exponent(glossiness);
                     const BlinnMDF<float> blinn_mdf;
-                    MicrofacetBRDFHelper<float>::sample(
+                    MicrofacetBRDFHelper::sample(
                         sampling_context,
                         blinn_mdf,
                         e,
@@ -192,7 +192,7 @@ namespace
                 {
                     const float a = glossiness_to_roughness(glossiness);
                     const BeckmannMDF<float> beckmann_mdf;
-                    MicrofacetBRDFHelper<float>::sample(
+                    MicrofacetBRDFHelper::sample(
                         sampling_context,
                         beckmann_mdf,
                         a,
@@ -207,7 +207,7 @@ namespace
                 {
                     const float a = glossiness_to_roughness(glossiness);
                     const WardMDF<float> ward_mdf;
-                    MicrofacetBRDFHelper<float>::sample(
+                    MicrofacetBRDFHelper::sample(
                         sampling_context,
                         ward_mdf,
                         a,
@@ -222,7 +222,7 @@ namespace
                 {
                     const float a = glossiness_to_roughness(glossiness);
                     const GGXMDF<float> ggx_mdf;
-                    MicrofacetBRDFHelper<float>::sample(
+                    MicrofacetBRDFHelper::sample(
                         sampling_context,
                         ggx_mdf,
                         a,
@@ -271,7 +271,7 @@ namespace
                 {
                     const float e = glossiness_to_blinn_exponent(glossiness);
                     const BlinnMDF<float> blinn_mdf;
-                    pdf = MicrofacetBRDFHelper<float>::evaluate(
+                    pdf = MicrofacetBRDFHelper::evaluate(
                         blinn_mdf,
                         e,
                         e,
@@ -289,7 +289,7 @@ namespace
                 {
                     const float a = glossiness_to_roughness(glossiness);
                     const BeckmannMDF<float> beckman_mdf;
-                    pdf = MicrofacetBRDFHelper<float>::evaluate(
+                    pdf = MicrofacetBRDFHelper::evaluate(
                         beckman_mdf,
                         a,
                         a,
@@ -307,7 +307,7 @@ namespace
                 {
                     const float a = glossiness_to_roughness(glossiness);
                     const WardMDF<float> ward_mdf;
-                    pdf = MicrofacetBRDFHelper<float>::evaluate(
+                    pdf = MicrofacetBRDFHelper::evaluate(
                         ward_mdf,
                         a,
                         a,
@@ -325,7 +325,7 @@ namespace
                 {
                     const float a = glossiness_to_roughness(glossiness);
                     const GGXMDF<float> ggx_mdf;
-                    pdf =  MicrofacetBRDFHelper<float>::evaluate(
+                    pdf =  MicrofacetBRDFHelper::evaluate(
                         ggx_mdf,
                         a,
                         a,
@@ -373,7 +373,7 @@ namespace
                 {
                     const float e = glossiness_to_blinn_exponent(glossiness);
                     const BlinnMDF<float> blinn_mdf;
-                    return MicrofacetBRDFHelper<float>::pdf(
+                    return MicrofacetBRDFHelper::pdf(
                         blinn_mdf,
                         e,
                         e,
@@ -387,7 +387,7 @@ namespace
                 {
                     const float a = glossiness_to_roughness(glossiness);
                     const BeckmannMDF<float> beckmann_mdf;
-                    return MicrofacetBRDFHelper<float>::pdf(
+                    return MicrofacetBRDFHelper::pdf(
                         beckmann_mdf,
                         a,
                         a,
@@ -401,7 +401,7 @@ namespace
                 {
                     const float a = glossiness_to_roughness(glossiness);
                     const WardMDF<float> ward_mdf;
-                    return MicrofacetBRDFHelper<float>::pdf(
+                    return MicrofacetBRDFHelper::pdf(
                         ward_mdf,
                         a,
                         a,
@@ -415,7 +415,7 @@ namespace
                 {
                     const float a = glossiness_to_roughness(glossiness);
                     const GGXMDF<float> ggx_mdf;
-                    return MicrofacetBRDFHelper<float>::pdf(
+                    return MicrofacetBRDFHelper::pdf(
                         ggx_mdf,
                         a,
                         a,

--- a/src/appleseed/renderer/modeling/bsdf/microfacethelper.h
+++ b/src/appleseed/renderer/modeling/bsdf/microfacethelper.h
@@ -38,7 +38,6 @@
 
 // appleseed.foundation headers.
 #include "foundation/math/basis.h"
-#include "foundation/math/fresnel.h"
 #include "foundation/math/scalar.h"
 #include "foundation/math/vector.h"
 
@@ -80,44 +79,6 @@ inline void microfacet_alpha_from_roughness(
         alpha_y = std::max(T(0.001), foundation::square(roughness) / aspect);
     }
 }
-
-
-template <typename T>
-class FresnelDielectricFun
-{
-  public:
-    FresnelDielectricFun(
-        const Spectrum& reflectance,
-        const T         reflectance_multiplier,
-        const T         eta)
-      : m_reflectance(reflectance)
-      , m_reflectance_multiplier(reflectance_multiplier)
-      , m_eta(eta)
-    {
-    }
-
-    void operator()(
-        const foundation::Vector<T, 3>& o,
-        const foundation::Vector<T, 3>& h,
-        const foundation::Vector<T, 3>& n,
-        Spectrum&                       value) const
-    {
-        T f;
-        foundation::fresnel_reflectance_dielectric(
-            f,
-            m_eta,
-            foundation::clamp(foundation::dot(o, h), T(-1.0), T(1.0)));
-
-        value = m_reflectance;
-        value *= static_cast<float>(f * m_reflectance_multiplier);
-    }
-
-  private:
-    const Spectrum& m_reflectance;
-    const T         m_reflectance_multiplier;
-    const T         m_eta;
-};
-
 
 template <typename T>
 class MicrofacetBRDFHelper

--- a/src/appleseed/renderer/modeling/bsdf/microfacethelper.h
+++ b/src/appleseed/renderer/modeling/bsdf/microfacethelper.h
@@ -53,53 +53,47 @@ namespace renderer
 // perceptually linear fashion. Refactored from the Disney BRDF implementation.
 //
 
-template <typename T>
-inline T microfacet_alpha_from_roughness(const T& roughness)
+inline float microfacet_alpha_from_roughness(const float& roughness)
 {
-    return std::max(T(0.001), foundation::square(roughness));
+    return std::max(0.001f, foundation::square(roughness));
 }
 
-template <typename T>
 inline void microfacet_alpha_from_roughness(
-    const T&   roughness,
-    const T&   anisotropic,
-    T&         alpha_x,
-    T&         alpha_y)
+    const float&   roughness,
+    const float&   anisotropic,
+    float&         alpha_x,
+    float&         alpha_y)
 {
-    if (anisotropic >= T(0.0))
+    if (anisotropic >= 0.0f)
     {
-        const T aspect = std::sqrt(T(1.0) - anisotropic * T(0.9));
-        alpha_x = std::max(T(0.001), foundation::square(roughness) / aspect);
-        alpha_y = std::max(T(0.001), foundation::square(roughness) * aspect);
+        const float aspect = std::sqrt(1.0f - anisotropic * 0.9f);
+        alpha_x = std::max(0.001f, foundation::square(roughness) / aspect);
+        alpha_y = std::max(0.001f, foundation::square(roughness) * aspect);
     }
     else
     {
-        const T aspect = std::sqrt(T(1.0) + anisotropic * T(0.9));
-        alpha_x = std::max(T(0.001), foundation::square(roughness) * aspect);
-        alpha_y = std::max(T(0.001), foundation::square(roughness) / aspect);
+        const float aspect = std::sqrt(1.0f + anisotropic * 0.9f);
+        alpha_x = std::max(0.001f, foundation::square(roughness) * aspect);
+        alpha_y = std::max(0.001f, foundation::square(roughness) / aspect);
     }
 }
 
-template <typename T>
 class MicrofacetBRDFHelper
 {
   public:
-    typedef foundation::Vector<T, 3> VectorType;
-    typedef foundation::Basis3<T> BasisType;
-
     template <typename MDF, typename FresnelFun>
     static void sample(
-        SamplingContext&    sampling_context,
-        const MDF&          mdf,
-        const T             alpha_x,
-        const T             alpha_y,
-        FresnelFun          f,
-        const T             cos_on,
-        BSDFSample&         sample)
+        SamplingContext&                sampling_context,
+        const MDF&                      mdf,
+        const float                     alpha_x,
+        const float                     alpha_y,
+        FresnelFun                      f,
+        const float                     cos_on,
+        BSDFSample&                     sample)
     {
         // gcc needs the qualifier, otherwise
         // it complains about missing operator() for BSDFSample.
-        MicrofacetBRDFHelper<T>::sample(
+        MicrofacetBRDFHelper::sample(
             sampling_context,
             mdf,
             alpha_x,
@@ -112,17 +106,17 @@ class MicrofacetBRDFHelper
     }
 
     template <typename MDF, typename FresnelFun>
-    static T evaluate(
-        const MDF&          mdf,
-        const T             alpha_x,
-        const T             alpha_y,
-        const BasisType&    shading_basis,
-        const VectorType&   outgoing,
-        const VectorType&   incoming,
-        FresnelFun          f,
-        const T             cos_in,
-        const T             cos_on,
-        Spectrum&           value)
+    static float evaluate(
+        const MDF&                      mdf,
+        const float                     alpha_x,
+        const float                     alpha_y,
+        const foundation::Basis3f&      shading_basis,
+        const foundation::Vector3f&     outgoing,
+        const foundation::Vector3f&     incoming,
+        FresnelFun                      f,
+        const float                     cos_in,
+        const float                     cos_on,
+        Spectrum&                       value)
     {
         return evaluate(
             mdf,
@@ -140,22 +134,22 @@ class MicrofacetBRDFHelper
     }
 
     template <typename MDF>
-    static T pdf(
-        const MDF&          mdf,
-        const T             alpha_x,
-        const T             alpha_y,
-        const BasisType&    shading_basis,
-        const VectorType&   outgoing,
-        const VectorType&   incoming)
+    static float pdf(
+        const MDF&                      mdf,
+        const float                     alpha_x,
+        const float                     alpha_y,
+        const foundation::Basis3f&      shading_basis,
+        const foundation::Vector3f&     outgoing,
+        const foundation::Vector3f&     incoming)
     {
-        const VectorType h = foundation::normalize(incoming + outgoing);
-        const T cos_oh = foundation::dot(outgoing, h);
+        const foundation::Vector3f h = foundation::normalize(incoming + outgoing);
+        const float cos_oh = foundation::dot(outgoing, h);
         return
             mdf.pdf(
                 shading_basis.transform_to_local(outgoing),
                 shading_basis.transform_to_local(h),
                 alpha_x,
-                alpha_y) / (T(4.0) * cos_oh);
+                alpha_y) / (4.0f * cos_oh);
     }
 
     //
@@ -165,33 +159,33 @@ class MicrofacetBRDFHelper
 
     template <typename MDF, typename FresnelFun>
     static void sample(
-        SamplingContext&    sampling_context,
-        const MDF&          mdf,
-        const T             alpha_x,
-        const T             alpha_y,
-        const T             g_alpha_x,
-        const T             g_alpha_y,
-        FresnelFun          f,
-        const T             cos_on,
-        BSDFSample&         sample)
+        SamplingContext&                sampling_context,
+        const MDF&                      mdf,
+        const float                     alpha_x,
+        const float                     alpha_y,
+        const float                     g_alpha_x,
+        const float                     g_alpha_y,
+        FresnelFun                      f,
+        const float                     cos_on,
+        BSDFSample&                     sample)
     {
         // Compute the incoming direction by sampling the MDF.
         sampling_context.split_in_place(3, 1);
-        const VectorType s = sampling_context.next2<VectorType>();
-        const VectorType wo = sample.m_shading_basis.transform_to_local(sample.m_outgoing.get_value());
-        const VectorType m = mdf.sample(wo, s, alpha_x, alpha_y);
-        const VectorType h = sample.m_shading_basis.transform_to_parent(m);
-        const VectorType incoming = foundation::reflect(sample.m_outgoing.get_value(), h);
-        const T cos_oh = foundation::dot(sample.m_outgoing.get_value(), h);
+        const foundation::Vector3f s = sampling_context.next2<foundation::Vector3f>();
+        const foundation::Vector3f wo = sample.m_shading_basis.transform_to_local(sample.m_outgoing.get_value());
+        const foundation::Vector3f m = mdf.sample(wo, s, alpha_x, alpha_y);
+        const foundation::Vector3f h = sample.m_shading_basis.transform_to_parent(m);
+        const foundation::Vector3f incoming = foundation::reflect(sample.m_outgoing.get_value(), h);
+        const float cos_oh = foundation::dot(sample.m_outgoing.get_value(), h);
 
         // No reflection below the shading surface.
-        const T cos_in = foundation::dot(incoming, sample.m_shading_basis.get_normal());
-        if (cos_in <= T(0.0))
+        const float cos_in = foundation::dot(incoming, sample.m_shading_basis.get_normal());
+        if (cos_in <= 0.0f)
             return;
 
-        const T D = mdf.D(m, alpha_x, alpha_y);
+        const float D = mdf.D(m, alpha_x, alpha_y);
 
-        const T G =
+        const float G =
             mdf.G(
                 sample.m_shading_basis.transform_to_local(incoming),
                 wo,
@@ -200,34 +194,34 @@ class MicrofacetBRDFHelper
                 g_alpha_y);
 
         f(sample.m_outgoing.get_value(), h, sample.m_shading_basis.get_normal(), sample.m_value);
-        sample.m_value *= static_cast<float>(D * G / (T(4.0) * cos_on * cos_in));
-        sample.m_probability = mdf.pdf(wo, m, alpha_x, alpha_y) / (T(4.0) * cos_oh);
+        sample.m_value *= static_cast<float>(D * G / (4.0f * cos_on * cos_in));
+        sample.m_probability = mdf.pdf(wo, m, alpha_x, alpha_y) / (4.0f * cos_oh);
         sample.m_mode = ScatteringMode::Glossy;
-        sample.m_incoming = foundation::Dual<VectorType>(incoming);
+        sample.m_incoming = foundation::Dual<foundation::Vector3f>(incoming);
         sample.compute_reflected_differentials();
     }
 
     template <typename MDF, typename FresnelFun>
-    static T evaluate(
-        const MDF&          mdf,
-        const T             alpha_x,
-        const T             alpha_y,
-        const T             g_alpha_x,
-        const T             g_alpha_y,
-        const BasisType&    shading_basis,
-        const VectorType&   outgoing,
-        const VectorType&   incoming,
-        FresnelFun          f,
-        const T             cos_in,
-        const T             cos_on,
-        Spectrum&           value)
+    static float evaluate(
+        const MDF&                      mdf,
+        const float                     alpha_x,
+        const float                     alpha_y,
+        const float                     g_alpha_x,
+        const float                     g_alpha_y,
+        const foundation::Basis3f&      shading_basis,
+        const foundation::Vector3f&     outgoing,
+        const foundation::Vector3f&     incoming,
+        FresnelFun                      f,
+        const float                     cos_in,
+        const float                     cos_on,
+        Spectrum&                       value)
     {
-        const VectorType h = foundation::normalize(incoming + outgoing);
-        const VectorType m = shading_basis.transform_to_local(h);
-        const T D = mdf.D(m, alpha_x, alpha_y);
+        const foundation::Vector3f h = foundation::normalize(incoming + outgoing);
+        const foundation::Vector3f m = shading_basis.transform_to_local(h);
+        const float D = mdf.D(m, alpha_x, alpha_y);
 
-        const VectorType wo = shading_basis.transform_to_local(outgoing);
-        const T G =
+        const foundation::Vector3f wo = shading_basis.transform_to_local(outgoing);
+        const float G =
             mdf.G(
                 shading_basis.transform_to_local(incoming),
                 wo,
@@ -235,10 +229,10 @@ class MicrofacetBRDFHelper
                 g_alpha_x,
                 g_alpha_y);
 
-        const T cos_oh = foundation::dot(outgoing, h);
+        const float cos_oh = foundation::dot(outgoing, h);
         f(outgoing, h, shading_basis.get_normal(), value);
-        value *= static_cast<float>(D * G / (T(4.0) * cos_on * cos_in));
-        return mdf.pdf(wo, m, alpha_x, alpha_y) / (T(4.0) * cos_oh);
+        value *= static_cast<float>(D * G / (4.0f * cos_on * cos_in));
+        return mdf.pdf(wo, m, alpha_x, alpha_y) / (4.0f * cos_oh);
     }
 };
 

--- a/src/appleseed/renderer/modeling/bsdf/specularbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/specularbrdf.cpp
@@ -34,6 +34,7 @@
 #include "renderer/kernel/lighting/scatteringmode.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
+#include "renderer/modeling/bsdf/fresnel.h"
 #include "renderer/modeling/bsdf/specularhelper.h"
 
 // appleseed.foundation headers.
@@ -50,33 +51,6 @@ namespace renderer
 
 namespace
 {
-    template <typename T>
-    class NoFresnelFun
-    {
-      public:
-        NoFresnelFun(
-            const Spectrum& reflectance,
-            const T         reflectance_multiplier)
-          : m_reflectance(reflectance)
-          , m_reflectance_multiplier(reflectance_multiplier)
-        {
-        }
-
-        void operator()(
-            const foundation::Vector<T, 3>& o,
-            const foundation::Vector<T, 3>& h,
-            const foundation::Vector<T, 3>& n,
-            Spectrum&                       value) const
-        {
-            value = m_reflectance;
-            value *= static_cast<float>(m_reflectance_multiplier);
-        }
-
-      private:
-        const Spectrum& m_reflectance;
-        const T         m_reflectance_multiplier;
-    };
-
     //
     // Specular BRDF.
     //
@@ -121,7 +95,7 @@ namespace
 
             const InputValues* values = static_cast<const InputValues*>(data);
 
-            const NoFresnelFun<float> f(
+            const NoFresnelFun f(
                 values->m_reflectance,
                 values->m_reflectance_multiplier);
 

--- a/src/appleseed/renderer/modeling/bsdf/specularhelper.h
+++ b/src/appleseed/renderer/modeling/bsdf/specularhelper.h
@@ -1,0 +1,85 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2016 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef APPLESEED_RENDERER_MODELING_BSDF_SPECULARHELPER_H
+#define APPLESEED_RENDERER_MODELING_BSDF_SPECULARHELPER_H
+
+// appleseed.renderer headers.
+#include "renderer/global/globaltypes.h"
+#include "renderer/kernel/lighting/scatteringmode.h"
+#include "renderer/modeling/bsdf/bsdf.h"
+#include "renderer/modeling/bsdf/bsdfsample.h"
+
+// appleseed.foundation headers.
+#include "foundation/math/scalar.h"
+#include "foundation/math/vector.h"
+
+namespace renderer
+{
+
+class SpecularBRDFHelper
+{
+  public:
+    typedef foundation::Vector3f VectorType;
+
+    template <typename FresnelFun>
+    static void sample(
+        FresnelFun          f,
+        BSDFSample&         sample)
+    {
+        const VectorType& n = sample.m_shading_basis.get_normal();
+        const VectorType& outgoing = sample.m_outgoing.get_value();
+
+        // Compute the incoming direction.
+        const VectorType incoming(
+            BSDF::force_above_surface(
+                foundation::reflect(outgoing, n),
+                sample.m_geometric_normal));
+
+        // No reflection below the shading surface.
+        const float cos_in = dot(incoming, n);
+        if (cos_in < 0.0f)
+            return;
+
+        f(outgoing, n, n, sample.m_value);
+        sample.m_value *= (1.0f / cos_in);
+
+        // The probability density of the sampled direction is the Dirac delta.
+        sample.m_probability = BSDF::DiracDelta;
+
+        // Set the scattering mode.
+        sample.m_mode = ScatteringMode::Specular;
+
+        sample.m_incoming = foundation::Dual3f(incoming);
+        sample.compute_reflected_differentials();
+    }
+};
+
+}       // namespace renderer
+
+#endif  // !APPLESEED_RENDERER_MODELING_BSDF_SPECULARHELPER_H

--- a/src/appleseed/renderer/modeling/bsdf/specularhelper.h
+++ b/src/appleseed/renderer/modeling/bsdf/specularhelper.h
@@ -45,18 +45,16 @@ namespace renderer
 class SpecularBRDFHelper
 {
   public:
-    typedef foundation::Vector3f VectorType;
-
     template <typename FresnelFun>
     static void sample(
         FresnelFun          f,
         BSDFSample&         sample)
     {
-        const VectorType& n = sample.m_shading_basis.get_normal();
-        const VectorType& outgoing = sample.m_outgoing.get_value();
+        const foundation::Vector3f& n = sample.m_shading_basis.get_normal();
+        const foundation::Vector3f& outgoing = sample.m_outgoing.get_value();
 
         // Compute the incoming direction.
-        const VectorType incoming(
+        const foundation::Vector3f incoming(
             BSDF::force_above_surface(
                 foundation::reflect(outgoing, n),
                 sample.m_geometric_normal));


### PR DESCRIPTION
- Use reflection for glossy and metal brdfs when roughness is zero.
- Refactored reflection brdf code into a helper class that can be reused.
- Moved fresnel function objects to its own headers for reuse.
- Moved appleseed custom OSL closures and extensions to its own header.
- Updated OSL related headers.
- Move conversions of some closures to the renderer, to reduce number of changes to stlosl.h.
- Removed unused template parameters from Fresnel function objects and brdf helpers.