### PR TITLE
MDF refactors

### DIFF
--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -279,6 +279,8 @@ set (foundation_math_sources
     foundation/math/rr.h
     foundation/math/sah.h
     foundation/math/scalar.h
+    foundation/math/specialfunctions.cpp
+    foundation/math/specialfunctions.h
     foundation/math/sphericaltriangle.h
     foundation/math/spline.h
     foundation/math/split.h

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -258,6 +258,7 @@ set (foundation_math_sources
     foundation/math/hash.h
     foundation/math/knn.h
     foundation/math/matrix.h
+    foundation/math/microfacet.cpp
     foundation/math/microfacet.h
     foundation/math/minmax.h
     foundation/math/mis.h

--- a/src/appleseed/foundation/math/microfacet.cpp
+++ b/src/appleseed/foundation/math/microfacet.cpp
@@ -311,7 +311,7 @@ Vector3f BlinnMDF::sample(
     const float         alpha_y) const
 {
     const float cos_theta = std::pow(1.0f - s[0], 1.0f / (alpha_x + 2.0f));
-    const float sin_theta = std::sqrt(1.0f - cos_theta * cos_theta);
+    const float sin_theta = std::sqrt(std::max(0.0f, 1.0f - square(cos_theta)));
 
     float cos_phi, sin_phi;
     sample_phi(s[1], cos_phi, sin_phi);
@@ -348,12 +348,13 @@ float BeckmannMDF::D(
         return 0.0f;
 
     const float cos_theta_2 = square(cos_theta);
+    const float sin_theta = std::sqrt(std::max(0.0f, 1.0f - cos_theta_2));
     const float cos_theta_4 = square(cos_theta_2);
     const float tan_theta_2 = (1.0f - cos_theta_2) / cos_theta_2;
 
     const float A = stretched_roughness(
         h,
-        sin_theta(h),
+        sin_theta,
         alpha_x,
         alpha_y);
 
@@ -389,7 +390,7 @@ float BeckmannMDF::lambda(
     if (cos_theta == 0.0f)
         return 0.0f;
 
-    const float sin_theta = MDF::sin_theta(v);
+    const float sin_theta = std::sqrt(std::max(0.0f, 1.0f - square(cos_theta)));
 
     const float alpha =
         projected_roughness(
@@ -500,13 +501,14 @@ float GGXMDF::D(
         return square(alpha_x) * RcpPi<float>();
 
     const float cos_theta_2 = square(cos_theta);
+    const float sin_theta = std::sqrt(std::max(0.0f, 1.0f - cos_theta_2));
     const float cos_theta_4 = square(cos_theta_2);
     const float tan_theta_2 = (1.0f - cos_theta_2) / cos_theta_2;
 
     const float A =
         stretched_roughness(
             h,
-            sin_theta(h),
+            sin_theta,
             alpha_x,
             alpha_y);
 
@@ -544,7 +546,7 @@ float GGXMDF::lambda(
         return 0.0f;
 
     const float cos_theta_2 = square(cos_theta);
-    const float sin_theta = MDF::sin_theta(v);
+    const float sin_theta = std::sqrt(std::max(0.0f, 1.0f - square(cos_theta)));
     const float tan_theta_2 = square(sin_theta) / cos_theta_2;
 
     const float alpha =
@@ -578,7 +580,7 @@ Vector2f GGXMDF::sample11(
     const float         cos_theta,
     const Vector3f&     s) const
 {
-    const float sin_theta = std::sqrt(1.0f - square(cos_theta));
+    const float sin_theta = std::sqrt(std::max(0.0f, 1.0f - square(cos_theta)));
 
     // Special case (normal incidence).
     if (sin_theta < 1.0e-4f)
@@ -762,7 +764,7 @@ float GTR1MDF::lambda(
 
     // [2] section 3.2.
     const float cos_theta_2 = square(cos_theta);
-    const float sin_theta = MDF::sin_theta(v);
+    const float sin_theta = std::sqrt(std::max(0.0f, 1.0f - square(cos_theta)));
     const float cot_theta_2 = cos_theta_2 / square(sin_theta);
     const float cot_theta = std::sqrt(cot_theta_2);
     const float alpha_2 = square(alpha_x);
@@ -784,7 +786,7 @@ Vector3f GTR1MDF::sample(
     const float alpha2 = square(alpha_x);
     const float a = 1.0f - std::pow(alpha2, 1.0f - s[0]);
     const float cos_theta = std::sqrt(a / (1.0f - alpha2));
-    const float sin_theta  = std::sqrt(1.0f - square(cos_theta));
+    const float sin_theta  = std::sqrt(std::max(0.0f, 1.0f - square(cos_theta)));
 
     float cos_phi, sin_phi;
     sample_phi(s[1], cos_phi, sin_phi);

--- a/src/appleseed/foundation/math/microfacet.cpp
+++ b/src/appleseed/foundation/math/microfacet.cpp
@@ -1,0 +1,43 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2014-2017 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "microfacet.h"
+
+namespace foundation
+{
+
+//
+// MDF class implementation.
+//
+
+MDF::~MDF()
+{
+}
+
+}   // namespace foundation

--- a/src/appleseed/foundation/math/microfacet.cpp
+++ b/src/appleseed/foundation/math/microfacet.cpp
@@ -143,7 +143,7 @@ Vector3f sample_visible_normals(
         stretched[1] < 0.99999f ? std::atan2(stretched[2], stretched[0]) : 0.0f;
 
     // Sample slope.
-    const Vector2f slope = mdf.sample11(cos_theta, s, gamma);
+    Vector2f slope = mdf.sample11(cos_theta, s, gamma);
 
     // Rotate.
     const float cos_phi = std::cos(phi);
@@ -542,8 +542,9 @@ Vector2f GGXMDF::sample11(
     if (sin_theta < 1.0e-4f)
     {
         const float r = std::sqrt(s[0] / (1.0f - s[0]));
-        const float cos_phi = std::cos(TwoPi<float>() * s[1]);
-        const float sin_phi = std::sin(TwoPi<float>() * s[1]);
+        const float two_pi_s1 = TwoOverPi<float>() * s[1];
+        const float cos_phi = std::cos(two_pi_s1);
+        const float sin_phi = std::sin(two_pi_s1);
         return Vector2f(r * cos_phi, r * sin_phi);
     }
 

--- a/src/appleseed/foundation/math/microfacet.cpp
+++ b/src/appleseed/foundation/math/microfacet.cpp
@@ -31,6 +31,7 @@
 
 // appleseed.foundation headers.
 #include "foundation/math/scalar.h"
+#include "foundation/math/specialfunctions.h"
 
 // Standard headers.
 #include <cassert>
@@ -175,76 +176,6 @@ float pdf_visible_normals(
     return
         mdf.G1(v, h, alpha_x, alpha_y) * std::abs(dot(v, h)) *
         mdf.D(h, alpha_x, alpha_y) / std::abs(cos_theta_v);
-}
-
-//
-// Reference:
-//
-//   Handbook of Mathematical Functions.
-//   Abramowitz and Stegun.
-//   http://people.math.sfu.ca/~cbm/aands/toc.htm
-//
-// Copied from from pbrt-v3.
-//
-
-float erf(const float x)
-{
-    // Constants.
-    const float a1 = 0.254829592f;
-    const float a2 = -0.284496736f;
-    const float a3 = 1.421413741f;
-    const float a4 = -1.453152027f;
-    const float a5 = 1.061405429f;
-    const float p  = 0.3275911f;
-
-    // A&S formula 7.1.26.
-    const float abs_x = std::abs(x);
-    const float t = 1.0f / (1.0f + p * abs_x);
-    const float y = 1.0f - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * std::exp(-square(abs_x * abs_x));
-    return x < 0.0f ? -y : y;
-}
-
-//
-// Reference:
-//
-//   Approximating the erfinv function, Mike Giles.
-//   https://people.maths.ox.ac.uk/gilesm/files/gems_erfinv.pdf
-//
-
-float erf_inv(const float x)
-{
-    const float y = clamp(x, -0.99999f, 0.99999f);
-    float w = -std::log((1 - y) * (1 + y));
-    float p;
-
-    if (w < 5.0f)
-    {
-        w = w - 2.5f;
-        p = 2.81022636e-08f;
-        p = 3.43273939e-07f + p * w;
-        p = -3.5233877e-06f + p * w;
-        p = -4.39150654e-06f + p * w;
-        p = 0.00021858087f + p * w;
-        p = -0.00125372503f + p * w;
-        p = -0.00417768164f + p * w;
-        p = 0.246640727f + p * w;
-        p = 1.50140941f + p * w;
-    }
-    else
-    {
-        w = std::sqrt(w) - 3.0f;
-        p = -0.000200214257f;
-        p = 0.000100950558f + p * w;
-        p = 0.00134934322f + p * w;
-        p = -0.00367342844f + p * w;
-        p = 0.00573950773f + p * w;
-        p = -0.0076224613f + p * w;
-        p = 0.00943887047f + p * w;
-        p = 1.00167406f + p * w;
-        p = 2.83297682f + p * w;
-    }
-
-    return p * y;
 }
 
 }

--- a/src/appleseed/foundation/math/microfacet.cpp
+++ b/src/appleseed/foundation/math/microfacet.cpp
@@ -29,15 +29,775 @@
 // Interface header.
 #include "microfacet.h"
 
+// appleseed.foundation headers.
+#include "foundation/math/scalar.h"
+
+// Standard headers.
+#include <cassert>
+#include <cmath>
+
 namespace foundation
 {
+
+namespace
+{
+
+void sample_phi(
+    const float         s,
+    float&              cos_phi,
+    float&              sin_phi)
+{
+    const float phi = TwoPi<float>() * s;
+    cos_phi = std::cos(phi);
+    sin_phi = std::sin(phi);
+}
+
+void sample_phi(
+    const float         s,
+    const float         alpha_x,
+    const float         alpha_y,
+    float&              cos_phi,
+    float&              sin_phi)
+{
+    Vector2f sin_cos_phi(
+        std::cos(TwoPi<float>() * s) * alpha_x,
+        std::sin(TwoPi<float>() * s) * alpha_y);
+    sin_cos_phi = normalize(sin_cos_phi);
+    cos_phi = sin_cos_phi[0];
+    sin_phi = sin_cos_phi[1];
+}
+
+float stretched_roughness(
+    const Vector3f&     h,
+    const float         sin_theta,
+    const float         alpha_x,
+    const float         alpha_y)
+{
+    if (alpha_x == alpha_y || sin_theta == 0.0f)
+        return 1.0f / square(alpha_x);
+
+    const float cos_phi_2_ax_2 = square(h.x / (sin_theta * alpha_x));
+    const float sin_phi_2_ay_2 = square(h.z / (sin_theta * alpha_y));
+    return cos_phi_2_ax_2 + sin_phi_2_ay_2;
+}
+
+float projected_roughness(
+    const Vector3f&     h,
+    const float         sin_theta,
+    const float         alpha_x,
+    const float         alpha_y)
+{
+    if (alpha_x == alpha_y || sin_theta == 0.0f)
+        return alpha_x;
+
+    const float cos_phi_2_ax_2 = square((h.x * alpha_x) / sin_theta);
+    const float sin_phi_2_ay_2 = square((h.z * alpha_y) / sin_theta);
+    return std::sqrt(cos_phi_2_ax_2 + sin_phi_2_ay_2);
+}
+
+Vector3f v_cavity_choose_microfacet_normal(
+    const Vector3f&     v,
+    const Vector3f&     h,
+    const float         s)
+{
+    // Preconditions.
+    assert(is_normalized(v));
+    assert(v.y >= 0.0f);
+
+    const Vector3f hm(-h[0], h[1], -h[2]);
+    const float dot_vh  = std::max(dot(v, h), 0.0f);
+    const float dot_vhm = std::max(dot(v, hm), 0.0f);
+
+    if (dot_vhm == 0.0f)
+        return h;
+
+    const float w = dot_vhm / (dot_vh + dot_vhm);
+    return s < w ? hm : h;
+}
+
+template <typename Distribution>
+Vector3f sample_visible_normals(
+    const Distribution& mdf,
+    const Vector3f&     v,
+    const Vector3f&     s,
+    const float         alpha_x,
+    const float         alpha_y)
+{
+    // Preconditions.
+    assert(is_normalized(v));
+
+    // Stretch incident.
+    const float sign_cos_vn = v.y < 0.0f ? -1.0f : 1.0f;
+    Vector3f stretched(
+        sign_cos_vn * v[0] * alpha_x,
+        sign_cos_vn * v[1],
+        sign_cos_vn * v[2] * alpha_y);
+
+    stretched = normalize(stretched);
+
+    const float cos_theta = stretched[1];
+    const float phi =
+        stretched[1] < 0.99999f ? std::atan2(stretched[2], stretched[0]) : 0.0f;
+
+    // Sample slope.
+    Vector2f slope = mdf.sample11(cos_theta, s);
+
+    // Rotate.
+    const float cos_phi = std::cos(phi);
+    const float sin_phi = std::sin(phi);
+    slope = Vector2f(
+        cos_phi * slope[0] - sin_phi * slope[1],
+        sin_phi * slope[0] + cos_phi * slope[1]);
+
+    // Stretch and normalize.
+    const Vector3f m(
+        -slope[0] * alpha_x,
+        1.0f,
+        -slope[1] * alpha_y);
+    return normalize(m);
+}
+
+template <typename Distribution>
+float pdf_visible_normals(
+    const Distribution& mdf,
+    const Vector3f&     v,
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y)
+{
+    assert(is_normalized(v));
+
+    const float cos_theta_v = v.y;
+
+    if (cos_theta_v == 0.0f)
+        return 0.0f;
+
+    return
+        mdf.G1(v, h, alpha_x, alpha_y) * std::abs(dot(v, h)) *
+        mdf.D(h, alpha_x, alpha_y) / std::abs(cos_theta_v);
+}
+
+//
+// Reference:
+//
+//   Handbook of Mathematical Functions.
+//   Abramowitz and Stegun.
+//   http://people.math.sfu.ca/~cbm/aands/toc.htm
+//
+// Copied from from pbrt-v3.
+//
+
+float erf(const float x)
+{
+    // Constants.
+    const float a1 = 0.254829592f;
+    const float a2 = -0.284496736f;
+    const float a3 = 1.421413741f;
+    const float a4 = -1.453152027f;
+    const float a5 = 1.061405429f;
+    const float p  = 0.3275911f;
+
+    // A&S formula 7.1.26.
+    const float abs_x = std::abs(x);
+    const float t = 1.0f / (1.0f + p * abs_x);
+    const float y = 1.0f - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * std::exp(-square(abs_x * abs_x));
+    return x < 0.0f ? -y : y;
+}
+
+//
+// Reference:
+//
+//   Approximating the erfinv function, Mike Giles.
+//   https://people.maths.ox.ac.uk/gilesm/files/gems_erfinv.pdf
+//
+
+float erf_inv(const float x)
+{
+    const float y = clamp(x, -0.99999f, 0.99999f);
+    float w = -std::log((1 - y) * (1 + y));
+    float p;
+
+    if (w < 5.0f)
+    {
+        w = w - 2.5f;
+        p = 2.81022636e-08f;
+        p = 3.43273939e-07f + p * w;
+        p = -3.5233877e-06f + p * w;
+        p = -4.39150654e-06f + p * w;
+        p = 0.00021858087f + p * w;
+        p = -0.00125372503f + p * w;
+        p = -0.00417768164f + p * w;
+        p = 0.246640727f + p * w;
+        p = 1.50140941f + p * w;
+    }
+    else
+    {
+        w = std::sqrt(w) - 3.0f;
+        p = -0.000200214257f;
+        p = 0.000100950558f + p * w;
+        p = 0.00134934322f + p * w;
+        p = -0.00367342844f + p * w;
+        p = 0.00573950773f + p * w;
+        p = -0.0076224613f + p * w;
+        p = 0.00943887047f + p * w;
+        p = 1.00167406f + p * w;
+        p = 2.83297682f + p * w;
+    }
+
+    return p * y;
+}
+
+}
 
 //
 // MDF class implementation.
 //
 
+MDF::MDF()
+{
+}
+
 MDF::~MDF()
 {
+}
+
+//
+// BlinnMDF class implementation.
+//
+
+BlinnMDF::BlinnMDF() {}
+
+float BlinnMDF::D(
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return (alpha_x + 2.0f) * RcpTwoPi<float>() * std::pow(h.y, alpha_x);
+}
+
+float BlinnMDF::G(
+    const Vector3f&     incoming,
+    const Vector3f&     outgoing,
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return std::min(G1(incoming, h, alpha_x, alpha_y), G1(outgoing, h, alpha_x, alpha_y));
+}
+
+float BlinnMDF::G1(
+    const Vector3f&     v,
+    const Vector3f&     m,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    if (v.y <= 0.0f)
+        return 0.0f;
+
+    if (dot(v, m) <= 0.0f)
+        return 0.0f;
+
+    const float cos_vh = std::abs(dot(v, m));
+    if (cos_vh == 0.0f)
+        return 0.0f;
+
+    return std::min(1.0f, 2.0f * std::abs(m.y * v.y) / cos_vh);
+}
+
+Vector3f BlinnMDF::sample(
+    const Vector3f&     v,
+    const Vector3f&     s,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    const float cos_theta = std::pow(1.0f - s[0], 1.0f / (alpha_x + 2.0f));
+    const float sin_theta = std::sqrt(1.0f - cos_theta * cos_theta);
+
+    float cos_phi, sin_phi;
+    sample_phi(s[1], cos_phi, sin_phi);
+
+    const Vector3f h =
+        Vector3f::make_unit_vector(cos_theta, sin_theta, cos_phi, sin_phi);
+
+    return v_cavity_choose_microfacet_normal(v, h, s[2]);
+}
+
+float BlinnMDF::pdf(
+    const Vector3f&     v,
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return pdf_visible_normals(*this, v, h, alpha_x, alpha_y);
+}
+
+//
+// BeckmannMDF class implementation.
+//
+
+BeckmannMDF::BeckmannMDF() {}
+
+float BeckmannMDF::D(
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    const float cos_theta = h.y;
+
+    if (cos_theta == 0.0f)
+        return 0.0f;
+
+    const float cos_theta_2 = square(cos_theta);
+    const float cos_theta_4 = square(cos_theta_2);
+    const float tan_theta_2 = (1.0f - cos_theta_2) / cos_theta_2;
+
+    const float A = stretched_roughness(
+        h,
+        sin_theta(h),
+        alpha_x,
+        alpha_y);
+
+    return std::exp(-tan_theta_2 * A) / (Pi<float>() * alpha_x * alpha_y * cos_theta_4);
+}
+
+float BeckmannMDF::G(
+    const Vector3f&     incoming,
+    const Vector3f&     outgoing,
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return 1.0f / (1.0f + lambda(outgoing, alpha_x, alpha_y) + lambda(incoming, alpha_x, alpha_y));
+}
+
+float BeckmannMDF::G1(
+    const Vector3f&     v,
+    const Vector3f&     m,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y));
+}
+
+float BeckmannMDF::lambda(
+    const Vector3f&     v,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    const float cos_theta = v.y;
+
+    if (cos_theta == 0.0f)
+        return 0.0f;
+
+    const float sin_theta = MDF::sin_theta(v);
+
+    const float alpha =
+        projected_roughness(
+            v,
+            sin_theta,
+            alpha_x,
+            alpha_y);
+
+    const float tan_theta = std::abs(sin_theta / cos_theta);
+    const float a = 1.0f / (alpha * tan_theta);
+
+    if (a < 1.6f)
+    {
+        const float a2 = square(a);
+        return (1.0f - 1.259f * a + 0.396f * a2) / (3.535f * a + 2.181f * a2);
+    }
+
+    return 0.0f;
+}
+
+Vector3f BeckmannMDF::sample(
+    const Vector3f&     v,
+    const Vector3f&     s,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return
+        sample_visible_normals(
+            *this,
+            v,
+            s,
+            alpha_x,
+            alpha_y);
+}
+
+// This code comes from OpenShadingLanguage test render.
+Vector2f BeckmannMDF::sample11(
+    const float         cos_theta,
+    const Vector3f&     s) const
+{
+    const float ct = std::max(cos_theta, 1.0e-6f);
+    const float tan_theta = std::sqrt(1.0f - square(ct)) / ct;
+    const float cot_theta = 1.0f / tan_theta;
+
+    // Sample slope X:
+    // compute a coarse approximation using the approximation:
+    // exp(-ierf(x)^2) ~= 1 - x * x
+    // solve y = 1 + b + K * (1 - b * b).
+
+    const float c = erf(cot_theta);
+    const float K = tan_theta / SqrtPi<float>();
+    const float y_approx = s[0] * (1.0f + c + K * (1 - c * c));
+    const float y_exact  = s[0] * (1.0f + c + K * std::exp(-square(cot_theta)));
+    float b = K > 0.0f
+        ? (0.5f - std::sqrt(K * (K - y_approx + 1.0f) + 0.25f)) / K
+        : y_approx - 1.0f;
+
+    // Perform a Newton step to refine toward the true root.
+    float inv_erf = erf_inv(b);
+    float value = 1.0f + b + K * std::exp(-square(inv_erf)) - y_exact;
+
+    // Check if we are close enough already.
+    // This also avoids NaNs as we get close to the root.
+    Vector2f slope;
+
+    if (std::abs(value) > 1.0e-6f)
+    {
+        b -= value / (1.0f - inv_erf * tan_theta); // newton step 1
+        inv_erf = erf_inv(b);
+        value = 1.0f + b + K * std::exp(-square(inv_erf)) - y_exact;
+        b -= value / (1.0f - inv_erf * tan_theta); // newton step 2
+        // Compute the slope from the refined value.
+        slope[0] = erf_inv(b);
+    }
+    else
+        slope[0] = inv_erf;
+
+    // Sample slope Y.
+    slope[1] = erf_inv(2.0f * s[1] - 1.0f);
+    return slope;
+}
+
+float BeckmannMDF::pdf(
+    const Vector3f&     v,
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return pdf_visible_normals(*this, v, h, alpha_x, alpha_y);
+}
+
+//
+// GGXMDF class implementation.
+//
+
+GGXMDF::GGXMDF()
+{
+}
+
+float GGXMDF::D(
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    const float cos_theta = h.y;
+
+    if (cos_theta == 0.0f)
+        return square(alpha_x) * RcpPi<float>();
+
+    const float cos_theta_2 = square(cos_theta);
+    const float cos_theta_4 = square(cos_theta_2);
+    const float tan_theta_2 = (1.0f - cos_theta_2) / cos_theta_2;
+
+    const float A =
+        stretched_roughness(
+            h,
+            sin_theta(h),
+            alpha_x,
+            alpha_y);
+
+    const float tmp = 1.0f + tan_theta_2 * A;
+    return 1.0f / (Pi<float>() * alpha_x * alpha_y * cos_theta_4 * square(tmp));
+}
+
+float GGXMDF::G(
+    const Vector3f&     incoming,
+    const Vector3f&     outgoing,
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return 1.0f / (1.0f + lambda(outgoing, alpha_x, alpha_y) + lambda(incoming, alpha_x, alpha_y));
+}
+
+float GGXMDF::G1(
+    const Vector3f&     v,
+    const Vector3f&     m,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y));
+}
+
+float GGXMDF::lambda(
+    const Vector3f&     v,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    const float cos_theta = std::abs(v.y);
+
+    if (cos_theta == 0.0f)
+        return 0.0f;
+
+    const float cos_theta_2 = square(cos_theta);
+    const float sin_theta = MDF::sin_theta(v);
+    const float tan_theta_2 = square(sin_theta) / cos_theta_2;
+
+    const float alpha =
+        projected_roughness(
+            v,
+            sin_theta,
+            alpha_x,
+            alpha_y);
+
+    const float a2_rcp = square(alpha) * tan_theta_2;
+    return (-1.0f + std::sqrt(1.0f + a2_rcp)) * 0.5f;
+}
+
+Vector3f GGXMDF::sample(
+    const Vector3f&     v,
+    const Vector3f&     s,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return
+        sample_visible_normals(
+            *this,
+            v,
+            s,
+            alpha_x,
+            alpha_y);
+}
+
+// Adapted from the sample code provided in [3].
+Vector2f GGXMDF::sample11(
+    const float         cos_theta,
+    const Vector3f&     s) const
+{
+    const float sin_theta = std::sqrt(1.0f - square(cos_theta));
+
+    // Special case (normal incidence).
+    if (sin_theta < 1.0e-4f)
+    {
+        const float r = std::sqrt(s[0] / (1.0f - s[0]));
+        const float cos_phi = std::cos(TwoPi<float>() * s[1]);
+        const float sin_phi = std::sin(TwoPi<float>() * s[1]);
+        return Vector2f(r * cos_phi, r * sin_phi);
+    }
+
+    Vector2f slope;
+
+    // Precomputations.
+    const float tan_theta = sin_theta / cos_theta;
+    const float tan_theta2 = square(tan_theta);
+    const float cot_theta = 1.0f / tan_theta;
+    const float G1 = 2.0f / (1.0f + std::sqrt(1.0f + tan_theta2));
+
+    // Sample slope x.
+    const float A = 2.0f * s[0] / G1 - 1.0f;
+    const float A2 = square(A);
+    const float rcp_A2_minus_one = std::min(1.0f / (A2 - 1.0f), 1.0e10f);
+    const float B = tan_theta;
+    const float B2 = square(B);
+    const float D = std::sqrt(std::max(B2 * square(rcp_A2_minus_one) - (A2 - B2) * rcp_A2_minus_one, 0.0f));
+    const float slope_x_1 = B * rcp_A2_minus_one - D;
+    const float slope_x_2 = B * rcp_A2_minus_one + D;
+    slope[0] =
+        A < 0.0f || slope_x_2 > cot_theta
+            ? slope_x_1
+            : slope_x_2;
+
+    // Sample slope y.
+    const float z =
+        (s[1] * (s[1] * (s[1] * 0.27385f - 0.73369f) + 0.46341f)) /
+        (s[1] * (s[1] * (s[1] * 0.093073f + 0.309420f) - 1.0f) + 0.597999f);
+    const float S = s[2] < 0.5f ? 1.0f : -1.0f;
+    slope[1] = S * z * std::sqrt(1.0f + square(slope[0]));
+
+    return slope;
+}
+
+float GGXMDF::pdf(
+    const Vector3f&     v,
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return pdf_visible_normals(*this, v, h, alpha_x, alpha_y);
+}
+
+//
+// WardMDF class implementation.
+//
+
+WardMDF::WardMDF()
+{
+}
+
+float WardMDF::D(
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    const float cos_theta = h.y;
+
+    assert(cos_theta >= 0.0f);
+
+    if (cos_theta == 0.0f)
+        return 0.0f;
+
+    const float cos_theta_2 = cos_theta * cos_theta;
+    const float cos_theta_3 = cos_theta * cos_theta_2;
+    const float tan_alpha_2 = (1.0f - cos_theta_2) / cos_theta_2;
+
+    const float alpha_x2 = square(alpha_x);
+    return std::exp(-tan_alpha_2 / alpha_x2) / (alpha_x2 * Pi<float>() * cos_theta_3);
+}
+
+float WardMDF::G(
+    const Vector3f&     incoming,
+    const Vector3f&     outgoing,
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return std::min(G1(incoming, h, alpha_x, alpha_y), G1(outgoing, h, alpha_x, alpha_y));
+}
+
+float WardMDF::G1(
+    const Vector3f&     v,
+    const Vector3f&     m,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    if (v.y <= 0.0f)
+        return 0.0f;
+
+    if (dot(v, m) <= 0.0f)
+        return 0.0f;
+
+    const float cos_vh = std::abs(dot(v, m));
+    if (cos_vh == 0.0f)
+        return 0.0f;
+
+    return std::min(1.0f, 2.0f * std::abs(m.y * v.y) / cos_vh);
+}
+
+Vector3f WardMDF::sample(
+    const Vector3f&     v,
+    const Vector3f&     s,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    const float tan_alpha_2 = square(alpha_x) * (-std::log(1.0f - s[0]));
+    const float cos_alpha = 1.0f / std::sqrt(1.0f + tan_alpha_2);
+    const float sin_alpha = cos_alpha * std::sqrt(tan_alpha_2);
+    const float phi = TwoPi<float>() * s[1];
+
+    return Vector3f::make_unit_vector(cos_alpha, sin_alpha, std::cos(phi), std::sin(phi));
+}
+
+float WardMDF::pdf(
+    const Vector3f&     v,
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return D(h, alpha_x, alpha_y);
+}
+
+//
+// GTR1MDF class implementation.
+//
+
+GTR1MDF::GTR1MDF() {}
+
+float GTR1MDF::D(
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    const float alpha_x_2 = square(alpha_x);
+    const float cos_theta_2 = square(h.y);
+    const float a = (alpha_x_2 - 1.0f) / (Pi<float>() * std::log(alpha_x_2));
+    const float b = (1.0f / (1.0f + (alpha_x_2 - 1.0f) * cos_theta_2));
+    return a * b;
+}
+
+float GTR1MDF::G(
+    const Vector3f&     incoming,
+    const Vector3f&     outgoing,
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return 1.0f / (1.0f + lambda(outgoing, alpha_x, alpha_y) + lambda(incoming, alpha_x, alpha_y));
+}
+
+float GTR1MDF::G1(
+    const Vector3f&     v,
+    const Vector3f&     m,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y));
+}
+
+float GTR1MDF::lambda(
+    const Vector3f&     v,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    const float cos_theta = std::abs(v.y);
+
+    if (cos_theta == 0.0f)
+        return 0.0f;
+
+    if (cos_theta == 1.0f)
+        return 1.0f;
+
+    // [2] section 3.2.
+    const float cos_theta_2 = square(cos_theta);
+    const float sin_theta = MDF::sin_theta(v);
+    const float cot_theta_2 = cos_theta_2 / square(sin_theta);
+    const float cot_theta = std::sqrt(cot_theta_2);
+    const float alpha_2 = square(alpha_x);
+
+    const float a = std::sqrt(cot_theta_2 + alpha_2);
+    const float b = std::sqrt(cot_theta_2 + 1.0f);
+    const float c = std::log(cot_theta + b);
+    const float d = std::log(cot_theta + a);
+
+    return (a - b + cot_theta * (c - d)) / (cot_theta * std::log(alpha_2));
+}
+
+Vector3f GTR1MDF::sample(
+    const Vector3f&     v,
+    const Vector3f&     s,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    const float alpha2 = square(alpha_x);
+    const float a = 1.0f - std::pow(alpha2, 1.0f - s[0]);
+    const float cos_theta = std::sqrt(a / (1.0f - alpha2));
+    const float sin_theta  = std::sqrt(1.0f - square(cos_theta));
+
+    float cos_phi, sin_phi;
+    sample_phi(s[1], cos_phi, sin_phi);
+    return Vector3f::make_unit_vector(cos_theta, sin_theta, cos_phi, sin_phi);
+}
+
+float GTR1MDF::pdf(
+    const Vector3f&     v,
+    const Vector3f&     h,
+    const float         alpha_x,
+    const float         alpha_y) const
+{
+    return D(h, alpha_x, alpha_y) * h.y;
 }
 
 }   // namespace foundation

--- a/src/appleseed/foundation/math/microfacet.h
+++ b/src/appleseed/foundation/math/microfacet.h
@@ -81,12 +81,6 @@ class MDF
         const Vector3f&     h,
         const float         alpha_x,
         const float         alpha_y) const = 0;
-
-  protected:
-    static float sin_theta(const Vector3f& v)
-    {
-        return std::sqrt(std::max(0.0f, 1.0f - square(v.y)));
-    }
 };
 
 

--- a/src/appleseed/foundation/math/microfacet.h
+++ b/src/appleseed/foundation/math/microfacet.h
@@ -47,187 +47,184 @@ namespace foundation
 // MDF: Base class for microfacet distribution functions.
 //
 
-template <typename T>
 class MDF
   : public NonCopyable
 {
   public:
-    typedef T ValueType;
-
     MDF() {}
 
-    virtual ~MDF() {}
+    virtual ~MDF();
 
-    virtual T D(
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const = 0;
+    virtual float D(
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const = 0;
 
-    virtual T G(
-        const Vector<T, 3>&     incoming,
-        const Vector<T, 3>&     outgoing,
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const = 0;
+    virtual float G(
+        const Vector3f&     incoming,
+        const Vector3f&     outgoing,
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const = 0;
 
-    virtual T G1(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     m,
-        const T                 alpha_x,
-        const T                 alpha_y) const = 0;
+    virtual float G1(
+        const Vector3f&     v,
+        const Vector3f&     m,
+        const float         alpha_x,
+        const float         alpha_y) const = 0;
 
-    virtual Vector<T, 3> sample(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     s,
-        const T                 alpha_x,
-        const T                 alpha_y) const = 0;
+    virtual Vector3f sample(
+        const Vector3f&     v,
+        const Vector3f&     s,
+        const float         alpha_x,
+        const float         alpha_y) const = 0;
 
-    virtual T pdf(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const = 0;
+    virtual float pdf(
+        const Vector3f&     v,
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const = 0;
 
   protected:
-    static T cos_theta(const Vector<T, 3>& v)
+    static float cos_theta(const Vector3f& v)
     {
         return v.y;
     }
 
-    static T sin_theta(const Vector<T, 3>& v)
+    static float sin_theta(const Vector3f& v)
     {
-        return std::sqrt(std::max(T(0.0), T(1.0) - square(cos_theta(v))));
+        return std::sqrt(std::max(0.0f, 1.0f - square(cos_theta(v))));
     }
 
     static void sample_phi(
-        const T                 s,
-        T&                      cos_phi,
-        T&                      sin_phi)
+        const float         s,
+        float&              cos_phi,
+        float&              sin_phi)
     {
-        const T phi = TwoPi<T>() * s;
+        const float phi = TwoPi<float>() * s;
         cos_phi = std::cos(phi);
         sin_phi = std::sin(phi);
     }
 
     static void sample_phi(
-        const T                 s,
-        const T                 alpha_x,
-        const T                 alpha_y,
-        T&                      cos_phi,
-        T&                      sin_phi)
+        const float         s,
+        const float         alpha_x,
+        const float         alpha_y,
+        float&              cos_phi,
+        float&              sin_phi)
     {
-        Vector<T, 2> sin_cos_phi(
-            std::cos(TwoPi<T>() * s) * alpha_x,
-            std::sin(TwoPi<T>() * s) * alpha_y);
+        Vector2f sin_cos_phi(
+            std::cos(TwoPi<float>() * s) * alpha_x,
+            std::sin(TwoPi<float>() * s) * alpha_y);
         sin_cos_phi = normalize(sin_cos_phi);
         cos_phi = sin_cos_phi[0];
         sin_phi = sin_cos_phi[1];
     }
 
-    static T stretched_roughness(
-        const Vector<T, 3>&     h,
-        const T                 sin_theta,
-        const T                 alpha_x,
-        const T                 alpha_y)
+    static float stretched_roughness(
+        const Vector3f&     h,
+        const float         sin_theta,
+        const float         alpha_x,
+        const float         alpha_y)
     {
-        if (alpha_x == alpha_y || sin_theta == T(0.0))
-            return T(1.0) / square(alpha_x);
+        if (alpha_x == alpha_y || sin_theta == 0.0f)
+            return 1.0f / square(alpha_x);
 
-        const T cos_phi_2_ax_2 = square(h.x / (sin_theta * alpha_x));
-        const T sin_phi_2_ay_2 = square(h.z / (sin_theta * alpha_y));
+        const float cos_phi_2_ax_2 = square(h.x / (sin_theta * alpha_x));
+        const float sin_phi_2_ay_2 = square(h.z / (sin_theta * alpha_y));
         return cos_phi_2_ax_2 + sin_phi_2_ay_2;
     }
 
-    static T projected_roughness(
-        const Vector<T, 3>&     h,
-        const T                 sin_theta,
-        const T                 alpha_x,
-        const T                 alpha_y)
+    static float projected_roughness(
+        const Vector3f&     h,
+        const float         sin_theta,
+        const float         alpha_x,
+        const float         alpha_y)
     {
-        if (alpha_x == alpha_y || sin_theta == T(0.0))
+        if (alpha_x == alpha_y || sin_theta == 0.0f)
             return alpha_x;
 
-        const T cos_phi_2_ax_2 = square((h.x * alpha_x) / sin_theta);
-        const T sin_phi_2_ay_2 = square((h.z * alpha_y) / sin_theta);
+        const float cos_phi_2_ax_2 = square((h.x * alpha_x) / sin_theta);
+        const float sin_phi_2_ay_2 = square((h.z * alpha_y) / sin_theta);
         return std::sqrt(cos_phi_2_ax_2 + sin_phi_2_ay_2);
     }
 
-    static Vector<T, 3> v_cavity_choose_microfacet_normal(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     h,
-        const T                 s)
+    static Vector3f v_cavity_choose_microfacet_normal(
+        const Vector3f&     v,
+        const Vector3f&     h,
+        const float         s)
     {
         // Preconditions.
         assert(is_normalized(v));
-        assert(v.y >= T(0.0));
+        assert(v.y >= 0.0f);
 
-        const Vector<T, 3> hm(-h[0], h[1], -h[2]);
-        const T dot_vh  = std::max(dot(v, h), T(0.0));
-        const T dot_vhm = std::max(dot(v, hm), T(0.0));
+        const Vector3f hm(-h[0], h[1], -h[2]);
+        const float dot_vh  = std::max(dot(v, h), 0.0f);
+        const float dot_vhm = std::max(dot(v, hm), 0.0f);
 
-        if (dot_vhm == T(0.0))
+        if (dot_vhm == 0.0f)
             return h;
 
-        const T w = dot_vhm / (dot_vh + dot_vhm);
+        const float w = dot_vhm / (dot_vh + dot_vhm);
         return s < w ? hm : h;
     }
 
     template <typename Distribution>
-    static Vector<T, 3> sample_visible_normals(
-        const Distribution&     mdf,
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     s,
-        const T                 alpha_x,
-        const T                 alpha_y)
+    static Vector3f sample_visible_normals(
+        const Distribution& mdf,
+        const Vector3f&     v,
+        const Vector3f&     s,
+        const float         alpha_x,
+        const float         alpha_y)
     {
         // Preconditions.
         assert(is_normalized(v));
 
         // Stretch incident.
-        const T sign_cos_vn = v.y < T(0.0) ? T(-1.0) : T(1.0);
-        Vector<T, 3> stretched(
+        const float sign_cos_vn = v.y < 0.0f ? -1.0f : 1.0f;
+        Vector3f stretched(
             sign_cos_vn * v[0] * alpha_x,
             sign_cos_vn * v[1],
             sign_cos_vn * v[2] * alpha_y);
 
         stretched = normalize(stretched);
 
-        const T cos_theta = stretched[1];
-        const T phi =
-            stretched[1] < T(0.99999) ? std::atan2(stretched[2], stretched[0]) : T(0.0);
+        const float cos_theta = stretched[1];
+        const float phi =
+            stretched[1] < 0.99999f ? std::atan2(stretched[2], stretched[0]) : 0.0f;
 
         // Sample slope.
-        Vector<T, 2> slope = mdf.sample11(cos_theta, s);
+        Vector2f slope = mdf.sample11(cos_theta, s);
 
         // Rotate.
-        const T cos_phi = std::cos(phi);
-        const T sin_phi = std::sin(phi);
-        slope = Vector<T, 2>(
+        const float cos_phi = std::cos(phi);
+        const float sin_phi = std::sin(phi);
+        slope = Vector2f(
             cos_phi * slope[0] - sin_phi * slope[1],
             sin_phi * slope[0] + cos_phi * slope[1]);
 
         // Stretch and normalize.
-        const Vector<T, 3> m(
+        const Vector3f m(
             -slope[0] * alpha_x,
-            T(1.0),
+            1.0f,
             -slope[1] * alpha_y);
         return normalize(m);
     }
 
     template <typename Distribution>
-    T pdf_visible_normals(
-        const Distribution&     mdf,
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const
+    static float pdf_visible_normals(
+        const Distribution& mdf,
+        const Vector3f&     v,
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y)
     {
         assert(is_normalized(v));
 
-        const T cos_theta_v = MDF<T>::cos_theta(v);
+        const float cos_theta_v = MDF::cos_theta(v);
 
-        if (cos_theta_v == T(0.0))
-            return T(0.0);
+        if (cos_theta_v == 0.0f)
+            return 0.0f;
 
         return
             mdf.G1(v, h, alpha_x, alpha_y) * std::abs(dot(v, h)) *
@@ -250,75 +247,74 @@ class MDF
 //   https://hal.inria.fr/hal-00996995/en
 //
 
-template <typename T>
 class BlinnMDF
-  : public MDF<T>
+  : public MDF
 {
   public:
     BlinnMDF() {}
 
-    virtual T D(
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float D(
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        return (alpha_x + T(2.0)) * RcpTwoPi<T>() * std::pow(MDF<T>::cos_theta(h), alpha_x);
+        return (alpha_x + 2.0f) * RcpTwoPi<float>() * std::pow(MDF::cos_theta(h), alpha_x);
     }
 
-    virtual T G(
-        const Vector<T, 3>&     incoming,
-        const Vector<T, 3>&     outgoing,
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float G(
+        const Vector3f&     incoming,
+        const Vector3f&     outgoing,
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
         return std::min(G1(incoming, h, alpha_x, alpha_y), G1(outgoing, h, alpha_x, alpha_y));
     }
 
-    T G1(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     m,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    float G1(
+        const Vector3f&     v,
+        const Vector3f&     m,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        if (v.y <= T(0.0))
-            return T(0.0);
+        if (v.y <= 0.0f)
+            return 0.0f;
 
-        if (dot(v, m) <= T(0.0))
-            return T(0.0);
+        if (dot(v, m) <= 0.0f)
+            return 0.0f;
 
-        const T cos_vh = std::abs(dot(v, m));
-        if (cos_vh == T(0.0))
-            return T(0.0);
+        const float cos_vh = std::abs(dot(v, m));
+        if (cos_vh == 0.0f)
+            return 0.0f;
 
-        return std::min(T(1.0), T(2.0) * std::abs(m.y * v.y) / cos_vh);
+        return std::min(1.0f, 2.0f * std::abs(m.y * v.y) / cos_vh);
     }
 
-    virtual Vector<T, 3> sample(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     s,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual Vector3f sample(
+        const Vector3f&     v,
+        const Vector3f&     s,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        const T cos_theta = std::pow(T(1.0) - s[0], T(1.0) / (alpha_x + T(2.0)));
-        const T sin_theta = std::sqrt(T(1.0) - cos_theta * cos_theta);
+        const float cos_theta = std::pow(1.0f - s[0], 1.0f / (alpha_x + 2.0f));
+        const float sin_theta = std::sqrt(1.0f - cos_theta * cos_theta);
 
-        T cos_phi, sin_phi;
-        MDF<T>::sample_phi(s[1], cos_phi, sin_phi);
+        float cos_phi, sin_phi;
+        MDF::sample_phi(s[1], cos_phi, sin_phi);
 
-        const Vector<T, 3> h =
-            Vector<T, 3>::make_unit_vector(cos_theta, sin_theta, cos_phi, sin_phi);
+        const Vector3f h =
+            Vector3f::make_unit_vector(cos_theta, sin_theta, cos_phi, sin_phi);
 
-        return MDF<T>::v_cavity_choose_microfacet_normal(v, h, s[2]);
+        return MDF::v_cavity_choose_microfacet_normal(v, h, s[2]);
     }
 
-    virtual T pdf(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float pdf(
+        const Vector3f&     v,
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        return MDF<T>::pdf_visible_normals(*this, v, h, alpha_x, alpha_y);
+        return MDF::pdf_visible_normals(*this, v, h, alpha_x, alpha_y);
     }
 };
 
@@ -346,94 +342,93 @@ class BlinnMDF
 //       http://www.mitsuba-renderer.org/~wenzel/files/visnormal.pdf
 //
 
-template <typename T>
 class BeckmannMDF
-  : public MDF<T>
+  : public MDF
 {
   public:
     BeckmannMDF() {}
 
-    virtual T D(
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float D(
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        const T cos_theta = MDF<T>::cos_theta(h);
+        const float cos_theta = MDF::cos_theta(h);
 
-        if (cos_theta == T(0.0))
-            return T(0.0);
+        if (cos_theta == 0.0f)
+            return 0.0f;
 
-        const T cos_theta_2 = square(cos_theta);
-        const T cos_theta_4 = square(cos_theta_2);
-        const T tan_theta_2 = (T(1.0) - cos_theta_2) / cos_theta_2;
+        const float cos_theta_2 = square(cos_theta);
+        const float cos_theta_4 = square(cos_theta_2);
+        const float tan_theta_2 = (1.0f - cos_theta_2) / cos_theta_2;
 
-        const T A = MDF<T>::stretched_roughness(
+        const float A = MDF::stretched_roughness(
             h,
-            MDF<T>::sin_theta(h),
+            MDF::sin_theta(h),
             alpha_x,
             alpha_y);
 
-        return std::exp(-tan_theta_2 * A) / (Pi<T>() * alpha_x * alpha_y * cos_theta_4);
+        return std::exp(-tan_theta_2 * A) / (Pi<float>() * alpha_x * alpha_y * cos_theta_4);
     }
 
-    virtual T G(
-        const Vector<T, 3>&     incoming,
-        const Vector<T, 3>&     outgoing,
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float G(
+        const Vector3f&     incoming,
+        const Vector3f&     outgoing,
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        return T(1.0) / (T(1.0) + lambda(outgoing, alpha_x, alpha_y) + lambda(incoming, alpha_x, alpha_y));
+        return 1.0f / (1.0f + lambda(outgoing, alpha_x, alpha_y) + lambda(incoming, alpha_x, alpha_y));
     }
 
-    virtual T G1(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     m,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float G1(
+        const Vector3f&     v,
+        const Vector3f&     m,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        return T(1.0) / (T(1.0) + lambda(v, alpha_x, alpha_y));
+        return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y));
     }
 
-    T lambda(
-        const Vector<T, 3>&     v,
-        const T                 alpha_x,
-        const T                 alpha_y) const
+    float lambda(
+        const Vector3f&     v,
+        const float         alpha_x,
+        const float         alpha_y) const
     {
-        const T cos_theta = MDF<T>::cos_theta(v);
+        const float cos_theta = MDF::cos_theta(v);
 
-        if (cos_theta == T(0.0))
-            return T(0.0);
+        if (cos_theta == 0.0f)
+            return 0.0f;
 
-        const T sin_theta = MDF<T>::sin_theta(v);
+        const float sin_theta = MDF::sin_theta(v);
 
-        const T alpha =
-            MDF<T>::projected_roughness(
+        const float alpha =
+            MDF::projected_roughness(
                 v,
                 sin_theta,
                 alpha_x,
                 alpha_y);
 
-        const T tan_theta = std::abs(sin_theta / cos_theta);
-        const T a = T(1.0) / (alpha * tan_theta);
+        const float tan_theta = std::abs(sin_theta / cos_theta);
+        const float a = 1.0f / (alpha * tan_theta);
 
-        if (a < T(1.6))
+        if (a < 1.6f)
         {
-            const T a2 = square(a);
-            return (T(1.0) - T(1.259) * a + T(0.396) * a2) / (T(3.535) * a + T(2.181) * a2);
+            const float a2 = square(a);
+            return (1.0f - 1.259f * a + 0.396f * a2) / (3.535f * a + 2.181f * a2);
         }
 
-        return T(0.0);
+        return 0.0f;
     }
 
-    virtual Vector<T, 3> sample(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     s,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual Vector3f sample(
+        const Vector3f&     v,
+        const Vector3f&     s,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
         return
-            MDF<T>::sample_visible_normals(
+            MDF::sample_visible_normals(
                 *this,
                 v,
                 s,
@@ -442,41 +437,41 @@ class BeckmannMDF
     }
 
     // This code comes from OpenShadingLanguage test render.
-    Vector<T, 2> sample11(
-        const T                 cos_theta,
-        const Vector<T, 3>&     s) const
+    Vector2f sample11(
+        const float         cos_theta,
+        const Vector3f&     s) const
     {
-        const T ct = std::max(cos_theta, T(1.0e-6));
-        const T tan_theta = std::sqrt(T(1.0) - square(ct)) / ct;
-        const T cot_theta = T(1.0) / tan_theta;
+        const float ct = std::max(cos_theta, 1.0e-6f);
+        const float tan_theta = std::sqrt(1.0f - square(ct)) / ct;
+        const float cot_theta = 1.0f / tan_theta;
 
         // Sample slope X:
         // compute a coarse approximation using the approximation:
         // exp(-ierf(x)^2) ~= 1 - x * x
         // solve y = 1 + b + K * (1 - b * b).
 
-        const T c = erf(cot_theta);
-        const T K = tan_theta / SqrtPi<T>();
-        const T y_approx = s[0] * (T(1.0) + c + K * (1 - c * c));
-        const T y_exact  = s[0] * (T(1.0) + c + K * std::exp(-square(cot_theta)));
-        T b = K > T(0.0)
-            ? (T(0.5) - std::sqrt(K * (K - y_approx + T(1.0)) + T(0.25))) / K
-            : y_approx - T(1.0);
+        const float c = erf(cot_theta);
+        const float K = tan_theta / SqrtPi<float>();
+        const float y_approx = s[0] * (1.0f + c + K * (1 - c * c));
+        const float y_exact  = s[0] * (1.0f + c + K * std::exp(-square(cot_theta)));
+        float b = K > 0.0f
+            ? (0.5f - std::sqrt(K * (K - y_approx + 1.0f) + 0.25f)) / K
+            : y_approx - 1.0f;
 
         // Perform a Newton step to refine toward the true root.
-        T inv_erf = erf_inv(b);
-        T value = T(1.0) + b + K * std::exp(-square(inv_erf)) - y_exact;
+        float inv_erf = erf_inv(b);
+        float value = 1.0f + b + K * std::exp(-square(inv_erf)) - y_exact;
 
         // Check if we are close enough already.
         // This also avoids NaNs as we get close to the root.
-        Vector<T, 2> slope;
+        Vector2f slope;
 
-        if (std::abs(value) > T(1.0e-6))
+        if (std::abs(value) > 1.0e-6f)
         {
-            b -= value / (T(1.0) - inv_erf * tan_theta); // newton step 1
+            b -= value / (1.0f - inv_erf * tan_theta); // newton step 1
             inv_erf = erf_inv(b);
-            value = T(1.0) + b + K * std::exp(-square(inv_erf)) - y_exact;
-            b -= value / (T(1.0) - inv_erf * tan_theta); // newton step 2
+            value = 1.0f + b + K * std::exp(-square(inv_erf)) - y_exact;
+            b -= value / (1.0f - inv_erf * tan_theta); // newton step 2
             // Compute the slope from the refined value.
             slope[0] = erf_inv(b);
         }
@@ -484,17 +479,17 @@ class BeckmannMDF
             slope[0] = inv_erf;
 
         // Sample slope Y.
-        slope[1] = erf_inv(T(2.0) * s[1] - T(1.0));
+        slope[1] = erf_inv(2.0f * s[1] - 1.0f);
         return slope;
     }
 
-    virtual T pdf(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float pdf(
+        const Vector3f&     v,
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        return MDF<T>::pdf_visible_normals(*this, v, h, alpha_x, alpha_y);
+        return MDF::pdf_visible_normals(*this, v, h, alpha_x, alpha_y);
     }
 
   private:
@@ -509,21 +504,21 @@ class BeckmannMDF
     // Copied from from pbrt-v3.
     //
 
-    inline T erf(const T x) const
+    inline float erf(const float x) const
     {
         // Constants.
-        const T a1 = T(0.254829592);
-        const T a2 = T(-0.284496736);
-        const T a3 = T(1.421413741);
-        const T a4 = T(-1.453152027);
-        const T a5 = T(1.061405429);
-        const T p = T(0.3275911);
+        const float a1 = 0.254829592f;
+        const float a2 = -0.284496736f;
+        const float a3 = 1.421413741f;
+        const float a4 = -1.453152027f;
+        const float a5 = 1.061405429f;
+        const float p  = 0.3275911f;
 
         // A&S formula 7.1.26.
-        const T abs_x = std::abs(x);
-        const T t = T(1.0) / (T(1.0) + p * abs_x);
-        const T y = T(1.0) - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * std::exp(-square(abs_x * abs_x));
-        return x < T(0.0) ? -y : y;
+        const float abs_x = std::abs(x);
+        const float t = 1.0f / (1.0f + p * abs_x);
+        const float y = 1.0f - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * std::exp(-square(abs_x * abs_x));
+        return x < 0.0f ? -y : y;
     }
 
     //
@@ -533,37 +528,37 @@ class BeckmannMDF
     //   https://people.maths.ox.ac.uk/gilesm/files/gems_erfinv.pdf
     //
 
-    inline T erf_inv(const T x) const
+    inline float erf_inv(const float x) const
     {
-        const T y = clamp(x, T(-0.99999), T(0.99999));
-        T w = -std::log((1 - y) * (1 + y));
-        T p;
+        const float y = clamp(x, -0.99999f, 0.99999f);
+        float w = -std::log((1 - y) * (1 + y));
+        float p;
 
-        if (w < T(5.0))
+        if (w < 5.0f)
         {
-            w = w - T(2.5);
-            p = T(2.81022636e-08);
-            p = T(3.43273939e-07) + p * w;
-            p = T(-3.5233877e-06) + p * w;
-            p = T(-4.39150654e-06) + p * w;
-            p = T(0.00021858087) + p * w;
-            p = T(-0.00125372503) + p * w;
-            p = T(-0.00417768164) + p * w;
-            p = T(0.246640727) + p * w;
-            p = T(1.50140941) + p * w;
+            w = w - 2.5f;
+            p = 2.81022636e-08f;
+            p = 3.43273939e-07f + p * w;
+            p = -3.5233877e-06f + p * w;
+            p = -4.39150654e-06f + p * w;
+            p = 0.00021858087f + p * w;
+            p = -0.00125372503f + p * w;
+            p = -0.00417768164f + p * w;
+            p = 0.246640727f + p * w;
+            p = 1.50140941f + p * w;
         }
         else
         {
-            w = std::sqrt(w) - T(3.0);
-            p = T(-0.000200214257);
-            p = T(0.000100950558) + p * w;
-            p = T(0.00134934322) + p * w;
-            p = T(-0.00367342844) + p * w;
-            p = T(0.00573950773) + p * w;
-            p = T(-0.0076224613) + p * w;
-            p = T(0.00943887047) + p * w;
-            p = T(1.00167406) + p * w;
-            p = T(2.83297682) + p * w;
+            w = std::sqrt(w) - 3.0f;
+            p = -0.000200214257f;
+            p = 0.000100950558f + p * w;
+            p = 0.00134934322f + p * w;
+            p = -0.00367342844f + p * w;
+            p = 0.00573950773f + p * w;
+            p = -0.0076224613f + p * w;
+            p = 0.00943887047f + p * w;
+            p = 1.00167406f + p * w;
+            p = 2.83297682f + p * w;
         }
 
         return p * y;
@@ -586,90 +581,89 @@ class BeckmannMDF
 //       https://hal.inria.fr/hal-00996995/en
 //
 
-template <typename T>
 class GGXMDF
-  : public MDF<T>
+  : public MDF
 {
   public:
     GGXMDF() {}
 
-    virtual T D(
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float D(
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        const T cos_theta = MDF<T>::cos_theta(h);
+        const float cos_theta = MDF::cos_theta(h);
 
-        if (cos_theta == T(0.0))
-            return square(alpha_x) * RcpPi<T>();
+        if (cos_theta == 0.0f)
+            return square(alpha_x) * RcpPi<float>();
 
-        const T cos_theta_2 = square(cos_theta);
-        const T cos_theta_4 = square(cos_theta_2);
-        const T tan_theta_2 = (T(1.0) - cos_theta_2) / cos_theta_2;
+        const float cos_theta_2 = square(cos_theta);
+        const float cos_theta_4 = square(cos_theta_2);
+        const float tan_theta_2 = (1.0f - cos_theta_2) / cos_theta_2;
 
-        const T A =
-            MDF<T>::stretched_roughness(
+        const float A =
+            MDF::stretched_roughness(
                 h,
-                MDF<T>::sin_theta(h),
+                MDF::sin_theta(h),
                 alpha_x,
                 alpha_y);
 
-        const T tmp = T(1.0) + tan_theta_2 * A;
-        return T(1.0) / (Pi<T>() * alpha_x * alpha_y * cos_theta_4 * square(tmp));
+        const float tmp = 1.0f + tan_theta_2 * A;
+        return 1.0f / (Pi<float>() * alpha_x * alpha_y * cos_theta_4 * square(tmp));
     }
 
-    virtual T G(
-        const Vector<T, 3>&     incoming,
-        const Vector<T, 3>&     outgoing,
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float G(
+        const Vector3f&     incoming,
+        const Vector3f&     outgoing,
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        return T(1.0) / (T(1.0) + lambda(outgoing, alpha_x, alpha_y) + lambda(incoming, alpha_x, alpha_y));
+        return 1.0f / (1.0f + lambda(outgoing, alpha_x, alpha_y) + lambda(incoming, alpha_x, alpha_y));
     }
 
-    virtual T G1(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     m,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float G1(
+        const Vector3f&     v,
+        const Vector3f&     m,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        return T(1.0) / (T(1.0) + lambda(v, alpha_x, alpha_y));
+        return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y));
     }
 
-    T lambda(
-        const Vector<T, 3>&     v,
-        const T                 alpha_x,
-        const T                 alpha_y) const
+    float lambda(
+        const Vector3f&     v,
+        const float         alpha_x,
+        const float         alpha_y) const
     {
-        const T cos_theta = std::abs(v.y);
+        const float cos_theta = std::abs(v.y);
 
-        if (cos_theta == T(0.0))
-            return T(0.0);
+        if (cos_theta == 0.0f)
+            return 0.0f;
 
-        const T cos_theta_2 = square(cos_theta);
-        const T sin_theta = MDF<T>::sin_theta(v);
-        const T tan_theta_2 = square(sin_theta) / cos_theta_2;
+        const float cos_theta_2 = square(cos_theta);
+        const float sin_theta = MDF::sin_theta(v);
+        const float tan_theta_2 = square(sin_theta) / cos_theta_2;
 
-        const T alpha =
-            MDF<T>::projected_roughness(
+        const float alpha =
+            MDF::projected_roughness(
                 v,
                 sin_theta,
                 alpha_x,
                 alpha_y);
 
-        const T a2_rcp = square(alpha) * tan_theta_2;
-        return (T(-1.0) + std::sqrt(T(1.0) + a2_rcp)) * T(0.5);
+        const float a2_rcp = square(alpha) * tan_theta_2;
+        return (-1.0f + std::sqrt(1.0f + a2_rcp)) * 0.5f;
     }
 
-    virtual Vector<T, 3> sample(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     s,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual Vector3f sample(
+        const Vector3f&     v,
+        const Vector3f&     s,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
         return
-            MDF<T>::sample_visible_normals(
+            MDF::sample_visible_normals(
                 *this,
                 v,
                 s,
@@ -678,60 +672,60 @@ class GGXMDF
     }
 
     // Adapted from the sample code provided in [3].
-    Vector<T, 2> sample11(
-        const T                 cos_theta,
-        const Vector<T, 3>&     s) const
+    Vector2f sample11(
+        const float         cos_theta,
+        const Vector3f&     s) const
     {
-        const T sin_theta = std::sqrt(T(1.0) - square(cos_theta));
+        const float sin_theta = std::sqrt(1.0f - square(cos_theta));
 
         // Special case (normal incidence).
-        if (sin_theta < T(1.0e-4))
+        if (sin_theta < 1.0e-4f)
         {
-            const T r = std::sqrt(s[0] / (T(1.0) - s[0]));
-            const T cos_phi = std::cos(TwoPi<T>() * s[1]);
-            const T sin_phi = std::sin(TwoPi<T>() * s[1]);
-            return Vector<T, 2>(r * cos_phi, r * sin_phi);
+            const float r = std::sqrt(s[0] / (1.0f - s[0]));
+            const float cos_phi = std::cos(TwoPi<float>() * s[1]);
+            const float sin_phi = std::sin(TwoPi<float>() * s[1]);
+            return Vector2f(r * cos_phi, r * sin_phi);
         }
 
-        Vector<T, 2> slope;
+        Vector2f slope;
 
         // Precomputations.
-        const T tan_theta = sin_theta / cos_theta;
-        const T tan_theta2 = square(tan_theta);
-        const T cot_theta = T(1.0) / tan_theta;
-        const T G1 = T(2.0) / (T(1.0) + std::sqrt(T(1.0) + tan_theta2));
+        const float tan_theta = sin_theta / cos_theta;
+        const float tan_theta2 = square(tan_theta);
+        const float cot_theta = 1.0f / tan_theta;
+        const float G1 = 2.0f / (1.0f + std::sqrt(1.0f + tan_theta2));
 
         // Sample slope x.
-        const T A = T(2.0) * s[0] / G1 - T(1.0);
-        const T A2 = square(A);
-        const T rcp_A2_minus_one = std::min(T(1.0) / (A2 - T(1.0)), T(1.0e10));
-        const T B = tan_theta;
-        const T B2 = square(B);
-        const T D = std::sqrt(std::max(B2 * square(rcp_A2_minus_one) - (A2 - B2) * rcp_A2_minus_one, T(0.0)));
-        const T slope_x_1 = B * rcp_A2_minus_one - D;
-        const T slope_x_2 = B * rcp_A2_minus_one + D;
+        const float A = 2.0f * s[0] / G1 - 1.0f;
+        const float A2 = square(A);
+        const float rcp_A2_minus_one = std::min(1.0f / (A2 - 1.0f), 1.0e10f);
+        const float B = tan_theta;
+        const float B2 = square(B);
+        const float D = std::sqrt(std::max(B2 * square(rcp_A2_minus_one) - (A2 - B2) * rcp_A2_minus_one, 0.0f));
+        const float slope_x_1 = B * rcp_A2_minus_one - D;
+        const float slope_x_2 = B * rcp_A2_minus_one + D;
         slope[0] =
-            A < T(0.0) || slope_x_2 > cot_theta
+            A < 0.0f || slope_x_2 > cot_theta
                 ? slope_x_1
                 : slope_x_2;
 
         // Sample slope y.
-        const T z =
-            (s[1] * (s[1] * (s[1] * T(0.27385) - T(0.73369)) + T(0.46341))) /
-            (s[1] * (s[1] * (s[1] * T(0.093073) + T(0.309420)) - T(1.0)) + T(0.597999));
-        const T S = s[2] < T(0.5) ? T(1.0) : T(-1.0);
-        slope[1] = S * z * std::sqrt(T(1.0) + square(slope[0]));
+        const float z =
+            (s[1] * (s[1] * (s[1] * 0.27385f - 0.73369f) + 0.46341f)) /
+            (s[1] * (s[1] * (s[1] * 0.093073f + 0.309420f) - 1.0f) + 0.597999f);
+        const float S = s[2] < 0.5f ? 1.0f : -1.0f;
+        slope[1] = S * z * std::sqrt(1.0f + square(slope[0]));
 
         return slope;
     }
 
-    virtual T pdf(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float pdf(
+        const Vector3f&     v,
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        return MDF<T>::pdf_visible_normals(*this, v, h, alpha_x, alpha_y);
+        return MDF::pdf_visible_normals(*this, v, h, alpha_x, alpha_y);
     }
 };
 
@@ -747,81 +741,80 @@ class GGXMDF
 // Note: not a true MDF as it integrates to values less than 1!
 //
 
-template <typename T>
 class WardMDF
-  : public MDF<T>
+  : public MDF
 {
   public:
     WardMDF() {}
 
-    virtual T D(
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float D(
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        const T cos_theta = MDF<T>::cos_theta(h);
+        const float cos_theta = MDF::cos_theta(h);
 
-        assert(cos_theta >= T(0.0));
+        assert(cos_theta >= 0.0f);
 
-        if (cos_theta == T(0.0))
-            return T(0.0);
+        if (cos_theta == 0.0f)
+            return 0.0f;
 
-        const T cos_theta_2 = cos_theta * cos_theta;
-        const T cos_theta_3 = cos_theta * cos_theta_2;
-        const T tan_alpha_2 = (T(1.0) - cos_theta_2) / cos_theta_2;
+        const float cos_theta_2 = cos_theta * cos_theta;
+        const float cos_theta_3 = cos_theta * cos_theta_2;
+        const float tan_alpha_2 = (1.0f - cos_theta_2) / cos_theta_2;
 
-        const T alpha_x2 = square(alpha_x);
-        return std::exp(-tan_alpha_2 / alpha_x2) / (alpha_x2 * Pi<T>() * cos_theta_3);
+        const float alpha_x2 = square(alpha_x);
+        return std::exp(-tan_alpha_2 / alpha_x2) / (alpha_x2 * Pi<float>() * cos_theta_3);
     }
 
-    virtual T G(
-        const Vector<T, 3>&     incoming,
-        const Vector<T, 3>&     outgoing,
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float G(
+        const Vector3f&     incoming,
+        const Vector3f&     outgoing,
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
         return std::min(G1(incoming, h, alpha_x, alpha_y), G1(outgoing, h, alpha_x, alpha_y));
     }
 
-    virtual T G1(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     m,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float G1(
+        const Vector3f&     v,
+        const Vector3f&     m,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        if (v.y <= T(0.0))
-            return T(0.0);
+        if (v.y <= 0.0f)
+            return 0.0f;
 
-        if (dot(v, m) <= T(0.0))
-            return T(0.0);
+        if (dot(v, m) <= 0.0f)
+            return 0.0f;
 
-        const T cos_vh = std::abs(dot(v, m));
-        if (cos_vh == T(0.0))
-            return T(0.0);
+        const float cos_vh = std::abs(dot(v, m));
+        if (cos_vh == 0.0f)
+            return 0.0f;
 
-        return std::min(T(1.0), T(2.0) * std::abs(m.y * v.y) / cos_vh);
+        return std::min(1.0f, 2.0f * std::abs(m.y * v.y) / cos_vh);
     }
 
-    virtual Vector<T, 3> sample(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     s,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual Vector3f sample(
+        const Vector3f&     v,
+        const Vector3f&     s,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        const T tan_alpha_2 = square(alpha_x) * (-std::log(T(1.0) - s[0]));
-        const T cos_alpha = T(1.0) / std::sqrt(T(1.0) + tan_alpha_2);
-        const T sin_alpha = cos_alpha * std::sqrt(tan_alpha_2);
-        const T phi = TwoPi<T>() * s[1];
+        const float tan_alpha_2 = square(alpha_x) * (-std::log(1.0f - s[0]));
+        const float cos_alpha = 1.0f / std::sqrt(1.0f + tan_alpha_2);
+        const float sin_alpha = cos_alpha * std::sqrt(tan_alpha_2);
+        const float phi = TwoPi<float>() * s[1];
 
-        return Vector<T, 3>::make_unit_vector(cos_alpha, sin_alpha, std::cos(phi), std::sin(phi));
+        return Vector3f::make_unit_vector(cos_alpha, sin_alpha, std::cos(phi), std::sin(phi));
     }
 
-    virtual T pdf(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float pdf(
+        const Vector3f&     v,
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
         return D(h, alpha_x, alpha_y);
     }
@@ -840,95 +833,94 @@ class WardMDF
 //       https://docs.chaosgroup.com/download/attachments/7147732/gtr_shadowing.pdf?version=2&modificationDate=1434539612000&api=v2
 //
 
-template <typename T>
 class GTR1MDF
-  : public MDF<T>
+  : public MDF
 {
   public:
     GTR1MDF() {}
 
-    virtual T D(
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float D(
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        const T alpha_x_2 = square(alpha_x);
-        const T cos_theta_2 = square(MDF<T>::cos_theta(h));
-        const T a = (alpha_x_2 - T(1.0)) / (Pi<T>() * std::log(alpha_x_2));
-        const T b = (T(1.0) / (T(1.0) + (alpha_x_2 - T(1.0)) * cos_theta_2));
+        const float alpha_x_2 = square(alpha_x);
+        const float cos_theta_2 = square(MDF::cos_theta(h));
+        const float a = (alpha_x_2 - 1.0f) / (Pi<float>() * std::log(alpha_x_2));
+        const float b = (1.0f / (1.0f + (alpha_x_2 - 1.0f) * cos_theta_2));
         return a * b;
     }
 
-    virtual T G(
-        const Vector<T, 3>&     incoming,
-        const Vector<T, 3>&     outgoing,
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float G(
+        const Vector3f&     incoming,
+        const Vector3f&     outgoing,
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        return T(1.0) / (T(1.0) + lambda(outgoing, alpha_x, alpha_y) + lambda(incoming, alpha_x, alpha_y));
+        return 1.0f / (1.0f + lambda(outgoing, alpha_x, alpha_y) + lambda(incoming, alpha_x, alpha_y));
     }
 
-    virtual T G1(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     m,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float G1(
+        const Vector3f&     v,
+        const Vector3f&     m,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        return T(1.0) / (T(1.0) + lambda(v, alpha_x, alpha_y));
+        return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y));
     }
 
-    T lambda(
-        const Vector<T, 3>&     v,
-        const T                 alpha_x,
-        const T                 alpha_y) const
+    float lambda(
+        const Vector3f&     v,
+        const float         alpha_x,
+        const float         alpha_y) const
     {
-        const T cos_theta = std::abs(v.y);
+        const float cos_theta = std::abs(v.y);
 
-        if (cos_theta == T(0.0))
-            return T(0.0);
+        if (cos_theta == 0.0f)
+            return 0.0f;
 
-        if (cos_theta == T(1.0))
-            return T(1.0);
+        if (cos_theta == 1.0f)
+            return 1.0f;
 
         // [2] section 3.2.
-        const T cos_theta_2 = square(cos_theta);
-        const T sin_theta = MDF<T>::sin_theta(v);
-        const T cot_theta_2 = cos_theta_2 / square(sin_theta);
-        const T cot_theta = std::sqrt(cot_theta_2);
-        const T alpha_2 = square(alpha_x);
+        const float cos_theta_2 = square(cos_theta);
+        const float sin_theta = MDF::sin_theta(v);
+        const float cot_theta_2 = cos_theta_2 / square(sin_theta);
+        const float cot_theta = std::sqrt(cot_theta_2);
+        const float alpha_2 = square(alpha_x);
 
-        const T a = std::sqrt(cot_theta_2 + alpha_2);
-        const T b = std::sqrt(cot_theta_2 + T(1.0));
-        const T c = std::log(cot_theta + b);
-        const T d = std::log(cot_theta + a);
+        const float a = std::sqrt(cot_theta_2 + alpha_2);
+        const float b = std::sqrt(cot_theta_2 + 1.0f);
+        const float c = std::log(cot_theta + b);
+        const float d = std::log(cot_theta + a);
 
         return (a - b + cot_theta * (c - d)) / (cot_theta * std::log(alpha_2));
     }
 
-    virtual Vector<T, 3> sample(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     s,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual Vector3f sample(
+        const Vector3f&     v,
+        const Vector3f&     s,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        const T alpha2 = square(alpha_x);
-        const T a = T(1.0) - std::pow(alpha2, T(1.0) - s[0]);
-        const T cos_theta = std::sqrt(a / (T(1.0) - alpha2));
-        const T sin_theta  = std::sqrt(T(1.0) - square(cos_theta));
+        const float alpha2 = square(alpha_x);
+        const float a = 1.0f - std::pow(alpha2, 1.0f - s[0]);
+        const float cos_theta = std::sqrt(a / (1.0f - alpha2));
+        const float sin_theta  = std::sqrt(1.0f - square(cos_theta));
 
-        T cos_phi, sin_phi;
-        MDF<T>::sample_phi(s[1], cos_phi, sin_phi);
-        return Vector<T, 3>::make_unit_vector(cos_theta, sin_theta, cos_phi, sin_phi);
+        float cos_phi, sin_phi;
+        MDF::sample_phi(s[1], cos_phi, sin_phi);
+        return Vector3f::make_unit_vector(cos_theta, sin_theta, cos_phi, sin_phi);
     }
 
-    virtual T pdf(
-        const Vector<T, 3>&     v,
-        const Vector<T, 3>&     h,
-        const T                 alpha_x,
-        const T                 alpha_y) const APPLESEED_OVERRIDE
+    virtual float pdf(
+        const Vector3f&     v,
+        const Vector3f&     h,
+        const float         alpha_x,
+        const float         alpha_y) const APPLESEED_OVERRIDE
     {
-        return D(h, alpha_x, alpha_y) * MDF<T>::cos_theta(h);
+        return D(h, alpha_x, alpha_y) * MDF::cos_theta(h);
     }
 };
 

--- a/src/appleseed/foundation/math/microfacet.h
+++ b/src/appleseed/foundation/math/microfacet.h
@@ -55,32 +55,37 @@ class MDF
     virtual float D(
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const = 0;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const = 0;
 
     virtual float G(
         const Vector3f&     incoming,
         const Vector3f&     outgoing,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const = 0;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const = 0;
 
     virtual float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y) const = 0;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const = 0;
 
     virtual Vector3f sample(
         const Vector3f&     v,
         const Vector3f&     s,
         const float         alpha_x,
-        const float         alpha_y) const = 0;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const = 0;
 
     virtual float pdf(
         const Vector3f&     v,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const = 0;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const = 0;
 };
 
 
@@ -107,32 +112,37 @@ class BlinnMDF
     virtual float D(
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual float G(
         const Vector3f&     incoming,
         const Vector3f&     outgoing,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual Vector3f sample(
         const Vector3f&     v,
         const Vector3f&     s,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual float pdf(
         const Vector3f&     v,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 };
 
 
@@ -168,42 +178,48 @@ class BeckmannMDF
     virtual float D(
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual float G(
         const Vector3f&     incoming,
         const Vector3f&     outgoing,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
-
-    float lambda(
-        const Vector3f&     v,
-        const float         alpha_x,
-        const float         alpha_y) const;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual Vector3f sample(
         const Vector3f&     v,
         const Vector3f&     s,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
-
-    // This code comes from OpenShadingLanguage test render.
-    Vector2f sample11(
-        const float         cos_theta,
-        const Vector3f&     s) const;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual float pdf(
         const Vector3f&     v,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
+
+    Vector2f sample11(
+        const float         cos_theta,
+        const Vector3f&     s,
+        const float         gamma) const;
+
+    float lambda(
+        const Vector3f&     v,
+        const float         alpha_x,
+        const float         alpha_y,
+        const float         gamma) const;
 };
 
 
@@ -231,42 +247,48 @@ class GGXMDF
     virtual float D(
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual float G(
         const Vector3f&     incoming,
         const Vector3f&     outgoing,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
-
-    float lambda(
-        const Vector3f&     v,
-        const float         alpha_x,
-        const float         alpha_y) const;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual Vector3f sample(
         const Vector3f&     v,
         const Vector3f&     s,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
-
-    // Adapted from the sample code provided in [3].
-    Vector2f sample11(
-        const float         cos_theta,
-        const Vector3f&     s) const;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual float pdf(
         const Vector3f&     v,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
+
+    Vector2f sample11(
+        const float         cos_theta,
+        const Vector3f&     s,
+        const float         gamma) const;
+
+    float lambda(
+        const Vector3f&     v,
+        const float         alpha_x,
+        const float         alpha_y,
+        const float         gamma) const;
 };
 
 
@@ -290,32 +312,37 @@ class WardMDF
     virtual float D(
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual float G(
         const Vector3f&     incoming,
         const Vector3f&     outgoing,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual Vector3f sample(
         const Vector3f&     v,
         const Vector3f&     s,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual float pdf(
         const Vector3f&     v,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 };
 
 
@@ -340,37 +367,44 @@ class GTR1MDF
     virtual float D(
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual float G(
         const Vector3f&     incoming,
         const Vector3f&     outgoing,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
-
-    float lambda(
-        const Vector3f&     v,
-        const float         alpha_x,
-        const float         alpha_y) const;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual Vector3f sample(
         const Vector3f&     v,
         const Vector3f&     s,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
 
     virtual float pdf(
         const Vector3f&     v,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE;
+        const float         alpha_y,
+        const float         gamma = 0.0f) const APPLESEED_OVERRIDE;
+
+  private:
+    float lambda(
+        const Vector3f&     v,
+        const float         alpha_x,
+        const float         alpha_y,
+        const float         gamma) const;
 };
 
 }       // namespace foundation

--- a/src/appleseed/foundation/math/microfacet.h
+++ b/src/appleseed/foundation/math/microfacet.h
@@ -31,14 +31,11 @@
 
 // appleseed.foundation headers.
 #include "foundation/core/concepts/noncopyable.h"
-#include "foundation/math/scalar.h"
 #include "foundation/math/vector.h"
 #include "foundation/platform/compiler.h"
 
 // Standard headers.
 #include <algorithm>
-#include <cassert>
-#include <cmath>
 
 namespace foundation
 {
@@ -51,7 +48,7 @@ class MDF
   : public NonCopyable
 {
   public:
-    MDF() {}
+    MDF();
 
     virtual ~MDF();
 
@@ -86,149 +83,9 @@ class MDF
         const float         alpha_y) const = 0;
 
   protected:
-    static float cos_theta(const Vector3f& v)
-    {
-        return v.y;
-    }
-
     static float sin_theta(const Vector3f& v)
     {
-        return std::sqrt(std::max(0.0f, 1.0f - square(cos_theta(v))));
-    }
-
-    static void sample_phi(
-        const float         s,
-        float&              cos_phi,
-        float&              sin_phi)
-    {
-        const float phi = TwoPi<float>() * s;
-        cos_phi = std::cos(phi);
-        sin_phi = std::sin(phi);
-    }
-
-    static void sample_phi(
-        const float         s,
-        const float         alpha_x,
-        const float         alpha_y,
-        float&              cos_phi,
-        float&              sin_phi)
-    {
-        Vector2f sin_cos_phi(
-            std::cos(TwoPi<float>() * s) * alpha_x,
-            std::sin(TwoPi<float>() * s) * alpha_y);
-        sin_cos_phi = normalize(sin_cos_phi);
-        cos_phi = sin_cos_phi[0];
-        sin_phi = sin_cos_phi[1];
-    }
-
-    static float stretched_roughness(
-        const Vector3f&     h,
-        const float         sin_theta,
-        const float         alpha_x,
-        const float         alpha_y)
-    {
-        if (alpha_x == alpha_y || sin_theta == 0.0f)
-            return 1.0f / square(alpha_x);
-
-        const float cos_phi_2_ax_2 = square(h.x / (sin_theta * alpha_x));
-        const float sin_phi_2_ay_2 = square(h.z / (sin_theta * alpha_y));
-        return cos_phi_2_ax_2 + sin_phi_2_ay_2;
-    }
-
-    static float projected_roughness(
-        const Vector3f&     h,
-        const float         sin_theta,
-        const float         alpha_x,
-        const float         alpha_y)
-    {
-        if (alpha_x == alpha_y || sin_theta == 0.0f)
-            return alpha_x;
-
-        const float cos_phi_2_ax_2 = square((h.x * alpha_x) / sin_theta);
-        const float sin_phi_2_ay_2 = square((h.z * alpha_y) / sin_theta);
-        return std::sqrt(cos_phi_2_ax_2 + sin_phi_2_ay_2);
-    }
-
-    static Vector3f v_cavity_choose_microfacet_normal(
-        const Vector3f&     v,
-        const Vector3f&     h,
-        const float         s)
-    {
-        // Preconditions.
-        assert(is_normalized(v));
-        assert(v.y >= 0.0f);
-
-        const Vector3f hm(-h[0], h[1], -h[2]);
-        const float dot_vh  = std::max(dot(v, h), 0.0f);
-        const float dot_vhm = std::max(dot(v, hm), 0.0f);
-
-        if (dot_vhm == 0.0f)
-            return h;
-
-        const float w = dot_vhm / (dot_vh + dot_vhm);
-        return s < w ? hm : h;
-    }
-
-    template <typename Distribution>
-    static Vector3f sample_visible_normals(
-        const Distribution& mdf,
-        const Vector3f&     v,
-        const Vector3f&     s,
-        const float         alpha_x,
-        const float         alpha_y)
-    {
-        // Preconditions.
-        assert(is_normalized(v));
-
-        // Stretch incident.
-        const float sign_cos_vn = v.y < 0.0f ? -1.0f : 1.0f;
-        Vector3f stretched(
-            sign_cos_vn * v[0] * alpha_x,
-            sign_cos_vn * v[1],
-            sign_cos_vn * v[2] * alpha_y);
-
-        stretched = normalize(stretched);
-
-        const float cos_theta = stretched[1];
-        const float phi =
-            stretched[1] < 0.99999f ? std::atan2(stretched[2], stretched[0]) : 0.0f;
-
-        // Sample slope.
-        Vector2f slope = mdf.sample11(cos_theta, s);
-
-        // Rotate.
-        const float cos_phi = std::cos(phi);
-        const float sin_phi = std::sin(phi);
-        slope = Vector2f(
-            cos_phi * slope[0] - sin_phi * slope[1],
-            sin_phi * slope[0] + cos_phi * slope[1]);
-
-        // Stretch and normalize.
-        const Vector3f m(
-            -slope[0] * alpha_x,
-            1.0f,
-            -slope[1] * alpha_y);
-        return normalize(m);
-    }
-
-    template <typename Distribution>
-    static float pdf_visible_normals(
-        const Distribution& mdf,
-        const Vector3f&     v,
-        const Vector3f&     h,
-        const float         alpha_x,
-        const float         alpha_y)
-    {
-        assert(is_normalized(v));
-
-        const float cos_theta_v = MDF::cos_theta(v);
-
-        if (cos_theta_v == 0.0f)
-            return 0.0f;
-
-        return
-            mdf.G1(v, h, alpha_x, alpha_y) * std::abs(dot(v, h)) *
-            mdf.D(h, alpha_x, alpha_y) / std::abs(cos_theta_v);
+        return std::sqrt(std::max(0.0f, 1.0f - square(v.y)));
     }
 };
 
@@ -251,71 +108,37 @@ class BlinnMDF
   : public MDF
 {
   public:
-    BlinnMDF() {}
+    BlinnMDF();
 
     virtual float D(
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return (alpha_x + 2.0f) * RcpTwoPi<float>() * std::pow(MDF::cos_theta(h), alpha_x);
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     virtual float G(
         const Vector3f&     incoming,
         const Vector3f&     outgoing,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return std::min(G1(incoming, h, alpha_x, alpha_y), G1(outgoing, h, alpha_x, alpha_y));
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        if (v.y <= 0.0f)
-            return 0.0f;
-
-        if (dot(v, m) <= 0.0f)
-            return 0.0f;
-
-        const float cos_vh = std::abs(dot(v, m));
-        if (cos_vh == 0.0f)
-            return 0.0f;
-
-        return std::min(1.0f, 2.0f * std::abs(m.y * v.y) / cos_vh);
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     virtual Vector3f sample(
         const Vector3f&     v,
         const Vector3f&     s,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        const float cos_theta = std::pow(1.0f - s[0], 1.0f / (alpha_x + 2.0f));
-        const float sin_theta = std::sqrt(1.0f - cos_theta * cos_theta);
-
-        float cos_phi, sin_phi;
-        MDF::sample_phi(s[1], cos_phi, sin_phi);
-
-        const Vector3f h =
-            Vector3f::make_unit_vector(cos_theta, sin_theta, cos_phi, sin_phi);
-
-        return MDF::v_cavity_choose_microfacet_normal(v, h, s[2]);
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     virtual float pdf(
         const Vector3f&     v,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return MDF::pdf_visible_normals(*this, v, h, alpha_x, alpha_y);
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 };
 
 
@@ -346,223 +169,47 @@ class BeckmannMDF
   : public MDF
 {
   public:
-    BeckmannMDF() {}
+    BeckmannMDF();
 
     virtual float D(
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        const float cos_theta = MDF::cos_theta(h);
-
-        if (cos_theta == 0.0f)
-            return 0.0f;
-
-        const float cos_theta_2 = square(cos_theta);
-        const float cos_theta_4 = square(cos_theta_2);
-        const float tan_theta_2 = (1.0f - cos_theta_2) / cos_theta_2;
-
-        const float A = MDF::stretched_roughness(
-            h,
-            MDF::sin_theta(h),
-            alpha_x,
-            alpha_y);
-
-        return std::exp(-tan_theta_2 * A) / (Pi<float>() * alpha_x * alpha_y * cos_theta_4);
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     virtual float G(
         const Vector3f&     incoming,
         const Vector3f&     outgoing,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return 1.0f / (1.0f + lambda(outgoing, alpha_x, alpha_y) + lambda(incoming, alpha_x, alpha_y));
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     virtual float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y));
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     float lambda(
         const Vector3f&     v,
         const float         alpha_x,
-        const float         alpha_y) const
-    {
-        const float cos_theta = MDF::cos_theta(v);
-
-        if (cos_theta == 0.0f)
-            return 0.0f;
-
-        const float sin_theta = MDF::sin_theta(v);
-
-        const float alpha =
-            MDF::projected_roughness(
-                v,
-                sin_theta,
-                alpha_x,
-                alpha_y);
-
-        const float tan_theta = std::abs(sin_theta / cos_theta);
-        const float a = 1.0f / (alpha * tan_theta);
-
-        if (a < 1.6f)
-        {
-            const float a2 = square(a);
-            return (1.0f - 1.259f * a + 0.396f * a2) / (3.535f * a + 2.181f * a2);
-        }
-
-        return 0.0f;
-    }
+        const float         alpha_y) const;
 
     virtual Vector3f sample(
         const Vector3f&     v,
         const Vector3f&     s,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return
-            MDF::sample_visible_normals(
-                *this,
-                v,
-                s,
-                alpha_x,
-                alpha_y);
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     // This code comes from OpenShadingLanguage test render.
     Vector2f sample11(
         const float         cos_theta,
-        const Vector3f&     s) const
-    {
-        const float ct = std::max(cos_theta, 1.0e-6f);
-        const float tan_theta = std::sqrt(1.0f - square(ct)) / ct;
-        const float cot_theta = 1.0f / tan_theta;
-
-        // Sample slope X:
-        // compute a coarse approximation using the approximation:
-        // exp(-ierf(x)^2) ~= 1 - x * x
-        // solve y = 1 + b + K * (1 - b * b).
-
-        const float c = erf(cot_theta);
-        const float K = tan_theta / SqrtPi<float>();
-        const float y_approx = s[0] * (1.0f + c + K * (1 - c * c));
-        const float y_exact  = s[0] * (1.0f + c + K * std::exp(-square(cot_theta)));
-        float b = K > 0.0f
-            ? (0.5f - std::sqrt(K * (K - y_approx + 1.0f) + 0.25f)) / K
-            : y_approx - 1.0f;
-
-        // Perform a Newton step to refine toward the true root.
-        float inv_erf = erf_inv(b);
-        float value = 1.0f + b + K * std::exp(-square(inv_erf)) - y_exact;
-
-        // Check if we are close enough already.
-        // This also avoids NaNs as we get close to the root.
-        Vector2f slope;
-
-        if (std::abs(value) > 1.0e-6f)
-        {
-            b -= value / (1.0f - inv_erf * tan_theta); // newton step 1
-            inv_erf = erf_inv(b);
-            value = 1.0f + b + K * std::exp(-square(inv_erf)) - y_exact;
-            b -= value / (1.0f - inv_erf * tan_theta); // newton step 2
-            // Compute the slope from the refined value.
-            slope[0] = erf_inv(b);
-        }
-        else
-            slope[0] = inv_erf;
-
-        // Sample slope Y.
-        slope[1] = erf_inv(2.0f * s[1] - 1.0f);
-        return slope;
-    }
+        const Vector3f&     s) const;
 
     virtual float pdf(
         const Vector3f&     v,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return MDF::pdf_visible_normals(*this, v, h, alpha_x, alpha_y);
-    }
-
-  private:
-
-    //
-    // Reference:
-    //
-    //   Handbook of Mathematical Functions.
-    //   Abramowitz and Stegun.
-    //   http://people.math.sfu.ca/~cbm/aands/toc.htm
-    //
-    // Copied from from pbrt-v3.
-    //
-
-    inline float erf(const float x) const
-    {
-        // Constants.
-        const float a1 = 0.254829592f;
-        const float a2 = -0.284496736f;
-        const float a3 = 1.421413741f;
-        const float a4 = -1.453152027f;
-        const float a5 = 1.061405429f;
-        const float p  = 0.3275911f;
-
-        // A&S formula 7.1.26.
-        const float abs_x = std::abs(x);
-        const float t = 1.0f / (1.0f + p * abs_x);
-        const float y = 1.0f - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * std::exp(-square(abs_x * abs_x));
-        return x < 0.0f ? -y : y;
-    }
-
-    //
-    // Reference:
-    //
-    //   Approximating the erfinv function, Mike Giles.
-    //   https://people.maths.ox.ac.uk/gilesm/files/gems_erfinv.pdf
-    //
-
-    inline float erf_inv(const float x) const
-    {
-        const float y = clamp(x, -0.99999f, 0.99999f);
-        float w = -std::log((1 - y) * (1 + y));
-        float p;
-
-        if (w < 5.0f)
-        {
-            w = w - 2.5f;
-            p = 2.81022636e-08f;
-            p = 3.43273939e-07f + p * w;
-            p = -3.5233877e-06f + p * w;
-            p = -4.39150654e-06f + p * w;
-            p = 0.00021858087f + p * w;
-            p = -0.00125372503f + p * w;
-            p = -0.00417768164f + p * w;
-            p = 0.246640727f + p * w;
-            p = 1.50140941f + p * w;
-        }
-        else
-        {
-            w = std::sqrt(w) - 3.0f;
-            p = -0.000200214257f;
-            p = 0.000100950558f + p * w;
-            p = 0.00134934322f + p * w;
-            p = -0.00367342844f + p * w;
-            p = 0.00573950773f + p * w;
-            p = -0.0076224613f + p * w;
-            p = 0.00943887047f + p * w;
-            p = 1.00167406f + p * w;
-            p = 2.83297682f + p * w;
-        }
-
-        return p * y;
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 };
 
 
@@ -585,148 +232,47 @@ class GGXMDF
   : public MDF
 {
   public:
-    GGXMDF() {}
+    GGXMDF();
 
     virtual float D(
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        const float cos_theta = MDF::cos_theta(h);
-
-        if (cos_theta == 0.0f)
-            return square(alpha_x) * RcpPi<float>();
-
-        const float cos_theta_2 = square(cos_theta);
-        const float cos_theta_4 = square(cos_theta_2);
-        const float tan_theta_2 = (1.0f - cos_theta_2) / cos_theta_2;
-
-        const float A =
-            MDF::stretched_roughness(
-                h,
-                MDF::sin_theta(h),
-                alpha_x,
-                alpha_y);
-
-        const float tmp = 1.0f + tan_theta_2 * A;
-        return 1.0f / (Pi<float>() * alpha_x * alpha_y * cos_theta_4 * square(tmp));
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     virtual float G(
         const Vector3f&     incoming,
         const Vector3f&     outgoing,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return 1.0f / (1.0f + lambda(outgoing, alpha_x, alpha_y) + lambda(incoming, alpha_x, alpha_y));
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     virtual float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y));
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     float lambda(
         const Vector3f&     v,
         const float         alpha_x,
-        const float         alpha_y) const
-    {
-        const float cos_theta = std::abs(v.y);
-
-        if (cos_theta == 0.0f)
-            return 0.0f;
-
-        const float cos_theta_2 = square(cos_theta);
-        const float sin_theta = MDF::sin_theta(v);
-        const float tan_theta_2 = square(sin_theta) / cos_theta_2;
-
-        const float alpha =
-            MDF::projected_roughness(
-                v,
-                sin_theta,
-                alpha_x,
-                alpha_y);
-
-        const float a2_rcp = square(alpha) * tan_theta_2;
-        return (-1.0f + std::sqrt(1.0f + a2_rcp)) * 0.5f;
-    }
+        const float         alpha_y) const;
 
     virtual Vector3f sample(
         const Vector3f&     v,
         const Vector3f&     s,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return
-            MDF::sample_visible_normals(
-                *this,
-                v,
-                s,
-                alpha_x,
-                alpha_y);
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     // Adapted from the sample code provided in [3].
     Vector2f sample11(
         const float         cos_theta,
-        const Vector3f&     s) const
-    {
-        const float sin_theta = std::sqrt(1.0f - square(cos_theta));
-
-        // Special case (normal incidence).
-        if (sin_theta < 1.0e-4f)
-        {
-            const float r = std::sqrt(s[0] / (1.0f - s[0]));
-            const float cos_phi = std::cos(TwoPi<float>() * s[1]);
-            const float sin_phi = std::sin(TwoPi<float>() * s[1]);
-            return Vector2f(r * cos_phi, r * sin_phi);
-        }
-
-        Vector2f slope;
-
-        // Precomputations.
-        const float tan_theta = sin_theta / cos_theta;
-        const float tan_theta2 = square(tan_theta);
-        const float cot_theta = 1.0f / tan_theta;
-        const float G1 = 2.0f / (1.0f + std::sqrt(1.0f + tan_theta2));
-
-        // Sample slope x.
-        const float A = 2.0f * s[0] / G1 - 1.0f;
-        const float A2 = square(A);
-        const float rcp_A2_minus_one = std::min(1.0f / (A2 - 1.0f), 1.0e10f);
-        const float B = tan_theta;
-        const float B2 = square(B);
-        const float D = std::sqrt(std::max(B2 * square(rcp_A2_minus_one) - (A2 - B2) * rcp_A2_minus_one, 0.0f));
-        const float slope_x_1 = B * rcp_A2_minus_one - D;
-        const float slope_x_2 = B * rcp_A2_minus_one + D;
-        slope[0] =
-            A < 0.0f || slope_x_2 > cot_theta
-                ? slope_x_1
-                : slope_x_2;
-
-        // Sample slope y.
-        const float z =
-            (s[1] * (s[1] * (s[1] * 0.27385f - 0.73369f) + 0.46341f)) /
-            (s[1] * (s[1] * (s[1] * 0.093073f + 0.309420f) - 1.0f) + 0.597999f);
-        const float S = s[2] < 0.5f ? 1.0f : -1.0f;
-        slope[1] = S * z * std::sqrt(1.0f + square(slope[0]));
-
-        return slope;
-    }
+        const Vector3f&     s) const;
 
     virtual float pdf(
         const Vector3f&     v,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return MDF::pdf_visible_normals(*this, v, h, alpha_x, alpha_y);
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 };
 
 
@@ -745,79 +291,37 @@ class WardMDF
   : public MDF
 {
   public:
-    WardMDF() {}
+    WardMDF();
 
     virtual float D(
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        const float cos_theta = MDF::cos_theta(h);
-
-        assert(cos_theta >= 0.0f);
-
-        if (cos_theta == 0.0f)
-            return 0.0f;
-
-        const float cos_theta_2 = cos_theta * cos_theta;
-        const float cos_theta_3 = cos_theta * cos_theta_2;
-        const float tan_alpha_2 = (1.0f - cos_theta_2) / cos_theta_2;
-
-        const float alpha_x2 = square(alpha_x);
-        return std::exp(-tan_alpha_2 / alpha_x2) / (alpha_x2 * Pi<float>() * cos_theta_3);
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     virtual float G(
         const Vector3f&     incoming,
         const Vector3f&     outgoing,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return std::min(G1(incoming, h, alpha_x, alpha_y), G1(outgoing, h, alpha_x, alpha_y));
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     virtual float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        if (v.y <= 0.0f)
-            return 0.0f;
-
-        if (dot(v, m) <= 0.0f)
-            return 0.0f;
-
-        const float cos_vh = std::abs(dot(v, m));
-        if (cos_vh == 0.0f)
-            return 0.0f;
-
-        return std::min(1.0f, 2.0f * std::abs(m.y * v.y) / cos_vh);
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     virtual Vector3f sample(
         const Vector3f&     v,
         const Vector3f&     s,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        const float tan_alpha_2 = square(alpha_x) * (-std::log(1.0f - s[0]));
-        const float cos_alpha = 1.0f / std::sqrt(1.0f + tan_alpha_2);
-        const float sin_alpha = cos_alpha * std::sqrt(tan_alpha_2);
-        const float phi = TwoPi<float>() * s[1];
-
-        return Vector3f::make_unit_vector(cos_alpha, sin_alpha, std::cos(phi), std::sin(phi));
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     virtual float pdf(
         const Vector3f&     v,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return D(h, alpha_x, alpha_y);
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 };
 
 
@@ -837,91 +341,42 @@ class GTR1MDF
   : public MDF
 {
   public:
-    GTR1MDF() {}
+    GTR1MDF();
 
     virtual float D(
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        const float alpha_x_2 = square(alpha_x);
-        const float cos_theta_2 = square(MDF::cos_theta(h));
-        const float a = (alpha_x_2 - 1.0f) / (Pi<float>() * std::log(alpha_x_2));
-        const float b = (1.0f / (1.0f + (alpha_x_2 - 1.0f) * cos_theta_2));
-        return a * b;
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     virtual float G(
         const Vector3f&     incoming,
         const Vector3f&     outgoing,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return 1.0f / (1.0f + lambda(outgoing, alpha_x, alpha_y) + lambda(incoming, alpha_x, alpha_y));
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     virtual float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y));
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     float lambda(
         const Vector3f&     v,
         const float         alpha_x,
-        const float         alpha_y) const
-    {
-        const float cos_theta = std::abs(v.y);
-
-        if (cos_theta == 0.0f)
-            return 0.0f;
-
-        if (cos_theta == 1.0f)
-            return 1.0f;
-
-        // [2] section 3.2.
-        const float cos_theta_2 = square(cos_theta);
-        const float sin_theta = MDF::sin_theta(v);
-        const float cot_theta_2 = cos_theta_2 / square(sin_theta);
-        const float cot_theta = std::sqrt(cot_theta_2);
-        const float alpha_2 = square(alpha_x);
-
-        const float a = std::sqrt(cot_theta_2 + alpha_2);
-        const float b = std::sqrt(cot_theta_2 + 1.0f);
-        const float c = std::log(cot_theta + b);
-        const float d = std::log(cot_theta + a);
-
-        return (a - b + cot_theta * (c - d)) / (cot_theta * std::log(alpha_2));
-    }
+        const float         alpha_y) const;
 
     virtual Vector3f sample(
         const Vector3f&     v,
         const Vector3f&     s,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        const float alpha2 = square(alpha_x);
-        const float a = 1.0f - std::pow(alpha2, 1.0f - s[0]);
-        const float cos_theta = std::sqrt(a / (1.0f - alpha2));
-        const float sin_theta  = std::sqrt(1.0f - square(cos_theta));
-
-        float cos_phi, sin_phi;
-        MDF::sample_phi(s[1], cos_phi, sin_phi);
-        return Vector3f::make_unit_vector(cos_theta, sin_theta, cos_phi, sin_phi);
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 
     virtual float pdf(
         const Vector3f&     v,
         const Vector3f&     h,
         const float         alpha_x,
-        const float         alpha_y) const APPLESEED_OVERRIDE
-    {
-        return D(h, alpha_x, alpha_y) * MDF::cos_theta(h);
-    }
+        const float         alpha_y) const APPLESEED_OVERRIDE;
 };
 
 }       // namespace foundation

--- a/src/appleseed/foundation/math/specialfunctions.cpp
+++ b/src/appleseed/foundation/math/specialfunctions.cpp
@@ -1,0 +1,111 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2014-2017 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "specialfunctions.h"
+
+// appleseed.foundation headers.
+#include "foundation/math/scalar.h"
+
+// Standard headers.
+#include <cmath>
+
+namespace foundation
+{
+
+//
+// Reference:
+//
+//   Handbook of Mathematical Functions.
+//   Abramowitz and Stegun.
+//   http://people.math.sfu.ca/~cbm/aands/toc.htm
+//
+// Copied from from pbrt-v3.
+//
+
+float erf(const float x)
+{
+    // Constants.
+    const float a1 = 0.254829592f;
+    const float a2 = -0.284496736f;
+    const float a3 = 1.421413741f;
+    const float a4 = -1.453152027f;
+    const float a5 = 1.061405429f;
+    const float p  = 0.3275911f;
+
+    // A&S formula 7.1.26.
+    const float abs_x = std::abs(x);
+    const float t = 1.0f / (1.0f + p * abs_x);
+    const float y = 1.0f - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * std::exp(-square(abs_x * abs_x));
+    return x < 0.0f ? -y : y;
+}
+
+//
+// Reference:
+//
+//   Approximating the erfinv function, Mike Giles.
+//   https://people.maths.ox.ac.uk/gilesm/files/gems_erfinv.pdf
+//
+
+float erf_inv(const float x)
+{
+    const float y = clamp(x, -0.99999f, 0.99999f);
+    float w = -std::log((1 - y) * (1 + y));
+    float p;
+
+    if (w < 5.0f)
+    {
+        w = w - 2.5f;
+        p = 2.81022636e-08f;
+        p = 3.43273939e-07f + p * w;
+        p = -3.5233877e-06f + p * w;
+        p = -4.39150654e-06f + p * w;
+        p = 0.00021858087f + p * w;
+        p = -0.00125372503f + p * w;
+        p = -0.00417768164f + p * w;
+        p = 0.246640727f + p * w;
+        p = 1.50140941f + p * w;
+    }
+    else
+    {
+        w = std::sqrt(w) - 3.0f;
+        p = -0.000200214257f;
+        p = 0.000100950558f + p * w;
+        p = 0.00134934322f + p * w;
+        p = -0.00367342844f + p * w;
+        p = 0.00573950773f + p * w;
+        p = -0.0076224613f + p * w;
+        p = 0.00943887047f + p * w;
+        p = 1.00167406f + p * w;
+        p = 2.83297682f + p * w;
+    }
+
+    return p * y;
+}
+
+}       // namespace foundation

--- a/src/appleseed/foundation/math/specialfunctions.h
+++ b/src/appleseed/foundation/math/specialfunctions.h
@@ -1,0 +1,43 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2014-2017 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef APPLESEED_FOUNDATION_MATH_SPECIAL_FUNCTIONS_H
+#define APPLESEED_FOUNDATION_MATH_SPECIAL_FUNCTIONS_H
+
+namespace foundation
+{
+
+// Error function.
+float erf(const float x);
+
+// Inverse error function.
+float erf_inv(const float x);
+
+}       // namespace foundation
+
+#endif  // !APPLESEED_FOUNDATION_MATH_SPECIAL_FUNCTIONS_H

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_microfacet.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_microfacet.cpp
@@ -42,23 +42,23 @@ BENCHMARK_SUITE(Foundation_Math_Microfacet)
     struct FixtureBase
     {
         LCG         m_rng;
-        Vector3d    m_outgoing;     // view direction, unit-length
-        double      m_dummy;
-        Vector3d    m_dummy_vec;
+        Vector3f    m_outgoing;     // view direction, unit-length
+        float       m_dummy;
+        Vector3f    m_dummy_vec;
 
         FixtureBase()
-          : m_outgoing(normalize(Vector3d(0.1, 0.2, 0.3)))
-          , m_dummy(0.0)
-          , m_dummy_vec(0.0)
+          : m_outgoing(normalize(Vector3f(0.1f, 0.2f, 0.3f)))
+          , m_dummy(0.0f)
+          , m_dummy_vec(0.0f)
         {
         }
 
-        void sample(const double alpha_x, const double alpha_y)
+        void sample(const float alpha_x, const float alpha_y)
         {
-            Vector3d s;
-            s[0] = rand_double2(m_rng);
-            s[1] = rand_double2(m_rng);
-            s[2] = rand_double2(m_rng);
+            Vector3f s;
+            s[0] = rand_float2(m_rng);
+            s[1] = rand_float2(m_rng);
+            s[2] = rand_float2(m_rng);
 
             m_dummy_vec +=
                 MDFType().sample(
@@ -68,15 +68,15 @@ BENCHMARK_SUITE(Foundation_Math_Microfacet)
                     alpha_y);
         }
 
-        void evaluate(const double alpha_x, const double alpha_y)
+        void evaluate(const float alpha_x, const float alpha_y)
         {
             Vector2d s;
-            s[0] = rand_double2(m_rng);
-            s[1] = rand_double2(m_rng);
+            s[0] = rand_float2(m_rng);
+            s[1] = rand_float2(m_rng);
 
             m_dummy +=
                 MDFType().D(
-                    normalize(Vector3d(s[0], 0.5, s[1])),
+                    normalize(Vector3f(s[0], 0.5f, s[1])),
                     alpha_x,
                     alpha_y);
         }
@@ -86,55 +86,55 @@ BENCHMARK_SUITE(Foundation_Math_Microfacet)
     // Blinn-Phong MDF.
     //
 
-    BENCHMARK_CASE_F(BlinnMDF_Sample, FixtureBase<BlinnMDF<double> >)
+    BENCHMARK_CASE_F(BlinnMDF_Sample, FixtureBase<BlinnMDF>)
     {
-        sample(10.0, 10.0);
+        sample(10.0f, 10.0f);
     }
 
-    BENCHMARK_CASE_F(BlinnMDF_Evaluate, FixtureBase<BlinnMDF<double> >)
+    BENCHMARK_CASE_F(BlinnMDF_Evaluate, FixtureBase<BlinnMDF>)
     {
-        evaluate(10.0, 10.0);
+        evaluate(10.0f, 10.0f);
     }
 
     //
     // Beckmann MDF.
     //
 
-    BENCHMARK_CASE_F(BeckmannMDF_Sample, FixtureBase<BeckmannMDF<double> >)
+    BENCHMARK_CASE_F(BeckmannMDF_Sample, FixtureBase<BeckmannMDF>)
     {
-        sample(0.5, 0.5);
+        sample(0.5f, 0.5f);
     }
 
-    BENCHMARK_CASE_F(BeckmannMDF_Evaluate, FixtureBase<BeckmannMDF<double> >)
+    BENCHMARK_CASE_F(BeckmannMDF_Evaluate, FixtureBase<BeckmannMDF>)
     {
-        evaluate(0.5, 0.5);
+        evaluate(0.5f, 0.5f);
     }
 
     //
     // Ward MDF.
     //
 
-    BENCHMARK_CASE_F(WardMDF_Sample, FixtureBase<WardMDF<double> >)
+    BENCHMARK_CASE_F(WardMDF_Sample, FixtureBase<WardMDF>)
     {
-        sample(0.5, 0.5);
+        sample(0.5f, 0.5f);
     }
 
-    BENCHMARK_CASE_F(WardMDF_Evaluate, FixtureBase<WardMDF<double> >)
+    BENCHMARK_CASE_F(WardMDF_Evaluate, FixtureBase<WardMDF>)
     {
-        evaluate(0.5, 0.5);
+        evaluate(0.5f, 0.5f);
     }
 
     //
     // GGX MDF.
     //
 
-    BENCHMARK_CASE_F(GGXMDF_Sample, FixtureBase<GGXMDF<double> >)
+    BENCHMARK_CASE_F(GGXMDF_Sample, FixtureBase<GGXMDF>)
     {
-        sample(0.5, 0.5);
+        sample(0.5f, 0.5f);
     }
 
-    BENCHMARK_CASE_F(GGXMDF_Evaluate, FixtureBase<GGXMDF<double> >)
+    BENCHMARK_CASE_F(GGXMDF_Evaluate, FixtureBase<GGXMDF>)
     {
-        evaluate(0.5, 0.5);
+        evaluate(0.5f, 0.5f);
     }
 }

--- a/src/appleseed/foundation/meta/tests/test_microfacet.cpp
+++ b/src/appleseed/foundation/meta/tests/test_microfacet.cpp
@@ -46,20 +46,20 @@ TEST_SUITE(Foundation_Math_Microfacet)
 {
     template <typename MDF>
     bool is_positive(
-        const MDF&                      mdf,
-        const typename MDF::ValueType   alpha_x,
-        const typename MDF::ValueType   alpha_y,
-        const size_t                    sample_count)
+        const MDF&    mdf,
+        const float   alpha_x,
+        const float   alpha_y,
+        const size_t  sample_count)
     {
         for (size_t i = 0; i < sample_count; ++i)
         {
             static const size_t Bases[] = { 2 };
-            const Vector2d s = hammersley_sequence<double, 2>(Bases, sample_count, i);
+            const Vector2f s = hammersley_sequence<float, 2>(Bases, sample_count, i);
 
-            const Vector<typename MDF::ValueType, 3> h = sample_hemisphere_uniform(s);
-            const double value = mdf.D(h, alpha_x, alpha_y);
+            const Vector3f h = sample_hemisphere_uniform(s);
+            const float value = mdf.D(h, alpha_x, alpha_y);
 
-            if (value < 0.0)
+            if (value < 0.0f)
                 return false;
         }
 
@@ -67,26 +67,24 @@ TEST_SUITE(Foundation_Math_Microfacet)
     }
 
     template <typename MDF>
-    typename MDF::ValueType integrate(
-        const MDF&                      mdf,
-        const typename MDF::ValueType   alpha,
-        const size_t                    sample_count)
+    float integrate(
+        const MDF&    mdf,
+        const float   alpha,
+        const size_t  sample_count)
     {
-        typedef typename MDF::ValueType ValueType;
-
-        ValueType integral = ValueType(0.0);
+        float integral = 0.0f;
 
         for (size_t i = 0; i < sample_count; ++i)
         {
-            const ValueType theta = radical_inverse_base2<ValueType>(i) * HalfPi<ValueType>();
-            const Vector<ValueType, 3> h(ValueType(0.0), cos(theta), ValueType(0.0));
-            const ValueType value = mdf.D(h, alpha, alpha);
+            const float theta = radical_inverse_base2<float>(i) * HalfPi<float>();
+            const Vector3f h(0.0f, cos(theta), 0.0f);
+            const float value = mdf.D(h, alpha, alpha);
 
             integral += value * h.y * sin(theta);
         }
 
-        integral *= HalfPi<ValueType>() / sample_count;     // integration over theta
-        integral *= TwoPi<ValueType>();                     // integration over phi
+        integral *= HalfPi<float>() / sample_count;     // integration over theta
+        integral *= TwoPi<float>();                     // integration over phi
 
         return integral;
     }
@@ -103,61 +101,61 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
     struct WeakWhiteFurnaceTestResult
     {
-        double m_min_G1;
-        double m_max_G1;
-        double m_min_result;
-        double m_max_result;
+        float m_min_G1;
+        float m_max_G1;
+        float m_min_result;
+        float m_max_result;
     };
 
     template <typename MDF>
     void weak_white_furnace_test(
-        size_t                          num_runs,
-        const double                    alpha_x,
-        const double                    alpha_y,
-        const double                    angle_step,
+        size_t                      num_runs,
+        const float                 alpha_x,
+        const float                 alpha_y,
+        const float                 angle_step,
         WeakWhiteFurnaceTestResult& result)
     {
-        result.m_min_G1 =  numeric_limits<double>::max();
-        result.m_max_G1 = -numeric_limits<double>::max();
-        result.m_min_result =  numeric_limits<double>::max();
-        result.m_max_result = -numeric_limits<double>::max();
+        result.m_min_G1 =  numeric_limits<float>::max();
+        result.m_max_G1 = -numeric_limits<float>::max();
+        result.m_min_result =  numeric_limits<float>::max();
+        result.m_max_result = -numeric_limits<float>::max();
 
         MDF mdf;
 
         for (size_t i = 0; i < num_runs; ++i)
         {
             static const size_t Bases[] = { 2 };
-            const Vector2d s = hammersley_sequence<double, 2>(Bases, num_runs, i);
-            const Vector3d v = sample_hemisphere_uniform(s);
-            const double G1 = mdf.G1(v, Vector3d(0.0, 1.0, 0.0), alpha_x, alpha_y);
+            const Vector2f s = hammersley_sequence<float, 2>(Bases, num_runs, i);
+            const Vector3f v = sample_hemisphere_uniform(s);
+            const float G1 = mdf.G1(v, Vector3f(0.0f, 1.0, 0.0f), alpha_x, alpha_y);
 
             result.m_min_G1 = std::min(result.m_min_G1, G1);
             result.m_max_G1 = std::max(result.m_max_G1, G1);
 
-            const double cos_thetha_o_4 = std::abs(4.0 * v.y);
+            const float cos_thetha_o_4 = std::abs(4.0 * v.y);
 
-            double integral = 0.0;
+            float integral = 0.0f;
 
-            for (double theta = 0.0; theta < Pi<double>(); theta += angle_step)
+            for (float theta = 0.0f; theta < Pi<float>(); theta += angle_step)
             {
-                const double cos_theta = std::cos(theta);
-                const double sin_theta = std::sin(theta);
+                const float cos_theta = std::cos(theta);
+                const float sin_theta = std::sin(theta);
 
-                for (double phi = 0.0; phi < TwoPi<double>(); phi += angle_step)
+                for (float phi = 0.0f; phi < TwoPi<float>(); phi += angle_step)
                 {
-                    const double cos_phi = std::cos(phi);
-                    const double sin_phi = std::sin(phi);
+                    const float cos_phi = std::cos(phi);
+                    const float sin_phi = std::sin(phi);
 
-                    const Vector3d l =
-                        Vector3d::make_unit_vector(
+                    const Vector3f l =
+                        Vector3f::make_unit_vector(
                             cos_theta,
                             sin_theta,
                             cos_phi,
                             sin_phi);
 
-                    const Vector3d h = normalize(v + l);
+                    const Vector3f h = normalize(v + l);
 
-                    if (h.y > 0.0)
+                    if (h.y > 0.0f)
                         integral += sin_theta * mdf.D(h, alpha_x, alpha_y) * G1 / cos_thetha_o_4;
                 }
             }
@@ -172,8 +170,8 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
 #define EXPECT_WEAK_WHITE_FURNACE_PASS(result) \
     EXPECT_NEQ(result.m_min_G1, result.m_max_G1); \
-    EXPECT_FEQ_EPS(1.0, result.m_min_result, WeakWhiteFurnaceEps); \
-    EXPECT_FEQ_EPS(1.0, result.m_max_result, WeakWhiteFurnaceEps);
+    EXPECT_FEQ_EPS(1.0f, result.m_min_result, WeakWhiteFurnaceEps); \
+    EXPECT_FEQ_EPS(1.0f, result.m_max_result, WeakWhiteFurnaceEps);
 
     //
     // Test settings.
@@ -183,10 +181,10 @@ TEST_SUITE(Foundation_Math_Microfacet)
     const size_t IntegrationSampleCount = 8192;
     const size_t FunctionPlotSampleCount = 256;
     const size_t FunctionSamplingSampleCount = 64;
-    const double IntegrationEps = 1.0e-3;
+    const float IntegrationEps = 1.0e-3f;
     const size_t WeakWhiteFurnaceRuns = 128;
-    const double WeakWhiteFurnaceAngleStep = 0.0125;
-    const double WeakWhiteFurnaceEps = 0.05;
+    const float WeakWhiteFurnaceAngleStep = 0.0125f;
+    const float WeakWhiteFurnaceEps = 0.05f;
 
 
     //
@@ -195,26 +193,26 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
     TEST_CASE(BlinnMDF_Evaluate_ReturnsNonNegativeValues)
     {
-        const BlinnMDF<double> mdf;
+        const BlinnMDF mdf;
 
-        EXPECT_TRUE(is_positive(mdf, 10.0, 10.0, PositivityTestSampleCount));
+        EXPECT_TRUE(is_positive(mdf, 10.0f, 10.0f, PositivityTestSampleCount));
     }
 
     TEST_CASE(BlinnMDF_Evaluate_GivenCosThetaIsZero_ReturnsZero)
     {
-        const BlinnMDF<double> mdf;
-        const double limit = mdf.D(Vector3d(0.0), 10.0, 10.0);
+        const BlinnMDF mdf;
+        const float limit = mdf.D(Vector3f(0.0f), 10.0f, 10.0f);
 
         EXPECT_FEQ(0.0, limit);
     }
 
     TEST_CASE(BlinnMDF_Integral_EqualsOne)
     {
-        const BlinnMDF<double> mdf;
+        const BlinnMDF mdf;
 
-        const double integral = integrate(mdf, 10.0, IntegrationSampleCount);
+        const float integral = integrate(mdf, 10.0f, IntegrationSampleCount);
 
-        EXPECT_FEQ_EPS(1.0, integral, IntegrationEps);
+        EXPECT_FEQ_EPS(1.0f, integral, IntegrationEps);
     }
 
 
@@ -224,36 +222,36 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
     TEST_CASE(BeckmannMDF_Evaluate_ReturnsNonNegativeValues)
     {
-        const BeckmannMDF<double> mdf;
+        const BeckmannMDF mdf;
 
-        EXPECT_TRUE(is_positive(mdf, 0.5, 0.5, PositivityTestSampleCount));
+        EXPECT_TRUE(is_positive(mdf, 0.5f, 0.5f, PositivityTestSampleCount));
     }
 
     TEST_CASE(BeckmannMDF_Evaluate_GivenCosThetaIsZero_ReturnsZero)
     {
-        const BeckmannMDF<double> mdf;
+        const BeckmannMDF mdf;
 
-        const double limit = mdf.D(Vector3d(0.0), 0.5, 0.5);
+        const float limit = mdf.D(Vector3f(0.0f), 0.5f, 0.5f);
 
         EXPECT_FEQ(0.0, limit);
     }
 
     TEST_CASE(BeckmannMDF_Integral_EqualsOne)
     {
-        const BeckmannMDF<double> mdf;
+        const BeckmannMDF mdf;
 
-        const double integral = integrate(mdf, 0.5, IntegrationSampleCount);
+        const float integral = integrate(mdf, 0.5f, IntegrationSampleCount);
 
-        EXPECT_FEQ_EPS(1.0, integral, IntegrationEps);
+        EXPECT_FEQ_EPS(1.0f, integral, IntegrationEps);
     }
 
     TEST_CASE(BeckmannMDF_Isotropic_WeakWhiteFurnace)
     {
         WeakWhiteFurnaceTestResult result;
-        weak_white_furnace_test<BeckmannMDF<double> >(
+        weak_white_furnace_test<BeckmannMDF >(
             WeakWhiteFurnaceRuns,
-            0.6,
-            0.6,
+            0.6f,
+            0.6f,
             WeakWhiteFurnaceAngleStep,
             result);
 
@@ -263,10 +261,10 @@ TEST_SUITE(Foundation_Math_Microfacet)
     TEST_CASE(BeckmannMDF_Anisotropic_WeakWhiteFurnace)
     {
         WeakWhiteFurnaceTestResult result;
-        weak_white_furnace_test<BeckmannMDF<double> >(
+        weak_white_furnace_test<BeckmannMDF >(
             WeakWhiteFurnaceRuns,
-            0.25,
-            0.5,
+            0.25f,
+            0.5f,
             WeakWhiteFurnaceAngleStep,
             result);
 
@@ -280,38 +278,38 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
     TEST_CASE(GGXMDF_Evaluate_ReturnsNonNegativeValues)
     {
-        const GGXMDF<double> mdf;
+        const GGXMDF mdf;
 
-        EXPECT_TRUE(is_positive(mdf, 0.5, 0.5, PositivityTestSampleCount));
+        EXPECT_TRUE(is_positive(mdf, 0.5f, 0.5f, PositivityTestSampleCount));
     }
 
     TEST_CASE(GGXMDF_Evaluate_GivenCosThetaIsZero_ReturnsLimitValue)
     {
-        const double AlphaG = 0.5;
-        const GGXMDF<double> mdf;
-        const double ExpectedLimit = AlphaG * AlphaG * RcpPi<double>();
+        const float AlphaG = 0.5f;
+        const GGXMDF mdf;
+        const float ExpectedLimit = AlphaG * AlphaG * RcpPi<float>();
 
-        const double limit = mdf.D(Vector3d(0.0), AlphaG, AlphaG);
+        const float limit = mdf.D(Vector3f(0.0f), AlphaG, AlphaG);
 
         EXPECT_FEQ(ExpectedLimit, limit);
     }
 
     TEST_CASE(GGXMDF_Integral_EqualsOne)
     {
-        const GGXMDF<double> mdf;
+        const GGXMDF mdf;
 
-        const double integral = integrate(mdf, 0.5, IntegrationSampleCount);
+        const float integral = integrate(mdf, 0.5f, IntegrationSampleCount);
 
-        EXPECT_FEQ_EPS(1.0, integral, IntegrationEps);
+        EXPECT_FEQ_EPS(1.0f, integral, IntegrationEps);
     }
 
     TEST_CASE(GGXMDF_Isotropic_WeakWhiteFurnace)
     {
         WeakWhiteFurnaceTestResult result;
-        weak_white_furnace_test<GGXMDF<double> >(
+        weak_white_furnace_test<GGXMDF >(
             WeakWhiteFurnaceRuns,
-            0.35,
-            0.35,
+            0.35f,
+            0.35f,
             WeakWhiteFurnaceAngleStep,
             result);
 
@@ -321,10 +319,10 @@ TEST_SUITE(Foundation_Math_Microfacet)
     TEST_CASE(GGXMDF_Anisotropic_WeakWhiteFurnace)
     {
         WeakWhiteFurnaceTestResult result;
-        weak_white_furnace_test<GGXMDF<double> >(
+        weak_white_furnace_test<GGXMDF >(
             WeakWhiteFurnaceRuns,
-            0.25,
-            0.5,
+            0.25f,
+            0.5f,
             WeakWhiteFurnaceAngleStep,
             result);
 
@@ -337,18 +335,18 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
     TEST_CASE(WardMDF_Evaluate_ReturnsNonNegativeValues)
     {
-        const WardMDF<double> mdf;
+        const WardMDF mdf;
 
-        EXPECT_TRUE(is_positive(mdf, 0.5, 0.5, PositivityTestSampleCount));
+        EXPECT_TRUE(is_positive(mdf, 0.5f, 0.5f, PositivityTestSampleCount));
     }
 
     TEST_CASE(WardMDF_Evaluate_GivenCosThetaIsZero_ReturnsZero)
     {
-        const WardMDF<double> mdf;
+        const WardMDF mdf;
 
-        const double limit = mdf.D(Vector3d(0.0), 0.5, 0.5);
+        const float limit = mdf.D(Vector3f(0.0f), 0.5f, 0.5f);
 
-        EXPECT_FEQ(0.0, limit);
+        EXPECT_FEQ(0.0f, limit);
     }
 
 
@@ -358,17 +356,17 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
     TEST_CASE(GTR1MDF_Evaluate_ReturnsNonNegativeValues)
     {
-        const GTR1MDF<double> mdf;
+        const GTR1MDF mdf;
 
-        EXPECT_TRUE(is_positive(mdf, 10.0, 10.0, PositivityTestSampleCount));
+        EXPECT_TRUE(is_positive(mdf, 10.0f, 10.0f, PositivityTestSampleCount));
     }
 
     TEST_CASE(GTR1MDF_Integral_EqualsOne)
     {
-        const GTR1MDF<double> mdf;
+        const GTR1MDF mdf;
 
-        const double integral = integrate(mdf, 10.0, IntegrationSampleCount);
+        const float integral = integrate(mdf, 10.0f, IntegrationSampleCount);
 
-        EXPECT_FEQ_EPS(1.0, integral, IntegrationEps);
+        EXPECT_FEQ_EPS(1.0f, integral, IntegrationEps);
     }
 }

--- a/src/appleseed/renderer/modeling/bsdf/alsurfacelayerbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/alsurfacelayerbrdf.cpp
@@ -167,7 +167,7 @@ namespace
             Vector3f wo = shading_basis.transform_to_local(sample.m_outgoing.get_value());
 
             // Compute the microfacet normal by sampling the MDF.
-            const MDF<float>& mdf = pick_mdf(values->m_distribution);
+            const MDF& mdf = pick_mdf(values->m_distribution);
             sampling_context.split_in_place(4, 1);
             const Vector4f s = sampling_context.next2<Vector4f>();
             Vector3f m = mdf.sample(
@@ -244,7 +244,7 @@ namespace
 
             if (ScatteringMode::has_glossy(modes) && (wi.y * wo.y >= 0.0f))
             {
-                const MDF<float>& mdf = pick_mdf(values->m_distribution);
+                const MDF& mdf = pick_mdf(values->m_distribution);
                 value = f_value;
                 evaluate_reflection(*values, mdf, wi, wo, m, value);
                 probability = layer_probability * reflection_pdf(*values, mdf, wo, m);
@@ -294,7 +294,7 @@ namespace
 
             if (ScatteringMode::has_glossy(modes) && (wi.y * wo.y >= 0.0f))
             {
-                const MDF<float>& mdf = pick_mdf(values->m_distribution);
+                const MDF& mdf = pick_mdf(values->m_distribution);
                 probability = layer_probability * reflection_pdf(*values, mdf, wo, m);
             }
 
@@ -353,7 +353,7 @@ namespace
             Metallic
         };
 
-        static const MDF<float>& pick_mdf(int distribution)
+        static const MDF& pick_mdf(int distribution)
         {
             if (distribution == Beckmann)
                 return m_beckmann_mdf;
@@ -420,7 +420,7 @@ namespace
 
         static void evaluate_reflection(
             const InputValues&      values,
-            const MDF<float>&       mdf,
+            const MDF&              mdf,
             const Vector3f&         wi,
             const Vector3f&         wo,
             const Vector3f&         m,
@@ -440,7 +440,7 @@ namespace
 
         static float reflection_pdf(
             const InputValues&      values,
-            const MDF<float>&       mdf,
+            const MDF&              mdf,
             const Vector3f&         wo,
             const Vector3f&         m)
         {
@@ -452,12 +452,12 @@ namespace
             return jacobian * mdf.pdf(wo, m, values.m_precomputed.m_alpha_x, values.m_precomputed.m_alpha_y);
         }
 
-        static GGXMDF<float>        m_ggx_mdf;
-        static BeckmannMDF<float>   m_beckmann_mdf;
+        static GGXMDF        m_ggx_mdf;
+        static BeckmannMDF   m_beckmann_mdf;
     };
 
-    GGXMDF<float>        AlSurfaceLayerBRDFImpl::m_ggx_mdf;
-    BeckmannMDF<float>   AlSurfaceLayerBRDFImpl::m_beckmann_mdf;
+    GGXMDF        AlSurfaceLayerBRDFImpl::m_ggx_mdf;
+    BeckmannMDF   AlSurfaceLayerBRDFImpl::m_beckmann_mdf;
 
     typedef BSDFWrapper<AlSurfaceLayerBRDFImpl> AlSurfaceLayerBRDF;
 }

--- a/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
@@ -426,7 +426,7 @@ namespace
                         alpha_x,
                         alpha_y);
 
-                    const GGXMDF<float> ggx_mdf;
+                    const GGXMDF ggx_mdf;
                     MicrofacetBRDFHelper::sample(
                         sampling_context,
                         ggx_mdf,
@@ -439,7 +439,7 @@ namespace
                 else
                 {
                     const float alpha = clearcoat_roughness(values);
-                    const GTR1MDF<float> gtr1_mdf;
+                    const GTR1MDF gtr1_mdf;
                     MicrofacetBRDFHelper::sample(
                         sampling_context,
                         gtr1_mdf,
@@ -515,7 +515,7 @@ namespace
                         alpha_x,
                         alpha_y);
 
-                    const GGXMDF<float> ggx_mdf;
+                    const GGXMDF ggx_mdf;
                     pdf += MicrofacetBRDFHelper::evaluate(
                         ggx_mdf,
                         alpha_x,
@@ -534,7 +534,7 @@ namespace
                 {
                     Spectrum clear;
                     const float alpha = clearcoat_roughness(values);
-                    const GTR1MDF<float> gtr1_mdf;
+                    const GTR1MDF gtr1_mdf;
                     pdf += MicrofacetBRDFHelper::evaluate(
                         gtr1_mdf,
                         alpha,
@@ -603,7 +603,7 @@ namespace
                         alpha_x,
                         alpha_y);
 
-                    const GGXMDF<float> ggx_mdf;
+                    const GGXMDF ggx_mdf;
                     pdf += MicrofacetBRDFHelper::pdf(
                         ggx_mdf,
                         alpha_x,
@@ -616,7 +616,7 @@ namespace
                 if (weights[CleatcoatComponent] != 0.0f)
                 {
                     const float alpha = clearcoat_roughness(values);
-                    const GTR1MDF<float> gtr1_mdf;
+                    const GTR1MDF gtr1_mdf;
                     pdf += MicrofacetBRDFHelper::pdf(
                         gtr1_mdf,
                         alpha,

--- a/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
@@ -139,9 +139,9 @@ namespace
                     context);
 
             if (mdf == "ggx")
-                m_mdf.reset(new GGXMDF<float>());
+                m_mdf.reset(new GGXMDF());
             else if (mdf == "beckmann")
-                m_mdf.reset(new BeckmannMDF<float>());
+                m_mdf.reset(new BeckmannMDF());
             else return false;
 
             const string volume_parameterization =
@@ -475,7 +475,7 @@ namespace
       private:
         typedef GlassBSDFInputValues InputValues;
 
-        auto_ptr<MDF<float> >   m_mdf;
+        auto_ptr<MDF>   m_mdf;
 
         enum VolumeParameterization
         {

--- a/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
@@ -182,7 +182,7 @@ namespace
 
             if (m_mdf == GGX)
             {
-                const GGXMDF<float> mdf;
+                const GGXMDF mdf;
                 MicrofacetBRDFHelper::sample(
                     sampling_context,
                     mdf,
@@ -194,7 +194,7 @@ namespace
             }
             else
             {
-                const BeckmannMDF<float> mdf;
+                const BeckmannMDF mdf;
                 MicrofacetBRDFHelper::sample(
                     sampling_context,
                     mdf,
@@ -243,7 +243,7 @@ namespace
 
             if (m_mdf == GGX)
             {
-                const GGXMDF<float> mdf;
+                const GGXMDF mdf;
                 return MicrofacetBRDFHelper::evaluate(
                     mdf,
                     alpha_x,
@@ -258,7 +258,7 @@ namespace
             }
             else
             {
-                const BeckmannMDF<float> mdf;
+                const BeckmannMDF mdf;
                 return MicrofacetBRDFHelper::evaluate(
                     mdf,
                     alpha_x,
@@ -302,7 +302,7 @@ namespace
 
             if (m_mdf == GGX)
             {
-                const GGXMDF<float> mdf;
+                const GGXMDF mdf;
                 return MicrofacetBRDFHelper::pdf(
                     mdf,
                     alpha_x,
@@ -313,7 +313,7 @@ namespace
             }
             else
             {
-                const BeckmannMDF<float> mdf;
+                const BeckmannMDF mdf;
                 return MicrofacetBRDFHelper::pdf(
                     mdf,
                     alpha_x,

--- a/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.cpp
@@ -73,46 +73,45 @@ namespace renderer
 
 namespace
 {
-    template <typename T>
     class WardMDFAdapter
     {
       public:
-        explicit WardMDFAdapter(const T alpha)
+        explicit WardMDFAdapter(const float alpha)
           : m_alpha(alpha)
         {
         }
 
-        Vector<T, 3> sample(const Vector<T, 2>& s) const
+        Vector3f sample(const Vector2f& s) const
         {
             return
-                WardMDF<T>().sample(
-                    Vector<T, 3>(0.0f, 0.0f, 0.0f),
-                    Vector<T, 3>(s[0], s[1], 0.0f),
+                WardMDF().sample(
+                    Vector3f(0.0f, 0.0f, 0.0f),
+                    Vector3f(s[0], s[1], 0.0f),
                     m_alpha,
                     m_alpha);
         }
 
-        T evaluate(const T cos_alpha) const
+        float evaluate(const float cos_alpha) const
         {
             return
-                WardMDF<T>().D(
-                    Vector<T, 3>(0.0f, cos_alpha, 0.0f),
+                WardMDF().D(
+                    Vector3f(0.0f, cos_alpha, 0.0f),
                     m_alpha,
                     m_alpha);
         }
 
-        T evaluate_pdf(const T cos_alpha) const
+        float evaluate_pdf(const float cos_alpha) const
         {
             return
-                WardMDF<T>().pdf(
-                    Vector<T, 3>(0.0f, 0.0f, 0.0f),
-                    Vector<T, 3>(0.0f, cos_alpha, 0.0f),
+                WardMDF().pdf(
+                    Vector3f(0.0f, 0.0f, 0.0f),
+                    Vector3f(0.0f, cos_alpha, 0.0f),
                     m_alpha,
                     m_alpha);
         }
 
       private:
-        const T m_alpha;
+        const float m_alpha;
     };
 
 
@@ -495,7 +494,7 @@ namespace
             float               m_roughness;                    // technically, root-mean-square of the microfacets slopes
         };
 
-        typedef WardMDFAdapter<float> MDFType;
+        typedef WardMDFAdapter MDFType;
 
         auto_ptr<MDFType>       m_mdf;                          // Microfacet Distribution Function
         Spectrum                m_a_spec[AlbedoTableSize];      // albedo of the specular component as V varies
@@ -658,7 +657,7 @@ namespace
             const float         m,
             const Spectrum&     rs)
         {
-            generate_specular_albedo_plot_data("Ward", m, WardMDFAdapter<float>(m), rs);
+            generate_specular_albedo_plot_data("Ward", m, WardMDFAdapter(m), rs);
         }
 
         template <typename MDF>

--- a/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
@@ -175,7 +175,7 @@ namespace
 
             if (m_mdf == GGX)
             {
-                const GGXMDF<float> mdf;
+                const GGXMDF mdf;
                 MicrofacetBRDFHelper::sample(
                     sampling_context,
                     mdf,
@@ -187,7 +187,7 @@ namespace
             }
             else
             {
-                const BeckmannMDF<float> mdf;
+                const BeckmannMDF mdf;
                 MicrofacetBRDFHelper::sample(
                     sampling_context,
                     mdf,
@@ -236,7 +236,7 @@ namespace
 
             if (m_mdf == GGX)
             {
-                const GGXMDF<float> mdf;
+                const GGXMDF mdf;
                 return MicrofacetBRDFHelper::evaluate(
                     mdf,
                     alpha_x,
@@ -251,7 +251,7 @@ namespace
             }
             else
             {
-                const BeckmannMDF<float> mdf;
+                const BeckmannMDF mdf;
                 return MicrofacetBRDFHelper::evaluate(
                     mdf,
                     alpha_x,
@@ -295,7 +295,7 @@ namespace
 
             if (m_mdf == GGX)
             {
-                const GGXMDF<float> mdf;
+                const GGXMDF mdf;
                 return MicrofacetBRDFHelper::pdf(
                     mdf,
                     alpha_x,
@@ -306,7 +306,7 @@ namespace
             }
             else
             {
-                const BeckmannMDF<float> mdf;
+                const BeckmannMDF mdf;
                 return MicrofacetBRDFHelper::pdf(
                     mdf,
                     alpha_x,

--- a/src/appleseed/renderer/modeling/bsdf/microfacetbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/microfacetbrdf.cpp
@@ -178,7 +178,7 @@ namespace
               case Blinn:
                 {
                     const float e = glossiness_to_blinn_exponent(glossiness);
-                    const BlinnMDF<float> blinn_mdf;
+                    const BlinnMDF blinn_mdf;
                     MicrofacetBRDFHelper::sample(
                         sampling_context,
                         blinn_mdf,
@@ -193,7 +193,7 @@ namespace
               case Beckmann:
                 {
                     const float a = glossiness_to_roughness(glossiness);
-                    const BeckmannMDF<float> beckmann_mdf;
+                    const BeckmannMDF beckmann_mdf;
                     MicrofacetBRDFHelper::sample(
                         sampling_context,
                         beckmann_mdf,
@@ -208,7 +208,7 @@ namespace
               case Ward:
                 {
                     const float a = glossiness_to_roughness(glossiness);
-                    const WardMDF<float> ward_mdf;
+                    const WardMDF ward_mdf;
                     MicrofacetBRDFHelper::sample(
                         sampling_context,
                         ward_mdf,
@@ -223,7 +223,7 @@ namespace
               case GGX:
                 {
                     const float a = glossiness_to_roughness(glossiness);
-                    const GGXMDF<float> ggx_mdf;
+                    const GGXMDF ggx_mdf;
                     MicrofacetBRDFHelper::sample(
                         sampling_context,
                         ggx_mdf,
@@ -272,7 +272,7 @@ namespace
               case Blinn:
                 {
                     const float e = glossiness_to_blinn_exponent(glossiness);
-                    const BlinnMDF<float> blinn_mdf;
+                    const BlinnMDF blinn_mdf;
                     pdf = MicrofacetBRDFHelper::evaluate(
                         blinn_mdf,
                         e,
@@ -290,7 +290,7 @@ namespace
               case Beckmann:
                 {
                     const float a = glossiness_to_roughness(glossiness);
-                    const BeckmannMDF<float> beckman_mdf;
+                    const BeckmannMDF beckman_mdf;
                     pdf = MicrofacetBRDFHelper::evaluate(
                         beckman_mdf,
                         a,
@@ -308,7 +308,7 @@ namespace
               case Ward:
                 {
                     const float a = glossiness_to_roughness(glossiness);
-                    const WardMDF<float> ward_mdf;
+                    const WardMDF ward_mdf;
                     pdf = MicrofacetBRDFHelper::evaluate(
                         ward_mdf,
                         a,
@@ -326,7 +326,7 @@ namespace
               case GGX:
                 {
                     const float a = glossiness_to_roughness(glossiness);
-                    const GGXMDF<float> ggx_mdf;
+                    const GGXMDF ggx_mdf;
                     pdf =  MicrofacetBRDFHelper::evaluate(
                         ggx_mdf,
                         a,
@@ -374,7 +374,7 @@ namespace
               case Blinn:
                 {
                     const float e = glossiness_to_blinn_exponent(glossiness);
-                    const BlinnMDF<float> blinn_mdf;
+                    const BlinnMDF blinn_mdf;
                     return MicrofacetBRDFHelper::pdf(
                         blinn_mdf,
                         e,
@@ -388,7 +388,7 @@ namespace
               case Beckmann:
                 {
                     const float a = glossiness_to_roughness(glossiness);
-                    const BeckmannMDF<float> beckmann_mdf;
+                    const BeckmannMDF beckmann_mdf;
                     return MicrofacetBRDFHelper::pdf(
                         beckmann_mdf,
                         a,
@@ -402,7 +402,7 @@ namespace
               case Ward:
                 {
                     const float a = glossiness_to_roughness(glossiness);
-                    const WardMDF<float> ward_mdf;
+                    const WardMDF ward_mdf;
                     return MicrofacetBRDFHelper::pdf(
                         ward_mdf,
                         a,
@@ -416,7 +416,7 @@ namespace
               case GGX:
                 {
                     const float a = glossiness_to_roughness(glossiness);
-                    const GGXMDF<float> ggx_mdf;
+                    const GGXMDF ggx_mdf;
                     return MicrofacetBRDFHelper::pdf(
                         ggx_mdf,
                         a,

--- a/src/appleseed/renderer/modeling/bsdf/plasticbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/plasticbrdf.cpp
@@ -129,11 +129,11 @@ namespace
                     context);
 
             if (mdf == "ggx")
-                m_mdf.reset(new GGXMDF<float>());
+                m_mdf.reset(new GGXMDF());
             else if (mdf == "beckmann")
-                m_mdf.reset(new BeckmannMDF<float>());
+                m_mdf.reset(new BeckmannMDF());
             else if (mdf == "gtr1")
-                m_mdf.reset(new GTR1MDF<float>());
+                m_mdf.reset(new GTR1MDF());
             else return false;
 
             return true;
@@ -386,7 +386,7 @@ namespace
 
         static void evaluate_specular(
             const Spectrum&         specular_reflectance,
-            const MDF<float>&       mdf,
+            const MDF&              mdf,
             const float             alpha,
             const Vector3f&         wi,
             const Vector3f&         wo,
@@ -411,7 +411,7 @@ namespace
         }
 
         static float specular_pdf(
-            const MDF<float>&       mdf,
+            const MDF&              mdf,
             const float             alpha,
             const Vector3f&         wo,
             const Vector3f&         m)
@@ -448,7 +448,7 @@ namespace
             }
         }
 
-        auto_ptr<MDF<float> >   m_mdf;
+        auto_ptr<MDF>   m_mdf;
     };
 
     typedef BSDFWrapper<PlasticBRDFImpl> PlasticBRDF;


### PR DESCRIPTION
- Removed template params for MDFs.
- Moved most code to cpp files, cleanup microfacet header.
- Refactored erf and erf_inv out of BackmannMDF.
- Added gamma param to MDFs in preparation for the STD MDF.