### PR TITLE
OSL subsurface fixes

### DIFF
--- a/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.cpp
@@ -446,20 +446,23 @@ namespace
                         vertex_aovs);
                 }
 
-                // If we have an OSL shader and this is not the last vertex of the path,
-                // we need to choose one of the closures and set its shading basis into the shading point
-                // for the DirectLightingIntegrator to use it.
-                if (!last_vertex && (m_params.m_enable_dl || m_params.m_enable_ibl))
+                if (vertex.m_bssrdf == 0)
                 {
-                    const Material::RenderData& material_data =
-                        vertex.m_shading_point->get_material()->get_render_data();
-
-                    if (material_data.m_shader_group)
+                    // If we have an OSL shader and this is not the last vertex of the path,
+                    // we need to choose one of the closures and set its shading basis into the shading point
+                    // for the DirectLightingIntegrator to use it.
+                    if (!last_vertex && (m_params.m_enable_dl || m_params.m_enable_ibl))
                     {
-                        m_sampling_context.split_in_place(2, 1);
-                        m_shading_context.choose_bsdf_closure_shading_basis(
-                            *vertex.m_shading_point,
-                            m_sampling_context.next2<Vector2f>());
+                        const Material::RenderData& material_data =
+                            vertex.m_shading_point->get_material()->get_render_data();
+
+                        if (material_data.m_shader_group)
+                        {
+                            m_sampling_context.split_in_place(2, 1);
+                            m_shading_context.choose_bsdf_closure_shading_basis(
+                                *vertex.m_shading_point,
+                                m_sampling_context.next2<Vector2f>());
+                        }
                     }
                 }
 

--- a/src/appleseed/renderer/modeling/bssrdf/separablebssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/separablebssrdf.cpp
@@ -225,9 +225,9 @@ namespace
             VisibilityFlags::ProbeRay,
             outgoing_point.get_ray().m_depth + 1);
 
-        assert(outgoing_point.get_material() != 0);
-        const BSSRDF* outgoing_bssrdf = &bssrdf;
         const ObjectInstance& outgoing_object_instance = outgoing_point.get_object_instance();
+        const Material* outgoing_material = outgoing_point.get_material();
+        assert(outgoing_material != 0);
 
         const size_t MaxIterations = 16;
         const size_t MaxSampleCount = 16;
@@ -248,22 +248,16 @@ namespace
             probe_ray.m_tmax = norm(exit_point - probe_ray.m_org);
 
             const Material* incoming_material = incoming_point.get_material();
-            const BSSRDF* incoming_bssrdf =
-                incoming_material == 0 ? 0 :
-                incoming_material->get_render_data().m_bssrdf;
             const Material* incoming_opposite_material = incoming_point.get_opposite_material();
-            const BSSRDF* incoming_opposite_bssrdf =
-                incoming_opposite_material == 0 ? 0 :
-                incoming_opposite_material->get_render_data().m_bssrdf;
 
-            bool same_bssrdf =
-                incoming_bssrdf == outgoing_bssrdf || incoming_opposite_bssrdf == outgoing_bssrdf;
-            bool same_sss_set =
+            const bool same_material =
+                incoming_material == outgoing_material || incoming_opposite_material == outgoing_material;
+            const bool same_sss_set =
                 incoming_point.get_object_instance().is_in_same_sss_set(outgoing_object_instance);
 
-            // Only consider hit points with the same BSSRDF as the outgoing point 
+            // Only consider hit points with the same material as the outgoing point
             // and belonging to the same SSS set.
-            if (same_bssrdf && same_sss_set)
+            if (same_material && same_sss_set)
             {
                 // Make sure the incoming point is on the front side of the surface.
                 // There is no such thing as subsurface scattering seen "from the inside".


### PR DESCRIPTION
- Replace same bssrdf check by same material check. It didn't work for OSL shaders.
- Avoid setting the shading basis for shading points generated by BSSRDF samples.