### PR TITLE
Remove file shader sequence options.

### DIFF
--- a/src/appleseed.shaders/src/maya/as_maya_file.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_file.osl
@@ -49,26 +49,6 @@ shader as_maya_file
         string label = "Disable File Load",
         string widget = "checkBox"
     ]],
-    int in_useFrameExtension = 0
-    [[
-        string as_maya_attribute_name = "useFrameExtension",
-        string label = "Use Frame Extension",
-        string widget = "checkBox"
-    ]],
-    int in_frameExtension = 1
-    [[
-        string as_maya_attribute_name = "frameExtension",
-        string label = "Frame Extension",
-        string widget = "number",
-        int slider = 0
-    ]],
-    int in_frameOffset = 0
-    [[
-        string as_maya_attribute_name = "frameOffset",
-        string label = "Frame Offset",
-        string widget = "number",
-        int slider = 0
-    ]],
     int in_filterType = 3
     [[
         string as_maya_attribute_name = "filterType",
@@ -263,15 +243,11 @@ shader as_maya_file
     }
     else
     {
-        string filename = in_useFrameExtension
-            ? format(in_fileTextureName, in_frameExtension + in_frameOffset)
-            : in_fileTextureName;
-
         int channels = 0;
         int size[2] = {0,0};
 
-        gettextureinfo(filename, "channels", channels);
-        gettextureinfo(filename, "resolution", size);
+        gettextureinfo(in_fileTextureName, "channels", channels);
+        gettextureinfo(in_fileTextureName, "resolution", size);
 
         out_outSize[0] = size[0];
         out_outSize[1] = size[1];
@@ -342,7 +318,7 @@ shader as_maya_file
         {
             out_outColor =
                 texture(
-                    filename,
+                    in_fileTextureName,
                     st[0], st[1],
                     dsdt[0], dsdt[1], dsdt[2], dsdt[3],
                     "blur", in_filterOffset,
@@ -358,7 +334,7 @@ shader as_maya_file
         {
             out_outColor =
                 texture(
-                    filename,
+                    in_fileTextureName,
                     st[0], st[1],
                     dsdt[0], dsdt[1], dsdt[2], dsdt[3],
                     "blur", in_filterOffset,
@@ -394,7 +370,7 @@ shader as_maya_file
         warning("[CMS] : CMS Config File Path = %s\n",
                 in_colorManagementConfigFilePath);
 #endif
-        
+
         if (in_colorManagementEnabled == 1 &&
             in_ignoreColorSpaceFileRules == 0 &&
             in_colorSpace != "Raw")


### PR DESCRIPTION
This is done now at export time by the Maya plugin using Maya's API.
https://github.com/appleseedhq/appleseed-maya/commit/0755ab2227500e12dc1ef293165702694be794f9