### PR TITLE
Move microfacet roughness to global AS header

### DIFF
--- a/src/appleseed.shaders/CMakeLists.txt
+++ b/src/appleseed.shaders/CMakeLists.txt
@@ -53,7 +53,6 @@ source_group ("include\\standard" FILES
 
 set (gaffer_osl_headers
     include/appleseed/gaffer/color.h
-    include/appleseed/gaffer/microfacet.h
     include/appleseed/gaffer/transform.h
     include/appleseed/gaffer/udim.h
 )
@@ -65,6 +64,7 @@ source_group ("include\\gaffer" FILES
 set (appleseed_library_osl_headers
     include/appleseed/color/as_color_data.h
     include/appleseed/color/as_color_helpers.h
+    include/appleseed/material/as_material_helpers.h
     include/appleseed/math/as_math_helpers.h
     include/appleseed/maya/as_maya_helpers.h
     include/appleseed/maya/as_maya_ramp_helpers.h

--- a/src/appleseed.shaders/include/appleseed/material/as_material_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/material/as_material_helpers.h
@@ -47,5 +47,12 @@ float microfacet_roughness(float roughness, float depth_scale)
     return out;
 }
 
+float ior_from_normal_reflectance(float f0)
+{
+    float sqrt_f0 = sqrt(f0);
+
+    return (sqrt_f0 + 1) / (1 - sqrt_f0);
+}
+
 #endif // AS_MATERIAL_HELPERS_H
 

--- a/src/appleseed.shaders/include/appleseed/material/as_material_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/material/as_material_helpers.h
@@ -5,7 +5,8 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2016 The masked shader writer, The appleseedhq Organization
+// Copyright (c) 2016 Luis Barrancos, The appleseedhq Organization
+// Copyright (c) 2016 Esteban Tovagliari, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,21 +27,25 @@
 // THE SOFTWARE.
 //
 
-#ifndef APPLESEED_SHADERS_MICROFACET_H
-#define APPLESEED_SHADERS_MICROFACET_H
+#ifndef AS_MATERIAL_HELPERS_H
+#define AS_MATERIAL_HELPERS_H
 
-float microfacet_roughness(float Roughness, float DepthScale)
+float microfacet_roughness(float roughness, float depth_scale)
 {
-    if (DepthScale > 1.0)
+    float out = roughness;
+
+    if (depth_scale > 1)
     {
-        int RayDepth;
-        getattribute("path:ray_depth", RayDepth);
+        int ray_depth;
+        getattribute("path:ray_depth", ray_depth);
 
-        if (RayDepth != 0)
-            return Roughness * DepthScale * RayDepth;
+        if (ray_depth)
+        {
+            out = roughness * depth_scale * ray_depth;
+        }
     }
-
-    return Roughness;
+    return out;
 }
 
-#endif
+#endif // AS_MATERIAL_HELPERS_H
+

--- a/src/appleseed.shaders/src/gaffer/surface/as_glossy_surface.osl
+++ b/src/appleseed.shaders/src/gaffer/surface/as_glossy_surface.osl
@@ -26,7 +26,7 @@
 // THE SOFTWARE.
 //
 
-#include "appleseed/gaffer/microfacet.h"
+#include "appleseed/material/as_material_helpers.h"
 
 shader as_glossy_surface
 [[

--- a/src/appleseed.shaders/src/gaffer/surface/as_metal_surface.osl
+++ b/src/appleseed.shaders/src/gaffer/surface/as_metal_surface.osl
@@ -26,7 +26,7 @@
 // THE SOFTWARE.
 //
 
-#include "appleseed/gaffer/microfacet.h"
+#include "appleseed/material/as_material_helpers.h"
 
 shader as_metal_surface
 [[


### PR DESCRIPTION
The microfacet roughness depth scaling factor is required for the
generic Appleseed shader library, so we can reuse the current function
set for Gaffer exclusive shaders, and update the relevant Gaffer surface
shaders at the same time.