### PR TITLE
Update AttributeEditor on changes made with EntityEditorWindow #1348

### DIFF
--- a/src/appleseed.studio/mainwindow/project/entityitem.h
+++ b/src/appleseed.studio/mainwindow/project/entityitem.h
@@ -186,6 +186,9 @@ void EntityItem<Entity, ParentEntity, CollectionItem>::edit(const foundation::Di
     // Move the item to its sorted position.
     if (!m_fixed_position && old_entity_name != new_entity_name)
         move_to_sorted_position(this);
+
+    if (Base::m_attrubute_editor)
+        Base::m_attrubute_editor->refresh();
 }
 
 template <typename Entity, typename ParentEntity, typename CollectionItem>

--- a/src/appleseed.studio/mainwindow/project/fixedmodelentityitem.h
+++ b/src/appleseed.studio/mainwindow/project/fixedmodelentityitem.h
@@ -115,6 +115,8 @@ void FixedModelEntityItem<Entity, ParentEntity, CollectionItem>::slot_edit(Attri
 
     if (attribute_editor)
     {
+        Base::m_attrubute_editor = attribute_editor;
+
         attribute_editor->edit(
             form_factory,
             entity_browser,

--- a/src/appleseed.studio/mainwindow/project/frameitem.cpp
+++ b/src/appleseed.studio/mainwindow/project/frameitem.cpp
@@ -87,6 +87,8 @@ void FrameItem::slot_edit(AttributeEditor* attribute_editor)
 
     if (attribute_editor)
     {
+        m_attrubute_editor = attribute_editor;
+
         attribute_editor->edit(
             form_factory,
             entity_browser,
@@ -132,6 +134,9 @@ void FrameItem::edit(const Dictionary& values)
     m_frame = m_editor_context.m_project_builder.edit_frame(values);
 
     set_title(QString::fromAscii(m_frame->get_name()));
+
+    if (m_attrubute_editor)
+        m_attrubute_editor->refresh();
 }
 
 const Dictionary FrameItem::get_values()

--- a/src/appleseed.studio/mainwindow/project/itembase.h
+++ b/src/appleseed.studio/mainwindow/project/itembase.h
@@ -93,6 +93,7 @@ class ItemBase
 
   protected:
     EntityEditorContext&        m_editor_context;
+    AttributeEditor*            m_attrubute_editor;
 
     template <typename Item>
     QList<Item*> get_action_items();

--- a/src/appleseed.studio/mainwindow/project/materialitem.cpp
+++ b/src/appleseed.studio/mainwindow/project/materialitem.cpp
@@ -118,6 +118,8 @@ void MaterialItem::slot_edit(AttributeEditor* attribute_editor)
 
     if (attribute_editor)
     {
+        m_attrubute_editor = attribute_editor;
+
         attribute_editor->edit(
             form_factory,
             entity_browser,

--- a/src/appleseed.studio/mainwindow/project/multimodelentityitem.h
+++ b/src/appleseed.studio/mainwindow/project/multimodelentityitem.h
@@ -115,6 +115,8 @@ void MultiModelEntityItem<Entity, ParentEntity, CollectionItem>::slot_edit(Attri
 
     if (attribute_editor)
     {
+        Base::m_attrubute_editor = attribute_editor;
+
         attribute_editor->edit(
             form_factory,
             entity_browser,

--- a/src/appleseed.studio/mainwindow/project/singlemodelentityitem.h
+++ b/src/appleseed.studio/mainwindow/project/singlemodelentityitem.h
@@ -109,6 +109,8 @@ void SingleModelEntityItem<Entity, ParentEntity, CollectionItem>::slot_edit(Attr
 
     if (attribute_editor)
     {
+        Base::m_attrubute_editor = attribute_editor;
+
         attribute_editor->edit(
             form_factory,
             entity_browser,


### PR DESCRIPTION
These are kind of basic changes which should be made to update `AttributeEditor` when changes to entity are made through `EntityEditorWindow`.

Any changes made to entity with `EntityEditor` widgets are actually addressed to `EntityItemBaseSlots::slot_edit_accepted()` method, no matter it they are done with `AttributeEditor` and  `EntityEditorWindow`. This slot can schedule the `EntityEditionAction`, which calles`EntityItem::edit()`, if we are rendering, or execute thismethod on its own. So, `EntityItem::edit()` should be the right place to place the `AttributeEditor::refresh()` call. However `ItemBase` don't know anything about `AttributeEditor` untill we will call `ItemBase::slot_edit(AttributeEditor*)`. Thus, we can save the ptr here (it is done now like that) or pass it on construction of project tree items (i.e. add as arg to `ItemBase` constrictor; not done now since it leads to massive changes).

Other possible improvements which could be made:

1. Add some kind of a bool flag to `ItemBase`, or special slots like `EntityItemBaseSlots::slot_edit_accepted()`, which would help to indicate taht we are editing with `EntityEditorWindow`. As a result we will avoid extra `AttributeEditor::refresh()` calls.
2. Make a special action for `EntityEditorWindow`. Same as previous.
3. Remember item in `ProjectExplorer` on select. Thus, we would be able to `ItemBase::finish_edit()` on next selection to clear `AttributeEditor` ptr.
