### PR TITLE
Reset EntityEditor auto_ptr properly while clearing the layout #1258

### DIFF
--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -1475,7 +1475,7 @@ namespace
             Project&        project) APPLESEED_OVERRIDE
         {
             project.get_frame()->reset_crop_window();
-            m_main_window->emit_signal_crop_window_cleared();
+            m_main_window->emit_refresh_attribute_editor_signal();
         }
 
       private:
@@ -1562,9 +1562,10 @@ void MainWindow::slot_render_widget_context_menu(const QPoint& point)
     menu->exec(point);
 }
 
-void MainWindow::emit_signal_crop_window_cleared() const {
+void MainWindow::emit_refresh_attribute_editor_signal() const
+{
     emit signal_refresh_attribute_editor(
-            m_project_manager.get_project()->get_frame()->get_parameters());
+        m_project_manager.get_project()->get_frame()->get_parameters());
 }
 
 namespace

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -1546,8 +1546,7 @@ void MainWindow::slot_set_render_region(const QRect& rect)
             *m_project_manager.get_project());
 
         if (m_settings.get_path_optional<bool>(SETTINGS_RENDER_REGION_TRIGGERS_RENDERING))
-            start_rendering(true);
-        else m_rendering_manager.reinitialize_rendering();
+            start_rendering(InteractiveRendering);
     }
     else
     {

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -1540,16 +1540,18 @@ void MainWindow::slot_set_render_region(const QRect& rect)
     auto_ptr<RenderingManager::IScheduledAction> set_render_region_action(
         new SetRenderRegionAction(rect, m_attribute_editor));
 
-    if (m_settings.get_path_optional<bool>(SETTINGS_RENDER_REGION_TRIGGERS_RENDERING)
-        && !m_rendering_manager.is_rendering())
-    {
-        m_rendering_manager.schedule(set_render_region_action);
-        start_rendering(true);
-    }
-    else
+    if (!m_rendering_manager.is_rendering())
     {
         set_render_region_action.get()->operator()(
             *m_project_manager.get_project());
+
+        if (m_settings.get_path_optional<bool>(SETTINGS_RENDER_REGION_TRIGGERS_RENDERING))
+            start_rendering(true);
+        else m_rendering_manager.reinitialize_rendering();
+    }
+    else
+    {
+        m_rendering_manager.schedule(set_render_region_action);
         m_rendering_manager.reinitialize_rendering();
     }
 }

--- a/src/appleseed.studio/mainwindow/mainwindow.h
+++ b/src/appleseed.studio/mainwindow/mainwindow.h
@@ -91,7 +91,7 @@ class MainWindow
     void open_project(const QString& filepath);
     void open_and_render_project(const QString& filepath, const QString& configuration);
 
-    void emit_signal_crop_window_cleared() const;
+    void emit_refresh_attribute_editor_signal() const;
 
   signals:
     void signal_refresh_attribute_editor(const foundation::Dictionary& values) const;

--- a/src/appleseed.studio/mainwindow/mainwindow.h
+++ b/src/appleseed.studio/mainwindow/mainwindow.h
@@ -91,8 +91,10 @@ class MainWindow
     void open_project(const QString& filepath);
     void open_and_render_project(const QString& filepath, const QString& configuration);
 
+    void emit_signal_crop_window_cleared() const;
+
   signals:
-    void signal_crop_window_cleared();
+    void signal_refresh_attribute_editor(const foundation::Dictionary& values) const;
 
   private:
     // Not wrapped in std::auto_ptr<> to avoid pulling in the UI definition code.

--- a/src/appleseed.studio/mainwindow/mainwindow.h
+++ b/src/appleseed.studio/mainwindow/mainwindow.h
@@ -91,8 +91,6 @@ class MainWindow
     void open_project(const QString& filepath);
     void open_and_render_project(const QString& filepath, const QString& configuration);
 
-    void emit_refresh_attribute_editor_signal() const;
-
   signals:
     void signal_refresh_attribute_editor(const foundation::Dictionary& values) const;
 

--- a/src/appleseed.studio/mainwindow/project/attributeeditor.cpp
+++ b/src/appleseed.studio/mainwindow/project/attributeeditor.cpp
@@ -84,13 +84,12 @@ void AttributeEditor::edit(
     QObject::connect(
         m_entity_editor.get(), SIGNAL(signal_applied(foundation::Dictionary)),
         receiver, slot_apply);
+}
 
-    FrameItem* frame_item = dynamic_cast<FrameItem*>(receiver);
-
-    if (frame_item)
-        QObject::connect(
-            m_parent->window(), SIGNAL(signal_refresh_attribute_editor(foundation::Dictionary)),
-            m_entity_editor.get(), SLOT(slot_refresh_widgets(foundation::Dictionary)));
+void AttributeEditor::refresh(const foundation::Dictionary &values) const
+{
+    if (m_entity_editor.get())
+        m_entity_editor.get()->refresh(values);
 }
 
 }   // namespace studio

--- a/src/appleseed.studio/mainwindow/project/attributeeditor.cpp
+++ b/src/appleseed.studio/mainwindow/project/attributeeditor.cpp
@@ -31,13 +31,11 @@
 #include "attributeeditor.h"
 
 // appleseed.studio headers.
-#include "frameitem.h"
+#include "entityvalueprovider.h"
 #include "utility/miscellaneous.h"
 
 // Qt headers.
 #include <QLayout>
-#include <QObject>
-#include <Qt>
 
 using namespace foundation;
 using namespace renderer;
@@ -61,6 +59,7 @@ void AttributeEditor::clear()
         clear_layout(m_parent->layout());
         delete m_parent->layout();
         m_entity_editor.reset();
+        m_value_provider = nullptr;
     }
 }
 
@@ -72,6 +71,10 @@ void AttributeEditor::edit(
     QObject*                                receiver,
     const char*                             slot_apply)
 {
+    IEntityValueProvider* value_provider = dynamic_cast<IEntityValueProvider*>(receiver);
+    if (value_provider)
+        m_value_provider = value_provider;
+
     m_entity_editor.reset(
         new EntityEditor(
             m_parent,
@@ -86,10 +89,10 @@ void AttributeEditor::edit(
         receiver, slot_apply);
 }
 
-void AttributeEditor::refresh(const foundation::Dictionary &values) const
+void AttributeEditor::refresh() const
 {
-    if (m_entity_editor.get())
-        m_entity_editor.get()->refresh(values);
+    if (m_entity_editor.get() && m_value_provider)
+        m_entity_editor.get()->refresh(m_value_provider->get_values());
 }
 
 }   // namespace studio

--- a/src/appleseed.studio/mainwindow/project/attributeeditor.cpp
+++ b/src/appleseed.studio/mainwindow/project/attributeeditor.cpp
@@ -31,6 +31,7 @@
 #include "attributeeditor.h"
 
 // appleseed.studio headers.
+#include "frameitem.h"
 #include "utility/miscellaneous.h"
 
 // Qt headers.
@@ -59,6 +60,7 @@ void AttributeEditor::clear()
     {
         clear_layout(m_parent->layout());
         delete m_parent->layout();
+        m_entity_editor.reset();
     }
 }
 
@@ -83,9 +85,12 @@ void AttributeEditor::edit(
         m_entity_editor.get(), SIGNAL(signal_applied(foundation::Dictionary)),
         receiver, slot_apply);
 
-    QObject::connect(
-        m_parent->window(), SIGNAL(signal_crop_window_cleared()),
-        m_entity_editor.get(), SLOT(slot_clear_crop_window_widget()));
+    FrameItem* frame_item = dynamic_cast<FrameItem*>(receiver);
+
+    if (frame_item)
+        QObject::connect(
+            m_parent->window(), SIGNAL(signal_refresh_attribute_editor(foundation::Dictionary)),
+            m_entity_editor.get(), SLOT(slot_refresh_widgets(foundation::Dictionary)));
 }
 
 }   // namespace studio

--- a/src/appleseed.studio/mainwindow/project/attributeeditor.cpp
+++ b/src/appleseed.studio/mainwindow/project/attributeeditor.cpp
@@ -59,7 +59,7 @@ void AttributeEditor::clear()
         clear_layout(m_parent->layout());
         delete m_parent->layout();
         m_entity_editor.reset();
-        m_value_provider = nullptr;
+        m_value_provider = 0;
     }
 }
 

--- a/src/appleseed.studio/mainwindow/project/attributeeditor.h
+++ b/src/appleseed.studio/mainwindow/project/attributeeditor.h
@@ -66,6 +66,8 @@ class AttributeEditor
         QObject*                                        receiver,
         const char*                                     slot_apply);
 
+    void refresh(const foundation::Dictionary& values) const;
+
   private:
     QWidget*                    m_parent;
     renderer::Project&          m_project;

--- a/src/appleseed.studio/mainwindow/project/entityeditor.cpp
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.cpp
@@ -501,7 +501,7 @@ void EntityEditor::slot_rebuild_form()
     emit signal_applied(get_values());
 }
 
-void EntityEditor::slot_refresh_widgets(const Dictionary& values)
+void EntityEditor::refresh(const Dictionary& values)
 {
     m_form_factory->update(values, m_input_metadata);
 

--- a/src/appleseed.studio/mainwindow/project/entityeditor.cpp
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.cpp
@@ -108,7 +108,6 @@ EntityEditor::EntityEditor(
     m_top_layout = new QVBoxLayout(m_parent);
     m_top_layout->setMargin(7);
 
-    create_form_layout();
     create_connections();
     rebuild_form(values);
 }
@@ -502,12 +501,21 @@ void EntityEditor::slot_rebuild_form()
     emit signal_applied(get_values());
 }
 
-void EntityEditor::slot_clear_crop_window_widget()
+void EntityEditor::slot_refresh_widgets(const Dictionary& values)
 {
-    IInputWidgetProxy* widget_proxy = m_widget_proxies.get("crop_window");
+    m_form_factory->update(values, m_input_metadata);
 
-    if (widget_proxy)
-        widget_proxy->set("");
+    for (const_each<InputMetadataCollection> i = m_input_metadata; i; ++i)
+    {
+        const Dictionary& metadata = *i;
+
+        IInputWidgetProxy* widget_proxy = m_widget_proxies.get(
+            metadata.strings().get<string>("name"));
+
+        if (widget_proxy)
+            widget_proxy->set(
+                metadata.strings().get<string>("value"));
+    }
 }
 
 namespace

--- a/src/appleseed.studio/mainwindow/project/entityeditor.h
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.h
@@ -108,6 +108,8 @@ class EntityEditor
 
     foundation::Dictionary get_values() const;
 
+    void refresh(const foundation::Dictionary& values);
+
   signals:
     void signal_applied(foundation::Dictionary values);
 
@@ -153,8 +155,6 @@ class EntityEditor
 
   private slots:
     void slot_rebuild_form();
-
-    void slot_refresh_widgets(const foundation::Dictionary& values);
 
     void slot_open_entity_browser(const QString& widget_name);
     void slot_entity_browser_accept(QString widget_name, QString page_name, QString entity_name);

--- a/src/appleseed.studio/mainwindow/project/entityeditor.h
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.h
@@ -154,7 +154,7 @@ class EntityEditor
   private slots:
     void slot_rebuild_form();
 
-    void slot_clear_crop_window_widget();
+    void slot_refresh_widgets(const foundation::Dictionary& values);
 
     void slot_open_entity_browser(const QString& widget_name);
     void slot_entity_browser_accept(QString widget_name, QString page_name, QString entity_name);

--- a/src/appleseed.studio/mainwindow/project/entityitem.h
+++ b/src/appleseed.studio/mainwindow/project/entityitem.h
@@ -35,6 +35,7 @@
 #include "mainwindow/project/entitycreatorbase.h"
 #include "mainwindow/project/entityeditorcontext.h"
 #include "mainwindow/project/entityitembase.h"
+#include "mainwindow/project/entityvalueprovider.h"
 #include "mainwindow/project/itemregistry.h"
 #include "mainwindow/project/projectbuilder.h"
 #include "mainwindow/rendering/renderingmanager.h"
@@ -67,7 +68,8 @@ namespace studio {
 
 template <typename Entity, typename ParentEntity, typename CollectionItem>
 class EntityItem
-  : public EntityItemBase<Entity>
+  : public  EntityItemBase<Entity>
+  , public  IEntityValueProvider
   , private EntityCreatorBase
 {
   public:
@@ -79,6 +81,8 @@ class EntityItem
 
     void set_fixed_position(const bool fixed);
     bool is_fixed_position() const;
+
+    virtual const foundation::Dictionary get_values() APPLESEED_OVERRIDE;
 
   protected:
     typedef EntityItemBase<Entity> Base;
@@ -131,6 +135,12 @@ template <typename Entity, typename ParentEntity, typename CollectionItem>
 bool EntityItem<Entity, ParentEntity, CollectionItem>::is_fixed_position() const
 {
     return m_fixed_position;
+}
+
+template <typename Entity, typename ParentEntity, typename CollectionItem>
+const foundation::Dictionary EntityItem<Entity, ParentEntity, CollectionItem>::get_values()
+{
+    return renderer::EntityTraits<Entity>::get_entity_values(Base::m_entity);
 }
 
 template <typename Entity, typename ParentEntity, typename CollectionItem>

--- a/src/appleseed.studio/mainwindow/project/entityvalueprovider.h
+++ b/src/appleseed.studio/mainwindow/project/entityvalueprovider.h
@@ -27,56 +27,21 @@
 // THE SOFTWARE.
 //
 
-#ifndef APPLESEED_STUDIO_MAINWINDOW_PROJECT_ATTRIBUTEEDITOR_H
-#define APPLESEED_STUDIO_MAINWINDOW_PROJECT_ATTRIBUTEEDITOR_H
-
-// appleseed.studio headers.
-#include "mainwindow/project/entityeditor.h"
-
-// appleseed.foundation headers.
-#include "foundation/core/concepts/noncopyable.h"
-
-// Standard headers.
-#include <memory>
+#ifndef APPLESEED_STUDIO_MAINWINDOW_PROJECT_ENTITYVALUEPROVIDER_H
+#define APPLESEED_STUDIO_MAINWINDOW_PROJECT_ENTITYVALUEPROVIDER_H
 
 // Forward declarations.
-namespace appleseed     { namespace studio { class IEntityValueProvider; } }
-namespace foundation    { class Dictionary; }
-namespace renderer      { class Project; }
-class QObject;
-class QWidget;
+namespace foundation { class Dictionary; }
 
 namespace appleseed {
 namespace studio {
 
-class AttributeEditor
-  : public foundation::NonCopyable
-{
+class IEntityValueProvider {
   public:
-    AttributeEditor(
-        QWidget*                parent,
-        renderer::Project&      project);
-
-    void clear();
-
-    void edit(
-        std::auto_ptr<EntityEditor::IFormFactory>       form_factory,
-        std::auto_ptr<EntityEditor::IEntityBrowser>     entity_browser,
-        std::auto_ptr<CustomEntityUI>                   custom_ui,
-        const foundation::Dictionary&                   values,
-        QObject*                                        receiver,
-        const char*                                     slot_apply);
-
-    void refresh() const;
-
-  private:
-    QWidget*                    m_parent;
-    IEntityValueProvider*       m_value_provider;
-    renderer::Project&          m_project;
-    std::auto_ptr<EntityEditor> m_entity_editor;
+    virtual const foundation::Dictionary get_values() = 0;
 };
 
-}       // namespace studio
-}       // namespace appleseed
+}
+}
 
-#endif  // !APPLESEED_STUDIO_MAINWINDOW_PROJECT_ATTRIBUTEEDITOR_H
+#endif  // !APPLESEED_STUDIO_MAINWINDOW_PROJECT_ENTITYVALUEPROVIDER_H

--- a/src/appleseed.studio/mainwindow/project/entityvalueprovider.h
+++ b/src/appleseed.studio/mainwindow/project/entityvalueprovider.h
@@ -5,8 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2010-2013 Francois Beaune, Jupiter Jazz Limited
-// Copyright (c) 2014-2017 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2017 Andrei Ivashchenko, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/appleseed.studio/mainwindow/project/frameitem.cpp
+++ b/src/appleseed.studio/mainwindow/project/frameitem.cpp
@@ -134,5 +134,10 @@ void FrameItem::edit(const Dictionary& values)
     set_title(QString::fromAscii(m_frame->get_name()));
 }
 
+const Dictionary FrameItem::get_values()
+{
+    return m_frame->get_parameters();
+}
+
 }   // namespace studio
 }   // namespace appleseed

--- a/src/appleseed.studio/mainwindow/project/frameitem.h
+++ b/src/appleseed.studio/mainwindow/project/frameitem.h
@@ -33,6 +33,7 @@
 // appleseed.studio headers.
 #include "mainwindow/project/entityactions.h"
 #include "mainwindow/project/entitycreatorbase.h"
+#include "mainwindow/project/entityvalueprovider.h"
 #include "mainwindow/project/itembase.h"
 
 // appleseed.foundation headers.
@@ -53,6 +54,7 @@ namespace studio {
 class FrameItem
   : public ItemBase
   , public EntityCreatorBase
+  , public IEntityValueProvider
 {
     Q_OBJECT
 
@@ -60,6 +62,8 @@ class FrameItem
     FrameItem(
         EntityEditorContext&    editor_context,
         renderer::Frame*        frame);
+
+  virtual const foundation::Dictionary get_values() APPLESEED_OVERRIDE;
 
   private slots:
     void slot_edit_accepted(foundation::Dictionary values);


### PR DESCRIPTION
Reset EntityEditor auto_ptr properly while clearing the layout
Update all EntityEditor form widgets with dictionary
Remove unnecessary create_form_layout call