### PR TITLE
Add werror defaults to some build targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ option (USE_CPP11                           "Use C++11"                         
 option (USE_STATIC_BOOST                    "Use static Boost libraries"                            ON)
 option (USE_STATIC_OIIO                     "Use static OpenImageIO libraries"                      ON)
 option (USE_STATIC_OSL                      "Use static OpenShadingLanguage libraries"              ON)
-option (WARNINGS_AS_ERRORS                  "Treat compiler warnings as errors"                     OFF)
+option (WARNINGS_AS_ERRORS                  "Treat compiler warnings as errors"                     ON)
 
 option (HIDE_SYMBOLS                        "When using gcc, hide symbols not on the public API"    ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,12 +117,7 @@ option (USE_CPP11                           "Use C++11"                         
 option (USE_STATIC_BOOST                    "Use static Boost libraries"                            ON)
 option (USE_STATIC_OIIO                     "Use static OpenImageIO libraries"                      ON)
 option (USE_STATIC_OSL                      "Use static OpenShadingLanguage libraries"              ON)
-
-if (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "Ship")
-    set (WARNINGS_AS_ERRORS OFF CACHE BOOL  "Treat compiler warnings as errors" FORCE)
-else ()
-    set (WARNINGS_AS_ERRORS ON CACHE BOOL   "Treat compiler warnings as errors" FORCE)
-endif ()
+option (WARNINGS_AS_ERRORS                  "Treat compiler warnings as errors"                     OFF)
 
 option (HIDE_SYMBOLS                        "When using gcc, hide symbols not on the public API"    ON)
 

--- a/src/cmake/config/linux-gcc.txt
+++ b/src/cmake/config/linux-gcc.txt
@@ -86,10 +86,14 @@ set (cxx_compiler_flags_common
     -Wno-reorder
 )
 if (WARNINGS_AS_ERRORS)
-    set (c_compiler_flags_common
-        ${c_compiler_flags_common}
-        -Werror                                         # treat Warnings As Errors
-    )
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR
+        CMAKE_BUILD_TYPE STREQUAL "Profile" OR
+        CMAKE_BUILD_TYPE STREQUAL "Release")
+        set (c_compiler_flags_common
+            ${c_compiler_flags_common}
+            -Werror                                     # treat Warnings As Errors
+        )
+    endif()
 endif ()
 
 if (USE_CPP11)

--- a/src/cmake/config/mac-clang.txt
+++ b/src/cmake/config/mac-clang.txt
@@ -69,9 +69,9 @@ if (WARNINGS_AS_ERRORS)
         CMAKE_BUILD_TYPE STREQUAL "Release")
         set (c_compiler_flags_common
             ${c_compiler_flags_common}
-            -Werror                                         # treat Warnings As Errors
+            -Werror                                     # treat Warnings As Errors
         )
-    endif()
+    endif ()
 endif ()
 if (USE_CPP11)
     set (cxx_compiler_flags_common

--- a/src/cmake/config/mac-clang.txt
+++ b/src/cmake/config/mac-clang.txt
@@ -64,10 +64,14 @@ set (c_compiler_flags_common
     -fno-math-errno                                     # ignore errno when calling math functions
 )
 if (WARNINGS_AS_ERRORS)
-    set (c_compiler_flags_common
-        ${c_compiler_flags_common}
-        -Werror                                         # treat Warnings As Errors
-    )
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR
+        CMAKE_BUILD_TYPE STREQUAL "Profile" OR
+        CMAKE_BUILD_TYPE STREQUAL "Release")
+        set (c_compiler_flags_common
+            ${c_compiler_flags_common}
+            -Werror                                         # treat Warnings As Errors
+        )
+    endif()
 endif ()
 if (USE_CPP11)
     set (cxx_compiler_flags_common

--- a/src/cmake/config/win-vs.txt
+++ b/src/cmake/config/win-vs.txt
@@ -80,10 +80,14 @@ set (c_compiler_flags_common
     /GF                                     # Enable String Pooling
 )
 if (WARNINGS_AS_ERRORS)
-    set (c_compiler_flags_common
-         ${c_compiler_flags_common}
-         /WX                                # Treat Warnings As Errors
-    )
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR
+        CMAKE_BUILD_TYPE STREQUAL "Profile" OR
+        CMAKE_BUILD_TYPE STREQUAL "Release")
+        set (c_compiler_flags_common
+            ${c_compiler_flags_common}
+            /WX                                # Treat Warnings As Errors
+        )
+    endif()
 endif ()
 set (cxx_compiler_flags_common
     /wd4068                                 # Disable warning C4068: unknown pragma


### PR DESCRIPTION
Add back the warnings as errors option to the cmake file, but make it so
that it's potentially enabled only in Release, Profile, Debug targets,
and has no effect in Ship targets.