### PR TITLE
Fix color value not updating when cancelling color picker

### DIFF
--- a/src/appleseed.studio/mainwindow/project/disneymateriallayerui.cpp
+++ b/src/appleseed.studio/mainwindow/project/disneymateriallayerui.cpp
@@ -247,7 +247,7 @@ void DisneyMaterialLayerUI::slot_open_color_picker(const QString& widget_name)
     dialog->setOptions(QColorDialog::DontUseNativeDialog);
 
     ForwardColorChangedSignal* forward_signal =
-        new ForwardColorChangedSignal(dialog, widget_name);
+        new ForwardColorChangedSignal(dialog, initial_color, widget_name);
     connect(
         dialog, SIGNAL(currentColorChanged(const QColor&)),
         forward_signal, SLOT(slot_color_changed(const QColor&)));

--- a/src/appleseed.studio/mainwindow/project/disneymateriallayerui.cpp
+++ b/src/appleseed.studio/mainwindow/project/disneymateriallayerui.cpp
@@ -247,7 +247,7 @@ void DisneyMaterialLayerUI::slot_open_color_picker(const QString& widget_name)
     dialog->setOptions(QColorDialog::DontUseNativeDialog);
 
     ForwardColorChangedSignal* forward_signal =
-        new ForwardColorChangedSignal(dialog, initial_color, widget_name);
+        new ForwardColorChangedSignal(dialog, widget_name, initial_color);
     connect(
         dialog, SIGNAL(currentColorChanged(const QColor&)),
         forward_signal, SLOT(slot_color_changed(const QColor&)));

--- a/src/appleseed.studio/mainwindow/project/entityeditor.cpp
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.cpp
@@ -596,32 +596,23 @@ void EntityEditor::slot_open_color_picker(const QString& widget_name)
     dialog->setWindowTitle("Pick Color");
     dialog->setOptions(QColorDialog::DontUseNativeDialog);
 
-    ForwardResetColorSignal* reset_signal =
-        new ForwardResetColorSignal(dialog, color_to_qcolor(initial_color), widget_name);
-    connect(dialog, SIGNAL(rejected()),
-        reset_signal, SLOT(slot_reset_color()));
-    connect(reset_signal, SIGNAL(signal_reset_color(const QString&, const QColor&)),
-        SLOT(slot_reset_color(const QString&, const QColor&)));
-
     ForwardColorChangedSignal* forward_signal =
-        new ForwardColorChangedSignal(dialog, widget_name);
+        new ForwardColorChangedSignal(dialog, color_to_qcolor(initial_color), widget_name);  
     connect(
         dialog, SIGNAL(currentColorChanged(const QColor&)),
         forward_signal, SLOT(slot_color_changed(const QColor&)));
     connect(
         forward_signal, SIGNAL(signal_color_changed(const QString&, const QColor&)),
         SLOT(slot_color_changed(const QString&, const QColor&)));
+    connect(
+        dialog, SIGNAL(rejected()),
+        forward_signal, SLOT(slot_reset_color()));
+    connect(
+        forward_signal, SIGNAL(signal_reset_color(const QString&, const QColor&)),
+        SLOT(slot_color_changed(const QString&, const QColor&)));
 
     dialog->exec();
 }
-
-void EntityEditor::slot_reset_color(const QString& widget_name, const QColor& color)
-{
-    IInputWidgetProxy* widget_proxy = m_widget_proxies.get(widget_name.toStdString());
-    widget_proxy->set(to_string(qcolor_to_color<Color3d>(color)));
-    widget_proxy->emit_signal_changed();
-}
-
 
 void EntityEditor::slot_color_changed(const QString& widget_name, const QColor& color)
 {

--- a/src/appleseed.studio/mainwindow/project/entityeditor.cpp
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.cpp
@@ -596,6 +596,13 @@ void EntityEditor::slot_open_color_picker(const QString& widget_name)
     dialog->setWindowTitle("Pick Color");
     dialog->setOptions(QColorDialog::DontUseNativeDialog);
 
+    ForwardResetColorSignal* reset_signal =
+        new ForwardResetColorSignal(dialog, color_to_qcolor(initial_color), widget_name);
+    connect(dialog, SIGNAL(rejected()),
+        reset_signal, SLOT(slot_reset_color()));
+    connect(reset_signal, SIGNAL(signal_reset_color(const QString&, const QColor&)),
+        SLOT(slot_reset_color(const QString&, const QColor&)));
+
     ForwardColorChangedSignal* forward_signal =
         new ForwardColorChangedSignal(dialog, widget_name);
     connect(
@@ -607,6 +614,14 @@ void EntityEditor::slot_open_color_picker(const QString& widget_name)
 
     dialog->exec();
 }
+
+void EntityEditor::slot_reset_color(const QString& widget_name, const QColor& color)
+{
+    IInputWidgetProxy* widget_proxy = m_widget_proxies.get(widget_name.toStdString());
+    widget_proxy->set(to_string(qcolor_to_color<Color3d>(color)));
+    widget_proxy->emit_signal_changed();
+}
+
 
 void EntityEditor::slot_color_changed(const QString& widget_name, const QColor& color)
 {

--- a/src/appleseed.studio/mainwindow/project/entityeditor.cpp
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.cpp
@@ -597,7 +597,7 @@ void EntityEditor::slot_open_color_picker(const QString& widget_name)
     dialog->setOptions(QColorDialog::DontUseNativeDialog);
 
     ForwardColorChangedSignal* forward_signal =
-        new ForwardColorChangedSignal(dialog, color_to_qcolor(initial_color), widget_name);  
+        new ForwardColorChangedSignal(dialog, widget_name, color_to_qcolor(initial_color));  
     connect(
         dialog, SIGNAL(currentColorChanged(const QColor&)),
         forward_signal, SLOT(slot_color_changed(const QColor&)));

--- a/src/appleseed.studio/mainwindow/project/entityeditor.h
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.h
@@ -164,7 +164,6 @@ class EntityEditor
 
     void slot_apply();
 
-    void slot_reset_color(const QString& widget_name, const QColor& color);
 };
 
 }       // namespace studio

--- a/src/appleseed.studio/mainwindow/project/entityeditor.h
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.h
@@ -163,6 +163,8 @@ class EntityEditor
     void slot_open_file_picker(const QString& widget_name);
 
     void slot_apply();
+
+    void slot_reset_color(const QString& widget_name, const QColor& color);
 };
 
 }       // namespace studio

--- a/src/appleseed.studio/mainwindow/project/entityeditor.h
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.h
@@ -163,7 +163,6 @@ class EntityEditor
     void slot_open_file_picker(const QString& widget_name);
 
     void slot_apply();
-
 };
 
 }       // namespace studio

--- a/src/appleseed.studio/mainwindow/project/tools.cpp
+++ b/src/appleseed.studio/mainwindow/project/tools.cpp
@@ -261,34 +261,22 @@ void LineEditDoubleSliderAdaptor::adjust_slider(const double new_value)
 
 ForwardColorChangedSignal::ForwardColorChangedSignal(
     QObject*        parent,
+    const QColor&   initial_color,
     const QString&  widget_name)
   : QObject(parent)
+  , m_initial_color(initial_color)
   , m_widget_name(widget_name)
 {
+}
+
+void ForwardColorChangedSignal::slot_reset_color()
+{
+    emit signal_reset_color(m_widget_name, m_initial_color);
 }
 
 void ForwardColorChangedSignal::slot_color_changed(const QColor& color)
 {
     emit signal_color_changed(m_widget_name, color);
-}
-
-//
-// ForwardResetColorSignal class implementation.
-//
-
-ForwardResetColorSignal::ForwardResetColorSignal(
-    QObject*        parent,
-    const QColor&   color,
-    const QString&  widget_name)
-  : QObject(parent)
-  , m_color(color)
-  , m_widget_name(widget_name)
-{
-}
-
-void ForwardResetColorSignal::slot_reset_color()
-{
-    emit signal_reset_color(m_widget_name, m_color);
 }
 
 }   // namespace studio

--- a/src/appleseed.studio/mainwindow/project/tools.cpp
+++ b/src/appleseed.studio/mainwindow/project/tools.cpp
@@ -272,5 +272,24 @@ void ForwardColorChangedSignal::slot_color_changed(const QColor& color)
     emit signal_color_changed(m_widget_name, color);
 }
 
+//
+// ForwardResetColorSignal class implementation.
+//
+
+ForwardResetColorSignal::ForwardResetColorSignal(
+    QObject*        parent,
+    const QColor&   color,
+    const QString&  widget_name)
+  : QObject(parent)
+  , m_color(color)
+  , m_widget_name(widget_name)
+{
+}
+
+void ForwardResetColorSignal::slot_reset_color()
+{
+    emit signal_reset_color(m_widget_name, m_color);
+}
+
 }   // namespace studio
 }   // namespace appleseed

--- a/src/appleseed.studio/mainwindow/project/tools.cpp
+++ b/src/appleseed.studio/mainwindow/project/tools.cpp
@@ -261,11 +261,11 @@ void LineEditDoubleSliderAdaptor::adjust_slider(const double new_value)
 
 ForwardColorChangedSignal::ForwardColorChangedSignal(
     QObject*        parent,
-    const QColor&   initial_color,
-    const QString&  widget_name)
+    const QString&  widget_name,
+    const QColor&   initial_color)
   : QObject(parent)
-  , m_initial_color(initial_color)
   , m_widget_name(widget_name)
+  , m_initial_color(initial_color)
 {
 }
 

--- a/src/appleseed.studio/mainwindow/project/tools.h
+++ b/src/appleseed.studio/mainwindow/project/tools.h
@@ -136,41 +136,19 @@ class ForwardColorChangedSignal
   public:
     ForwardColorChangedSignal(
         QObject*        parent,
+        const QColor&   initial_color,
         const QString&  widget_name);
 
   public slots:
     void slot_color_changed(const QColor& color);
-
-  signals:
-    void signal_color_changed(const QString& widget_name, const QColor& color);
-
-  private:
-    const QString m_widget_name;
-};
-
-//
-// Adds extra information to the signal emitted when the color resets.
-//
-
-class ForwardResetColorSignal
-  : public QObject
-{
-    Q_OBJECT
-
-  public:
-    ForwardResetColorSignal(
-        QObject*        parent,
-        const QColor&   color,
-        const QString&  widget_name);
-
-  public slots:
     void slot_reset_color();
 
   signals:
+    void signal_color_changed(const QString& widget_name, const QColor& color);
     void signal_reset_color(const QString& widget_name, const QColor& color);
 
   private:
-    const QColor m_color;
+    const QColor m_initial_color;
     const QString m_widget_name;
 };
 

--- a/src/appleseed.studio/mainwindow/project/tools.h
+++ b/src/appleseed.studio/mainwindow/project/tools.h
@@ -148,6 +148,32 @@ class ForwardColorChangedSignal
     const QString m_widget_name;
 };
 
+//
+// Adds extra information to the signal emitted when the color resets.
+//
+
+class ForwardResetColorSignal
+  : public QObject
+{
+    Q_OBJECT
+
+  public:
+    ForwardResetColorSignal(
+        QObject*        parent,
+        const QColor&   color,
+        const QString&  widget_name);
+
+  public slots:
+    void slot_reset_color();
+
+  signals:
+    void signal_reset_color(const QString& widget_name, const QColor& color);
+
+  private:
+    const QColor m_color;
+    const QString m_widget_name;
+};
+
 }       // namespace studio
 }       // namespace appleseed
 

--- a/src/appleseed.studio/mainwindow/project/tools.h
+++ b/src/appleseed.studio/mainwindow/project/tools.h
@@ -136,8 +136,8 @@ class ForwardColorChangedSignal
   public:
     ForwardColorChangedSignal(
         QObject*        parent,
-        const QColor&   initial_color,
-        const QString&  widget_name);
+        const QString&  widget_name,
+        const QColor&   initial_color);
 
   public slots:
     void slot_color_changed(const QColor& color);
@@ -148,8 +148,8 @@ class ForwardColorChangedSignal
     void signal_reset_color(const QString& widget_name, const QColor& color);
 
   private:
-    const QColor m_initial_color;
     const QString m_widget_name;
+    const QColor m_initial_color;
 };
 
 }       // namespace studio


### PR DESCRIPTION
This commit will add a signal-slot pair to address the situation
when the color changes are rejected.