### PR TITLE
OSL Misc work

### DIFF
--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -1735,6 +1735,8 @@ set (renderer_modeling_surfaceshader_sources
     renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
     renderer/modeling/surfaceshader/diagnosticsurfaceshader.h
     renderer/modeling/surfaceshader/isurfaceshaderfactory.h
+    renderer/modeling/surfaceshader/oslsurfaceshader.cpp
+    renderer/modeling/surfaceshader/oslsurfaceshader.h
     renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
     renderer/modeling/surfaceshader/physicalsurfaceshader.h
     renderer/modeling/surfaceshader/surfaceshader.cpp

--- a/src/appleseed/renderer/kernel/rendering/rendererservices.h
+++ b/src/appleseed/renderer/kernel/rendering/rendererservices.h
@@ -374,6 +374,10 @@ class RendererServices
     DECLARE_ATTR_GETTER(appleseed_version_patch);
     DECLARE_ATTR_GETTER(appleseed_version);
 
+    // Surface shader attributes.
+    DECLARE_ATTR_GETTER(surface_shader_color);
+    DECLARE_ATTR_GETTER(surface_shader_alpha);
+
     #undef DECLARE_ATTR_GETTER
 
     #define DECLARE_USER_DATA_GETTER(name)      \

--- a/src/appleseed/renderer/kernel/rendering/rendererservices.h
+++ b/src/appleseed/renderer/kernel/rendering/rendererservices.h
@@ -32,6 +32,7 @@
 
 // appleseed.foundation headers.
 #include "foundation/core/concepts/noncopyable.h"
+#include "foundation/math/vector.h"
 #include "foundation/platform/compiler.h"
 
 // OSL headers.
@@ -324,14 +325,15 @@ class RendererServices
     typedef boost::unordered_map<OIIO::ustring, UserDataGetterFun, OIIO::ustringHash> UserDataGetterMapType;
 
     OIIO::TextureSystem&            m_texture_sys;
-    const Project&                  m_project;
     AttrGetterMapType               m_global_attr_getters;
     UserDataGetterMapType           m_global_user_data_getters;
     const Camera*                   m_camera;
-    TextureStore*                   m_texture_store;
+    foundation::Vector2i            m_resolution;
     OIIO::ustring                   m_cam_projection_str;
     float                           m_shutter[2];
     float                           m_shutter_interval;
+    const Project&                  m_project;
+    TextureStore*                   m_texture_store;
 
     #define DECLARE_ATTR_GETTER(name)           \
         bool get_attr_##name(                   \

--- a/src/appleseed/renderer/kernel/shading/oslshadergroupexec.cpp
+++ b/src/appleseed/renderer/kernel/shading/oslshadergroupexec.cpp
@@ -215,6 +215,20 @@ Color3f OSLShaderGroupExec::execute_background(
     return process_background_tree(sg.Ci);
 }
 
+void OSLShaderGroupExec::execute_surface_shader(
+    const ShaderGroup&              shader_group,
+    const ShadingPoint&             shading_point,
+    const Color3f&                  color,
+    const float                     alpha) const
+{
+    shading_point.m_surface_shader_color = color;
+    shading_point.m_surface_shader_alpha = alpha;
+    do_execute(
+        shader_group,
+        shading_point,
+        shading_point.get_ray().m_flags);
+}
+
 void OSLShaderGroupExec::do_execute(
     const ShaderGroup&              shader_group,
     const ShadingPoint&             shading_point,

--- a/src/appleseed/renderer/kernel/shading/oslshadergroupexec.h
+++ b/src/appleseed/renderer/kernel/shading/oslshadergroupexec.h
@@ -110,6 +110,12 @@ class OSLShaderGroupExec
         const ShaderGroup&              shader_group,
         const foundation::Vector3f&     outgoing) const;
 
+    void execute_surface_shader(
+        const ShaderGroup&              shader_group,
+        const ShadingPoint&             shading_point,
+        const foundation::Color3f&      color,
+        const float                     alpha) const;
+
     void do_execute(
         const ShaderGroup&              shader_group,
         const ShadingPoint&             shading_point,

--- a/src/appleseed/renderer/kernel/shading/shadingcontext.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingcontext.cpp
@@ -72,6 +72,16 @@ OIIO::TextureSystem& ShadingContext::get_oiio_texture_system() const
     return m_oiio_texture_system;
 }
 
+OSL::ShadingSystem& ShadingContext::get_osl_shading_system() const
+{
+    return m_shadergroup_exec.m_osl_shading_system;
+}
+
+OSL::ShadingContext* ShadingContext::get_osl_shading_context() const
+{
+    return m_shadergroup_exec.m_osl_shading_context;
+}
+
 void ShadingContext::execute_osl_shading(
     const ShaderGroup&      shader_group,
     const ShadingPoint&     shading_point) const
@@ -143,6 +153,19 @@ void ShadingContext::execute_osl_background(
         m_shadergroup_exec.execute_background(
             shader_group,
             outgoing);
+}
+
+void ShadingContext::execute_osl_surface_shader(
+    const ShaderGroup&      shader_group,
+    const ShadingPoint&     shading_point,
+    const Color3f&          color,
+    const float             alpha) const
+{
+    m_shadergroup_exec.execute_surface_shader(
+        shader_group,
+        shading_point,
+        color,
+        alpha);
 }
 
 void* ShadingContext::osl_mem_alloc(const size_t size) const

--- a/src/appleseed/renderer/kernel/shading/shadingcontext.h
+++ b/src/appleseed/renderer/kernel/shading/shadingcontext.h
@@ -95,6 +95,9 @@ class ShadingContext
     // Return the maximum number of iterations in ray/path tracing loops.
     size_t get_max_iterations() const;
 
+    OSL::ShadingSystem& get_osl_shading_system() const;
+    OSL::ShadingContext* get_osl_shading_context() const;
+
     void execute_osl_shading(
         const ShaderGroup&          shader_group,
         const ShadingPoint&         shading_point) const;
@@ -129,6 +132,12 @@ class ShadingContext
         const ShaderGroup&          shader_group,
         const foundation::Vector3f& outgoing,
         Spectrum&                   value) const;
+
+    void execute_osl_surface_shader(
+        const ShaderGroup&          shader_group,
+        const ShadingPoint&         shading_point,
+        const foundation::Color3f&  color,
+        const float                 alpha) const;
 
     void* osl_mem_alloc(const size_t size) const;
 

--- a/src/appleseed/renderer/kernel/shading/shadingpoint.h
+++ b/src/appleseed/renderer/kernel/shading/shadingpoint.h
@@ -260,6 +260,7 @@ class ShadingPoint
     friend class Intersector;
     friend class OSLShaderGroupExec;
     friend class RegionLeafVisitor;
+    friend class RendererServices;
     friend class ShadingPointBuilder;
     friend class TriangleLeafVisitor;
     friend class foundation::PoisonImpl<ShadingPoint>;
@@ -346,6 +347,9 @@ class ShadingPoint
     mutable OSLObjectTransformInfo      m_obj_transform_info;
     mutable OSLTraceData                m_osl_trace_data;
     mutable OSL::ShaderGlobals          m_shader_globals;
+
+    mutable foundation::Color3f         m_surface_shader_color;
+    mutable float                       m_surface_shader_alpha;
 
     // Fetch and cache the source geometry.
     void cache_source_geometry() const;

--- a/src/appleseed/renderer/modeling/shadergroup/shadergroup.h
+++ b/src/appleseed/renderer/modeling/shadergroup/shadergroup.h
@@ -134,6 +134,10 @@ class APPLESEED_DLLSYMBOL ShaderGroup
     // Return a reference-counted (but opaque) reference to the internal OSL shader group.
     OSL::ShaderGroupRef& shader_group_ref() const;
 
+    // OSL symbols.
+    const OSL::ShaderSymbol* surface_shader_color_symbol() const;
+    const OSL::ShaderSymbol* surface_shader_alpha_symbol() const;
+
   private:
     friend class LightSampler;
     friend class ShaderGroupFactory;

--- a/src/appleseed/renderer/modeling/surfaceshader/oslsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/oslsurfaceshader.cpp
@@ -1,0 +1,246 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2016 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "oslsurfaceshader.h"
+
+// appleseed.renderer headers.
+#include "renderer/global/globaltypes.h"
+#include "renderer/kernel/aov/shadingfragmentstack.h"
+#include "renderer/kernel/aov/spectrumstack.h"
+#include "renderer/kernel/shading/shadingcontext.h"
+#include "renderer/kernel/shading/shadingfragment.h"
+#include "renderer/kernel/shading/shadingpoint.h"
+#include "renderer/kernel/shading/shadingresult.h"
+#include "renderer/modeling/frame/frame.h"
+#include "renderer/modeling/input/inputarray.h"
+#include "renderer/modeling/shadergroup/shadergroup.h"
+#include "renderer/modeling/surfaceshader/surfaceshader.h"
+#include "renderer/modeling/project/project.h"
+#include "renderer/utility/paramarray.h"
+
+// appleseed.foundation headers.
+#include "foundation/image/colorspace.h"
+#include "foundation/utility/api/specializedapiarrays.h"
+#include "foundation/utility/containers/dictionary.h"
+
+// Forward declarations.
+namespace renderer  { class PixelContext; }
+
+using namespace foundation;
+using namespace std;
+
+namespace renderer
+{
+
+namespace
+{
+    //
+    // OSL surface shader.
+    //
+
+    const char* Model = "osl_surface_shader";
+
+    OIIO::ustring g_color_output("Cout");
+    OIIO::ustring g_alpha_output("Aout");
+
+    class OSLSurfaceShader
+      : public SurfaceShader
+    {
+      public:
+        OSLSurfaceShader(
+            const char*                 name,
+            const ParamArray&           params)
+          : SurfaceShader(name, params)
+        {
+            m_inputs.declare("surface_shader", InputFormatEntity, 0);
+            m_inputs.declare("osl_shader", InputFormatEntity, "");
+        }
+
+        virtual void release() APPLESEED_OVERRIDE
+        {
+            delete this;
+        }
+
+        virtual const char* get_model() const APPLESEED_OVERRIDE
+        {
+            return Model;
+        }
+
+        virtual bool on_frame_begin(
+            const Project&              project,
+            const BaseGroup*            parent,
+            OnFrameBeginRecorder&       recorder,
+            foundation::IAbortSwitch*   abort_switch) APPLESEED_OVERRIDE
+        {
+            if (!SurfaceShader::on_frame_begin(project, parent, recorder, abort_switch))
+                return false;
+
+            m_surface_shader =
+                static_cast<SurfaceShader*>(m_inputs.get_entity("surface_shader"));
+
+            m_lighting_conditions =
+                &project.get_frame()->get_lighting_conditions();
+
+            m_shader_group =
+                static_cast<const ShaderGroup*>(m_inputs.get_entity("osl_shader"));
+
+            if (m_shader_group && !m_shader_group->is_valid())
+                m_shader_group = 0;
+
+            return true;
+        }
+
+        virtual void on_frame_end(
+            const Project&              project,
+            const BaseGroup*            parent) APPLESEED_OVERRIDE
+        {
+            m_surface_shader = 0;
+            m_lighting_conditions = 0;
+            m_shader_group = 0;
+
+            SurfaceShader::on_frame_end(project, parent);
+        }
+
+        virtual void evaluate(
+            SamplingContext&            sampling_context,
+            const PixelContext&         pixel_context,
+            const ShadingContext&       shading_context,
+            const ShadingPoint&         shading_point,
+            ShadingResult&              shading_result) const APPLESEED_OVERRIDE
+        {
+            if (m_shader_group)
+            {
+                const OSL::ShaderSymbol* color_sym =
+                    m_shader_group->surface_shader_color_symbol();
+
+                const OSL::ShaderSymbol* alpha_sym =
+                    m_shader_group->surface_shader_alpha_symbol();
+
+                if (color_sym && alpha_sym)
+                {
+                    m_surface_shader->evaluate(
+                        sampling_context,
+                        pixel_context,
+                        shading_context,
+                        shading_point,
+                        shading_result);
+
+                    shading_result.transform_to_linear_rgb(*m_lighting_conditions);
+
+                    shading_context.execute_osl_surface_shader(
+                        *m_shader_group,
+                        shading_point,
+                        shading_result.m_main.m_color.rgb(),
+                        shading_result.m_main.m_alpha[0]);
+
+                    const float* c =
+                        reinterpret_cast<const float*>(
+                            shading_context.get_osl_shading_system().symbol_address(
+                                *shading_context.get_osl_shading_context(),
+                                color_sym));
+
+                    const float* a =
+                        reinterpret_cast<const float*>(
+                            shading_context.get_osl_shading_system().symbol_address(
+                                *shading_context.get_osl_shading_context(),
+                                alpha_sym));
+
+                    shading_result.set_main_to_linear_rgba(Color4f(c[0], c[1], c[2], *a));
+                    return;
+                }
+            }
+
+            // If we arrive here, something went wrong.
+            shading_result.set_main_to_opaque_pink_linear_rgba();
+        }
+
+      private:
+        const SurfaceShader*        m_surface_shader;
+        const LightingConditions*   m_lighting_conditions;
+        const ShaderGroup*          m_shader_group;
+        const void*                 m_color_symbol;
+        const void*                 m_alpha_symbol;
+    };
+}
+
+
+//
+// OSLSurfaceShaderFactory class implementation.
+//
+
+const char* OSLSurfaceShaderFactory::get_model() const
+{
+    return Model;
+}
+
+Dictionary OSLSurfaceShaderFactory::get_model_metadata() const
+{
+    return
+        Dictionary()
+            .insert("name", Model)
+            .insert("label", "OSL");
+}
+
+DictionaryArray OSLSurfaceShaderFactory::get_input_metadata() const
+{
+    DictionaryArray metadata;
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "surface_shader")
+            .insert("label", "Surface Shader")
+            .insert("type", "entity")
+            .insert("entity_types",
+                Dictionary()
+                    .insert("surface_shader", "Surface Shaders"))
+            .insert("use", "required"));
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "osl_shader")
+            .insert("label", "OSL Shader")
+            .insert("type", "entity")
+            .insert("entity_types",
+                Dictionary()
+                    .insert("shader_group", "Shader Groups"))
+            .insert("use", "optional"));
+
+    return metadata;
+}
+
+auto_release_ptr<SurfaceShader> OSLSurfaceShaderFactory::create(
+    const char*         name,
+    const ParamArray&   params) const
+{
+    return
+        auto_release_ptr<SurfaceShader>(
+            new OSLSurfaceShader(name, params));
+}
+
+}   // namespace renderer

--- a/src/appleseed/renderer/modeling/surfaceshader/oslsurfaceshader.h
+++ b/src/appleseed/renderer/modeling/surfaceshader/oslsurfaceshader.h
@@ -1,0 +1,76 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2016 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef APPLESEED_RENDERER_MODELING_SURFACESHADER_OSLSURFACESHADER_H
+#define APPLESEED_RENDERER_MODELING_SURFACESHADER_OSLSURFACESHADER_H
+
+// appleseed.renderer headers.
+#include "renderer/modeling/surfaceshader/isurfaceshaderfactory.h"
+
+// appleseed.foundation headers.
+#include "foundation/platform/compiler.h"
+#include "foundation/utility/autoreleaseptr.h"
+
+// appleseed.main headers.
+#include "main/dllsymbol.h"
+
+// Forward declarations.
+namespace foundation    { class Dictionary; }
+namespace foundation    { class DictionaryArray; }
+namespace renderer      { class ParamArray; }
+namespace renderer      { class SurfaceShader; }
+
+namespace renderer
+{
+
+//
+// OSL surface shader factory.
+//
+
+class APPLESEED_DLLSYMBOL OSLSurfaceShaderFactory
+  : public ISurfaceShaderFactory
+{
+  public:
+    // Return a string identifying this surface shader model.
+    virtual const char* get_model() const APPLESEED_OVERRIDE;
+
+    // Return metadata for this surface shader model.
+    virtual foundation::Dictionary get_model_metadata() const APPLESEED_OVERRIDE;
+
+    // Return metadata for the inputs of this surface shader model.
+    virtual foundation::DictionaryArray get_input_metadata() const APPLESEED_OVERRIDE;
+
+    // Create a new surface shader instance.
+    virtual foundation::auto_release_ptr<SurfaceShader> create(
+        const char*         name,
+        const ParamArray&   params) const APPLESEED_OVERRIDE;
+};
+
+}       // namespace renderer
+
+#endif  // !APPLESEED_RENDERER_MODELING_SURFACESHADER_OSLSURFACESHADER_H

--- a/src/appleseed/renderer/modeling/surfaceshader/surfaceshaderfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/surfaceshaderfactoryregistrar.cpp
@@ -35,6 +35,7 @@
 #include "renderer/modeling/surfaceshader/constantsurfaceshader.h"
 #include "renderer/modeling/surfaceshader/diagnosticsurfaceshader.h"
 #include "renderer/modeling/surfaceshader/isurfaceshaderfactory.h"
+#include "renderer/modeling/surfaceshader/oslsurfaceshader.h"
 #include "renderer/modeling/surfaceshader/physicalsurfaceshader.h"
 #include "renderer/modeling/surfaceshader/surfaceshadercollection.h"
 
@@ -65,6 +66,7 @@ SurfaceShaderFactoryRegistrar::SurfaceShaderFactoryRegistrar()
     register_factory(auto_ptr<FactoryType>(new AOSurfaceShaderFactory()));
     register_factory(auto_ptr<FactoryType>(new ConstantSurfaceShaderFactory()));
     register_factory(auto_ptr<FactoryType>(new DiagnosticSurfaceShaderFactory()));
+    register_factory(auto_ptr<FactoryType>(new OSLSurfaceShaderFactory()));
     register_factory(auto_ptr<FactoryType>(new PhysicalSurfaceShaderFactory()));
     register_factory(auto_ptr<FactoryType>(new SurfaceShaderCollectionFactory()));
 }


### PR DESCRIPTION
Added OSL's coordinate systems transforms from object, camera and world to NDC and raster spaces.

OSL's SurfaceShaders:
A surface shader that runs an OSL shader to post-process the shading results. Might be useful to do color corrections and other special effects.
The commit includes useful things, like marking OSL shader parameters as outputs and getting shader symbols to be able to fetch results from them.
