### PR TITLE
Fix edge wrap, add UVWRAP definition

### DIFF
--- a/src/appleseed.shaders/include/appleseed/maya/as_maya_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/maya/as_maya_helpers.h
@@ -34,6 +34,7 @@
 #include "appleseed/math/as_math_helpers.h"
 
 #define OUTSIDE_UVFRAME 999999
+#define UVWRAP          1.00001
 
 #define MAYA_COLORBALANCE_PARAMETERS                        \
     color in_defaultColor = color(0.5)                      \

--- a/src/appleseed.shaders/src/maya/as_maya_bulge.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_bulge.osl
@@ -76,7 +76,9 @@ shader as_maya_bulge
     }
     else
     {
-        float st[2] = {mod(in_uvCoord[0], 1), mod(in_uvCoord[1], 1)};
+        float st[2] = {
+            mod(in_uvCoord[0], UVWRAP),
+            mod(in_uvCoord[1], UVWRAP)};
 
         float a = smoothstep(in_uWidth / 2, 0.5, st[0]) *
             ( 1 - smoothstep(0.5, 1 - (in_uWidth / 2), st[0]));

--- a/src/appleseed.shaders/src/maya/as_maya_checker.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_checker.osl
@@ -84,10 +84,10 @@ shader as_maya_checker
     else
     {
         float dsdt[2] = {0, 0};
-        float st[2] = {in_uvCoord[0], 1 - in_uvCoord[1]};
+        float st[2] = {in_uvCoord[0], in_uvCoord[1]};
 
-        st[0] = mod(st[0], 1);
-        st[1] = mod(st[1], 1);
+        st[0] = mod(st[0], UVWRAP);
+        st[1] = mod(st[1], UVWRAP);
 
         if (in_filter)
         {
@@ -115,10 +115,8 @@ shader as_maya_checker
         color B = mix(color_blend, in_color2, in_contrast);
 
         float weight = 0.5 - 2 *
-            (filtered_pulsetrain(0.5, 1, mod(in_uvCoord[0], 1),
-                dsdt[0]) - 0.5) *
-            (filtered_pulsetrain(0.5, 1, mod(in_uvCoord[1], 1),
-                dsdt[1]) - 0.5);
+            (filtered_pulsetrain(0.5, 1, st[0], dsdt[0]) - 0.5) *
+            (filtered_pulsetrain(0.5, 1, st[1], dsdt[1]) - 0.5);
 
         out_outColor = mix(A, B, weight);
         out_outAlpha = mix(alpha_blend, 1 - weight, in_contrast);

--- a/src/appleseed.shaders/src/maya/as_maya_grid.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_grid.osl
@@ -99,8 +99,8 @@ shader as_maya_grid
         float st[2] = {in_uvCoord[0], 1 - in_uvCoord[1]};
         float width[2] = {in_uWidth, in_vWidth};
 
-        st[0] = mod(st[0], 1);
-        st[1] = mod(st[1], 1);
+        st[0] = mod(st[0], UVWRAP);
+        st[1] = mod(st[1], UVWRAP);
         
         if (in_filter)
         {


### PR DESCRIPTION
Repeating patterns show a tiny discontinuity at the edge of their UV
wrapping, i.e: a quad with a checkerboard pattern shows a small white
thin line at the edge of the mesh where a black square ends. Change
mod() calls accordingly and add UVWRAP to extend period slightly.