### PR TITLE
Change delimiter ';' on ' ' in QT file dialog filters

### DIFF
--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -1289,7 +1289,7 @@ QString MainWindow::get_filter_string(const int filter)
     QStringList filters;
 
     if (filter & ProjectDialogFilterAllProjects)
-        filters << "Project Files (*.appleseed;*.appleseedz)";
+        filters << "Project Files (*.appleseed *.appleseedz)";
 
     if (filter & ProjectDialogFilterPlainProjects)
         filters << "Plain Project Files (*.appleseed)";

--- a/src/appleseed.studio/mainwindow/project/objectcollectionitem.cpp
+++ b/src/appleseed.studio/mainwindow/project/objectcollectionitem.cpp
@@ -131,9 +131,9 @@ void ObjectCollectionItem::slot_import_objects()
             treeWidget(),
             "Import Objects...",
 #ifdef APPLESEED_WITH_ALEMBIC
-            "Geometry Files (*.abc;*.binarymesh;*.obj);;All Files (*.*)",
+            "Geometry Files (*.abc *.binarymesh *.obj);;All Files (*.*)",
 #else
-            "Geometry Files (*.binarymesh;*.obj);;All Files (*.*)",
+            "Geometry Files (*.binarymesh *.obj);;All Files (*.*)",
 #endif
             m_editor_context.m_settings,
             SETTINGS_FILE_DIALOG_PROJECTS);

--- a/src/appleseed.studio/utility/miscellaneous.cpp
+++ b/src/appleseed.studio/utility/miscellaneous.cpp
@@ -82,7 +82,7 @@ using namespace std;
 namespace appleseed {
 namespace studio {
 
-const QString g_appleseed_image_files_filter = "Bitmap Files (*.png;*.exr);;OpenEXR (*.exr);;PNG (*.png);;All Files (*.*)";
+const QString g_appleseed_image_files_filter = "Bitmap Files (*.png *.exr);;OpenEXR (*.exr);;PNG (*.png);;All Files (*.*)";
 
 QString get_oiio_image_files_filter()
 {
@@ -115,7 +115,7 @@ QString get_oiio_image_files_filter()
             for (const_each<vector<string> > e = exts; e; ++e)
             {
                 if (e.it() != exts.begin())
-                    sstr << ";";
+                    sstr << " ";
                 sstr << "*." << *e;
             }
 


### PR DESCRIPTION
With ';' wildcards of extensions are not recognized on some systems.
For example with filter equals (*.png;*.exr) not png not exr files are shown.
On the other hand, ' ' delimiter works well on any system and also advised in documentation.