### PR TITLE
Fix a crash when using OSL and nested dielectrics.

### DIFF
--- a/src/appleseed/renderer/kernel/shading/shadingray.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingray.cpp
@@ -52,7 +52,7 @@ void ShadingRay::copy_media_from(const ShadingRay& source)
 void ShadingRay::add_medium(
     const ShadingRay&       source,
     const ObjectInstance*   object_instance,
-    const BSDF*             bsdf,
+    const Material*         material,
     const float             ior)
 {
     assert(m_medium_count == 0);
@@ -67,7 +67,7 @@ void ShadingRay::add_medium(
     if (j < MaxMediumCount)
     {
         m_media[j].m_object_instance = object_instance;
-        m_media[j].m_bsdf = bsdf;
+        m_media[j].m_material = material;
         m_media[j].m_ior = ior;
         ++j;
     }

--- a/src/appleseed/renderer/kernel/shading/shadingray.h
+++ b/src/appleseed/renderer/kernel/shading/shadingray.h
@@ -45,7 +45,7 @@
 #include <cassert>
 
 // Forward declarations.
-namespace renderer  { class BSDF; }
+namespace renderer  { class Material; }
 
 namespace renderer
 {
@@ -90,7 +90,7 @@ class ShadingRay
     struct Medium
     {
         const ObjectInstance*       m_object_instance;
-        const BSDF*                 m_bsdf;
+        const Material*             m_material;
         float                       m_ior;
     };
 
@@ -128,7 +128,7 @@ class ShadingRay
     void add_medium(
         const ShadingRay&           source,
         const ObjectInstance*       object_instance,
-        const BSDF*                 bsdf,
+        const Material*             material,
         const float                 ior);
 
     // Copy all media from the source ray except a given medium.


### PR DESCRIPTION
Sometimes we'd call BSDF::evaluate_inputs without running the OSL shader of the previous medium.