### PR TITLE
Force gcc 5+ old C++ ABI when building in C++03 mode

### DIFF
--- a/src/cmake/config/linux-gcc.txt
+++ b/src/cmake/config/linux-gcc.txt
@@ -106,6 +106,7 @@ elseif (CMAKE_COMPILER_IS_GNUCC AND (NOT CMAKE_COMPILER_IS_CLANG))
         )
 
         add_definitions (-DBOOST_NO_CXX11_SCOPED_ENUMS)
+        add_definitions (-D_GLIBCXX_USE_CXX11_ABI=0)
     endif()
 endif ()
 


### PR DESCRIPTION
Fixes gcc 5.X link errors with prebuilt deps when building in C++03 mode for linux distributions that enable the new ABI by default.