### PR TITLE
Fix crash on Windows

### DIFF
--- a/src/appleseed.studio/mainwindow/project/disneymateriallayerui.cpp
+++ b/src/appleseed.studio/mainwindow/project/disneymateriallayerui.cpp
@@ -302,7 +302,7 @@ namespace
 
                 search_path =
                     QDir::cleanPath(
-                        QString::fromStdString(s.get_root_path()) +
+                        QString::fromAscii(s.get_root_path().c_str()) +
                         QDir::separator() +
                         search_path);
             }
@@ -316,7 +316,7 @@ namespace
 
         if (s.has_root_path())
         {
-            const QDir root_dir(QString::fromStdString(s.get_root_path()));
+            const QDir root_dir(QString::fromAscii(s.get_root_path().c_str()));
             assert(root_dir.isAbsolute());
 
             QString relative_path;

--- a/src/appleseed/foundation/meta/tests/test_searchpaths.cpp
+++ b/src/appleseed/foundation/meta/tests/test_searchpaths.cpp
@@ -27,6 +27,7 @@
 //
 
 // appleseed.foundation headers.
+#include "foundation/utility/api/apistring.h"
 #include "foundation/utility/searchpaths.h"
 #include "foundation/utility/test.h"
 
@@ -59,8 +60,8 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
 
         const SearchPaths searchpaths(TestEnvVarName, ';');
 
-        const string result = searchpaths.to_string(';');
-        EXPECT_EQ("", result);
+        const APIString result = searchpaths.to_string(';');
+        EXPECT_EQ("", to_string(result));
     }
 
     TEST_CASE(Constructor_NonEmptyEnvironmentVariable)
@@ -69,8 +70,8 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
 
         const SearchPaths searchpaths(TestEnvVarName, ';');
 
-        const string result = searchpaths.to_string(';');
-        EXPECT_EQ("C:\\Windows\\System32;C:\\Windows;C:\\Program Files", result);
+        const APIString result = searchpaths.to_string(';');
+        EXPECT_EQ("C:\\Windows\\System32;C:\\Windows;C:\\Program Files", to_string(result));
     }
 
     TEST_CASE(Reset)
@@ -82,8 +83,8 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
         searchpaths.push_back("C:\\Users\\UserName\\appleseed");
         searchpaths.reset();
 
-        const string result = searchpaths.to_string(';');
-        EXPECT_EQ("C:\\Some\\Root\\Path;C:\\Windows\\System32;C:\\Windows;C:\\Program Files", result);
+        const APIString result = searchpaths.to_string(';');
+        EXPECT_EQ("C:\\Some\\Root\\Path;C:\\Windows\\System32;C:\\Windows;C:\\Program Files", to_string(result));
     }
 
     TEST_CASE(SplitAndPushBack)
@@ -91,8 +92,8 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
         SearchPaths searchpaths;
         searchpaths.split_and_push_back("C:\\Windows\\System32;C:\\Windows;C:\\Program Files", ';');
 
-        const string result = searchpaths.to_string(';');
-        EXPECT_EQ("C:\\Windows\\System32;C:\\Windows;C:\\Program Files", result);
+        const APIString result = searchpaths.to_string(';');
+        EXPECT_EQ("C:\\Windows\\System32;C:\\Windows;C:\\Program Files", to_string(result));
     }
 
     TEST_CASE(ToStringReversed)
@@ -100,8 +101,8 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
         SearchPaths searchpaths;
         searchpaths.split_and_push_back("C:\\Windows\\System32;C:\\Windows;C:\\Program Files", ';');
 
-        const string result = searchpaths.to_string_reversed(';');
-        EXPECT_EQ("C:\\Program Files;C:\\Windows;C:\\Windows\\System32", result);
+        const APIString result = searchpaths.to_string_reversed(';');
+        EXPECT_EQ("C:\\Program Files;C:\\Windows;C:\\Windows\\System32", to_string(result));
     }
 
 #else
@@ -121,8 +122,8 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
 
         const SearchPaths searchpaths(TestEnvVarName, ':');
 
-        const string result = searchpaths.to_string(':');
-        EXPECT_EQ("", result);
+        const APIString result = searchpaths.to_string(':');
+        EXPECT_EQ("", to_string(result));
     }
 
     TEST_CASE(Constructor_NonEmptyEnvironmentVariable)
@@ -131,8 +132,8 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
 
         const SearchPaths searchpaths(TestEnvVarName, ':');
 
-        const string result = searchpaths.to_string(':');
-        EXPECT_EQ("/tmp:/usr/tmp:/var/local/tmp", result);
+        const APIString result = searchpaths.to_string(':');
+        EXPECT_EQ("/tmp:/usr/tmp:/var/local/tmp", to_string(result));
     }
 
     TEST_CASE(Reset)
@@ -144,8 +145,8 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
         searchpaths.push_back("/home/username/appleseed");
         searchpaths.reset();
 
-        const string result = searchpaths.to_string(':');
-        EXPECT_EQ("/some/root/path:/tmp:/usr/tmp:/var/local/tmp", result);
+        const APIString result = searchpaths.to_string(':');
+        EXPECT_EQ("/some/root/path:/tmp:/usr/tmp:/var/local/tmp", to_string(result));
     }
 
     TEST_CASE(SplitAndPushBack)
@@ -153,8 +154,8 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
         SearchPaths searchpaths;
         searchpaths.split_and_push_back("/tmp:/usr/tmp:/var/local/tmp", ':');
 
-        const string result = searchpaths.to_string(':');
-        EXPECT_EQ("/tmp:/usr/tmp:/var/local/tmp", result);
+        const APIString result = searchpaths.to_string(':');
+        EXPECT_EQ("/tmp:/usr/tmp:/var/local/tmp", to_string(result));
     }
 
     TEST_CASE(ToStringReversed)
@@ -162,8 +163,8 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
         SearchPaths searchpaths;
         searchpaths.split_and_push_back("/tmp:/usr/tmp:/var/local/tmp", ':');
 
-        const string result = searchpaths.to_string_reversed(':');
-        EXPECT_EQ("/var/local/tmp:/usr/tmp:/tmp", result);
+        const APIString result = searchpaths.to_string_reversed(':');
+        EXPECT_EQ("/var/local/tmp:/usr/tmp:/tmp", to_string(result));
     }
 
 #endif

--- a/src/appleseed/foundation/utility/api/apistring.cpp
+++ b/src/appleseed/foundation/utility/api/apistring.cpp
@@ -29,8 +29,16 @@
 // Interface header.
 #include "apistring.h"
 
+// Standard headers.
+#include <cassert>
+
 namespace foundation
 {
+
+APIString::APIString()
+  : m_s(0)
+{
+}
 
 APIString::APIString(const char* s)
   : m_s(duplicate_string(s))
@@ -38,7 +46,7 @@ APIString::APIString(const char* s)
 }
 
 APIString::APIString(const APIString& rhs)
-  : m_s(duplicate_string(rhs.m_s))
+  : m_s(rhs.m_s ? duplicate_string(rhs.m_s) : 0)
 {
 }
 
@@ -47,9 +55,21 @@ APIString::~APIString()
     free_string(m_s);
 }
 
+APIString& APIString::operator=(const APIString& rhs)
+{
+    free_string(m_s);
+    m_s = rhs.m_s ? duplicate_string(rhs.m_s) : 0;
+    return *this;
+}
+
 const char* APIString::c_str() const
 {
-    return m_s;
+    return m_s ? m_s : "";
+}
+
+bool APIString::empty() const
+{
+    return m_s ? m_s[0] == '\0' : true;
 }
 
 }   // namespace foundation

--- a/src/appleseed/foundation/utility/api/apistring.h
+++ b/src/appleseed/foundation/utility/api/apistring.h
@@ -48,17 +48,20 @@ namespace foundation
 class APPLESEED_DLLSYMBOL APIString
 {
   public:
+    APIString();
     explicit APIString(const char* s);
     APIString(const APIString& rhs);
 
     ~APIString();
 
+    APIString& operator=(const APIString& rhs);
+
     const char* c_str() const;
+
+    bool empty() const;
 
   private:
     const char* m_s;
-
-    APIString& operator=(const APIString& rhs);
 };
 
 template <>

--- a/src/appleseed/foundation/utility/searchpaths.cpp
+++ b/src/appleseed/foundation/utility/searchpaths.cpp
@@ -136,6 +136,11 @@ void SearchPaths::set_root_path(const char* path)
     impl->m_root_path = bf::path(path).make_preferred();
 }
 
+APIString SearchPaths::get_root_path() const
+{
+    return APIString(impl->m_root_path.string().c_str());
+}
+
 bool SearchPaths::has_root_path() const
 {
     return !impl->m_root_path.empty();
@@ -228,12 +233,14 @@ bool SearchPaths::exist(const char* filepath) const
     return bf::exists(fp);
 }
 
-char* SearchPaths::do_get_root_path() const
+APIString SearchPaths::qualify(const char* filepath) const
 {
-    return duplicate_string(impl->m_root_path.string().c_str());
+    APIString qualified_filepath;
+    qualify(filepath, &qualified_filepath, 0);
+    return qualified_filepath;
 }
 
-void SearchPaths::do_qualify(const char* filepath, char** qualified_filepath_cstr, char** search_path_cstr) const
+void SearchPaths::qualify(const char* filepath, APIString* qualified_filepath_str, APIString* search_path_str) const
 {
     assert(filepath);
 
@@ -256,9 +263,9 @@ void SearchPaths::do_qualify(const char* filepath, char** qualified_filepath_cst
             if (bf::exists(qualified_fp))
             {
                 qualified_fp.make_preferred();
-                *qualified_filepath_cstr = duplicate_string(qualified_fp.string().c_str());
-                if (search_path_cstr)
-                    *search_path_cstr = duplicate_string(i->c_str());
+                *qualified_filepath_str = APIString(qualified_fp.string().c_str());
+                if (search_path_str)
+                    *search_path_str = APIString(i->c_str());
                 return;
             }
         }
@@ -271,20 +278,20 @@ void SearchPaths::do_qualify(const char* filepath, char** qualified_filepath_cst
             if (bf::exists(qualified_fp))
             {
                 qualified_fp.make_preferred();
-                *qualified_filepath_cstr = duplicate_string(qualified_fp.string().c_str());
-                if (search_path_cstr)
-                    *search_path_cstr = 0;
+                *qualified_filepath_str = APIString(qualified_fp.string().c_str());
+                if (search_path_str)
+                    *search_path_str = APIString();
                 return;
             }
         }
     }
 
-    *qualified_filepath_cstr = duplicate_string(fp.string().c_str());
-    if (search_path_cstr)
-        *search_path_cstr = 0;
+    *qualified_filepath_str = APIString(fp.string().c_str());
+    if (search_path_str)
+        *search_path_str = APIString();
 }
 
-char* SearchPaths::do_to_string(const char separator, const bool reversed) const
+APIString SearchPaths::do_to_string(const char separator, const bool reversed) const
 {
     Impl::PathCollection paths;
 
@@ -319,7 +326,7 @@ char* SearchPaths::do_to_string(const char separator, const bool reversed) const
         paths_str.append(p.string());
     }
 
-    return duplicate_string(paths_str.c_str());
+    return APIString(paths_str.c_str());
 }
 
 }   // namespace foundation

--- a/src/appleseed/foundation/utility/searchpaths.h
+++ b/src/appleseed/foundation/utility/searchpaths.h
@@ -31,7 +31,7 @@
 #define APPLESEED_FOUNDATION_UTILITY_SEARCHPATHS_H
 
 // appleseed.foundation headers.
-#include "foundation/utility/string.h"
+#include "foundation/utility/api/apistring.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
@@ -83,7 +83,7 @@ class APPLESEED_DLLSYMBOL SearchPaths
     void set_root_path(const std::string& path);
 
     // Return the root path used to resolve relative search paths.
-    std::string get_root_path() const;
+    APIString get_root_path() const;
 
     // Return true if the root path has been set.
     bool has_root_path() const;
@@ -120,23 +120,24 @@ class APPLESEED_DLLSYMBOL SearchPaths
     bool exist(const std::string& filepath) const;
 
     // Find a file in the search paths. If the file was found, the qualified path to
-    // this file is returned. Otherwise the input path is returned. The second variant
-    // also returns the search path inside which the file was found.
-    std::string qualify(const std::string& filepath) const;
-    void qualify(const std::string& filepath, std::string& qualified_filepath, std::string& search_path);
+    // this file is returned. Otherwise the input path is returned.
+    APIString qualify(const char* filepath) const;
+    APIString qualify(const std::string& filepath) const;
+
+    // Same as above but also returns the search path inside which the file was found.
+    void qualify(const char* filepath, APIString* qualified_filepath, APIString* search_path) const;
+    void qualify(const std::string& filepath, APIString* qualified_filepath, APIString* search_path) const;
 
     // Return a string with all the search paths separated by the specified separator.
     // The second variant returns the search paths in reverse order.
-    std::string to_string(const char separator) const;
-    std::string to_string_reversed(const char separator) const;
+    APIString to_string(const char separator) const;
+    APIString to_string_reversed(const char separator) const;
 
   protected:
     struct Impl;
     Impl* impl;
 
-    char* do_get_root_path() const;
-    void do_qualify(const char* filepath, char** qualified_filepath_cstr, char** search_path_cstr) const;
-    char* do_to_string(const char separator, const bool reversed) const;
+    APIString do_to_string(const char separator, const bool reversed) const;
 };
 
 
@@ -147,11 +148,6 @@ class APPLESEED_DLLSYMBOL SearchPaths
 inline void SearchPaths::set_root_path(const std::string& path)
 {
     set_root_path(path.c_str());
-}
-
-inline std::string SearchPaths::get_root_path() const
-{
-    return convert_to_std_string(do_get_root_path());
 }
 
 inline void SearchPaths::push_back(const std::string& path)
@@ -169,32 +165,24 @@ inline bool SearchPaths::exist(const std::string& filepath) const
     return exist(filepath.c_str());
 }
 
-inline std::string SearchPaths::qualify(const std::string& filepath) const
+inline APIString SearchPaths::qualify(const std::string& filepath) const
 {
-    char* qualified_filepath_cstr;
-    do_qualify(filepath.c_str(), &qualified_filepath_cstr, 0);
-
-    return convert_to_std_string(qualified_filepath_cstr);
+    return qualify(filepath.c_str());
 }
 
-inline void SearchPaths::qualify(const std::string& filepath, std::string& qualified_filepath, std::string& search_path)
+inline void SearchPaths::qualify(const std::string& filepath, APIString* qualified_filepath, APIString* search_path) const
 {
-    char* qualified_filepath_cstr;
-    char* search_path_cstr;
-    do_qualify(filepath.c_str(), &qualified_filepath_cstr, &search_path_cstr);
-
-    qualified_filepath = convert_to_std_string(qualified_filepath_cstr);
-    search_path = search_path_cstr ? convert_to_std_string(search_path_cstr) : std::string();
+    qualify(filepath.c_str(), qualified_filepath, search_path);
 }
 
-inline std::string SearchPaths::to_string(const char separator) const
+inline APIString SearchPaths::to_string(const char separator) const
 {
-    return convert_to_std_string(do_to_string(separator, false));
+    return do_to_string(separator, false);
 }
 
-inline std::string SearchPaths::to_string_reversed(const char separator) const
+inline APIString SearchPaths::to_string_reversed(const char separator) const
 {
-    return convert_to_std_string(do_to_string(separator, true));
+    return do_to_string(separator, true);
 }
 
 }       // namespace foundation

--- a/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
@@ -56,6 +56,7 @@
 #include "foundation/platform/thread.h"
 #include "foundation/platform/timers.h"
 #include "foundation/platform/types.h"
+#include "foundation/utility/api/apistring.h"
 #include "foundation/utility/containers/dictionary.h"
 #include "foundation/utility/foreach.h"
 #include "foundation/utility/gnuplotfile.h"
@@ -151,7 +152,7 @@ namespace
             if (!m_params.m_ref_image_path.empty())
             {
                 const string ref_image_path =
-                    project.search_paths().qualify(m_params.m_ref_image_path);
+                    to_string(project.search_paths().qualify(m_params.m_ref_image_path));
 
                 RENDERER_LOG_DEBUG("loading reference image %s...", ref_image_path.c_str());
 
@@ -541,7 +542,7 @@ namespace
                 if (!m_sample_count_records.empty())
                 {
                     const string filepath =
-                        (bf::path(m_project.search_paths().get_root_path()) / "sample_count.gnuplot").string();
+                        (bf::path(m_project.search_paths().get_root_path().c_str()) / "sample_count.gnuplot").string();
                     RENDERER_LOG_DEBUG("writing %s...", filepath.c_str());
 
                     GnuplotFile plotfile;
@@ -557,7 +558,7 @@ namespace
                 if (!m_rmsd_records.empty())
                 {
                     const string filepath =
-                        (bf::path(m_project.search_paths().get_root_path()) / "rms_deviation.gnuplot").string();
+                        (bf::path(m_project.search_paths().get_root_path().c_str()) / "rms_deviation.gnuplot").string();
                     RENDERER_LOG_DEBUG("writing %s...", filepath.c_str());
 
                     GnuplotFile plotfile;

--- a/src/appleseed/renderer/modeling/display/display.cpp
+++ b/src/appleseed/renderer/modeling/display/display.cpp
@@ -37,6 +37,7 @@
 
 // appleseed.foundation headers.
 #include "foundation/platform/sharedlibrary.h"
+#include "foundation/utility/api/apistring.h"
 #include "foundation/utility/searchpaths.h"
 
 // Standard headers.
@@ -107,9 +108,9 @@ bool Display::open(const Project& project)
 
     try
     {
-        plugin = get_parameters().get("plugin_name");
+        plugin = m_params.get("plugin_name");
         plugin += Plugin::get_default_file_extension();
-        plugin = project.search_paths().qualify(plugin);
+        plugin = to_string(project.search_paths().qualify(plugin));
     }
     catch (const ExceptionDictionaryKeyNotFound&)
     {
@@ -119,7 +120,7 @@ bool Display::open(const Project& project)
 
     try
     {
-        impl = new Impl(plugin.c_str(), get_parameters());
+        impl = new Impl(plugin.c_str(), m_params);
     }
     catch (const ExceptionCannotLoadSharedLib& e)
     {

--- a/src/appleseed/renderer/modeling/object/curveobjectreader.cpp
+++ b/src/appleseed/renderer/modeling/object/curveobjectreader.cpp
@@ -47,6 +47,7 @@
 #include "foundation/math/vector.h"
 #include "foundation/platform/defaulttimers.h"
 #include "foundation/platform/types.h"
+#include "foundation/utility/api/apistring.h"
 #include "foundation/utility/memory.h"
 #include "foundation/utility/otherwise.h"
 #include "foundation/utility/searchpaths.h"
@@ -201,7 +202,7 @@ auto_release_ptr<CurveObject> CurveObjectReader::load_text_curve_file(
 {
     auto_release_ptr<CurveObject> object = CurveObjectFactory::create(name, params);
 
-    const string filepath = search_paths.qualify(params.get<string>("filepath"));
+    const string filepath = to_string(search_paths.qualify(params.get("filepath")));
     const size_t split_count = params.get_optional<size_t>("presplits", 0);
 
     ifstream input;
@@ -301,7 +302,7 @@ auto_release_ptr<CurveObject> CurveObjectReader::load_mitsuba_curve_file(
 
     auto_release_ptr<CurveObject> object = CurveObjectFactory::create(name, params);
 
-    const string filepath = search_paths.qualify(params.get<string>("filepath"));
+    const string filepath = to_string(search_paths.qualify(params.get("filepath")));
 
     FILE* file = fopen(filepath.c_str(), "rb");
     if (file == 0)

--- a/src/appleseed/renderer/modeling/project/assethandler.cpp
+++ b/src/appleseed/renderer/modeling/project/assethandler.cpp
@@ -39,6 +39,7 @@
 
 // appleseed.foundation headers.
 #include "foundation/platform/path.h"
+#include "foundation/utility/api/apistring.h"
 #include "foundation/utility/api/specializedapiarrays.h"
 #include "foundation/utility/foreach.h"
 #include "foundation/utility/otherwise.h"
@@ -203,18 +204,15 @@ bool AssetHandler::handle_asset(string& asset_path) const
         return handle_absolute_asset(asset_path);
 
     // Otherwise, let's check if the asset is found in a search path.
-    string qualified_asset_path;
-    string search_path;
-    m_project.search_paths().qualify(
-        asset_path,
-        qualified_asset_path,
-        search_path);
+    APIString qualified_asset_path;
+    APIString search_path;
+    m_project.search_paths().qualify(asset_path, &qualified_asset_path, &search_path);
 
-    if (search_path.empty() || path(search_path).is_relative())
+    if (search_path.empty() || path(search_path.c_str()).is_relative())
     {
         // Relative asset path, found in a relative search path or in the root directory.
         if (m_project_old_root_dir == m_project_new_root_dir ||
-            is_extension_of(qualified_asset_path, m_project.search_paths().get_root_path()))
+            is_extension_of(qualified_asset_path.c_str(), m_project.search_paths().get_root_path().c_str()))
         {
             // Relative asset/search path, below the project's root path.
             return copy_relative_asset(asset_path);
@@ -261,8 +259,7 @@ bool AssetHandler::make_absolute_asset_path(string& asset_path) const
 {
     // Make sure the asset path is qualified and canonized.
     path absolute_asset_path =
-        canonical(
-            m_project.search_paths().qualify(asset_path));
+        canonical(m_project.search_paths().qualify(asset_path).c_str());
 
     // Make sure absolute paths use native separators.
     absolute_asset_path.make_preferred();
@@ -280,7 +277,7 @@ bool AssetHandler::copy_absolute_asset(string& asset_path) const
 
     // Copy the asset file.
     if (!safe_copy_file(
-            m_project.search_paths().qualify(asset_path),
+            m_project.search_paths().qualify(asset_path).c_str(),
             new_absolute_asset_path))
         return false;
 
@@ -300,7 +297,7 @@ bool AssetHandler::copy_relative_asset(string& asset_path) const
     {
         // Copy the asset file.
         if (!safe_copy_file(
-                m_project.search_paths().qualify(asset_path),
+                m_project.search_paths().qualify(asset_path).c_str(),
                 m_project_new_root_dir / asset_path))
             return false;
     }

--- a/src/appleseed/renderer/modeling/project/project.cpp
+++ b/src/appleseed/renderer/modeling/project/project.cpp
@@ -161,7 +161,7 @@ SearchPaths& Project::search_paths() const
 
 string Project::make_search_path_string() const
 {
-    return impl->m_search_paths.to_string_reversed(SearchPaths::osl_path_separator());
+    return to_string(impl->m_search_paths.to_string_reversed(SearchPaths::osl_path_separator()));
 }
 
 void Project::set_scene(auto_release_ptr<Scene> scene)

--- a/src/appleseed/renderer/modeling/scene/archiveassembly.cpp
+++ b/src/appleseed/renderer/modeling/scene/archiveassembly.cpp
@@ -39,6 +39,7 @@
 #include "renderer/utility/paramarray.h"
 
 // appleseed.foundation headers.
+#include "foundation/utility/api/apistring.h"
 #include "foundation/utility/api/specializedapiarrays.h"
 #include "foundation/utility/containers/dictionary.h"
 #include "foundation/utility/foreach.h"
@@ -101,7 +102,8 @@ bool ArchiveAssembly::expand_contents(
     {
         // Establish and store the qualified path to the archive project.
         const SearchPaths& search_paths = project.search_paths();
-        const string filepath = search_paths.qualify(m_params.get_required<string>("filename", ""));
+        const string filepath =
+            to_string(search_paths.qualify(m_params.get_required<string>("filename", "")));
 
         ProjectFileReader reader;
         auto_release_ptr<Assembly> assembly =

--- a/src/appleseed/renderer/modeling/shadergroup/shaderquery.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderquery.cpp
@@ -31,6 +31,7 @@
 
 // appleseed.foundation headers.
 #include "foundation/math/vector.h"
+#include "foundation/utility/api/apistring.h"
 #include "foundation/utility/containers/dictionary.h"
 #include "foundation/utility/iostreamop.h"
 #include "foundation/utility/searchpaths.h"
@@ -174,7 +175,8 @@ ShaderQuery::ShaderQuery(const char* search_path)
 ShaderQuery::ShaderQuery(const SearchPaths& search_paths)
   : impl(new Impl())
 {
-    impl->m_search_path = search_paths.to_string_reversed(SearchPaths::osl_path_separator());
+    impl->m_search_path =
+        to_string(search_paths.to_string_reversed(SearchPaths::osl_path_separator()));
 }
 
 ShaderQuery::~ShaderQuery()

--- a/src/appleseed/renderer/modeling/texture/disktexture2d.cpp
+++ b/src/appleseed/renderer/modeling/texture/disktexture2d.cpp
@@ -42,6 +42,7 @@
 #include "foundation/image/genericprogressiveimagefilereader.h"
 #include "foundation/image/tile.h"
 #include "foundation/platform/thread.h"
+#include "foundation/utility/api/apistring.h"
 #include "foundation/utility/api/specializedapiarrays.h"
 #include "foundation/utility/containers/dictionary.h"
 #include "foundation/utility/makevector.h"
@@ -79,7 +80,7 @@ namespace
             const EntityDefMessageContext message_context("texture", this);
 
             // Establish and store the qualified path to the texture file.
-            m_filepath = search_paths.qualify(m_params.get_required<string>("filename", ""));
+            m_filepath = to_string(search_paths.qualify(m_params.get_required<string>("filename", "")));
 
             // Retrieve the color space.
             const string color_space =


### PR DESCRIPTION
Even a thorough investigation wasn't entirely conclusive. I believe that the compiler was refusing to obey the force-inlining directives, and thus an std::string was allocated in appleseed.dll and freed in appleseed.studio.exe. Using foundation::APIString is a more robust solution.

Please review carefully.