### PR TITLE
Add shader/surface, drawdb node classification

### DIFF
--- a/src/appleseed.shaders/src/appleseed/asDisneyMaterial.osl
+++ b/src/appleseed.shaders/src/appleseed/asDisneyMaterial.osl
@@ -31,7 +31,7 @@
 shader asDisneyMaterial
 [[
     string as_maya_node_name = "asDisneyMaterial",
-    string as_maya_classification = "appleseed/surface:swatch/appleseedRenderSwatch",
+    string as_maya_classification = "shader/surface:drawdb/shader/surface:appleseed/surface:swatch/appleseedRenderSwatch",
     string help = "Disney material",
     int as_maya_type_id = 1210819
 ]]

--- a/src/appleseed.shaders/src/appleseed/asGlass.osl
+++ b/src/appleseed.shaders/src/appleseed/asGlass.osl
@@ -29,7 +29,7 @@
 shader asGlass
 [[
     string as_maya_node_name = "asGlass",
-    string as_maya_classification = "appleseed/surface:swatch/appleseedRenderSwatch",
+    string as_maya_classification = "shader/surface:drawdb/shader/surface:appleseed/surface:swatch/appleseedRenderSwatch",
     string help = "Glass material",
     int as_maya_type_id = 1210820
 ]]

--- a/src/appleseed.shaders/src/appleseed/asVoronoi2D.osl
+++ b/src/appleseed.shaders/src/appleseed/asVoronoi2D.osl
@@ -34,7 +34,7 @@
 shader asVoronoi2D
 [[
     string as_maya_node_name = "asVoronoi2D",
-    string as_maya_classification = "appleseed/texture/2d",
+    string as_maya_classification = "texture/2d:drawdb/shader:appleseed/texture/2d",
     int as_maya_type_id = 1210823
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/asVoronoi3D.osl
+++ b/src/appleseed.shaders/src/appleseed/asVoronoi3D.osl
@@ -34,7 +34,7 @@
 shader asVoronoi3D
 [[
     string as_maya_node_name = "asVoronoi3D",
-    string as_maya_classification = "appleseed/texture/3d",
+    string as_maya_classification = "texture/3d:drawdb/shader:appleseed/texture/3d",
     int as_maya_type_id = 1210822
 ]]
 (


### PR DESCRIPTION
For issue appleseedhq/appleseed-maya#41. This adds back the maya shader/surface classification where needed. Perhaps we can find a workaround later to restrict AS nodes to the AS menus/entries only.