### PR TITLE
Fix bug when valid packed project doesn't open

### DIFF
--- a/src/appleseed/foundation/utility/unzipper.cpp
+++ b/src/appleseed/foundation/utility/unzipper.cpp
@@ -31,6 +31,7 @@
 
 // appleseed.foundation headers.
 #include "foundation/core/exceptions/exception.h"
+#include "foundation/utility/string.h"
 #include "foundation/utility/minizip/unzip.h"
 
 // Boost headers.
@@ -160,12 +161,6 @@ void unzip(const string& zip_filename, const string& unzipped_dir)
     }
 }
 
-bool has_extension(const string& filename, const string& extension) 
-{
-    size_t extension_start = filename.rfind(extension);
-    return  extension_start != string::npos && extension_start == filename.size() - extension.size();
-}
-
 vector<string> get_filenames_with_extension_from_zip(const string& zip_filename, const string& extension) 
 {
     vector<string> filenames;
@@ -180,7 +175,7 @@ vector<string> get_filenames_with_extension_from_zip(const string& zip_filename,
     while (has_next == UNZ_OK)
     {
         string filename = read_filename(zip_file);
-        if (has_extension(filename, extension))
+        if (ends_with(filename, extension))
             filenames.push_back(filename);
 
         has_next = unzGoToNextFile(zip_file);

--- a/src/appleseed/foundation/utility/unzipper.cpp
+++ b/src/appleseed/foundation/utility/unzipper.cpp
@@ -38,7 +38,6 @@
 
 // Standard headers.
 #include <fstream>
-#include <iostream>
 #include <string>
 #include <sstream>
 
@@ -163,7 +162,8 @@ void unzip(const string& zip_filename, const string& unzipped_dir)
 
 bool has_extension(const string& filename, const string& extension) 
 {
-    return filename.rfind(extension) == filename.size() - extension.size();
+    size_t extension_start = filename.rfind(extension);
+    return  extension_start != string::npos && extension_start == filename.size() - extension.size();
 }
 
 vector<string> get_filenames_with_extension_from_zip(const string& zip_filename, const string& extension) 


### PR DESCRIPTION
The reason was in has_extension(). It didn't check rfind() result on npos
When filename.size() == extension.size() - 1 substraction of this two values is -1
npos == -1 so in this case function returned true although file don't have such extension