### PR TITLE
alShaders part 1

### DIFF
--- a/src/appleseed.shaders/CMakeLists.txt
+++ b/src/appleseed.shaders/CMakeLists.txt
@@ -151,7 +151,7 @@ source_group ("src\\gaffer" FILES
     ${gaffer_osl_sources}
 )
 
-set (appleseed_maya2_osl_sources
+set (appleseed_maya_osl_sources
      src/maya/as_maya_addDoubleLinear.osl
      src/maya/as_maya_addMatrix.osl
      src/maya/as_maya_areaLight.osl
@@ -204,9 +204,25 @@ set (appleseed_maya2_osl_sources
      src/maya/as_maya_vectorProduct.osl
      src/maya/as_maya_wtAddMatrix.osl
 )
-list (APPEND osl_sources ${appleseed_maya2_osl_sources})
+list (APPEND osl_sources ${appleseed_maya_osl_sources})
 source_group ("src\\maya" FILES
-    ${appleseed_maya2_osl_sources}
+    ${appleseed_maya_osl_sources}
+)
+
+set (appleseed_alshaders_osl_sources
+     src/alshaders/alCombineColor.osl
+     src/alshaders/alCombineFloat.osl
+     src/alshaders/alJitterColor.osl
+     src/alshaders/alLayerColor.osl
+     src/alshaders/alLayerFloat.osl
+     src/alshaders/alRemapColor.osl
+     src/alshaders/alSurface.osl
+     src/alshaders/alSwitchColor.osl
+     src/alshaders/alSwitchFloat.osl
+)
+list (APPEND osl_sources ${appleseed_alshaders_osl_sources})
+source_group ("src\\alshaders" FILES
+    ${appleseed_alshaders_osl_sources}
 )
 
 

--- a/src/appleseed.shaders/as_osl_extensions.h.in
+++ b/src/appleseed.shaders/as_osl_extensions.h.in
@@ -145,12 +145,6 @@ closure color as_subsurface(
     color   mean_free_path,
     float   ior) BUILTIN;
 
-closure color as_subsurface_gaussian(
-    normal  N,
-    color   reflectance,
-    color   radius,
-    float   ior) BUILTIN;
-
 closure color as_ashikhmin_shirley(
     normal  N,
     vector  T,

--- a/src/appleseed.shaders/as_osl_extensions.h.in
+++ b/src/appleseed.shaders/as_osl_extensions.h.in
@@ -145,6 +145,12 @@ closure color as_subsurface(
     color   mean_free_path,
     float   ior) BUILTIN;
 
+closure color as_subsurface_gaussian(
+    normal  N,
+    color   reflectance,
+    float   radius,
+    float   ior) BUILTIN;
+
 closure color as_ashikhmin_shirley(
     normal  N,
     vector  T,

--- a/src/appleseed.shaders/as_osl_extensions.h.in
+++ b/src/appleseed.shaders/as_osl_extensions.h.in
@@ -143,7 +143,14 @@ closure color as_subsurface(
     normal  N,
     color   reflectance,
     color   mean_free_path,
-    float   ior) BUILTIN;
+    float   ior
+//
+//  keyword arguments:
+//  ==================
+//
+//      float "fresnel_weight" = 1
+//
+    ) BUILTIN;
 
 closure color as_ashikhmin_shirley(
     normal  N,

--- a/src/appleseed.shaders/as_osl_extensions.h.in
+++ b/src/appleseed.shaders/as_osl_extensions.h.in
@@ -148,7 +148,7 @@ closure color as_subsurface(
 closure color as_subsurface_gaussian(
     normal  N,
     color   reflectance,
-    float   radius,
+    color   radius,
     float   ior) BUILTIN;
 
 closure color as_ashikhmin_shirley(

--- a/src/appleseed.shaders/src/alshaders/alCombineColor.osl
+++ b/src/appleseed.shaders/src/alshaders/alCombineColor.osl
@@ -1,0 +1,88 @@
+
+//
+// This software is released under the MIT licence
+//
+// Copyright (c) 2013 Anders Langlands
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// This code comes from alshaders's OSL branch, with minimal changes.
+// https://bitbucket.org/anderslanglands/alshaders/branch/osl
+
+shader alCombineColor
+[[
+    string maya_node_name = "alCombineColor"
+]]
+(
+    color input1 = color(0),
+    color input2 = color(1),
+    float input3 = 0,
+    int combineOp = 0,
+    output color result = color(0)
+    [[
+        string maya_attribute_name = "outColor",
+        string maya_attribute_short_name = "oc"
+    ]]
+)
+{
+    if (combineOp == 0)
+    {
+        // multiply
+        result = input1*input2;
+    }
+    else if (combineOp == 1)
+    {
+        // add
+        result = input1+input2;
+    }
+    else if (combineOp == 2)
+    {
+        // divide
+        result = input1/input2;
+    }
+    else if (combineOp == 3)
+    {
+        // subtract
+        result = input1-input2;
+    }
+    else if (combineOp == 4)
+    {
+        // lerp
+        if (input3 <= 0) result = input1;
+        else if (input3 >= 1) result = input2;
+        else result = mix(input1, input2, input3);
+    }
+    else if (combineOp == 5)
+    {
+        // dot
+        result = dot(input1, input2);
+    }
+    else if (combineOp == 6)
+    {
+        // distance
+        result = distance(input1, input2);
+    }
+    else if (combineOp == 7)
+    {
+        // cross
+        result = cross(input1, input2);
+    }
+    else
+        result = input1;
+}

--- a/src/appleseed.shaders/src/alshaders/alCombineFloat.osl
+++ b/src/appleseed.shaders/src/alshaders/alCombineFloat.osl
@@ -1,0 +1,70 @@
+
+//
+// This software is released under the MIT licence
+//
+// Copyright (c) 2013 Anders Langlands
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// This code comes from alshaders's OSL branch, with minimal changes.
+// https://bitbucket.org/anderslanglands/alshaders/branch/osl
+
+shader alCombineFloat
+[[
+    string maya_node_name = "alCombineFloat"
+]]
+(
+    float input1 = 0,
+    float input2 = 1,
+    float input3 = 0,
+    int combineOp = 0,
+    output float result = 0
+    [[
+        string maya_attribute_name = "outValue"
+    ]]
+)
+{
+    if (combineOp==0)
+    {
+        // multiply
+        result = input1*input2;
+    }
+    else if (combineOp == 1)
+    {
+        // add
+        result = input1+input2;
+    }
+    else if (combineOp == 2)
+    {
+        // divide
+        result = input1/input2;
+    }
+    else if (combineOp == 3)
+    {
+        // subtract
+        result = input1-input2;
+    }
+    else
+    {
+        // lerp
+        if (input3 <= 0) result = input1;
+        else if (input3 >= 1) result = input2;
+        else result = mix(input1, input2, input3);
+    }
+}

--- a/src/appleseed.shaders/src/alshaders/alJitterColor.osl
+++ b/src/appleseed.shaders/src/alshaders/alJitterColor.osl
@@ -1,0 +1,76 @@
+
+//
+// This software is released under the MIT licence
+//
+// Copyright (c) 2013 Anders Langlands
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// This code comes from alshaders's OSL branch, with minimal changes.
+// https://bitbucket.org/anderslanglands/alshaders/branch/osl
+
+shader alJitterColor
+[[
+    string maya_node_name = "alJitterColor"
+]]
+(
+    color input = color(1),
+    float minSaturation = 0.0,
+    float maxSaturation = 1.0,
+    float minHueOffset = -1.0,
+    float maxHueOffset = 1.0,
+    float minGain = 0.0,
+    float maxGain = 1.0,
+    float clampResult = 1,
+    float signal = 0.0,
+    output color result = color(0)
+    [[
+        string maya_attribute_name = "outColor",
+        string maya_attribute_short_name = "oc"
+    ]]
+)
+{
+    result = input;
+
+    float saturation = noise("cell", signal, 51731.132151);
+    saturation = mix(minSaturation, maxSaturation, saturation);
+    if (saturation != 1)
+    {
+        float l = luminance(result);
+        result = mix(color(l), result, saturation);
+    }
+
+    float hueOffset = noise("cell", signal, 173.1231);
+    hueOffset = mix(minHueOffset, maxHueOffset, hueOffset);
+    if (hueOffset != 0)
+    {
+        color hsv = transformc("hsv", result);
+        hsv[0] += hueOffset;
+        result = transformc("rgb", hsv);
+    }
+
+    float gain = noise("cell", signal, 413.7254);
+    gain = mix(minGain, maxGain, gain);
+    result *= gain;
+
+    if (clampResult)
+    {
+        result = clamp(result, color(0), color(1));
+    }
+}

--- a/src/appleseed.shaders/src/alshaders/alLayerColor.osl
+++ b/src/appleseed.shaders/src/alshaders/alLayerColor.osl
@@ -1,0 +1,288 @@
+
+//
+// This software is released under the MIT licence
+//
+// Copyright (c) 2013 Anders Langlands
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// This code comes from alshaders's OSL branch, with minimal changes.
+// https://bitbucket.org/anderslanglands/alshaders/branch/osl
+
+#define BM_NORMAL         0
+#define BM_LIGHTEN        1
+#define BM_DARKEN         2
+#define BM_MULTIPLY       3
+#define BM_AVERAGE        4
+#define BM_ADD            5
+#define BM_SUBTRACT       6
+#define BM_DIFFERENCE     7
+#define BM_NEGATION       8
+#define BM_EXCLUSION      9
+#define BM_SCREEN        10
+#define BM_OVERLAY       11
+#define BM_SOFTLIGHT     12
+#define BM_HARDLIGHT     13
+#define BM_COLORDODGE    14
+#define BM_COLORBURN     15
+#define BM_LINEARDODGE   16
+#define BM_LINEARBURN    17
+#define BM_LINEARLIGHT   18
+#define BM_VIVIDLIGHT    19
+#define BM_PINLIGHT      20
+#define BM_HARDMIX       21
+#define BM_REFLECT       22
+#define BM_GLOW          23
+#define BM_PHOENIX       24
+
+color overlay(color l1, color l2)
+{
+    color result;
+    for (int i=0; i < 3; ++i)
+    {
+        l1[i] < 0.5 ? result[i] = 2.0 * l1[i] * l2[i] : result[i] = (1.0 - 2.0 * (1.0-l1[i]) * (1.0-l2[i]));
+    }
+
+    return result;
+}
+
+color softlight(color l1, color l2)
+{
+    color result;
+    for (int i=0; i < 3; ++i)
+    {
+        if (l2[i] < 0.5)
+            result[i] = 2.0 * l1[i] * l2[i] + (l1[i]*l1[i]) * (1.0 - 2.0 * l2[i]);
+        else
+            result[i] = sqrt(l1[i]) * (2.0 * l2[i] - 1.0) + 2.0 * l1[i] * (1.0 - l2[i]);
+    }
+
+    return result;
+}
+
+float colordodgef(float l1, float l2)
+{
+    if (l2 == 1.0)
+        return l2;
+    else
+        return min(l1 / (1.0 - l2), 1.0);
+}
+
+color colordodge(color l1, color l2)
+{
+    color result;
+    for (int i=0; i < 3; ++i)
+    {
+        result[i] = colordodgef(l1[i], l2[i]);
+    }
+
+    return result;
+}
+
+float colorburnf(float l1, float l2)
+{
+    if (l2 == 0.0)
+        return l2;
+    else
+        return max(1.0 - (1.0 - l1) / l2, 0.0);
+}
+
+color colorburn(color l1, color l2)
+{
+    color result;
+    for (int i=0; i < 3; ++i)
+    {
+        result[i] = colorburnf(l1[i], l2[i]);
+    }
+
+    return result;
+}
+
+color linearlight(color l1, color l2)
+{
+    color result;
+    for (int i=0; i < 3; ++i)
+    {
+        if (l2[i] < 0.5)
+            result[i] = max(l1[i] + 2.0 * l2[i] - 1.0, 0.0);
+        else
+            result[i] = min(l1[i] + 2.0 * (l2[i] - 0.5), 1.0);
+    }
+
+    return result;
+}
+
+color vividlight(color l1, color l2)
+{
+    color result;
+    for (int i=0; i < 3; ++i)
+    {
+        if (l2[i] < 0.5)
+            result[i] = colorburnf(l1[i], 2.0 * l2[i]);
+        else
+            result[i] = colordodgef(l1[i], 2.0 * (l2[i] - 0.5));
+    }
+
+    return result;
+}
+
+color pinlight(color l1, color l2)
+{
+    color result;
+    for (int i=0; i < 3; ++i)
+    {
+        if (l2[i] < 0.5)
+            result[i] = min(l1[i], 2.0 * l2[i]);
+        else
+            result[i] = max(l1[i], 2.0 * (l2[i] - 0.5));
+    }
+
+    return result;
+}
+
+color hardmix(color l1, color l2)
+{
+    color result = vividlight(l1, l2);
+    for (int i=0; i < 3; ++i)
+    {
+        result[i] < 0.5 ? result[i] = 0.0 : result[i] = 1.0;
+    }
+
+    return result;
+}
+
+color reflect(color l1, color l2)
+{
+    color result;
+    for (int i=0; i < 3; ++i)
+    {
+        if (l2[i] == 1.0)
+            result[i] = l2[i];
+        else
+            result[i] = min((l1[i]*l1[i]) / (1.0 - l2[i]), 1.0);
+    }
+
+    return result;
+}
+
+color blend(color l1, color l2, float a, int mode)
+{
+    color result = l2;
+    if (mode == BM_LIGHTEN)
+        result = max(l1, l2);
+    else if (mode == BM_DARKEN)
+        result = min(l1, l2);
+    else if (mode == BM_MULTIPLY)
+        result = l1 * l2;
+    else if (mode == BM_AVERAGE)
+        result = (l1 + l2) * 0.5;
+    else if (mode == BM_ADD || mode == BM_LINEARDODGE)
+        result = min(l1 + l2, color(1));
+    else if (mode == BM_SUBTRACT || mode == BM_LINEARBURN)
+        result = max(l1 + l2 - color(1), color(0));
+    else if (mode == BM_DIFFERENCE)
+        result = fabs(l1 - l2);
+    else if (mode == BM_NEGATION)
+        result = color(1) - fabs(color(1) - l1 - l2);
+    else if (mode == BM_EXCLUSION)
+        result = l1 + l2 - (2.0 * l1 * l2);
+    else if (mode == BM_SCREEN)
+        result = color(1) - ((color(1)-l1) * (color(1)-l2));
+    else if (mode == BM_OVERLAY)
+        result = overlay(l1, l2);
+    else if (mode == BM_SOFTLIGHT)
+        result = softlight(l1, l2);
+    else if (mode == BM_HARDLIGHT)
+        result = overlay(l2, l1);
+    else if (mode == BM_COLORDODGE)
+        result = colordodge(l1, l2);
+    else if (mode == BM_COLORBURN)
+        result = colorburn(l1, l2);
+    else if (mode == BM_LINEARLIGHT)
+        result = linearlight(l1, l2);
+    else if (mode == BM_VIVIDLIGHT)
+        result = vividlight(l1, l2);
+    else if (mode == BM_PINLIGHT)
+        result = pinlight(l1, l2);
+    else if (mode == BM_HARDMIX)
+        result = hardmix(l1, l2);
+    else if (mode == BM_REFLECT)
+        result = reflect(l1, l2);
+    else if (mode == BM_GLOW)
+        result = reflect(l2, l1);
+    else if (mode == BM_PHOENIX)
+        result = min(l1, l2) - max(l1, l2) + color(1);
+
+    return result;
+}
+
+shader alLayerColor
+[[
+    string maya_node_name = "alLayerColor"
+]]
+(
+    color layer1 = color(0),
+    float layer1a = 0,
+    int layer1Blend = 0,
+
+    color layer2 = color(0),
+    float layer2a = 0,
+    int layer2Blend = 0,
+
+    color layer3 = color(0),
+    float layer3a = 0,
+    int layer3Blend = 0,
+
+    color layer4 = color(0),
+    float layer4a = 0,
+    int layer4Blend = 0,
+
+    color layer5 = color(0),
+    float layer5a = 0,
+    int layer5Blend = 0,
+
+    color layer6 = color(0),
+    float layer6a = 0,
+    int layer6Blend = 0,
+
+    color layer7 = color(0),
+    float layer7a = 0,
+    int layer7Blend = 0,
+
+    color layer8 = color(0),
+    float layer8a = 0,
+    int layer8Blend = 0,
+
+    output color result = 0
+    [[
+        string maya_attribute_name = "outColor",
+        string maya_attribute_short_name = "oc"
+    ]]
+)
+{
+    result = blend(result, layer1, layer1a, layer1Blend);
+    result = blend(result, layer2, layer2a, layer2Blend);
+    result = blend(result, layer3, layer3a, layer3Blend);
+    result = blend(result, layer4, layer4a, layer4Blend);
+    result = blend(result, layer5, layer5a, layer5Blend);
+    result = blend(result, layer6, layer6a, layer6Blend);
+    result = blend(result, layer7, layer7a, layer7Blend);
+    result = blend(result, layer8, layer8a, layer8Blend);
+
+}

--- a/src/appleseed.shaders/src/alshaders/alLayerFloat.osl
+++ b/src/appleseed.shaders/src/alshaders/alLayerFloat.osl
@@ -1,0 +1,63 @@
+
+//
+// This software is released under the MIT licence
+//
+// Copyright (c) 2013 Anders Langlands
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// This code comes from alshaders's OSL branch, with minimal changes.
+// https://bitbucket.org/anderslanglands/alshaders/branch/osl
+
+shader alLayerFloat
+[[
+    string maya_node_name = "alLayerFloat"
+]]
+(
+    float layer1 = 0,
+    float layer1a = 0,
+    float layer2 = 0,
+    float layer2a = 0,
+    float layer3 = 0,
+    float layer3a = 0,
+    float layer4 = 0,
+    float layer4a = 0,
+    float layer5 = 0,
+    float layer5a = 0,
+    float layer6 = 0,
+    float layer6a = 0,
+    float layer7 = 0,
+    float layer7a = 0,
+    float layer8 = 0,
+    float layer8a = 0,
+
+    output float result = 0
+    [[
+        string maya_attribute_name = "outValue"
+    ]]
+)
+{
+    result = mix(layer1, layer2, layer2a);
+    result = mix(layer2, layer3, layer3a);
+    result = mix(layer3, layer4, layer4a);
+    result = mix(layer4, layer5, layer5a);
+    result = mix(layer5, layer6, layer6a);
+    result = mix(layer6, layer7, layer7a);
+    result = mix(layer7, layer8, layer8a);
+}

--- a/src/appleseed.shaders/src/alshaders/alRemapColor.osl
+++ b/src/appleseed.shaders/src/alshaders/alRemapColor.osl
@@ -1,0 +1,89 @@
+
+//
+// This software is released under the MIT licence
+//
+// Copyright (c) 2013 Anders Langlands
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// This code comes from alshaders's OSL branch, with minimal changes.
+// https://bitbucket.org/anderslanglands/alshaders/branch/osl
+
+shader alRemapColor
+[[
+    string maya_node_name = "alRemapColor"
+]]
+(
+    color input = color(0.18, 0.18, 0.18),
+    float gamma = 1,
+    float saturation = 1,
+    float hueOffset = 0,
+    float contrastVal = 1,
+    float contrastPivot = 0.18,
+    float gain = 1,
+    float exposure = 0,
+    float mask = 1,
+    output color result = color(0,0,0)
+    [[
+        string maya_attribute_name = "outColor",
+        string maya_attribute_short_name = "oc"
+    ]]
+)
+{
+    result = input;
+
+    if (mask > 0)
+    {
+        // gamma
+        if (gamma != 1)
+        {
+            result = pow(result, 1/gamma);
+        }
+
+        // saturation
+        if (saturation != 1)
+        {
+            float l = luminance(result);
+            result = mix(color(l), result, saturation);
+        }
+
+        // hue
+        if (hueOffset != 0)
+        {
+            color hsv = transformc("hsv", result);
+            hsv[0] += hueOffset;
+            result = transformc("rgb", result);
+        }
+
+        // contrast
+        if (contrastVal != 1)
+        {
+            result = (result-color(contrastPivot))*contrastVal + color(contrastPivot);
+        }
+
+        // gain & exposure
+        result = result * gain * pow(2, exposure);
+
+        // mask
+        if (mask < 1)
+        {
+            result = mix(input, result, mask);
+        }
+    }
+}

--- a/src/appleseed.shaders/src/alshaders/alSurface.osl
+++ b/src/appleseed.shaders/src/alshaders/alSurface.osl
@@ -1,0 +1,332 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 The masked shader writer, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "appleseed/material/as_material_helpers.h"
+
+#define IMPORTANCE_EPS 1e-5
+
+float minh(color c)
+{
+    return min(c[0], min(c[1], c[2]));
+}
+
+float maxh(color c)
+{
+    return max(c[0], max(c[1], c[2]));
+}
+
+shader alSurface
+[[
+    string maya_node_name = "alSurface"
+]]
+(
+    normal globalNormal = N
+    [[
+        string maya_attribute_name = "normalCamera",
+        string maya_attribute_short_name = "n"
+    ]],
+    vector Tn = 0
+    [[
+        int    lockgeom = 0
+    ]],
+
+    normal diffuseNormal = normal(0),
+    float diffuseStrength = 1,
+    color diffuseColor =  color(0.5),
+    float diffuseRoughness = 0,
+
+    float backlightStrength = 0,
+    color backlightColor = color(0.18),
+
+    float sssMix = 0,
+    int sssMode = 0,
+    float sssRadius = 1.5,
+    float sssWeight1 = 1,
+    color sssRadiusColor = color(0.439, 0.156, 0.078),
+    float sssRadius2 = 4.0,
+    float sssWeight2 = 0,
+    color sssRadiusColor2 = color(0.439, 0.08, 0.018),
+    float sssRadius3 = 0.75,
+    float sssWeight3 = 0,
+    color sssRadiusColor3 = color(0.523, 0.637, 0.667),
+    float sssDensityScale = 1,
+
+    normal specular1Normal = normal(0),
+    float specular1Strength = 1,
+    color specular1Color = color(1),
+    float specular1Roughness = 0.3,
+    float specular1Anisotropy = 0,
+    float specular1Rotation = 0,
+    int specular1FresnelMode = 0,
+    float specular1Ior= 1.4,
+    color specular1Reflectivity = color(0.548, 0.549, 0.570),
+    color specular1EdgeTint = color(0.579, 0.598, 0.620),
+    float specular1RoughnessDepthScale = 1,
+    int specular1Distribution = 0,
+
+    normal specular2Normal = normal(0),
+    float specular2Strength = 0,
+    color specular2Color = color(1),
+    float specular2Roughness = 0,
+    float specular2Anisotropy = 0,
+    float specular2Rotation = 0,
+    int specular2FresnelMode = 0,
+    float specular2Ior = 1.4,
+    color specular2Reflectivity = color(0.548, 0.549, 0.570),
+    color specular2EdgeTint = color(0.579, 0.598, 0.620),
+    float specular2RoughnessDepthScale = 1,
+    int specular2Distribution = 0,
+
+    normal transmissionNormal = normal(0),
+    float transmissionStrength = 0,
+    color transmissionColor = color(1),
+    int transmissionLinkToSpecular1 = 1,
+    float transmissionRoughness = 0,
+    float transmissionIor = 1.4,
+    float transmissionRoughnessDepthScale = 1,
+
+    color ssAttenuationColor = color(1),
+    float ssDensityScale = 1,
+
+    float emissionStrength = 0,
+    color emissionColor = color(1),
+
+    color opacity = 1,
+
+    output closure color rgb = 0
+    [[
+        string maya_attribute_name = "outColor",
+        string maya_attribute_short_name = "oc"
+    ]]
+)
+{
+    if (raytype("transparency"))
+    {
+        rgb = (color(1) - opacity) * transparent();
+        return;
+    }
+
+    int do_diffuse = 1;
+    int do_backlight = 1;
+    int do_sss = 1;
+    int do_transmission = 1;
+    int do_emission = 1;
+    int do_glossy2 = 1;
+    int do_glossy = 1;
+
+    if (raytype("shadow"))
+    {
+        do_diffuse = 0;
+        do_backlight = 0;
+        do_sss = 0;
+        do_transmission = 1;
+        do_emission = 0;
+        do_glossy2 = 0;
+        do_glossy = 0;
+    }
+    else if (raytype("light"))
+    {
+        do_diffuse = 0;
+        do_backlight = 0;
+        do_sss = 0;
+        do_transmission = 0;
+        do_emission = 1;
+        do_glossy2 = 1;
+        do_glossy = 1;
+    }
+
+    // balance diffuse, transmission and backlight
+    color transmissionColor_ = transmissionColor * transmissionStrength;
+    color diffuseColor_ = diffuseColor * diffuseStrength;
+    color backlightColor_ = backlightColor * backlightStrength;
+    float t_sum = maxh(transmissionColor_) + maxh(diffuseColor_) + maxh(backlightColor_);
+
+    if (t_sum > 1.0)
+    {
+        float t_sum_inv = 1.0 / t_sum;
+        transmissionColor_ *= t_sum_inv;
+        diffuseColor_      *= t_sum_inv;
+        backlightColor_    *= t_sum_inv;
+    }
+
+    if (maxh(diffuseColor_) < IMPORTANCE_EPS || sssMix == 1.0)
+        do_diffuse = 0;
+
+    if (maxh(backlightColor_) < IMPORTANCE_EPS || sssMix == 1.0)
+        do_backlight = 0;
+
+    if (sssMix == 0.0 || maxh(diffuseColor_) < IMPORTANCE_EPS)
+        do_sss = 0;
+
+    if (maxh(transmissionColor_) < IMPORTANCE_EPS || sssMix == 1.0)
+        do_transmission = 0;
+
+    color emissionColor_ = emissionColor * emissionStrength;
+    if (maxh(emissionColor_) < IMPORTANCE_EPS)
+        do_emission = 0;
+
+    color specular1Color_ = specular1Color * specular1Strength;
+    if (maxh(specular1Color_) < IMPORTANCE_EPS)
+        do_glossy = 0;
+
+    color specular2Color_ = specular2Color * specular2Strength;
+    if (maxh(specular2Color_) < IMPORTANCE_EPS)
+        do_glossy2 = 0;
+
+    // Create closures.
+    normal globalNormal_ = normalize(globalNormal);
+
+    normal diffuseNormal_ = globalNormal_;
+    if (isconnected(diffuseNormal) == 1)
+        diffuseNormal_ = normalize(diffuseNormal);
+
+    if (do_diffuse)
+    {
+        rgb += diffuseColor_ * (1.0 - sssMix) * oren_nayar(diffuseNormal_, diffuseRoughness);
+    }
+
+    if (do_backlight)
+        rgb += backlightColor_ * (1.0 - sssMix) * translucent(diffuseNormal_);
+
+    if (do_sss)
+    {
+        // Normalize the SSS weights.
+        float sssWeight1_ = sssWeight1;
+        float sssWeight2_ = sssWeight2;
+        float sssWeight3_ = sssWeight3;
+
+        float normweight = 1.0 / (sssWeight1_ + sssWeight2_ + sssWeight3_);
+        sssWeight1_ *= normweight;
+        sssWeight2_ *= normweight;
+        sssWeight3_ *= normweight;
+
+        float sssIor = 1.3;
+
+        // todo: handle SSS...
+    }
+
+    if (do_transmission)
+    {
+        normal transmissionNormal_ = globalNormal_;
+        if (isconnected(transmissionNormal) == 1)
+            transmissionNormal_ = normalize(transmissionNormal);
+
+        float transmissionRoughness_;
+        float transmissionIor_;
+        if (transmissionLinkToSpecular1)
+        {
+            transmissionRoughness_ = specular1Roughness;
+            transmissionIor_ = specular1Ior;
+        }
+        else
+        {
+            transmissionRoughness_ = transmissionRoughness;
+            transmissionIor = transmissionIor;
+        }
+
+        color volumeTransmittanceColor = color(1);
+        float volumeTransmittanceDistance = 0.0;
+
+        if (minh(ssAttenuationColor) < 1.0)
+        {
+            color sigmaA =
+                (color(1) - clamp(ssAttenuationColor, color(0), color(0.999))) * ssDensityScale;
+
+            // Convert to transmittance.
+            volumeTransmittanceColor = exp(-sigmaA);
+            volumeTransmittanceDistance = 1.0;
+        }
+
+        rgb += (1.0 - sssMix) * as_glass(
+            "beckmann",
+            transmissionNormal_,
+            transmissionColor_,
+            color(0), // transmission only.
+            color(1),
+            transmissionRoughness_,
+            transmissionIor_,
+            volumeTransmittanceColor,
+            volumeTransmittanceDistance);
+    }
+
+    if (do_emission)
+        rgb += emissionColor_ * emission();
+
+    if (do_glossy2)
+    {
+        normal specular2Normal_ = globalNormal_;
+        if (isconnected(specular2Normal) == 1)
+            specular2Normal_ = normalize(specular2Normal);
+
+        vector T = Tn;
+        if (specular2Rotation != 0.0)
+        {
+            // todo: handle T rotation here...
+        }
+
+        rgb = as_alsurface_layer(
+            rgb,
+            specular2Distribution,
+            specular2Normal_,
+            T,
+            specular2Color_,
+            specular2Roughness,
+            specular2Anisotropy,
+            specular2FresnelMode,
+            specular2Ior,
+            specular2Reflectivity,
+            specular2EdgeTint);
+    }
+
+    if (do_glossy)
+    {
+        normal specular1Normal_ = globalNormal_;
+        if (isconnected(specular1Normal) == 1)
+            specular1Normal_ = normalize(specular1Normal);
+
+        vector T = Tn;
+
+        if (specular1Rotation != 0.0)
+        {
+            // todo: handle T rotation here...
+        }
+
+        rgb = as_alsurface_layer(
+            rgb,
+            specular1Distribution,
+            specular1Normal_,
+            T,
+            specular1Color_,
+            specular1Roughness,
+            specular1Anisotropy,
+            specular1FresnelMode,
+            specular1Ior,
+            specular1Reflectivity,
+            specular1EdgeTint);
+    }
+}

--- a/src/appleseed.shaders/src/alshaders/alSurface.osl
+++ b/src/appleseed.shaders/src/alshaders/alSurface.osl
@@ -237,30 +237,28 @@ shader alSurface
         sssWeight2_ *= normweight;
         sssWeight3_ *= normweight;
 
+        color sssColor = diffuseColor_ * sssMix;
         float sssIor = 1.3;
 
         if (sssMode == SSSMODE_CUBIC)
         {
             if (sssWeight1_ > IMPORTANCE_EPS)
             {
-                float radiusFactor = 30;
-                float weightFactor = 1.15;
-
                 color radius = max(
                     color(0.0001),
-                    sssRadius * sssRadiusColor / (sssDensityScale * radiusFactor));
+                    sssRadius * sssRadiusColor / sssDensityScale);
 
-                rgb += diffuseColor_ * sssMix * weightFactor * red * sssWeight1_ * as_subsurface_gaussian(
+                rgb += sssColor * red * sssWeight1_ * as_subsurface_gaussian(
                     diffuseNormal_,
                     white,
                     radius[0],
                     sssIor);
-                rgb += diffuseColor_ * sssMix * weightFactor * green * sssWeight1_ * as_subsurface_gaussian(
+                rgb += sssColor * green * sssWeight1_ * as_subsurface_gaussian(
                     diffuseNormal_,
                     white,
                     radius[1],
                     sssIor);
-                rgb += diffuseColor_ * sssMix * weightFactor * blue * sssWeight1_ * as_subsurface_gaussian(
+                rgb += sssColor * blue * sssWeight1_ * as_subsurface_gaussian(
                     diffuseNormal_,
                     white,
                     radius[2],
@@ -269,20 +267,13 @@ shader alSurface
         }
         else if (sssMode == SSSMODE_EMPIRICAL)
         {
-            float radiusFactor = 7 * 1.0;
-            float weightFactor = 1.0;
-            float radiusSaturation = 0.33;
-
             if (sssWeight1_ > IMPORTANCE_EPS)
             {
                 color radius = max(
                     color(0.0001),
-                    sssRadius * sssRadiusColor / (sssDensityScale * radiusFactor));
+                    sssRadius * sssRadiusColor / (sssDensityScale * 7.0));
 
-                float radiusAvg = (radius[0] + radius[1] + radius[2]) / 3.0;
-                radius = mix(color(radiusAvg), radius, radiusSaturation);
-
-                rgb += diffuseColor_ * sssMix * weightFactor * sssWeight1_ * as_subsurface(
+                rgb += sssColor * sssWeight1_ * as_subsurface(
                     "normalized_diffusion",
                     diffuseNormal_,
                     white,

--- a/src/appleseed.shaders/src/alshaders/alSurface.osl
+++ b/src/appleseed.shaders/src/alshaders/alSurface.osl
@@ -222,6 +222,7 @@ shader alSurface
 
     if (do_sss)
     {
+        color sssColor = diffuseColor_ * sssMix;
         color white = color(1, 1, 1);
         color red   = color(1, 0, 0);
         color green = color(0, 1, 0);
@@ -237,35 +238,13 @@ shader alSurface
         sssWeight2_ *= normweight;
         sssWeight3_ *= normweight;
 
-        color sssColor = diffuseColor_ * sssMix;
         float sssIor = 1.3;
 
-        if (sssMode == SSSMODE_CUBIC)
+        if (sssMode == SSSMODE_DIFFUSION || sssMode == SSSMODE_DIRECTIONAL)
         {
-            if (sssWeight1_ > IMPORTANCE_EPS)
-            {
-                color radius = max(
-                    color(0.0001),
-                    sssRadius * sssRadiusColor / sssDensityScale);
-
-                rgb += sssColor * red * sssWeight1_ * as_subsurface_gaussian(
-                    diffuseNormal_,
-                    white,
-                    radius[0],
-                    sssIor);
-                rgb += sssColor * green * sssWeight1_ * as_subsurface_gaussian(
-                    diffuseNormal_,
-                    white,
-                    radius[1],
-                    sssIor);
-                rgb += sssColor * blue * sssWeight1_ * as_subsurface_gaussian(
-                    diffuseNormal_,
-                    white,
-                    radius[2],
-                    sssIor);
-            }
+            // TODO: implement this.
         }
-        else if (sssMode == SSSMODE_EMPIRICAL)
+        else // SSSMODE_CUBIC || SSSMODE_EMPIRICAL
         {
             if (sssWeight1_ > IMPORTANCE_EPS)
             {
@@ -274,15 +253,14 @@ shader alSurface
                     sssRadius * sssRadiusColor / (sssDensityScale * 7.0));
 
                 rgb += sssColor * sssWeight1_ * as_subsurface(
-                    "normalized_diffusion",
+                    sssMode == SSSMODE_CUBIC ? "gaussian" : "normalized_diffusion",
                     diffuseNormal_,
                     white,
                     radius,
                     sssIor);
             }
-        }
-        else // SSSMODE_DIFFUSION || SSSMODE_DIRECTIONAL
-        {
+
+            // TODO: add lobes 2 and 3.
         }
     }
 

--- a/src/appleseed.shaders/src/alshaders/alSurface.osl
+++ b/src/appleseed.shaders/src/alshaders/alSurface.osl
@@ -28,7 +28,14 @@
 
 #include "appleseed/material/as_material_helpers.h"
 
+
 #define IMPORTANCE_EPS 1e-5
+
+#define SSSMODE_CUBIC       0
+#define SSSMODE_DIFFUSION   1
+#define SSSMODE_DIRECTIONAL 2
+#define SSSMODE_EMPIRICAL   3
+
 
 float minh(color c)
 {
@@ -215,6 +222,11 @@ shader alSurface
 
     if (do_sss)
     {
+        color white = color(1, 1, 1);
+        color red   = color(1, 0, 0);
+        color green = color(0, 1, 0);
+        color blue  = color(0, 0, 1);
+
         // Normalize the SSS weights.
         float sssWeight1_ = sssWeight1;
         float sssWeight2_ = sssWeight2;
@@ -227,7 +239,60 @@ shader alSurface
 
         float sssIor = 1.3;
 
-        // todo: handle SSS...
+        if (sssMode == SSSMODE_CUBIC)
+        {
+            if (sssWeight1_ > IMPORTANCE_EPS)
+            {
+                float radiusFactor = 30;
+                float weightFactor = 1.15;
+
+                color radius = max(
+                    color(0.0001),
+                    sssRadius * sssRadiusColor / (sssDensityScale * radiusFactor));
+
+                rgb += diffuseColor_ * sssMix * weightFactor * red * sssWeight1_ * as_subsurface_gaussian(
+                    diffuseNormal_,
+                    white,
+                    radius[0],
+                    sssIor);
+                rgb += diffuseColor_ * sssMix * weightFactor * green * sssWeight1_ * as_subsurface_gaussian(
+                    diffuseNormal_,
+                    white,
+                    radius[1],
+                    sssIor);
+                rgb += diffuseColor_ * sssMix * weightFactor * blue * sssWeight1_ * as_subsurface_gaussian(
+                    diffuseNormal_,
+                    white,
+                    radius[2],
+                    sssIor);
+            }
+        }
+        else if (sssMode == SSSMODE_EMPIRICAL)
+        {
+            float radiusFactor = 7 * 1.0;
+            float weightFactor = 1.0;
+            float radiusSaturation = 0.33;
+
+            if (sssWeight1_ > IMPORTANCE_EPS)
+            {
+                color radius = max(
+                    color(0.0001),
+                    sssRadius * sssRadiusColor / (sssDensityScale * radiusFactor));
+
+                float radiusAvg = (radius[0] + radius[1] + radius[2]) / 3.0;
+                radius = mix(color(radiusAvg), radius, radiusSaturation);
+
+                rgb += diffuseColor_ * sssMix * weightFactor * sssWeight1_ * as_subsurface(
+                    "normalized_diffusion",
+                    diffuseNormal_,
+                    white,
+                    radius,
+                    sssIor);
+            }
+        }
+        else // SSSMODE_DIFFUSION || SSSMODE_DIRECTIONAL
+        {
+        }
     }
 
     if (do_transmission)

--- a/src/appleseed.shaders/src/alshaders/alSurface.osl
+++ b/src/appleseed.shaders/src/alshaders/alSurface.osl
@@ -257,7 +257,8 @@ shader alSurface
                     diffuseNormal_,
                     white,
                     radius,
-                    sssIor);
+                    sssIor,
+                    "fresnel_weight", 0);
             }
 
             // TODO: add lobes 2 and 3.

--- a/src/appleseed.shaders/src/alshaders/alSwitchColor.osl
+++ b/src/appleseed.shaders/src/alshaders/alSwitchColor.osl
@@ -1,0 +1,61 @@
+
+//
+// This software is released under the MIT licence
+//
+// Copyright (c) 2013 Anders Langlands
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// This code comes from alshaders's OSL branch, with minimal changes.
+// https://bitbucket.org/anderslanglands/alshaders/branch/osl
+
+shader alSwitchColor
+[[
+    string maya_node_name = "alSwitchColor"
+]]
+(
+    color inputA = 0,
+    color inputB = 1,
+    color inputC = 0.15,
+    color inputD = 0.3,
+    color inputE = 0.45,
+    color inputF = 0.6,
+    color inputG = 0.75,
+    color inputH = 0.9,
+    float mixer=1,
+    float threshold=0.5,
+    output color result = 0
+    [[
+        string maya_attribute_name = "outColor",
+        string maya_attribute_short_name = "oc"
+    ]]
+)
+{
+    float input = floor(mixer);
+    if (mixer-input >= threshold) input++;
+    input = clamp(input, 0, 7);
+    if (input == 0) result = inputA;
+    else if (input == 1) result = inputB;
+    else if (input == 2) result = inputC;
+    else if (input == 3) result = inputD;
+    else if (input == 4) result = inputE;
+    else if (input == 5) result = inputF;
+    else if (input == 6) result = inputG;
+    else if (input == 7) result = inputH;
+}

--- a/src/appleseed.shaders/src/alshaders/alSwitchFloat.osl
+++ b/src/appleseed.shaders/src/alshaders/alSwitchFloat.osl
@@ -1,0 +1,60 @@
+
+//
+// This software is released under the MIT licence
+//
+// Copyright (c) 2013 Anders Langlands
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// This code comes from alshaders's OSL branch, with minimal changes.
+// https://bitbucket.org/anderslanglands/alshaders/branch/osl
+
+shader alSwitchFloat
+[[
+    string maya_node_name = "alSwitchFloat"
+]]
+(
+    float inputA = 0,
+    float inputB = 1,
+    float inputC = 0.15,
+    float inputD = 0.3,
+    float inputE = 0.45,
+    float inputF = 0.6,
+    float inputG = 0.75,
+    float inputH = 0.9,
+    float mixer=1,
+    float threshold=0.5,
+    output float result = 0
+    [[
+        string maya_attribute_name = "outValue"
+    ]]
+)
+{
+    float input = floor(mixer);
+    if (mixer-input >= threshold) input++;
+    input = clamp(input, 0, 7);
+    if (input == 0) result = inputA;
+    else if (input == 1) result = inputB;
+    else if (input == 2) result = inputC;
+    else if (input == 3) result = inputD;
+    else if (input == 4) result = inputE;
+    else if (input == 5) result = inputF;
+    else if (input == 6) result = inputG;
+    else if (input == 7) result = inputH;
+}

--- a/src/appleseed.shaders/src/maya/as_maya_areaLight.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_areaLight.osl
@@ -47,7 +47,18 @@ surface as_maya_areaLight
         string label = "intensity",
         string page = "Area Light Attributes"
     ]],
-
+    float in_intensity_scale = 1.0
+    [[
+        string maya_attribute_name = "asIntensityScale"
+    ]],
+    float in_exposure = 0.0
+    [[
+        string maya_attribute_name = "asExposure"
+    ]],
+    int in_normalize = 0
+    [[
+        string maya_attribute_name = "asNormalize"
+    ]],
     output point out_center = 0
     [[
         string maya_attribute_name = "center",
@@ -119,6 +130,11 @@ surface as_maya_areaLight
     out_uvCoord[0] = u;
     out_uvCoord[1] = v;
 
-    out_lightIntensity = in_intensity * in_color * emission();
+    float power = in_intensity * in_intensity_scale * pow(2.0, in_exposure);
+
+    if (in_normalize)
+        power /= surfacearea();
+
+    out_lightIntensity = power * in_color * emission();
     Ci = out_lightIntensity;
 }

--- a/src/appleseed/renderer/kernel/shading/closures.cpp
+++ b/src/appleseed/renderer/kernel/shading/closures.cpp
@@ -946,6 +946,7 @@ namespace
             OSL::Color3     reflectance;
             OSL::Color3     mean_free_path;
             float           ior;
+            float           fresnel_weight;
         };
 
         static const char* name()
@@ -958,6 +959,16 @@ namespace
             return SubsurfaceID;
         }
 
+        static void prepare_closure(
+            OSL::RendererServices*          render_services,
+            int                             id,
+            void*                           data)
+        {
+            // Initialize keyword parameter defaults.
+            Params* params = new (data) Params();
+            params->fresnel_weight = 1.0f;
+        }
+
         static void register_closure(OSL::ShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
@@ -967,10 +978,11 @@ namespace
                 CLOSURE_COLOR_PARAM(Params, reflectance),
                 CLOSURE_COLOR_PARAM(Params, mean_free_path),
                 CLOSURE_FLOAT_PARAM(Params, ior),
+                CLOSURE_FLOAT_KEYPARAM(Params, fresnel_weight, "fresnel_weight"),
                 CLOSURE_FINISH_PARAM(Params)
             };
 
-            shading_system.register_closure(name(), id(), params, 0, 0);
+            shading_system.register_closure(name(), id(), params, &prepare_closure, 0);
         }
 
         static void convert_closure(
@@ -991,12 +1003,7 @@ namespace
                         weight,
                         p->N);
 
-                values->m_weight = 1.0f;
-                values->m_reflectance = Color3f(p->reflectance);
-                values->m_reflectance_multiplier = 1.0f;
-                values->m_mfp = Color3f(p->mean_free_path);
-                values->m_mfp_multiplier = 1.0f;
-                values->m_ior = p->ior;
+                copy_parameters(p, values);
 #else
                 throw ExceptionOSLRuntimeError("unknown subsurface profile: normalized_diffusion");
 #endif
@@ -1010,12 +1017,7 @@ namespace
                         weight,
                         p->N);
 
-                values->m_reflectance = Color3f(p->reflectance);
-                values->m_reflectance_multiplier = 1.0f;
-                values->m_mfp = Color3f(p->mean_free_path);
-                values->m_mfp_multiplier = 1.0f;
-                values->m_reflectance_multiplier = 1.0f;
-                values->m_ior = p->ior;
+                copy_parameters(p, values);
             }
             else
             {
@@ -1055,14 +1057,22 @@ namespace
                     throw ExceptionOSLRuntimeError(msg.c_str());
                 }
 
-                values->m_weight = 1.0f;
-                values->m_reflectance = Color3f(p->reflectance);
-                values->m_reflectance_multiplier = 1.0f;
-                values->m_mfp = Color3f(p->mean_free_path);
-                values->m_mfp_multiplier = 1.0f;
-                values->m_g = 0.0;
-                values->m_ior = p->ior;
+                copy_parameters(p, values);
             }
+        }
+
+        template <typename InputValues>
+        static void copy_parameters(
+            const Params*                   p,
+            InputValues*                    values)
+        {
+            values->m_weight = 1.0f;
+            values->m_reflectance = Color3f(p->reflectance);
+            values->m_reflectance_multiplier = 1.0f;
+            values->m_mfp = Color3f(p->mean_free_path);
+            values->m_mfp_multiplier = 1.0f;
+            values->m_ior = p->ior;
+            values->m_fresnel_weight = saturate(p->fresnel_weight);
         }
     };
 

--- a/src/appleseed/renderer/kernel/shading/closures.cpp
+++ b/src/appleseed/renderer/kernel/shading/closures.cpp
@@ -1055,7 +1055,7 @@ namespace
         {
             OSL::Vec3       N;
             OSL::Color3     reflectance;
-            float           radius;
+            OSL::Color3     radius;
             float           ior;
         };
 
@@ -1075,7 +1075,7 @@ namespace
             {
                 CLOSURE_VECTOR_PARAM(Params, N),
                 CLOSURE_COLOR_PARAM(Params, reflectance),
-                CLOSURE_FLOAT_PARAM(Params, radius),
+                CLOSURE_COLOR_PARAM(Params, radius),
                 CLOSURE_FLOAT_PARAM(Params, ior),
                 CLOSURE_FINISH_PARAM(Params)
             };
@@ -1099,7 +1099,8 @@ namespace
 
             values->m_reflectance = Color3f(p->reflectance);
             values->m_reflectance_multiplier = 1.0f;
-            values->m_radius = p->radius;
+            values->m_radius = Color3f(p->radius);
+            values->m_reflectance_multiplier = 1.0f;
             values->m_ior = p->ior;
         }
     };

--- a/src/appleseed/renderer/kernel/shading/closures.cpp
+++ b/src/appleseed/renderer/kernel/shading/closures.cpp
@@ -1099,7 +1099,7 @@ namespace
 
             values->m_reflectance = Color3f(p->reflectance);
             values->m_reflectance_multiplier = 1.0f;
-            values->m_v = p->radius;
+            values->m_radius = p->radius;
             values->m_ior = p->ior;
         }
     };

--- a/src/appleseed/renderer/kernel/shading/closures.h
+++ b/src/appleseed/renderer/kernel/shading/closures.h
@@ -41,6 +41,7 @@
 #include "renderer/modeling/bsdf/sheenbrdf.h"
 #include "renderer/modeling/bssrdf/dipolebssrdf.h"
 #include "renderer/modeling/bssrdf/directionaldipolebssrdf.h"
+#include "renderer/modeling/bssrdf/gaussianbssrdf.h"
 #ifdef APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF
 #include "renderer/modeling/bssrdf/normalizeddiffusionbssrdf.h"
 #endif
@@ -118,6 +119,7 @@ enum ClosureID
     SubsurfaceStandardDipoleID,
     SubsurfaceDirectionalDipoleID,
     SubsurfaceNormalizedDiffusionID,
+    SubsurfaceGaussianID,
 
     // Emission closures.
     EmissionID,
@@ -201,6 +203,7 @@ class APPLESEED_ALIGN(16) CompositeClosure
         DiffuseEDFInputValues,
         DipoleBSSRDFInputValues,
         DisneyBRDFInputValues,
+        GaussianBSSRDFInputValues,
         GlassBSDFInputValues,
         GlossyBRDFInputValues,
         MetalBRDFInputValues,

--- a/src/appleseed/renderer/meta/tests/test_sss.cpp
+++ b/src/appleseed/renderer/meta/tests/test_sss.cpp
@@ -118,6 +118,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
             m_bssrdf->get_inputs().find("sigma_s").source()->evaluate_uniform(m_values.m_sigma_s);
             m_values.m_g = g;
             m_values.m_ior = eta;
+            m_values.m_fresnel_weight = 1.0f;
 
             m_bssrdf->prepare_inputs(m_outgoing_point, &m_values);
         }
@@ -138,6 +139,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
             poison(m_values.m_sigma_s);
             m_values.m_g = 0.0f;
             m_values.m_ior = eta;
+            m_values.m_fresnel_weight = 1.0f;
 
             m_bssrdf->prepare_inputs(m_outgoing_point, &m_values);
         }

--- a/src/appleseed/renderer/modeling/bssrdf/bssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/bssrdf.cpp
@@ -157,4 +157,26 @@ void BSSRDF::make_reflectance_and_mfp_compatible(
     }
 }
 
+void BSSRDF::build_cdf_and_pdf(
+    const Spectrum&         src,
+    Spectrum&               cdf,
+    Spectrum&               pdf) const
+{
+    pdf.resize(src.size());
+    cdf.resize(src.size());
+
+    float cumulated_pdf = 0.0f;
+    for (size_t i = 0, e = src.size(); i < e; ++i)
+    {
+        pdf[i] = src[i];
+        cumulated_pdf += pdf[i];
+        cdf[i] = cumulated_pdf;
+    }
+
+    const float rcp_cumulated_pdf = 1.0f / cumulated_pdf;
+    pdf *= rcp_cumulated_pdf;
+    cdf *= rcp_cumulated_pdf;
+    cdf[src.size() - 1] = 1.0f;
+}
+
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/bssrdf/bssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/bssrdf.cpp
@@ -114,6 +114,11 @@ void BSSRDF::prepare_inputs(
 {
 }
 
+float BSSRDF::get_fresnel_weight(const void* data) const
+{
+    return 1.0f;
+}
+
 float BSSRDF::compute_eta(
     const ShadingPoint&     shading_point,
     const float             ior) const

--- a/src/appleseed/renderer/modeling/bssrdf/bssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/bssrdf.h
@@ -148,6 +148,11 @@ class APPLESEED_DLLSYMBOL BSSRDF
     void make_reflectance_and_mfp_compatible(
         Spectrum&                   reflectance,
         const Spectrum&             mfp) const;
+
+    void build_cdf_and_pdf(
+        const Spectrum&             src,
+        Spectrum&                   cdf,
+        Spectrum&                   pdf) const;
 };
 
 }       // namespace renderer

--- a/src/appleseed/renderer/modeling/bssrdf/bssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/bssrdf.h
@@ -135,6 +135,8 @@ class APPLESEED_DLLSYMBOL BSSRDF
         const size_t                channel,
         const float                 radius) const = 0;
 
+    virtual float get_fresnel_weight(const void* data) const;
+
   protected:
     struct Impl;
     Impl* impl;

--- a/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.cpp
@@ -68,6 +68,7 @@ DipoleBSSRDF::DipoleBSSRDF(
     m_inputs.declare("sigma_s", InputFormatSpectralReflectance, "");
     m_inputs.declare("g", InputFormatFloat, "0.0");
     m_inputs.declare("ior", InputFormatFloat);
+    m_inputs.declare("fresnel_weight", InputFormatFloat, "1.0");
 }
 
 bool DipoleBSSRDF::sample(
@@ -203,6 +204,16 @@ DictionaryArray DipoleBSSRDFFactory::get_input_metadata() const
             .insert("max_value", "2.5")
             .insert("use", "required")
             .insert("default", "1.3"));
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "fresnel_weight")
+            .insert("label", "Fresnel Weight")
+            .insert("type", "numeric")
+            .insert("min_value", "0.0")
+            .insert("max_value", "1.0")
+            .insert("use", "optional")
+            .insert("default", "1.0"));
 
     return metadata;
 }

--- a/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.h
@@ -214,27 +214,21 @@ void DipoleBSSRDF::do_prepare_inputs(
         values->m_g,
         values->m_precomputed.m_sigma_tr);
 
-    // Precompute some coefficients and build a CDF for channel sampling.
+    // Precompute some coefficients.
     values->m_precomputed.m_alpha_prime.resize(values->m_reflectance.size());
-    values->m_precomputed.m_channel_pdf.resize(values->m_reflectance.size());
-    values->m_precomputed.m_channel_cdf.resize(values->m_reflectance.size());
 
-    float cumulated_pdf = 0.0f;
-    for (size_t i = 0, e = values->m_precomputed.m_channel_cdf.size(); i < e; ++i)
+    for (size_t i = 0, e = values->m_reflectance.size(); i < e; ++i)
     {
         const float sigma_s_prime = values->m_sigma_s[i] * static_cast<float>(1.0 - values->m_g);
         const float sigma_t_prime = sigma_s_prime + values->m_sigma_a[i];
         values->m_precomputed.m_alpha_prime[i] = sigma_s_prime / sigma_t_prime;
-
-        values->m_precomputed.m_channel_pdf[i] = values->m_precomputed.m_alpha_prime[i];
-        cumulated_pdf += values->m_precomputed.m_channel_pdf[i];
-        values->m_precomputed.m_channel_cdf[i] = cumulated_pdf;
     }
 
-    const float rcp_cumulated_pdf = 1.0f / cumulated_pdf;
-    values->m_precomputed.m_channel_pdf *= rcp_cumulated_pdf;
-    values->m_precomputed.m_channel_cdf *= rcp_cumulated_pdf;
-    values->m_precomputed.m_channel_cdf[values->m_precomputed.m_channel_cdf.size() - 1] = 1.0f;
+    // Build a CDF and PDF for channel sampling.
+    build_cdf_and_pdf(
+        values->m_precomputed.m_alpha_prime,
+        values->m_precomputed.m_channel_cdf,
+        values->m_precomputed.m_channel_pdf);
 
     // Precompute the (square of the) max radius.
     values->m_precomputed.m_rmax2 = foundation::square(dipole_max_radius(foundation::min_value(values->m_precomputed.m_sigma_tr)));

--- a/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.h
@@ -70,6 +70,7 @@ APPLESEED_DECLARE_INPUT_VALUES(DipoleBSSRDFInputValues)
     Spectrum        m_sigma_s;
     float           m_g;
     float           m_ior;
+    float           m_fresnel_weight;
 
     struct Precomputed
     {
@@ -124,6 +125,9 @@ class DipoleBSSRDF
     virtual float get_eta(
         const void*                 data) const APPLESEED_OVERRIDE;
 
+    virtual float get_fresnel_weight(
+        const void*                 data) const APPLESEED_OVERRIDE;
+
   protected:
     template <typename ComputeRdFun>
     void do_prepare_inputs(
@@ -159,6 +163,12 @@ inline float DipoleBSSRDF::get_eta(
     const void*                 data) const
 {
     return reinterpret_cast<const DipoleBSSRDFInputValues*>(data)->m_precomputed.m_eta;
+}
+
+inline float DipoleBSSRDF::get_fresnel_weight(
+    const void*         data) const
+{
+    return reinterpret_cast<const DipoleBSSRDFInputValues*>(data)->m_fresnel_weight;
 }
 
 template <typename ComputeRdFun>

--- a/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.h
@@ -125,10 +125,10 @@ class DipoleBSSRDF
     virtual float get_eta(
         const void*                 data) const APPLESEED_OVERRIDE;
 
+  protected:
     virtual float get_fresnel_weight(
         const void*                 data) const APPLESEED_OVERRIDE;
 
-  protected:
     template <typename ComputeRdFun>
     void do_prepare_inputs(
         const ShadingPoint&         shading_point,

--- a/src/appleseed/renderer/modeling/bssrdf/directionaldipolebssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/directionaldipolebssrdf.cpp
@@ -124,9 +124,7 @@ namespace
                 }
             }
             else
-            {
                 values->m_precomputed.m_dirpole_reparam_weight.set(1.0f);
-            }
         }
 
         virtual void evaluate_profile(
@@ -177,13 +175,21 @@ namespace
             value *= 0.5f;
 #endif
 
-            float fo;
-            const float cos_on = abs(dot(outgoing_dir, Vector3f(outgoing_point.get_shading_normal())));
-            fresnel_transmittance_dielectric(fo, values->m_precomputed.m_eta, cos_on);
+            float fi = 1.0f;
+            float fo = 1.0f;
 
-            float fi;
-            const float cos_in = abs(dot(incoming_dir, Vector3f(incoming_point.get_shading_normal())));
-            fresnel_transmittance_dielectric(fi, values->m_precomputed.m_eta, cos_in);
+            const float fresnel_weight = saturate(get_fresnel_weight(data));
+
+            if (fresnel_weight != 0.0f)
+            {
+                const float cos_on = abs(dot(outgoing_dir, Vector3f(outgoing_point.get_shading_normal())));
+                fresnel_transmittance_dielectric(fo, values->m_precomputed.m_eta, cos_on);
+                fo = lerp(1.0f, fo, fresnel_weight);
+
+                const float cos_in = abs(dot(incoming_dir, Vector3f(incoming_point.get_shading_normal())));
+                fresnel_transmittance_dielectric(fi, values->m_precomputed.m_eta, cos_in);
+                fi = lerp(1.0f, fi, fresnel_weight);
+            }
 
             const float radius = static_cast<float>(norm(incoming_point.get_point() - outgoing_point.get_point()));
             value *= radius * fo * fi * values->m_weight;

--- a/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
@@ -128,6 +128,7 @@ namespace
             m_inputs.declare("mfp", InputFormatSpectralReflectance);
             m_inputs.declare("mfp_multiplier", InputFormatFloat, "1.0");
             m_inputs.declare("ior", InputFormatFloat);
+            m_inputs.declare("fresnel_weight", InputFormatFloat, "1.0");
         }
 
         virtual void release() APPLESEED_OVERRIDE
@@ -227,6 +228,12 @@ namespace
             const void*         data) const APPLESEED_OVERRIDE
         {
             return reinterpret_cast<const GaussianBSSRDFInputValues*>(data)->m_precomputed.m_eta;
+        }
+
+        virtual float get_fresnel_weight(
+            const void*         data) const APPLESEED_OVERRIDE
+        {
+            return reinterpret_cast<const GaussianBSSRDFInputValues*>(data)->m_fresnel_weight;
         }
 
         virtual void evaluate_profile(
@@ -357,6 +364,16 @@ DictionaryArray GaussianBSSRDFFactory::get_input_metadata() const
             .insert("max_value", "2.5")
             .insert("use", "required")
             .insert("default", "1.3"));
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "fresnel_weight")
+            .insert("label", "Fresnel Weight")
+            .insert("type", "numeric")
+            .insert("min_value", "0.0")
+            .insert("max_value", "1.0")
+            .insert("use", "optional")
+            .insert("default", "1.0"));
 
     return metadata;
 }

--- a/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
@@ -123,6 +123,7 @@ namespace
             const ParamArray&   params)
           : SeparableBSSRDF(name, params)
         {
+            m_inputs.declare("weight", InputFormatFloat, "1.0");
             m_inputs.declare("reflectance", InputFormatSpectralReflectance);
             m_inputs.declare("reflectance_multiplier", InputFormatFloat, "1.0");
             m_inputs.declare("mfp", InputFormatSpectralReflectance);
@@ -162,7 +163,7 @@ namespace
             make_reflectance_and_mfp_compatible(values->m_reflectance, values->m_mfp);
 
             // Apply multipliers to input values.
-            values->m_reflectance *= values->m_reflectance_multiplier;
+            values->m_reflectance *= values->m_reflectance_multiplier * values->m_weight;
             values->m_mfp *= values->m_mfp_multiplier;
 
             // Build a CDF and PDF for channel sampling.
@@ -310,6 +311,16 @@ Dictionary GaussianBSSRDFFactory::get_model_metadata() const
 DictionaryArray GaussianBSSRDFFactory::get_input_metadata() const
 {
     DictionaryArray metadata;
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "weight")
+            .insert("label", "Weight")
+            .insert("type", "colormap")
+            .insert("entity_types",
+                Dictionary().insert("texture_instance", "Textures"))
+            .insert("use", "optional")
+            .insert("default", "1.0"));
 
     metadata.push_back(
         Dictionary()

--- a/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
@@ -164,23 +164,11 @@ namespace
             values->m_reflectance *= values->m_reflectance_multiplier;
             values->m_radius *= values->m_radius_multiplier;
 
-            // Build a CDF for channel sampling.
-            values->m_precomputed.m_channel_pdf.resize(values->m_reflectance.size());
-            values->m_precomputed.m_channel_cdf.resize(values->m_reflectance.size());
-
-            float cumulated_pdf = 0.0f;
-            for (size_t i = 0, e = values->m_precomputed.m_channel_pdf.size(); i < e; ++i)
-            {
-                const float r = values->m_reflectance[i];
-                values->m_precomputed.m_channel_pdf[i] = r;
-                cumulated_pdf += r;
-                values->m_precomputed.m_channel_cdf[i] = cumulated_pdf;
-            }
-
-            const float rcp_cumulated_pdf = 1.0f / cumulated_pdf;
-            values->m_precomputed.m_channel_pdf *= rcp_cumulated_pdf;
-            values->m_precomputed.m_channel_cdf *= rcp_cumulated_pdf;
-            values->m_precomputed.m_channel_cdf[values->m_precomputed.m_channel_cdf.size() - 1] = 1.0f;
+            // Build a CDF and PDF for channel sampling.
+            build_cdf_and_pdf(
+                values->m_reflectance,
+                values->m_precomputed.m_channel_cdf,
+                values->m_precomputed.m_channel_pdf);
 
             // Precompute v and the (square of the) max radius.
             float max_v = 0.0f;

--- a/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
@@ -178,7 +178,7 @@ namespace
             for (size_t i = 0, e = values->m_precomputed.m_channel_pdf.size(); i < e; ++i)
             {
                 // The remapping from mfp to radius comes from alSurface.
-                const float radius = values->m_mfp[i] * 7.0f;
+                const float radius = max(values->m_mfp[i], 0.0001f) * 7.0f;
 
                 // The remapping from radius to v comes from Cycles.
                 const float v = square(radius) * square(0.25f);
@@ -198,9 +198,6 @@ namespace
                 reinterpret_cast<const GaussianBSSRDFInputValues*>(data);
 
             const float rmax2 = values->m_precomputed.m_rmax2;
-
-            if (rmax2 <= 0.0f)
-                return false;
 
             sampling_context.split_in_place(3, 1);
             const Vector3f s = sampling_context.next2<Vector3f>();

--- a/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.h
@@ -55,6 +55,7 @@ namespace renderer
 
 APPLESEED_DECLARE_INPUT_VALUES(GaussianBSSRDFInputValues)
 {
+    float           m_weight;
     Spectrum        m_reflectance;
     float           m_reflectance_multiplier;
     Spectrum        m_mfp;

--- a/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.h
@@ -60,6 +60,7 @@ APPLESEED_DECLARE_INPUT_VALUES(GaussianBSSRDFInputValues)
     Spectrum        m_mfp;
     float           m_mfp_multiplier;
     float           m_ior;
+    float           m_fresnel_weight;
 
     struct Precomputed
     {

--- a/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.h
@@ -57,8 +57,8 @@ APPLESEED_DECLARE_INPUT_VALUES(GaussianBSSRDFInputValues)
 {
     Spectrum        m_reflectance;
     float           m_reflectance_multiplier;
-    Spectrum        m_radius;
-    float           m_radius_multiplier;
+    Spectrum        m_mfp;
+    float           m_mfp_multiplier;
     float           m_ior;
 
     struct Precomputed

--- a/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.h
@@ -57,11 +57,12 @@ APPLESEED_DECLARE_INPUT_VALUES(GaussianBSSRDFInputValues)
 {
     Spectrum    m_reflectance;
     float       m_reflectance_multiplier;
-    float       m_v;
+    float       m_radius;
     float       m_ior;
 
     struct Precomputed
     {
+        float   m_v;
         float   m_rmax2;
         float   m_eta;
     };

--- a/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.h
@@ -55,16 +55,19 @@ namespace renderer
 
 APPLESEED_DECLARE_INPUT_VALUES(GaussianBSSRDFInputValues)
 {
-    Spectrum    m_reflectance;
-    float       m_reflectance_multiplier;
-    float       m_radius;
-    float       m_ior;
+    Spectrum        m_reflectance;
+    float           m_reflectance_multiplier;
+    Spectrum        m_radius;
+    float           m_radius_multiplier;
+    float           m_ior;
 
     struct Precomputed
     {
-        float   m_v;
-        float   m_rmax2;
-        float   m_eta;
+        Spectrum    m_v;
+        float       m_rmax2;
+        float       m_eta;
+        Spectrum    m_channel_pdf;
+        Spectrum    m_channel_cdf;
     };
 
     Precomputed m_precomputed;

--- a/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.cpp
@@ -126,27 +126,19 @@ namespace
             clamp_in_place(values->m_reflectance, 0.001f, 0.999f);
             clamp_low_in_place(values->m_mfp, 1.0e-6f);
 
-            // Build a CDF for channel sampling.
-
             values->m_precomputed.m_s.resize(values->m_reflectance.size());
-            values->m_precomputed.m_channel_pdf.resize(values->m_reflectance.size());
-            values->m_precomputed.m_channel_cdf.resize(values->m_reflectance.size());
 
-            float cumulated_pdf = 0.0f;
-            for (size_t i = 0, e = values->m_precomputed.m_channel_pdf.size(); i < e; ++i)
+            for (size_t i = 0, e = values->m_reflectance.size(); i < e; ++i)
             {
                 const float a = values->m_reflectance[i];
                 values->m_precomputed.m_s[i] = normalized_diffusion_s_mfp(a);
-
-                values->m_precomputed.m_channel_pdf[i] = a;
-                cumulated_pdf += a;
-                values->m_precomputed.m_channel_cdf[i] = cumulated_pdf;
             }
 
-            const float rcp_cumulated_pdf = 1.0f / cumulated_pdf;
-            values->m_precomputed.m_channel_pdf *= rcp_cumulated_pdf;
-            values->m_precomputed.m_channel_cdf *= rcp_cumulated_pdf;
-            values->m_precomputed.m_channel_cdf[values->m_precomputed.m_channel_cdf.size() - 1] = 1.0f;
+            // Build a CDF and PDF for channel sampling.
+            build_cdf_and_pdf(
+                values->m_reflectance,
+                values->m_precomputed.m_channel_cdf,
+                values->m_precomputed.m_channel_pdf);
 
             // Precompute the (square of the) max radius.
             values->m_precomputed.m_rmax2 = 0.0f;

--- a/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.cpp
@@ -86,6 +86,7 @@ namespace
             m_inputs.declare("mfp", InputFormatSpectralReflectance);
             m_inputs.declare("mfp_multiplier", InputFormatFloat, "1.0");
             m_inputs.declare("ior", InputFormatFloat);
+            m_inputs.declare("fresnel_weight", InputFormatFloat, "1.0");
         }
 
         virtual void release() APPLESEED_OVERRIDE
@@ -196,6 +197,12 @@ namespace
             const void*         data) const APPLESEED_OVERRIDE
         {
             return reinterpret_cast<const NormalizedDiffusionBSSRDFInputValues*>(data)->m_precomputed.m_eta;
+        }
+
+        virtual float get_fresnel_weight(
+            const void*         data) const APPLESEED_OVERRIDE
+        {
+            return reinterpret_cast<const NormalizedDiffusionBSSRDFInputValues*>(data)->m_fresnel_weight;
         }
 
         virtual void evaluate_profile(
@@ -334,6 +341,16 @@ DictionaryArray NormalizedDiffusionBSSRDFFactory::get_input_metadata() const
             .insert("max_value", "2.5")
             .insert("use", "required")
             .insert("default", "1.3"));
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "fresnel_weight")
+            .insert("label", "Fresnel Weight")
+            .insert("type", "numeric")
+            .insert("min_value", "0.0")
+            .insert("max_value", "1.0")
+            .insert("use", "optional")
+            .insert("default", "1.0"));
 
     return metadata;
 }

--- a/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.h
@@ -61,6 +61,7 @@ APPLESEED_DECLARE_INPUT_VALUES(NormalizedDiffusionBSSRDFInputValues)
     Spectrum        m_mfp;
     float           m_mfp_multiplier;
     float           m_ior;
+    float           m_fresnel_weight;
 
     struct Precomputed
     {

--- a/src/appleseed/renderer/modeling/bssrdf/oslbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/oslbssrdf.cpp
@@ -36,6 +36,7 @@
 #include "renderer/modeling/bssrdf/bssrdf.h"
 #include "renderer/modeling/bssrdf/bssrdfsample.h"
 #include "renderer/modeling/bssrdf/directionaldipolebssrdf.h"
+#include "renderer/modeling/bssrdf/gaussianbssrdf.h"
 #ifdef APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF
 #include "renderer/modeling/bssrdf/normalizeddiffusionbssrdf.h"
 #endif
@@ -81,6 +82,11 @@ namespace
                 create_and_register_bssrdf<DirectionalDipoleBSSRDFFactory>(
                     SubsurfaceDirectionalDipoleID,
                     "dir_dipole");
+
+            m_gaussian =
+                create_and_register_bssrdf<GaussianBSSRDFFactory>(
+                    SubsurfaceGaussianID,
+                    "gaussian");
 
 #ifdef APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF
             m_normalized =

--- a/src/appleseed/renderer/modeling/bssrdf/separablebssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/separablebssrdf.h
@@ -136,22 +136,29 @@ inline void SeparableBSSRDF::evaluate(
     //
 
     const float eta = get_eta(data);
+    const float fresnel_weight = foundation::saturate(get_fresnel_weight(data));
 
-    float fo;
-    const float cos_on =
-        std::abs(
-            foundation::dot(
-                outgoing_dir,
-                foundation::Vector3f(outgoing_point.get_shading_normal())));
-    foundation::fresnel_transmittance_dielectric(fo, eta, cos_on);
+    float fi = 1.0f;
+    float fo = 1.0f;
 
-    float fi;
-    const float cos_in =
-        std::abs(
-            foundation::dot(
-                incoming_dir,
-                foundation::Vector3f(incoming_point.get_shading_normal())));
-    foundation::fresnel_transmittance_dielectric(fi, eta, cos_in);
+    if (fresnel_weight != 0.0f)
+    {
+        const float cos_on =
+            std::abs(
+                foundation::dot(
+                    outgoing_dir,
+                    foundation::Vector3f(outgoing_point.get_shading_normal())));
+        foundation::fresnel_transmittance_dielectric(fo, eta, cos_on);
+        fo = foundation::lerp(1.0f, fo, fresnel_weight);
+
+        const float cos_in =
+            std::abs(
+                foundation::dot(
+                    incoming_dir,
+                    foundation::Vector3f(incoming_point.get_shading_normal())));
+        foundation::fresnel_transmittance_dielectric(fi, eta, cos_in);
+        fi = foundation::lerp(1.0f, fi, fresnel_weight);
+    }
 
     const float square_radius =
         static_cast<float>(

--- a/src/appleseed/renderer/modeling/shadergroup/shadergroup.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shadergroup.cpp
@@ -66,6 +66,7 @@ namespace
     const OIIO::ustring g_emission_str("emission");
     const OIIO::ustring g_transparent_str("transparent");
     const OIIO::ustring g_subsurface_str("as_subsurface");
+    const OIIO::ustring g_subsurface_gaussian_str("as_subsurface_gaussian");
     const OIIO::ustring g_holdout_str("holdout");
     const OIIO::ustring g_debug_str("debug");
     const OIIO::ustring g_dPdtime_str("dPdtime");
@@ -383,6 +384,8 @@ void ShaderGroup::get_shadergroup_closures_info(OSL::ShadingSystem& shading_syst
             else if (closures[i] == g_transparent_str)
                 m_flags |= HasTransparency;
             else if (closures[i] == g_subsurface_str)
+                m_flags |= HasSubsurface;
+            else if (closures[i] == g_subsurface_gaussian_str)
                 m_flags |= HasSubsurface;
             else if (closures[i] == g_holdout_str)
                 m_flags |= HasHoldout;

--- a/src/appleseed/renderer/modeling/shadergroup/shadergroup.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shadergroup.cpp
@@ -66,7 +66,6 @@ namespace
     const OIIO::ustring g_emission_str("emission");
     const OIIO::ustring g_transparent_str("transparent");
     const OIIO::ustring g_subsurface_str("as_subsurface");
-    const OIIO::ustring g_subsurface_gaussian_str("as_subsurface_gaussian");
     const OIIO::ustring g_holdout_str("holdout");
     const OIIO::ustring g_debug_str("debug");
     const OIIO::ustring g_dPdtime_str("dPdtime");
@@ -384,8 +383,6 @@ void ShaderGroup::get_shadergroup_closures_info(OSL::ShadingSystem& shading_syst
             else if (closures[i] == g_transparent_str)
                 m_flags |= HasTransparency;
             else if (closures[i] == g_subsurface_str)
-                m_flags |= HasSubsurface;
-            else if (closures[i] == g_subsurface_gaussian_str)
                 m_flags |= HasSubsurface;
             else if (closures[i] == g_holdout_str)
                 m_flags |= HasHoldout;


### PR DESCRIPTION
- alSurface layer BRDF fixes and improvements.
- Imported OSL utility shaders from alShaders.
- Started alSurface shader.
- Use the same inputs for the Gaussian and the other BSSRDFs.
- Expose the Gaussian BSSRDF to OSL.
- Add a fresnel weight input to BSSRDFs.
- Maya area light shader improvements.
