### PR TITLE
Metadata fixes

### DIFF
--- a/src/appleseed.shaders/include/appleseed/maya/as_maya_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/maya/as_maya_helpers.h
@@ -42,6 +42,7 @@
     color in_defaultColor = color(0.5)                                      \
     [[                                                                      \
         string as_maya_attribute_name = "defaultColor",                     \
+        string as_maya_attribute_short_name = "dc",                         \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Default Color",                                     \
         string page = "Color Balance"                                       \
@@ -49,6 +50,7 @@
     color in_colorGain = color(1.0)                                         \
     [[                                                                      \
         string as_maya_attribute_name = "colorGain",                        \
+        string as_maya_attribute_short_name = "cg",                         \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Color Gain",                                        \
         string page = "Color Balance"                                       \
@@ -56,6 +58,7 @@
     color in_colorOffset = color(0.0)                                       \
     [[                                                                      \
         string as_maya_attribute_name = "colorOffset",                      \
+        string as_maya_attribute_short_name = "co",                         \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Color Offset",                                      \
         string page = "Color Balance"                                       \
@@ -63,6 +66,7 @@
     float in_alphaGain = 1.0                                                \
     [[                                                                      \
         string as_maya_attribute_name = "alphaGain",                        \
+        string as_maya_attribute_short_name = "ag",                         \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Alpha Gain",                                        \
         string page = "Color Balance"                                       \
@@ -70,6 +74,7 @@
     float in_alphaOffset = 0.0                                              \
     [[                                                                      \
         string as_maya_attribute_name = "alphaOffset",                      \
+        string as_maya_attribute_short_name = "ao",                         \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Alpha Offset",                                      \
         string page = "Color Balance"                                       \
@@ -77,6 +82,7 @@
     int in_alphaIsLuminance = 1                                             \
     [[                                                                      \
         string as_maya_attribute_name = "alphaIsLuminance",                 \
+        string as_maya_attribute_short_name = "ail",                        \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Alpha Is Luminance",                                \
         string widget = "checkBox",                                         \
@@ -111,6 +117,7 @@
     int in_wrap = 1                                                         \
     [[                                                                      \
         string as_maya_attribute_name = "wrap",                             \
+        string as_maya_attribute_short_name = "w",                          \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Wrap",                                              \
         string widget = "checkBox",                                         \
@@ -119,6 +126,7 @@
     int in_local = 0                                                        \
     [[                                                                      \
         string as_maya_attribute_name = "local",                            \
+        string as_maya_attribute_short_name = "lo",                         \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Local",                                             \
         string widget = "checkBox",                                         \
@@ -127,6 +135,7 @@
     float in_blend = 0.0                                                    \
     [[                                                                      \
         string as_maya_attribute_name = "blend",                            \
+        string as_maya_attribute_short_name = "b",                          \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Blend",                                             \
         string widget = "slider",                                           \
@@ -141,6 +150,7 @@
     float in_uvCoord[2] = {u, v}                                            \
     [[                                                                      \
         string as_maya_attribute_name = "uvCoord",                          \
+        string as_maya_attribute_short_name = "uv",                         \
         string label = "UV Coordinates",                                    \
         string page = "UV Coordinates"                                      \
     ]],                                                                     \
@@ -148,6 +158,7 @@
         UNDEFINED_UVFILTER, UNDEFINED_UVFILTER}                             \
     [[                                                                      \
         string as_maya_attribute_name = "uvFilterSize",                     \
+        string as_maya_attribute_short_name = "fs",                         \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "UV Filter Size",                                    \
         string page = "UV Coordinates"                                      \
@@ -158,49 +169,51 @@
     [[                                                                      \
         string as_maya_attribute_name = "colorProfile",                     \
         int as_maya_attribute_hidden = 1,                                   \
-        string widget = "string",                                           \
-        string label = "Color Profile"                                      \
+        string widget = "null",                                             \
+        string label = "Color Profile",                                     \
     ]],                                                                     \
     int in_ignoreColorSpaceFileRules = 0                                    \
     [[                                                                      \
         string as_maya_attribute_name = "ignoreColorSpaceFileRules",        \
         int as_maya_attribute_hidden = 1,                                   \
         string widget = "checkBox",                                         \
-        string label = "Ignore Color Space File Rules"                      \
+        string label = "Ignore Color Space File Rules",                     \
+        string page = "File Attributes"                                     \
     ]],                                                                     \
     string in_colorSpace = ""                                               \
     [[                                                                      \
         string as_maya_attribute_name = "colorSpace",                       \
         int as_maya_attribute_hidden = 1,                                   \
         string widget = "string",                                           \
-        string label = "Color Space"                                        \
+        string label = "Color Space",                                       \
+        string page = "File Attributes"                                     \
     ]],                                                                     \
     string in_workingSpace = ""                                             \
     [[                                                                      \
         string as_maya_attribute_name = "workingSpace",                     \
         int as_maya_attribute_hidden = 1,                                   \
-        string widget = "string",                                           \
+        string widget = "null",                                             \
         string label = "Working Space"                                      \
     ]],                                                                     \
     int in_colorManagementEnabled = 0                                       \
     [[                                                                      \
         string as_maya_attribute_name = "colorManagementEnabled",           \
         int as_maya_attribute_hidden = 1,                                   \
-        string widget = "checkBox",                                         \
+        string widget = "null",                                             \
         string label = "Color Management Enabled"                           \
     ]],                                                                     \
     int in_colorManagementConfigFileEnabled = 0                             \
     [[                                                                      \
         string as_maya_attribute_name = "colorManagementConfigFileEnabled", \
         int as_maya_attribute_hidden = 1,                                   \
-        string widget = "checkBox",                                         \
+        string widget = "null",                                             \
         string label = "Enable CMS Config"                                  \
     ]],                                                                     \
     string in_colorManagementConfigFilePath = ""                            \
     [[                                                                      \
         string as_maya_attribute_name = "colorManagementConfigFilePath",    \
         int as_maya_attribute_hidden = 1,                                   \
-        string widget = "filename",                                         \
+        string widget = "null",                                             \
         string label = "Color Management Config File Path"                  \
     ]]
 

--- a/src/appleseed.shaders/include/appleseed/maya/as_maya_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/maya/as_maya_helpers.h
@@ -174,7 +174,6 @@
     [[                                                                      \
         string as_maya_attribute_name = "colorSpace",                       \
         int as_maya_attribute_hidden = 1,                                   \
-        string widget = "string",                                           \
         string label = "Color Space",                                       \
         string page = "File Attributes"                                     \
     ]],                                                                     \

--- a/src/appleseed.shaders/include/appleseed/maya/as_maya_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/maya/as_maya_helpers.h
@@ -42,7 +42,6 @@
     color in_defaultColor = color(0.5)                                      \
     [[                                                                      \
         string as_maya_attribute_name = "defaultColor",                     \
-        string as_maya_attribute_short_name = "dc",                         \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Default Color",                                     \
         string page = "Color Balance"                                       \
@@ -50,7 +49,6 @@
     color in_colorGain = color(1.0)                                         \
     [[                                                                      \
         string as_maya_attribute_name = "colorGain",                        \
-        string as_maya_attribute_short_name = "cg",                         \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Color Gain",                                        \
         string page = "Color Balance"                                       \
@@ -58,7 +56,6 @@
     color in_colorOffset = color(0.0)                                       \
     [[                                                                      \
         string as_maya_attribute_name = "colorOffset",                      \
-        string as_maya_attribute_short_name = "co",                         \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Color Offset",                                      \
         string page = "Color Balance"                                       \
@@ -66,7 +63,6 @@
     float in_alphaGain = 1.0                                                \
     [[                                                                      \
         string as_maya_attribute_name = "alphaGain",                        \
-        string as_maya_attribute_short_name = "ag",                         \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Alpha Gain",                                        \
         string page = "Color Balance"                                       \
@@ -74,7 +70,6 @@
     float in_alphaOffset = 0.0                                              \
     [[                                                                      \
         string as_maya_attribute_name = "alphaOffset",                      \
-        string as_maya_attribute_short_name = "ao",                         \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Alpha Offset",                                      \
         string page = "Color Balance"                                       \
@@ -82,7 +77,6 @@
     int in_alphaIsLuminance = 1                                             \
     [[                                                                      \
         string as_maya_attribute_name = "alphaIsLuminance",                 \
-        string as_maya_attribute_short_name = "ail",                        \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Alpha Is Luminance",                                \
         string widget = "checkBox",                                         \
@@ -117,7 +111,6 @@
     int in_wrap = 1                                                         \
     [[                                                                      \
         string as_maya_attribute_name = "wrap",                             \
-        string as_maya_attribute_short_name = "w",                          \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Wrap",                                              \
         string widget = "checkBox",                                         \
@@ -126,7 +119,6 @@
     int in_local = 0                                                        \
     [[                                                                      \
         string as_maya_attribute_name = "local",                            \
-        string as_maya_attribute_short_name = "lo",                         \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Local",                                             \
         string widget = "checkBox",                                         \
@@ -135,7 +127,6 @@
     float in_blend = 0.0                                                    \
     [[                                                                      \
         string as_maya_attribute_name = "blend",                            \
-        string as_maya_attribute_short_name = "b",                          \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Blend",                                             \
         string widget = "slider",                                           \
@@ -150,7 +141,6 @@
     float in_uvCoord[2] = {u, v}                                            \
     [[                                                                      \
         string as_maya_attribute_name = "uvCoord",                          \
-        string as_maya_attribute_short_name = "uv",                         \
         string label = "UV Coordinates",                                    \
         string page = "UV Coordinates"                                      \
     ]],                                                                     \
@@ -158,7 +148,6 @@
         UNDEFINED_UVFILTER, UNDEFINED_UVFILTER}                             \
     [[                                                                      \
         string as_maya_attribute_name = "uvFilterSize",                     \
-        string as_maya_attribute_short_name = "fs",                         \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "UV Filter Size",                                    \
         string page = "UV Coordinates"                                      \

--- a/src/appleseed.shaders/include/appleseed/maya/as_maya_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/maya/as_maya_helpers.h
@@ -88,6 +88,8 @@
     [[                                                                      \
         string as_maya_attribute_name = "filter",                           \
         int as_maya_attribute_hidden = 1,                                   \
+        float min = 0.0,                                                    \
+        float softmax = 1.0,                                                \
         string label = "Filter",                                            \
         string page = "Effects"                                             \
     ]],                                                                     \
@@ -95,6 +97,8 @@
     [[                                                                      \
         string as_maya_attribute_name = "filterOffset",                     \
         int as_maya_attribute_hidden = 1,                                   \
+        float softmin = 0.0,                                                \
+        float softmax = 1.0,                                                \
         string label = "Filter Offset",                                     \
         string page = "Effects"                                             \
     ]],                                                                     \
@@ -129,11 +133,8 @@
         string as_maya_attribute_name = "blend",                            \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Blend",                                             \
-        string widget = "slider",                                           \
         float min = 0.0,                                                    \
         float max = 1.0,                                                    \
-        float slidermin = 0.0,                                              \
-        float slidermax = 1.0,                                              \
         string page = "Effects"                                             \
     ]]
 

--- a/src/appleseed.shaders/src/maya/as_maya_addDoubleLinear.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_addDoubleLinear.osl
@@ -36,12 +36,14 @@ shader as_maya_addDoubleLinear
     float in_input1 = 0.0
     [[
         string as_maya_attribute_name = "input1",
-        string label = "Input 1"
+        string label = "Input 1",
+        string page = "Add Double Linear Attributes"
     ]],
     float in_input2 = 0.0
     [[
         string as_maya_attribute_name = "input2",
-        string label = "Input 2"
+        string label = "Input 2",
+        string page = "Add Double Linear Attributes"
     ]],
 
     output float out_output = 0.0

--- a/src/appleseed.shaders/src/maya/as_maya_anisotropic.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_anisotropic.osl
@@ -143,7 +143,8 @@ shader as_maya_anisotropic
     color in_specularColor = color(0.5)
     [[
         string as_maya_attribute_name = "specularColor",
-        string label = "Specular Color"
+        string label = "Specular Color",
+        string page = "Specular Shading"
     ]],
     float in_reflectivity = 0.5
     [[

--- a/src/appleseed.shaders/src/maya/as_maya_blendColors.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_blendColors.osl
@@ -36,17 +36,20 @@ shader as_maya_blendColors
     color in_color1 = color(1,0,0)
     [[
         string as_maya_attribute_name = "color1",
-        string label = "Color 1"
+        string label = "Color 1",
+        string page = "Blend Color Attributes"
     ]],
     color in_color2 = color(0,0,1)
     [[
         string as_maya_attribute_name = "color2",
-        string label = "Color 2"
+        string label = "Color 2",
+        string page = "Blend Color Attributes"
     ]],
     float in_blender = 0.0
     [[
         string as_maya_attribute_name = "blender",
-        string label = "Weight"
+        string label = "Weight",
+        string page = "Blend Color Attributes"
     ]],
 
     output color out_output = color(0)

--- a/src/appleseed.shaders/src/maya/as_maya_blendColors.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_blendColors.osl
@@ -55,7 +55,6 @@ shader as_maya_blendColors
     output color out_output = color(0)
     [[
         string as_maya_attribute_name = "output",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_blinn.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_blinn.osl
@@ -185,28 +185,24 @@ shader as_maya_blinn
     output closure color out_outColor = 0
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output closure color out_outTransparency = 0
     [[
         string as_maya_attribute_name = "outTransparency",
-        string as_maya_attribute_short_name = "ot",
         string label = "Output Transparency",
         string widget = "null"
     ]],
     output closure color out_outGlowColor = 0
     [[
         string as_maya_attribute_name = "outGlowColor",
-        string as_maya_attribute_short_name = "og",
         string label = "Output Glow Color",
         string widget = "null"
     ]],
     output closure color out_outMatteOpacity = 0
     [[
         string as_maya_attribute_name = "outMatteOpacity",
-        string as_maya_attribute_short_name = "om",
         string label = "Output Matte Opacity",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_bulge.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_bulge.osl
@@ -38,12 +38,14 @@ shader as_maya_bulge
     float in_uWidth = 0.0
     [[
         string as_maya_attribute_name = "uWidth",
-        string label = "U Width"
+        string label = "U Width",
+        string page = "Bulge Attributes"
     ]],
     float in_vWidth = 0.0
     [[
         string as_maya_attribute_name = "vWidth",
-        string label = "V Width"
+        string label = "V Width",
+        string page = "Bulge Attributes"
     ]],
 
     MAYA_COLORBALANCE_PARAMETERS,

--- a/src/appleseed.shaders/src/maya/as_maya_bulge.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_bulge.osl
@@ -55,14 +55,12 @@ shader as_maya_bulge
     output color out_outColor = color(0.0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
-        string as_maya_attribute_short_name = "oa",
         string label = "Output Alpha",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_bump2d.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_bump2d.osl
@@ -38,21 +38,18 @@ shader as_maya_bump2d
     float in_bumpValue = 0.0
     [[
         string as_maya_attribute_name = "bumpValue",
-        string as_maya_attribute_short_name = "bv",
         string label = "Bump Value",
         string page = "2D Bump Attributes"
     ]],
     float in_bumpDepth = 1.0
     [[
         string as_maya_attribute_name = "bumpDepth",
-        string as_maya_attribute_short_name = "bd",
         string label = "Bump Depth",
         string page = "2D Bump Attributes"
     ]],
     int in_bumpInterp = 0
     [[
         string as_maya_attribute_name = "bumpInterp",
-        string as_maya_attribute_short_name = "bi",
         string label = "Bump Interpolation Mode",
         string widget = "mapper",
         string options = "Bump:0|Tangent Space Normals:1|Object Space Normals:2",
@@ -61,21 +58,18 @@ shader as_maya_bump2d
     float in_bumpFilter = 1.0
     [[
         string as_maya_attribute_name = "bumpFilter",
-        string as_maya_attribute_short_name = "bf",
         string label = "Bump Filter",
         string page = "Effects"
     ]],
     float in_bumpFilterOffset = 0.0
     [[
         string as_maya_attribute_name = "bumpFilterOffset",
-        string as_maya_attribute_short_name = "bfo",
         string label = "Bump Filter Offset",
         string page = "Effects"
     ]],
     int in_adjustEdges = 0
     [[
         string as_maya_attribute_name = "adjustEdges",
-        string as_maya_attribute_short_name = "ae",
         string label = "Adjust Edges",
         string page = "Effects",
         string widget = "checkBox"
@@ -83,14 +77,12 @@ shader as_maya_bump2d
     color in_normalMap = color(0)
     [[
         string as_maya_attribute_name = "asNormalMap",
-        string as_maya_attribute_short_name = "anm",
         string page = "Appleseed",
         string widget = "null"
     ]],
     int in_normalMapMode = 0
     [[
         string as_maya_attribute_name = "asNormalMapMode",
-        string as_maya_attribute_short_name = "amm",
         string widget = "mapper",
         string options = "unsigned:0|signed:1",
         string page = "Appleseed",
@@ -98,21 +90,18 @@ shader as_maya_bump2d
     int in_normalMapFlipR = 0
     [[
         string as_maya_attribute_name = "asNormalMapFlipR",
-        string as_maya_attribute_short_name = "amr",
         string widget = "checkBox",
         string page = "Appleseed"
     ]],
     int in_normalMapFlipG = 0
     [[
         string as_maya_attribute_name = "asNormalMapFlipG",
-        string as_maya_attribute_short_name = "amg",
         string widget = "checkBox",
         string page = "Appleseed"
     ]],
     int in_normalMapSwapRG = 0
     [[
         string as_maya_attribute_name = "asNormalMapSwapRG",
-        string as_maya_attribute_short_name = "ams",
         string widget = "checkBox",
         string page = "Appleseed"
     ]],
@@ -144,7 +133,6 @@ shader as_maya_bump2d
     output normal out_outNormal = normal(0.0, 0.0, 1.0)
     [[
         string as_maya_attribute_name = "outNormal",
-        string as_maya_attribute_short_name = "n",
         string label = "Output Normal",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_bump2d.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_bump2d.osl
@@ -35,119 +35,98 @@ shader as_maya_bump2d
     string as_maya_node_name = "bump2d"
 ]]
 (
-    point in_pointCamera = P
+    float in_bumpValue = 0.0
     [[
-        string as_maya_attribute_name = "pointCamera",
-        string label = "Surface Point"
-    ]],
-    point in_pointObj = point(0)
-    [[
-        string as_maya_attribute_name = "pointObj",
-        string label = "Point Object Space"
-    ]],
-    point in_refPointObj = point(0)
-    [[
-        string as_maya_attribute_name = "refPointObj",
-        string label = "Reference Point Object Space"
-    ]],
-    point in_refPointCamera = point(0)
-    [[
-        string as_maya_attribute_name = "refPointCamera",
-        string label = "Reference Surface Point"
-    ]],
-    point in_rayOrigin = point(0)
-    [[
-        string as_maya_attribute_name = "rayOrigin",
-        string label = "Ray Origin"
-    ]],
-    float in_xPixelAngle = 0.002053
-    [[
-        string as_maya_attribute_name = "xPixelAngle",
-        string label = "X Pixel Angle"
-    ]],
-    int in_infoBits = 0
-    [[
-        string as_maya_attribute_name = "infoBits",
-        string label = "Info Bits"
-    ]],
-    normal in_normalCamera = N
-    [[
-        string as_maya_attribute_name = "normalCamera",
-        string label = "Surface Normal"
-    ]],
-    vector in_tangentUCamera = vector(1.0, 0.0, 0.0)
-    [[
-        string as_maya_attribute_name = "tangentUCamera",
-        string label = "Tangent U Direction"
-    ]],
-    vector in_tangentVCamera = vector(0.0, 1.0, 0.0)
-    [[
-        string as_maya_attribute_name = "tangentVCamera",
-        string label = "Tangent V Direction"
-    ]],
-    int in_adjustEdges = 0
-    [[
-        string as_maya_attribute_name = "adjustEdges",
-        string label = "Adjust Edges",
-        string widget = "checkBox"
+        string as_maya_attribute_name = "bumpValue",
+        string as_maya_attribute_short_name = "bv",
+        string label = "Bump Value",
+        string page = "2D Bump Attributes"
     ]],
     float in_bumpDepth = 1.0
     [[
         string as_maya_attribute_name = "bumpDepth",
-        string label = "Bump Depth"
+        string as_maya_attribute_short_name = "bd",
+        string label = "Bump Depth",
+        string page = "2D Bump Attributes"
     ]],
     int in_bumpInterp = 0
     [[
         string as_maya_attribute_name = "bumpInterp",
+        string as_maya_attribute_short_name = "bi",
         string label = "Bump Interpolation Mode",
         string widget = "mapper",
-        string options = "Bump:0|Tangent Space Normals:1|Object Space Normals:2"
+        string options = "Bump:0|Tangent Space Normals:1|Object Space Normals:2",
+        string page = "2D Bump Attributes"
     ]],
     float in_bumpFilter = 1.0
     [[
         string as_maya_attribute_name = "bumpFilter",
-        string label = "Bump Filter"
+        string as_maya_attribute_short_name = "bf",
+        string label = "Bump Filter",
+        string page = "Effects"
     ]],
     float in_bumpFilterOffset = 0.0
     [[
         string as_maya_attribute_name = "bumpFilterOffset",
-        string label = "Bump Filter Offset"
+        string as_maya_attribute_short_name = "bfo",
+        string label = "Bump Filter Offset",
+        string page = "Effects"
     ]],
-    float in_bumpValue = 0.0
+    int in_adjustEdges = 0
     [[
-        string as_maya_attribute_name = "bumpValue",
-        string label = "Bump Value"
+        string as_maya_attribute_name = "adjustEdges",
+        string as_maya_attribute_short_name = "ae",
+        string label = "Adjust Edges",
+        string page = "Effects",
+        string widget = "checkBox"
     ]],
     color in_normalMap = color(0)
     [[
         string as_maya_attribute_name = "asNormalMap",
-        string as_maya_attribute_short_name = "nM",
+        string as_maya_attribute_short_name = "anm",
+        string page = "Appleseed",
         string widget = "null"
     ]],
     int in_normalMapMode = 0
     [[
         string as_maya_attribute_name = "asNormalMapMode",
-        string as_maya_attribute_short_name = "mM",
+        string as_maya_attribute_short_name = "amm",
         string widget = "mapper",
-        string options = "unsigned:0|signed:1"
+        string options = "unsigned:0|signed:1",
+        string page = "Appleseed",
     ]],
     int in_normalMapFlipR = 0
     [[
         string as_maya_attribute_name = "asNormalMapFlipR",
-        string as_maya_attribute_short_name = "fR",
-        string widget = "checkBox"
+        string as_maya_attribute_short_name = "amr",
+        string widget = "checkBox",
+        string page = "Appleseed"
     ]],
     int in_normalMapFlipG = 0
     [[
         string as_maya_attribute_name = "asNormalMapFlipG",
-        string as_maya_attribute_short_name = "fG",
-        string widget = "checkBox"
+        string as_maya_attribute_short_name = "amg",
+        string widget = "checkBox",
+        string page = "Appleseed"
     ]],
     int in_normalMapSwapRG = 0
     [[
         string as_maya_attribute_name = "asNormalMapSwapRG",
-        string as_maya_attribute_short_name = "sW",
-        string widget = "checkBox"
+        string as_maya_attribute_short_name = "ams",
+        string widget = "checkBox",
+        string page = "Appleseed"
+    ]],
+    point in_pointCamera = P
+    [[
+        string as_maya_attribute_name = "pointCamera",
+        string label = "Surface Point",
+        string widget = "null"
+    ]],
+    normal in_normalCamera = N
+    [[
+        string as_maya_attribute_name = "normalCamera",
+        string label = "Surface Normal",
+        string widget = "null"
     ]],
     vector Tn = vector(0)
     [[

--- a/src/appleseed.shaders/src/maya/as_maya_bump3d.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_bump3d.osl
@@ -35,81 +35,43 @@ shader as_maya_bump3d
     string as_maya_node_name = "bump3d"
 ]]
 (
+    float in_bumpValue = 0.0
+    [[
+        string as_maya_attribute_name = "bumpValue",
+        string as_maya_attribute_short_name = "bv",
+        string label = "Bump Value",
+        string page = "3D Bump Attributes"
+    ]],
+    float in_bumpDepth = 1.0
+    [[
+        string as_maya_attribute_name = "bumpDepth",
+        string as_maya_attribute_short_name = "bd",
+        string label = "Bump Depth",
+        string page = "3D Bump Attributes"
+    ]],
+    float in_bumpFilter = 1.0
+    [[
+        string as_maya_attribute_name = "bumpFilter",
+        string as_maya_attribute_short_name = "bf",
+        string label = "Bump Filter",
+        string page = "Effects"
+    ]],
+    float in_bumpFilterOffset = 0.0
+    [[
+        string as_maya_attribute_name = "bumpFilterOffset",
+        string as_maya_attribute_short_name = "bfo",
+        string label = "Bump Filter Offset",
+        string page = "Effects"
+    ]],
     point in_pointCamera = P
     [[
         string as_maya_attribute_name = "pointCamera",
         string label = "Surface Point"
     ]],
-    point in_pointObj = point(0)
-    [[
-        string as_maya_attribute_name = "pointObj",
-        string label = "Point Object Space"
-    ]],
-    point in_refPointObj = point(0)
-    [[
-        string as_maya_attribute_name = "refPointObj",
-        string label = "Reference Point Object Space"
-    ]],
-    point in_refPointCamera = point(0)
-    [[
-        string as_maya_attribute_name = "refPointCamera",
-        string label = "Reference Surface Point"
-    ]],
-    point in_rayOrigin = point(0)
-    [[
-        string as_maya_attribute_name = "rayOrigin",
-        string label = "Ray Origin"
-    ]],
-    float in_xPixelAngle = 0.002053
-    [[
-        string as_maya_attribute_name = "xPixelAngle",
-        string label = "X Pixel Angle"
-    ]],
-    int in_infoBits = 0
-    [[
-        string as_maya_attribute_name = "infoBits",
-        string label = "Info Bits"
-    ]],
     normal in_normalCamera = N
     [[
         string as_maya_attribute_name = "normalCamera",
         string label = "Surface Normal"
-    ]],
-    vector in_tangentUCamera = vector(1.0, 0.0, 0.0)
-    [[
-        string as_maya_attribute_name = "tangentUCamera",
-        string label = "Tangent U Direction"
-    ]],
-    vector in_tangentVCamera = vector(0.0, 1.0, 0.0)
-    [[
-        string as_maya_attribute_name = "tangentVCamera",
-        string label = "Tangent V Direction"
-    ]],
-    int in_adjustEdges = 0
-    [[
-        string as_maya_attribute_name = "adjustEdges",
-        string label = "Adjust Edges",
-        string widget = "checkBox"
-    ]],
-    float in_bumpDepth = 1.0
-    [[
-        string as_maya_attribute_name = "bumpDepth",
-        string label = "Bump Depth"
-    ]],
-    float in_bumpFilter = 1.0
-    [[
-        string as_maya_attribute_name = "bumpFilter",
-        string label = "Bump Filter"
-    ]],
-    float in_bumpFilterOffset = 0.0
-    [[
-        string as_maya_attribute_name = "bumpFilterOffset",
-        string label = "Bump Filter Offset"
-    ]],
-    float in_bumpValue = 0.0
-    [[
-        string as_maya_attribute_name = "bumpValue",
-        string label = "Bump Value"
     ]],
 
     MAYA_UV_PARAMETERS,

--- a/src/appleseed.shaders/src/maya/as_maya_bump3d.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_bump3d.osl
@@ -38,28 +38,24 @@ shader as_maya_bump3d
     float in_bumpValue = 0.0
     [[
         string as_maya_attribute_name = "bumpValue",
-        string as_maya_attribute_short_name = "bv",
         string label = "Bump Value",
         string page = "3D Bump Attributes"
     ]],
     float in_bumpDepth = 1.0
     [[
         string as_maya_attribute_name = "bumpDepth",
-        string as_maya_attribute_short_name = "bd",
         string label = "Bump Depth",
         string page = "3D Bump Attributes"
     ]],
     float in_bumpFilter = 1.0
     [[
         string as_maya_attribute_name = "bumpFilter",
-        string as_maya_attribute_short_name = "bf",
         string label = "Bump Filter",
         string page = "Effects"
     ]],
     float in_bumpFilterOffset = 0.0
     [[
         string as_maya_attribute_name = "bumpFilterOffset",
-        string as_maya_attribute_short_name = "bfo",
         string label = "Bump Filter Offset",
         string page = "Effects"
     ]],
@@ -79,7 +75,6 @@ shader as_maya_bump3d
     output normal out_outNormal = normal(0.0, 0.0, 1.0)
     [[
         string as_maya_attribute_name = "outNormal",
-        string as_maya_attribute_short_name = "n",
         string label = "Output Normal",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_checker.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_checker.osl
@@ -39,17 +39,23 @@ shader as_maya_checker
     color in_color1 = color(1)
     [[
         string as_maya_attribute_name = "color1",
-        string label = "Color 1"
+        string as_maya_attribute_short_name = "c1",
+        string label = "Color 1",
+        string page = "Checker Attributes"
     ]],
     color in_color2 = color(0)
     [[
         string as_maya_attribute_name = "color2",
-        string label = "Color 2"
+        string as_maya_attribute_short_name = "c2",
+        string label = "Color 2",
+        string page = "Checker Attributes"
     ]],
     float in_contrast = 1.0
     [[
         string as_maya_attribute_name = "contrast",
-        string label = "Contrast"
+        string as_maya_attribute_short_name = "ct",
+        string label = "Contrast",
+        string page = "Checker Attributes"
     ]],
 
     MAYA_COLORBALANCE_PARAMETERS,

--- a/src/appleseed.shaders/src/maya/as_maya_checker.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_checker.osl
@@ -39,21 +39,18 @@ shader as_maya_checker
     color in_color1 = color(1)
     [[
         string as_maya_attribute_name = "color1",
-        string as_maya_attribute_short_name = "c1",
         string label = "Color 1",
         string page = "Checker Attributes"
     ]],
     color in_color2 = color(0)
     [[
         string as_maya_attribute_name = "color2",
-        string as_maya_attribute_short_name = "c2",
         string label = "Color 2",
         string page = "Checker Attributes"
     ]],
     float in_contrast = 1.0
     [[
         string as_maya_attribute_name = "contrast",
-        string as_maya_attribute_short_name = "ct",
         string label = "Contrast",
         string page = "Checker Attributes"
     ]],
@@ -65,14 +62,12 @@ shader as_maya_checker
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
-        string as_maya_attribute_short_name = "oa",
         string label = "Output Alpha",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_clamp.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_clamp.osl
@@ -36,22 +36,29 @@ shader as_maya_clamp
     color in_min = color(0)
     [[
         string as_maya_attribute_name = "min",
-        string label = "Lower Bound"
+        string as_maya_attribute_short_name = "mn",
+        string label = "Lower Bound",
+        string page = "Clamp Color Attributes"
     ]],
     color in_max = color(0)
     [[
         string as_maya_attribute_name = "max",
-        string label = "Upper Bound"
+        string as_maya_attribute_short_name = "mx",
+        string label = "Upper Bound",
+        string page = "Clamp Color Attributes"
     ]],
     color in_input = color(0)
     [[
         string as_maya_attribute_name = "input",
-        string label = "Input Color"
+        string as_maya_attribute_short_name = "ip",
+        string label = "Input Color",
+        string page = "Clamp Color Attributes"
     ]],
 
     output color out_output = color(0)
     [[
         string as_maya_attribute_name = "output",
+        string as_maya_attribute_short_name = "op",
         string label = "Output Color",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_clamp.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_clamp.osl
@@ -36,21 +36,18 @@ shader as_maya_clamp
     color in_min = color(0)
     [[
         string as_maya_attribute_name = "min",
-        string as_maya_attribute_short_name = "mn",
         string label = "Lower Bound",
         string page = "Clamp Color Attributes"
     ]],
     color in_max = color(0)
     [[
         string as_maya_attribute_name = "max",
-        string as_maya_attribute_short_name = "mx",
         string label = "Upper Bound",
         string page = "Clamp Color Attributes"
     ]],
     color in_input = color(0)
     [[
         string as_maya_attribute_name = "input",
-        string as_maya_attribute_short_name = "ip",
         string label = "Input Color",
         string page = "Clamp Color Attributes"
     ]],
@@ -58,7 +55,6 @@ shader as_maya_clamp
     output color out_output = color(0)
     [[
         string as_maya_attribute_name = "output",
-        string as_maya_attribute_short_name = "op",
         string label = "Output Color",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_cloth.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_cloth.osl
@@ -39,12 +39,14 @@ shader as_maya_cloth
     color in_gapColor = color(0)
     [[
         string as_maya_attribute_name = "gapColor",
-        string label = "Gap Color"
+        string label = "Gap Color",
+        string page = "Cloth Attributes"
     ]],
     color in_uColor = color(1)
     [[
         string as_maya_attribute_name = "uColor",
-        string label = "U Color"
+        string label = "U Color",
+        string page = "Cloth Attributes"
     ]],
     color in_vColor = color(0.5)
     [[
@@ -54,43 +56,51 @@ shader as_maya_cloth
     float in_uWidth = 0.75
     [[
         string as_maya_attribute_name = "uWidth",
-        string label = "U Width"
+        string label = "U Width",
+        string page = "Cloth Attributes"
     ]],
     float in_vWidth = 0.75
     [[
         string as_maya_attribute_name = "vWidth",
-        string label = "V Width"
+        string label = "V Width",
+        string page = "Cloth Attributes"
     ]],
     float in_uWave = 0.0
     [[
         string as_maya_attribute_name = "uWave",
-        string label = "U Wave"
+        string label = "U Wave",
+        string page = "Cloth Attributes"
     ]],
     float in_vWave = 0.0
     [[
         string as_maya_attribute_name = "vWave",
-        string label = "V Wave"
+        string label = "V Wave",
+        string page = "Cloth Attributes"
     ]],
     float in_randomness = 0.0
     [[
         string as_maya_attribute_name = "randomness",
-        string label = "Randomness"
+        string label = "Randomness",
+        string page = "Cloth Attributes"
     ]],
     float in_widthSpread = 0.0
     [[
         string as_maya_attribute_name = "widthSpread",
-        string label = "Width Spread"
+        string label = "Width Spread",
+        string page = "Cloth Attributes"
     ]],
     float in_brightSpread = 0.0
     [[
         string as_maya_attribute_name = "brightSpread",
-        string label = "Bright Spread"
+        string label = "Bright Spread",
+        string page = "Cloth Attributes"
     ]],
     int in_invert = 0
     [[
         string as_maya_attribute_name = "invert",
         string label = "Invert",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "Effects",
     ]],
 
     MAYA_COLORBALANCE_PARAMETERS,

--- a/src/appleseed.shaders/src/maya/as_maya_cloud.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_cloud.osl
@@ -143,14 +143,12 @@ shader as_maya_cloud
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
-        string as_maya_attribute_short_name = "oa",
         string label = "Output Alpha",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_condition.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_condition.osl
@@ -38,27 +38,32 @@ shader as_maya_condition
         string as_maya_attribute_name = "operation",
         string label = "Operation",
         string widget = "mapper",
-        string options = "Equal:0|Not Equal:1|Greater Than:2|Greater Or Equal:3|Less Than:4|Less Or Equal:5"
+        string options = "Equal:0|Not Equal:1|Greater Than:2|Greater Or Equal:3|Less Than:4|Less Or Equal:5",
+        string page = "Condition Attributes"
     ]],
     float in_firstTerm = 0.0
     [[
         string as_maya_attribute_name = "firstTerm",
-        string label = "First Term"
+        string label = "First Term",
+        string page = "Condition Attributes"
     ]],
     float in_secondTerm = 0.0
     [[
         string as_maya_attribute_name = "secondTerm",
-        string label = "Second Term"
+        string label = "Second Term",
+        string page = "Condition Attributes"
     ]],
     color in_colorIfTrue = color(0)
     [[
         string as_maya_attribute_name = "colorIfTrue",
-        string label = "Color If True"
+        string label = "Color If True",
+        string page = "Condition Attributes"
     ]],
     color in_colorIfFalse = color(0)
     [[
         string as_maya_attribute_name = "colorIfFalse",
-        string label = "Color If False"
+        string label = "Color If False",
+        string page = "Condition Attributes"
     ]],
 
     output color out_outColor = color(0)

--- a/src/appleseed.shaders/src/maya/as_maya_contrast.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_contrast.osl
@@ -44,13 +44,13 @@ shader as_maya_contrast
     color in_contrast = color(0)
     [[
         string as_maya_attribute_name = "contrast",
-        string label = "Contrast"",
+        string label = "Contrast",
         string page = "Contrast Attributes"
     ]],
     color in_bias = color(0)
     [[
         string as_maya_attribute_name = "bias",
-        string label = "Bias"",
+        string label = "Bias",
         string page = "Contrast Attributes"
     ]],
 

--- a/src/appleseed.shaders/src/maya/as_maya_contrast.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_contrast.osl
@@ -38,17 +38,20 @@ shader as_maya_contrast
     color in_value = color(0)
     [[
         string as_maya_attribute_name = "value",
-        string label = "Input Color"
+        string label = "Input Color",
+        string page = "Contrast Attributes"
     ]],
     color in_contrast = color(0)
     [[
         string as_maya_attribute_name = "contrast",
-        string label = "Contrast"
+        string label = "Contrast"",
+        string page = "Contrast Attributes"
     ]],
     color in_bias = color(0)
     [[
         string as_maya_attribute_name = "bias",
-        string label = "Bias"
+        string label = "Bias"",
+        string page = "Contrast Attributes"
     ]],
 
     output color out_outValue = color(0)

--- a/src/appleseed.shaders/src/maya/as_maya_distanceBetween.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_distanceBetween.osl
@@ -36,22 +36,26 @@ shader as_maya_distanceBetween
     point in_point1 = point(0)
     [[
         string as_maya_attribute_name = "point1",
-        string label = "Point 1"
+        string label = "Point 1",
+        string page = "Distance Between Attributes"
     ]], 
     matrix in_inMatrix1 = matrix(1)
     [[
         string as_maya_attribute_name = "inMatrix1",
-        string label = "Matrix 1"
+        string label = "Matrix 1",
+        string widget = "null"
     ]],
     point in_point2 = point(0)
     [[
         string as_maya_attribute_name = "point2",
-        string label = "Point 2"
+        string label = "Point 2",
+        string page = "Distance Between Attributes"
     ]],
     matrix in_inMatrix2 = matrix(1)
     [[
         string as_maya_attribute_name = "inMatrix2",
-        string label = "Matrix 2"
+        string label = "Matrix 2",
+        string widget = "null"
     ]],
 
     output float out_distance = 0.0

--- a/src/appleseed.shaders/src/maya/as_maya_doubleShadingSwitch.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_doubleShadingSwitch.osl
@@ -36,17 +36,20 @@ shader as_maya_doubleShadingSwitch
     vector in_inDouble[] = {0}
     [[
         string as_maya_attribute_name = "inputs",
-        string label = "Input Values"
+        string label = "Input Values",
+        string page = "Switch Attributes"
     ]],
     string in_inShape[] = {""}
     [[
         string as_maya_attribute_name = "inputs",
-        string label = "Shape Names"
+        string label = "Shape Names",
+        string page = "Switch Attributes"
     ]],
     float in_default[2] = {0,0}
     [[
         string as_maya_attribute_name = "default",
-        string label = "Default Values"
+        string label = "Default Values",
+        string page = "Switch Attributes"
     ]],
 
     output float out_output[2] = {0,0}

--- a/src/appleseed.shaders/src/maya/as_maya_envChrome.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_envChrome.osl
@@ -178,14 +178,12 @@ shader as_maya_envChrome
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
-        string as_maya_attribute_short_name = "oa",
         string label = "Output Alpha",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_file.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_file.osl
@@ -80,8 +80,7 @@ shader as_maya_file
         string as_maya_attribute_name = "ptexFilterType",
         string label = "Ptex Filter Type",
         string widget = "mapper",
-        string options =
-        "Point:0|Bilinear:1|Box:2|Gaussian:3|Bicubic:4|B-Spline:5|Catmull-Rom:6|Mitchell:7",
+        string options = "Point:0|Bilinear:1|Box:2|Gaussian:3|Bicubic:4|B-Spline:5|Catmull-Rom:6|Mitchell:7",
         string page = "Ptex Controls"
     ]],
     float in_ptexFilterWidth = 0.0

--- a/src/appleseed.shaders/src/maya/as_maya_file.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_file.osl
@@ -36,82 +36,83 @@ shader as_maya_file
     string as_maya_node_name = "file"
 ]]
 (
-    string in_fileTextureName = ""
-    [[
-        string as_maya_attribute_name = "fileTextureName",
-        string label = "Image File",
-        string widget = "filename"
-    ]],
-    int in_disableFileLoad = 0
-    [[
-        string as_maya_attribute_name = "disableFileLoad",
-        string label = "Disable File Load",
-        string widget = "checkBox"
-    ]],
     int in_filterType = 3
     [[
         string as_maya_attribute_name = "filterType",
         string label = "Filter Type",
         string widget = "mapper",
-        string options = "None:0|Mip Map:1|Box:2|Quadratic:3|Quartic:4|Gaussian:5"
-    ]],
-    float in_filterWidth = 0.707
-    [[
-        string as_maya_attribute_name = "filterWidth",
-        string label = "Filter Width"
+        string options = "None:0|Mip Map:1|Box:2|Quadratic:3|Quartic:4|Gaussian:5",
+        string page = "File Attributes"
     ]],
     int in_preFilter = 0
     [[
         string as_maya_attribute_name = "preFilter",
         string label = "Pre-Filter",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "File Attributes"
     ]],
     float in_preFilterRadius = 2.0
     [[
         string as_maya_attribute_name = "preFilterRadius",
         string label = "Pre-Filter Radius",
-        int slider = 1,
-        int slidermin = 1,
-        int slidermax = 10,
-        int digits = 4
+        float min = 1.0,
+        float max = 10.0,
+        string page = "File Attributes",
+        int divider = 1
     ]],
-    int in_useMaximumRes = 0
+    string in_fileTextureName = ""
     [[
-        string as_maya_attribute_name = "useMaximumRes",
-        string label = "Use Maximum Res",
-        string widget = "checkBox"
+        string as_maya_attribute_name = "fileTextureName",
+        string label = "Image File",
+        string widget = "filename",
+        string page = "File Attributes",
+        int divider = 1
     ]],
-    float in_ptexFilterBlur = 0.0
+    int in_disableFileLoad = 0
     [[
-        string as_maya_attribute_name = "ptexFilterBlur",
-        string label = "PTex Filter Blur",
-        int slider = 1
-    ]],
-    float in_ptexFilterWidth = 0.0
-    [[
-        string as_maya_attribute_name = "ptexFilterWidth",
-        string label = "PTex Filter Width",
-        int slider = 1
+        string as_maya_attribute_name = "disableFileLoad",
+        string label = "Disable File Load",
+        string widget = "checkBox",
+        string page = "File Attributes"
     ]],
     int in_ptexFilterType = 3
     [[
         string as_maya_attribute_name = "ptexFilterType",
-        string label = "PTex Filter Type",
+        string label = "Ptex Filter Type",
         string widget = "mapper",
         string options =
-        "Point:0|Bilinear:1|Box:2|Gaussian:3|Bicubic:4|B-Spline:5|Catmull-Rom:6|Mitchell:7"
+        "Point:0|Bilinear:1|Box:2|Gaussian:3|Bicubic:4|B-Spline:5|Catmull-Rom:6|Mitchell:7",
+        string page = "Ptex Controls"
+    ]],
+    float in_ptexFilterWidth = 0.0
+    [[
+        string as_maya_attribute_name = "ptexFilterWidth",
+        float min = -10.0,
+        float max = 10.0,
+        string label = "Ptex Filter Width",
+        string page = "Ptex Controls"
+    ]],
+    float in_ptexFilterBlur = 0.0
+    [[
+        string as_maya_attribute_name = "ptexFilterBlur",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Ptex Filter Blur",
+        string page = "Ptex Controls"
     ]],
     int in_ptexFilterInterpolateLevels = 0
     [[
         string as_maya_attribute_name = "ptexFilterInterpolateLevels",
-        string label = "PTex Filter Interpolate Levels",
-        string widget = "checkBox"
+        string label = "Ptex Filter Interpolate Levels",
+        string widget = "checkBox",
+        string page = "Ptex Controls"
     ]],
 
     float in_exposure = 0.0
     [[
         string as_maya_attribute_name = "exposure",
-        string label = "Exposure"
+        string label = "Exposure",
+        string page = "Color Balance"
     ]],
 
     MAYA_COLORMANAGEMENT_PARAMETERS,
@@ -302,7 +303,7 @@ shader as_maya_file
 
         if (in_preFilter)
         {
-            float fw = in_filterWidth * in_preFilterRadius;
+            float fw = in_preFilterRadius;
 
             dsdt[0] *= fw;
             dsdt[1] *= fw;
@@ -310,7 +311,7 @@ shader as_maya_file
             dsdt[3] *= fw;
         }
 
-        if (in_filterType == 1 && in_useMaximumRes)
+        if (in_filterType == 1)
         {
             out_outColor =
                 texture(

--- a/src/appleseed.shaders/src/maya/as_maya_file.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_file.osl
@@ -122,21 +122,18 @@ shader as_maya_file
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
-        string as_maya_attribute_short_name = "oa",
         string label = "Output File Alpha",
         string widget = "null"
     ]],
     output color out_outTransparency = color(0)
     [[
         string as_maya_attribute_name = "outTransparency",
-        string as_maya_attribute_short_name = "ot",
         string label = "Output Transparency",
         string widget = "null"
     ]],

--- a/src/appleseed.shaders/src/maya/as_maya_gammaCorrect.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_gammaCorrect.osl
@@ -38,12 +38,14 @@ shader as_maya_gammaCorrect
     color in_value = color(0)
     [[
         string as_maya_attribute_name = "value",
-        string label = "Input Value"
+        string label = "Input Value",
+        string page = "Gamma Correction Attributes"
     ]],
     color in_gamma = color(1)
     [[
         string as_maya_attribute_name = "gamma",
-        string label = "Gamma Correction"
+        string label = "Gamma Correction",
+        string page = "Gamma Correction Attributes"
     ]],
 
     output color out_outValue = color(0)

--- a/src/appleseed.shaders/src/maya/as_maya_grid.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_grid.osl
@@ -39,27 +39,32 @@ shader as_maya_grid
     color in_fillerColor = color(0)
     [[
         string as_maya_attribute_name = "fillerColor",
-        string label = "Filler Color"
+        string label = "Filler Color",
+        string page = "Grid Attributes"
     ]],
     color in_lineColor = color(0)
     [[
         string as_maya_attribute_name = "lineColor",
-        string label = "Line Color"
+        string label = "Line Color",
+        string page = "Grid Attributes"
     ]],
     float in_contrast = 1.0
     [[
         string as_maya_attribute_name = "contrast",
-        string label = "Contrast"
+        string label = "Contrast",
+        string page = "Grid Attributes"
     ]],
     float in_uWidth = 0.1
     [[
         string as_maya_attribute_name = "uWidth",
-        string label = "U Width"
+        string label = "U Width",
+        string page = "Grid Attributes"
     ]],
     float in_vWidth = 0.1
     [[
         string as_maya_attribute_name = "vWidth",
-        string label = "V Width"
+        string label = "V Width",
+        string page = "Grid Attributes"
     ]],
 
     MAYA_COLORBALANCE_PARAMETERS,

--- a/src/appleseed.shaders/src/maya/as_maya_grid.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_grid.osl
@@ -69,7 +69,6 @@ shader as_maya_grid
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],

--- a/src/appleseed.shaders/src/maya/as_maya_hsvToRgb.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_hsvToRgb.osl
@@ -36,7 +36,8 @@ shader as_maya_hsvToRgb
     color in_inHsv = color(0)
     [[
         string as_maya_attribute_name = "inHsv",
-        string label = "HSV Input Color"
+        string label = "HSV Input Color",
+        string page = "HSV to RGB Attributes"
     ]],
 
     output color out_outRgb = color(0)

--- a/src/appleseed.shaders/src/maya/as_maya_lambert.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_lambert.osl
@@ -141,28 +141,24 @@ shader as_maya_lambert
     output closure color out_outColor = 0
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output closure color out_outTransparency = 0
     [[
         string as_maya_attribute_name = "outTransparency",
-        string as_maya_attribute_short_name = "ot",
         string label = "Output Transparency",
         string widget = "null"
     ]],
     output closure color out_outGlowColor = 0
     [[
         string as_maya_attribute_name = "outGlowColor",
-        string as_maya_attribute_short_name = "og",
         string label = "Output Glow Color",
         string widget = "null"
     ]],
     output closure color out_outMatteOpacity = 0
     [[
         string as_maya_attribute_name = "outMatteOpacity",
-        string as_maya_attribute_short_name = "om",
         string label = "Output Matte Opacity",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_lambert.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_lambert.osl
@@ -38,59 +38,83 @@ shader as_maya_lambert
     color in_color = color(0.5)
     [[
         string as_maya_attribute_name = "color",
-        string label = "Color"
+        string label = "Color",
+        string page = "Common Material Attributes"
     ]],
     color in_transparency = color(0)
     [[
         string as_maya_attribute_name = "transparency",
-        string label = "Transparency"
+        string label = "Transparency",
+        string page = "Common Material Attributes"
     ]],
     color in_ambientColor = color(0)
     [[
         string as_maya_attribute_name = "ambientColor",
-        string label = "Ambient Color"
+        string label = "Ambient Color",
+        string page = "Common Material Attributes"
     ]],
     color in_incandescence = color(0)
     [[
         string as_maya_attribute_name = "incandescence",
-        string label = "Incandescence Color"
+        string label = "Incandescence Color",
+        string page = "Common Material Attributes"
     ]],
     normal in_normalCamera = N
     [[
         string as_maya_attribute_name = "normalCamera",
-        string label = "Bump Mapping Normal"
+        string label = "Bump Mapping Normal",
+        string page = "Common Material Attributes"
     ]],
     float in_diffuse = 0.8
     [[
         string as_maya_attribute_name = "diffuse",
-        string label = "Diffuse Intensity"
+        string label = "Diffuse Intensity",
+        string page = "Common Material Attributes"
     ]],
     float in_translucence = 0.0
     [[
         string as_maya_attribute_name = "translucence",
-        string label = "Translucence"
+        string label = "Translucence",
+        string page = "Common Material Attributes"
     ]],
     float in_translucenceDepth = 0.5
     [[
         string as_maya_attribute_name = "translucenceDepth",
-        string label = "Translucence Depth"
+        string label = "Translucence Depth",
+        string page = "Common Material Attributes"
     ]],
     float in_translucenceFocus = 0.5
     [[
         string as_maya_attribute_name = "translucenceFocus",
-        string label = "Translucence Focus"
+        string label = "Translucence Focus",
+        string page = "Common Material Attributes"
+    ]],
+    int in_hideSource = 0
+    [[
+        string as_maya_attribute_name = "hideSource",
+        string label = "Hide Glow Source",
+        string widget = "checkBox",
+        string page = "Special Effects"
+    ]],
+    float in_glowIntensity = 0.0
+    [[
+        string as_maya_attribute_name = "glowIntensity",
+        string label = "Glow Intensity",
+        string page = "Special Effects"
     ]],
     int in_matteOpacityMode = 2
     [[
         string as_maya_attribute_name = "matteOpacityMode",
         string label = "Matte Opacity Mode",
         string widget = "mapper",
-        string options = "Black Hole:0|Solid Matte:1|Opacity Gain:2"
+        string options = "Black Hole:0|Solid Matte:1|Opacity Gain:2",
+        string page = "Matte Opacity"
     ]],
     float in_matteOpacity = 1.0
     [[
         string as_maya_attribute_name = "matteOpacity",
-        string label = "Matte Opacity"
+        string label = "Matte Opacity",
+        string page = "Matte Opacity"
     ]],
     int in_refractions = 0
     [[
@@ -104,8 +128,6 @@ shader as_maya_lambert
         string as_maya_attribute_name = "refractiveIndex",
         string label = "Refractive Index",
         float min = 0.010,
-        float max = 3.0,
-        float softmin = 0.010,
         float softmax = 3.0,
         string page = "Raytrace Options"
     ]],
@@ -113,11 +135,8 @@ shader as_maya_lambert
     [[
         string as_maya_attribute_name = "refractionLimit",
         string label = "Refraction Limit",
-        string widget = "intslider",
         int min = 0,
         int max = 10,
-        int softmin = 0,
-        int softmax = 10,
         string page = "Raytrace Options"
     ]],
     float in_shadowAttenuation = 0.5
@@ -125,17 +144,6 @@ shader as_maya_lambert
         string as_maya_attribute_name = "shadowAttenuation",
         string label = "Shadow Attenuation",
         string page = "Raytrace Options"
-    ]],
-    int in_hideSource = 0
-    [[
-        string as_maya_attribute_name = "hideSource",
-        string label = "Hide Glow Source",
-        string widget = "checkBox"
-    ]],
-    float in_glowIntensity = 0.0
-    [[
-        string as_maya_attribute_name = "glowIntensity",
-        string label = "Glow Intensity"
     ]],
 
     output closure color out_outColor = 0

--- a/src/appleseed.shaders/src/maya/as_maya_layeredTexture.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_layeredTexture.osl
@@ -36,35 +36,39 @@ shader as_maya_layeredTexture
     string as_maya_node_name = "layeredTexture"
 ]]
 (
-    color in_color[] = {0}
+    color in_color[] = {color(0)}
     [[
         string as_maya_attribute_name = "inputs",
-        string label = "Color"
+        string label = "Color",
+        string page = "Layered Texture Attributes"
     ]],
     float in_alpha[] = {1.0}
     [[
         string as_maya_attribute_name = "inputs",
-        string label = "Alpha"
+        string label = "Alpha",
+        string page = "Layered Texture Attributes"
     ]],
     int in_blendMode[] = {1}
     [[
         string as_maya_attribute_name = "inputs",
         string label = "Blend Mode",
         string widget = "mapper",
-        string options =
-        "None:0|Over:1|In:2|Out:3|Add:4|Subtract:5|Multiply:6|Difference:7|Lighten:8|Darken:9|Saturate:10|Desaturate:11|Illuminate:12"
+        string options = "None:0|Over:1|In:2|Out:3|Add:4|Subtract:5|Multiply:6|Difference:7|Lighten:8|Darken:9|Saturate:10|Desaturate:11|Illuminate:12",
+        string page = "Layered Texture Attributes"
     ]],
     int in_isVisible[] = {1}
     [[
         string as_maya_attribute_name = "inputs",
         string label = "Visible",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "Layered Texture Attributes"
     ]],
     int in_alphaIsLuminance = 0
     [[
         string as_maya_attribute_name = "alphaIsLuminance",
         string label = "Alpha Is Luminance",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "Layered Texture Attributes"
     ]],
     output float out_outAlpha = 0.0
     [[

--- a/src/appleseed.shaders/src/maya/as_maya_layeredTexture.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_layeredTexture.osl
@@ -75,14 +75,12 @@ shader as_maya_layeredTexture
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output color out_outTransparency = color(0)
     [[
         string as_maya_attribute_name = "outTransparency",
-        string as_maya_attribute_short_name = "ot",
         string label = "Output Transparency",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_luminance.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_luminance.osl
@@ -38,7 +38,8 @@ shader as_maya_luminance
     color in_value = color(0)
     [[
         string as_maya_attribute_name = "value",
-        string label = "Input Color"
+        string label = "Input Color",
+        string page = "Luminance Attributes"
     ]],
 
     output float out_outValue = 0

--- a/src/appleseed.shaders/src/maya/as_maya_mountain.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_mountain.osl
@@ -101,14 +101,12 @@ shader as_maya_mountain
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
-        string as_maya_attribute_short_name = "oa",
         string label = "Output Alpha",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_mountain.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_mountain.osl
@@ -40,58 +40,68 @@ shader as_maya_mountain
     color in_snowColor = color(1)
     [[
         string as_maya_attribute_name = "snowColor",
-        string label = "Snow Color"
+        string label = "Snow Color",
+        string page = "Mountain Attributes"
     ]],
     color in_rockColor = color(0.262, 0.102, 0.0)
     [[
         string as_maya_attribute_name = "rockColor",
-        string label = "Rock Color"
+        string label = "Rock Color",
+        string page = "Mountain Attributes"
     ]],
     float in_amplitude = 1.0
     [[
         string as_maya_attribute_name = "amplitude",
-        string label = "Amplitude"
+        string label = "Amplitude",
+        string page = "Mountain Attributes"
     ]],
     float in_snowRoughness = 0.4
     [[
         string as_maya_attribute_name = "snowRoughness",
-        string label = "Snow Roughness"
+        string label = "Snow Roughness",
+        string page = "Mountain Attributes"
     ]],
     float in_rockRoughness = 0.707
     [[
         string as_maya_attribute_name = "rockRoughness",
-        string label = "Rock Roughness"
+        string label = "Rock Roughness",
+        string page = "Mountain Attributes"
     ]],
     float in_boundary = 1.0
     [[
         string as_maya_attribute_name = "boundary",
-        string label = "Boundary"
+        string label = "Boundary",
+        string page = "Mountain Attributes"
     ]],
     float in_snowAltitude = 0.5
     [[
         string as_maya_attribute_name = "snowAltitude",
-        string label = "Snow Altitude"
+        string label = "Snow Altitude",
+        string page = "Mountain Attributes"
     ]],
     float in_snowDropoff = 2.0
     [[
         string as_maya_attribute_name = "snowDropoff",
         float slidermin = 0.0,
         float slidermax = 2.0,
-        string label = "Snow Dropoff"
+        string label = "Snow Dropoff",
+        string page = "Mountain Attributes"
     ]],
     float in_snowSlope = 0.8
     [[
         string as_maya_attribute_name = "snowSlope",
         float slidermin = 0.0,
         float slidermax = 3.0,
-        string label = "Snow Slope"
+        string label = "Snow Slope",
+        string page = "Mountain Attributes"
     ]],
     float in_depthMax = 20.0
     [[
         string as_maya_attribute_name = "depthMax",
         float slidermin = 0.0,
         float slidermax = 40.0,
-        string label = "Depth Max"
+        string label = "Depth Max",
+        string page = "Mountain Attributes"
     ]],
     
     MAYA_COLORBALANCE_PARAMETERS,

--- a/src/appleseed.shaders/src/maya/as_maya_movie.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_movie.osl
@@ -40,60 +40,61 @@ shader as_maya_movie
     [[
         string as_maya_attribute_name = "fileTextureName",
         string label = "Image File",
-        string widget = "filename"
+        string widget = "filename",
+        string page = "File Attributes"
     ]],
     int in_disableFileLoad = 0
     [[
         string as_maya_attribute_name = "disableFileLoad",
         string label = "Disable File Load",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "File Attributes"
     ]],
     int in_useFrameExtension = 0
     [[
         string as_maya_attribute_name = "useFrameExtension",
         string label = "Use Frame Extension",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "File Attributes"
     ]],
     int in_frameExtension = 1
     [[
         string as_maya_attribute_name = "frameExtension",
         string label = "Frame Extension",
         string widget = "number",
-        int slider = 0
+        int slider = 0,
+        string page = "File Attributes"
     ]],
     int in_frameOffset = 0
     [[
         string as_maya_attribute_name = "frameOffset",
         string label = "Frame Offset",
         string widget = "number",
-        int slider = 0
+        int slider = 0,
+        string page = "File Attributes"
     ]],
     int in_filterType = 3
     [[
         string as_maya_attribute_name = "filterType",
         string label = "Filter Type",
         string widget = "mapper",
-        string options = "None:0|Mip Map:1|Box:2|Quadratic:3|Quartic:4|Gaussian:5"
-    ]],
-    float in_filterWidth = 0.707
-    [[
-        string as_maya_attribute_name = "filterWidth",
-        string label = "Filter Width"
+        string options = "None:0|Mip Map:1|Box:2|Quadratic:3|Quartic:4|Gaussian:5",
+        string page = "File Attributes"
     ]],
     int in_preFilter = 0
     [[
         string as_maya_attribute_name = "preFilter",
         string label = "Pre-Filter",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "File Attributes"
     ]],
     float in_preFilterRadius = 2.0
     [[
         string as_maya_attribute_name = "preFilterRadius",
         string label = "Pre-Filter Radius",
-        int slider = 1,
-        int slidermin = 1,
-        int slidermax = 10,
-        int digits = 4
+        float min = 1.0,
+        float max = 10.0,
+        string page = "File Attributes"
     ]],
 
     MAYA_COLORMANAGEMENT_PARAMETERS,
@@ -221,7 +222,7 @@ shader as_maya_movie
 
         if (in_preFilter)
         {
-            float fw = in_filterWidth * in_preFilterRadius;
+            float fw = in_preFilterRadius;
 
             dsdt[0] *= fw;
             dsdt[1] *= fw;

--- a/src/appleseed.shaders/src/maya/as_maya_movie.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_movie.osl
@@ -104,21 +104,18 @@ shader as_maya_movie
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
-        string as_maya_attribute_short_name = "oa",
         string label = "Output File Alpha",
         string widget = "null"
     ]],
     output color out_outTransparency = color(0)
     [[
         string as_maya_attribute_name = "outTransparency",
-        string as_maya_attribute_short_name = "ot",
         string label = "Output Transparency",
         string widget = "null"
     ]],

--- a/src/appleseed.shaders/src/maya/as_maya_multiplyDivide.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_multiplyDivide.osl
@@ -38,17 +38,20 @@ shader as_maya_multiplyDivide
         string as_maya_attribute_name = "operation",
         string label = "Operation",
         string widget = "mapper",
-        string options = "No Operation:0|Multiply:1|Divide:2|Power:3"
+        string options = "No Operation:0|Multiply:1|Divide:2|Power:3",
+        string page = "Multiply-Divide Attributes"
     ]],
     vector in_input1 = 1.0
     [[
         string as_maya_attribute_name = "input1",
-        string label = "Input 1"
+        string label = "Input 1",
+        string page = "Multiply-Divide Attributes"
     ]],
     vector in_input2 = 1.0
     [[
         string as_maya_attribute_name = "input2",
-        string label = "Input 2"
+        string label = "Input 2",
+        string page = "Multiply-Divide Attributes"
     ]],
 
     output vector out_output = 1.0

--- a/src/appleseed.shaders/src/maya/as_maya_noise.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_noise.osl
@@ -150,14 +150,12 @@ shader as_maya_noise
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
-        string as_maya_attribute_short_name = "oa",
         string label = "Output Alpha",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_noise.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_noise.osl
@@ -40,17 +40,20 @@ shader as_maya_noise
     float in_amplitude = 1.0
     [[
         string as_maya_attribute_name = "amplitude",
-        string label = "Amplitude"
+        string label = "Amplitude",
+        string page = "Noise Attributes"
     ]],
     float in_ratio = 0.707
     [[
         string as_maya_attribute_name = "ratio",
-        string label = "Ratio"
+        string label = "Ratio",
+        string page = "Noise Attributes"
     ]],
     float in_threshold = 0.0
     [[
         string as_maya_attribute_name = "threshold",
-        string label = "Threshold"
+        string label = "Threshold",
+        string page = "Noise Attributes"
     ]],
     int in_depthMax = 3
     [[
@@ -58,7 +61,8 @@ shader as_maya_noise
         string widget = "slider",
         int slidermin = 1,
         int slidermax = 8,
-        string label = "Maximum Depth"
+        string label = "Maximum Depth",
+        string page = "Noise Attributes"
     ]],
     float in_frequency = 8.0
     [[
@@ -66,7 +70,8 @@ shader as_maya_noise
         string widget = "slider",
         float slidermin = 0.0,
         float slidermax = 100.0,
-        string label = "Frequency"
+        string label = "Frequency",
+        string page = "Noise Attributes"
     ]],
     float in_frequencyRatio = 2.0
     [[
@@ -74,52 +79,61 @@ shader as_maya_noise
         string widget = "slider",
         float slidermin = 1.0,
         float slidermax = 10.0,
-        string label = "Frequency Ratio"
+        string label = "Frequency Ratio",
+        string page = "Noise Attributes"
     ]],
     int in_inflection = 0
     [[
         string as_maya_attribute_name = "inflection",
         string widget = "checkBox",
-        string label = "Inflection"
+        string label = "Inflection",
+        string page = "Noise Attributes"
     ]],
     float in_time = 0.0
     [[
         string as_maya_attribute_name = "time",
-        string label = "Time"
+        string label = "Time",
+        string page = "Noise Attributes"
     ]],
     int in_noiseType = 1
     [[
         string as_maya_attribute_name = "noiseType",
         string widget = "mapper",
         string options = "Perlin:0|Billow:1|Wave:2|Wispy:3|SpaceTime:4",
-        string label = "Noise Type"
+        string label = "Noise Type",
+        string page = "Noise Attributes"
     ]],
     float in_density = 1.0
     [[
         string as_maya_attribute_name = "density",
-        string label = "Density"
+        string label = "Density",
+        string page = "Noise Attributes"
     ]],
     float in_spottyness = 0.1
     [[
         string as_maya_attribute_name = "spottyness",
-        string label = "Spottyness"
+        string label = "Spottyness",
+        string page = "Noise Attributes"
     ]],
     float in_sizeRand = 0.0
     [[
         string as_maya_attribute_name = "sizeRand",
-        string label = "Size Randomness"
+        string label = "Size Randomness",
+        string page = "Noise Attributes"
     ]],
     float in_randomness = 1.0
     [[
         string as_maya_attribute_name = "randomness",
-        string label = "Randomness"
+        string label = "Randomness",
+        string page = "Noise Attributes"
     ]],
     int in_falloff = 2
     [[
         string as_maya_attribute_name = "falloff",
         string widget = "mapper",
         string options = "Linear:0|Smooth:1|Fast:2|Bubble:3",
-        string label = "Falloff"
+        string label = "Falloff",
+        string page = "Noise Attributes"
     ]],
     int in_numWaves = 5
     [[
@@ -127,7 +141,8 @@ shader as_maya_noise
         string widget = "slider",
         int slidermin = 1,
         int slidermax = 20,
-        string label = "Number of Waves"
+        string label = "Number of Waves",
+        string page = "Noise Attributes"
     ]],
     float in_implode = 0.0
     [[
@@ -135,12 +150,14 @@ shader as_maya_noise
         string widget = "slider",
         float slidermin = -1.0,
         float slidermax = 1.0,
-        string label = "Implode"
+        string label = "Implode",
+        string page = "Noise Attributes"
     ]],
     float in_implodeCenter[2] = {0.5, 0.5}
     [[
         string as_maya_attribute_name = "implodeCenter",
-        string label = "Implode Center"
+        string label = "Implode Center",
+        string page = "Noise Attributes"
     ]],
 
     MAYA_COLORBALANCE_PARAMETERS,

--- a/src/appleseed.shaders/src/maya/as_maya_phong.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_phong.osl
@@ -183,28 +183,24 @@ shader as_maya_phong
     output closure color out_outColor = 0
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output closure color out_outTransparency = 0
     [[
         string as_maya_attribute_name = "outTransparency",
-        string as_maya_attribute_short_name = "ot",
         string label = "Output Transparency",
         string widget = "null"
     ]],
     output closure color out_outGlowColor = 0
     [[
         string as_maya_attribute_name = "outGlowColor",
-        string as_maya_attribute_short_name = "og",
         string label = "Output Glow Color",
         string widget = "null"
     ]],
     output closure color out_outMatteOpacity = 0
     [[
         string as_maya_attribute_name = "outMatteOpacity",
-        string as_maya_attribute_short_name = "om",
         string label = "Output Matte Opacity",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_phongE.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_phongE.osl
@@ -191,28 +191,24 @@ shader as_maya_phongE
     output closure color out_outColor = 0
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output closure color out_outTransparency = 0
     [[
         string as_maya_attribute_name = "outTransparency",
-        string as_maya_attribute_short_name = "ot",
         string label = "Output Transparency",
         string widget = "null"
     ]],
     output closure color out_outGlowColor = 0
     [[
         string as_maya_attribute_name = "outGlowColor",
-        string as_maya_attribute_short_name = "og",
         string label = "Output Glow Color",
         string widget = "null"
     ]],
     output closure color out_outMatteOpacity = 0
     [[
         string as_maya_attribute_name = "outMatteOpacity",
-        string as_maya_attribute_short_name = "om",
         string label = "Output Matte Opacity",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_place2dTexture.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_place2dTexture.osl
@@ -33,84 +33,101 @@
 
 shader as_maya_place2dTexture
 [[
-    string as_maya_node_name = "place2dTexture"
+    string as_maya_node_name = "place2dTexture",
+    string help = "ZOMGER",
+    string URL = "http://www.appleseedhq.net"
 ]]
 (
-    MAYA_UV_PARAMETERS,
-
     float in_coverage[2] = {1.0, 1.0}
     [[
         string as_maya_attribute_name = "coverage",
-        string label = "Coverage"
+        string label = "Coverage",
+        string page = "2D Texture Placement Attributes",
+        string help = "FOO BAR"
     ]],
     float in_translateFrame[2] = {0.0, 0.0}
     [[
         string as_maya_attribute_name = "translateFrame",
-        string label = "UV Frame Translation"
+        string label = "UV Frame Translation",
+        string page = "2D Texture Placement Attributes"
     ]],
     float in_rotateFrame = 0.0
     [[
         string as_maya_attribute_name = "rotateFrame",
+        string widget = "slider",
         string units = "degrees",
-        string label = "UV Frame Rotation"
+        string label = "UV Frame Rotation",
+        string page = "2D Texture Placement Attributes"
     ]],
     int in_mirrorU = 0
     [[
         string as_maya_attribute_name = "mirrorU",
         string label = "Mirror U",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "2D Texture Placement Attributes"
     ]],
     int in_mirrorV = 0
     [[
         string as_maya_attribute_name = "mirrorV",
         string label = "Mirror V",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "2D Texture Placement Attributes"
     ]],
     int in_stagger = 0
     [[
         string as_maya_attribute_name = "stagger",
         string label = "Stagger",
-        string widget = "c heckBox"
+        string widget = "checkBox",
+        string page = "2D Texture Placement Attributes"
     ]],
     int in_wrapU = 0
     [[
         string as_maya_attribute_name = "wrapU",
         string label = "Wrap U",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "2D Texture Placement Attributes"
     ]],
     int in_wrapV = 0
     [[
         string as_maya_attribute_name = "wrapV",
         string label = "Wrap V",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "2D Texture Placement Attributes"
     ]],
     float in_repeatUV[2] = {1.0, 1.0}
     [[
         string as_maya_attribute_name = "repeatUV",
-        string label = "Repeat UV"
+        string label = "Repeat UV",
+        string page = "2D Texture Placement Attributes"
     ]],
     float in_offset[2] = {0.0, 0.0}
     [[
         string as_maya_attribute_name = "offset",
-        string label = "Offset"
+        string label = "Offset",
+        string page = "2D Texture Placement Attributes"
     ]],
     float in_rotateUV = 0.0
     [[
         string as_maya_attribute_name = "rotateUV",
         string units = "degrees",
-        string label = "Rotate UV"
+        string label = "Rotate UV",
+        string page = "2D Texture Placement Attributes"
     ]],
     float in_noiseUV[2] = {0.0, 0.0}
     [[
         string as_maya_attribute_name = "noiseUV",
-        string label = "Noise UV"
+        string label = "Noise UV",
+        string page = "2D Texture Placement Attributes"
     ]],
     int in_fast = 0
     [[
         string as_maya_attribute_name = "fast",
         string label = "Fast",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "2D Texture Placement Attributes"
     ]],
+
+    MAYA_UV_PARAMETERS,
 
     output float out_outUV[2] = {0.0, 0.0}
     [[

--- a/src/appleseed.shaders/src/maya/as_maya_plusMinusAverage.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_plusMinusAverage.osl
@@ -38,22 +38,26 @@ shader as_maya_plusMinusAverage
         string as_maya_attribute_name = "operation",
         string label = "Operation",
         string widget = "mapper",
-        string options = "No Operation:0|Sum:1|Subtraction:2|Average:3"
+        string options = "No Operation:0|Sum:1|Subtraction:2|Average:3",
+        string page = "Plus-Minus-Average Attributes"
     ]],
     float in_input1D[] = {0}
     [[
         string as_maya_attribute_name = "input1D",
-        string label = "Input 1D"
+        string label = "Input 1D",
+        string page = "Plus-Minus-Average Attributes"
     ]],
     vector in_input2D[] = {0}
     [[
         string as_maya_attribute_name = "input2D",
-        string label = "Input 2D"
+        string label = "Input 2D",
+        string page = "Plus-Minus-Average Attributes"
     ]],
     vector in_input3D[] = {0}
     [[
         string as_maya_attribute_name = "input3D",
-        string label = "Input 3D"
+        string label = "Input 3D",
+        string page = "Plus-Minus-Average Attributes"
     ]],
 
     output float out_output1D = 0.0

--- a/src/appleseed.shaders/src/maya/as_maya_psdFileTex.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_psdFileTex.osl
@@ -40,51 +40,53 @@ shader as_maya_psdFileTex
     [[
         string as_maya_attribute_name = "fileTextureName",
         string label = "Image File",
-        string widget = "filename"
+        string widget = "filename",
+        string page = "File Attributes"
     ]],
     int in_disableFileLoad = 0
     [[
         string as_maya_attribute_name = "disableFileLoad",
         string label = "Disable File Load",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "File Attributes"
     ]],
     int in_useFrameExtension = 0
     [[
         string as_maya_attribute_name = "useFrameExtension",
         string label = "Use Frame Extension",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "File Attributes"
     ]],
     int in_frameExtension = 1
     [[
         string as_maya_attribute_name = "frameExtension",
         string label = "Frame Extension",
         string widget = "number",
-        int slider = 0
+        int slider = 0,
+        string page = "File Attributes"
     ]],
     int in_frameOffset = 0
     [[
         string as_maya_attribute_name = "frameOffset",
         string label = "Frame Offset",
         string widget = "number",
-        int slider = 0
+        int slider = 0,
+        string page = "File Attributes"
     ]],
     int in_filterType = 3
     [[
         string as_maya_attribute_name = "filterType",
         string label = "Filter Type",
         string widget = "mapper",
-        string options = "None:0|Mip Map:1|Box:2|Quadratic:3|Quartic:4|Gaussian:5"
-    ]],
-    float in_filterWidth = 0.707
-    [[
-        string as_maya_attribute_name = "filterWidth",
-        string label = "Filter Width"
+        string options = "None:0|Mip Map:1|Box:2|Quadratic:3|Quartic:4|Gaussian:5",
+        string page = "File Attributes"
     ]],
     int in_preFilter = 0
     [[
         string as_maya_attribute_name = "preFilter",
         string label = "Pre-Filter",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "File Attributes"
     ]],
     float in_preFilterRadius = 2.0
     [[
@@ -93,13 +95,8 @@ shader as_maya_psdFileTex
         int slider = 1,
         int slidermin = 1,
         int slidermax = 10,
-        int digits = 4
-    ]],
-    int in_useMaximumRes = 0
-    [[
-        string as_maya_attribute_name = "useMaximumRes",
-        string label = "Use Maximum Res",
-        string widget = "checkBox"
+        int digits = 4,
+        string page = "File Attributes"
     ]],
     // We have no mechanism to load channels by string names in OSL/OIIO,
     // so don't expose the (multi)channel options, assume RGBA for now.
@@ -107,25 +104,29 @@ shader as_maya_psdFileTex
     [[
         string as_maya_attribute_name = "layerSetName",
         string label = "Layer Set Name",
-        string widget = "null"
+        string widget = "null",
+        string page = "File Attributes"
     ]],
     string in_layerSets[] = {""}
     [[
         string as_maya_attribute_name = "layerSets",
         string label = "Layer Sets",
-        string widget = "null"
+        string widget = "null",
+        string page = "File Attributes"
     ]],
     string in_alpha = ""
     [[
         string as_maya_attribute_name = "alpha",
         string label = "Alpha",
-        string widget = "null"
+        string widget = "null",
+        string page = "File Attributes"
     ]],
     string in_alphaList[] = {""}
     [[
         string as_maya_attribute_name = "alphaList",
         string label = "Alpha List",
-        string widget = "null"
+        string widget = "null",
+        string page = "File Attributes"
     ]],
 
     MAYA_COLORMANAGEMENT_PARAMETERS,
@@ -253,7 +254,7 @@ shader as_maya_psdFileTex
 
         if (in_preFilter)
         {
-            float fw = in_filterWidth * in_preFilterRadius;
+            float fw = in_preFilterRadius;
 
             dsdt[0] *= fw;
             dsdt[1] *= fw;
@@ -261,7 +262,7 @@ shader as_maya_psdFileTex
             dsdt[3] *= fw;
         }
 
-        if (in_filterType == 1 && in_useMaximumRes)
+        if (in_filterType == 1)
         {
             out_outColor =
                 texture(

--- a/src/appleseed.shaders/src/maya/as_maya_psdFileTex.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_psdFileTex.osl
@@ -136,21 +136,18 @@ shader as_maya_psdFileTex
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
-        string as_maya_attribute_short_name = "oa",
         string label = "Output File Alpha",
         string widget = "null"
     ]],
     output color out_outTransparency = color(0)
     [[
         string as_maya_attribute_name = "outTransparency",
-        string as_maya_attribute_short_name = "ot",
         string label = "Output Transparency",
         string widget = "null"
     ]],

--- a/src/appleseed.shaders/src/maya/as_maya_quadShadingSwitch.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_quadShadingSwitch.osl
@@ -36,27 +36,32 @@ shader as_maya_quadShadingSwitch
     color in_inTriple[] = {0}
     [[
         string as_maya_attribute_name = "inputs",
-        string label = "Triple Value Component"
+        string label = "Triple Value Component",
+        string page = "Switch Attributes"
     ]],
     float in_inSingle[] = {0.0}
     [[
         string as_maya_attribute_name = "inputs",
-        string label = "Single Value Component"
+        string label = "Single Value Component",
+        string page = "Switch Attributes"
     ]],
     string in_inShape[] = {""}
     [[
         string as_maya_attribute_name = "inputs",
-        string label = "Shape Name"
+        string label = "Shape Name",
+        string page = "Switch Attributes"
     ]],
     color in_defTriple = color(0.8)
     [[
         string as_maya_attribute_name = "default",
-        string label = "Default Triple Value"
+        string label = "Default Triple Value",
+        string page = "Switch Attributes"
     ]],
     float in_defSingle = 0.0
     [[
         string as_maya_attribute_name = "default",
-        string label = "Default Single Value"
+        string label = "Default Single Value",
+        string page = "Switch Attributes"
     ]],
 
     output color out_outTriple = color(0)

--- a/src/appleseed.shaders/src/maya/as_maya_ramp.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_ramp.osl
@@ -132,14 +132,12 @@ shader as_maya_ramp
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
-        string as_maya_attribute_short_name = "oa",
         string label = "Output Alpha",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_remapColor.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_remapColor.osl
@@ -125,7 +125,6 @@ shader as_maya_remapColor
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_remapColor.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_remapColor.osl
@@ -39,27 +39,8 @@ shader as_maya_remapColor
     color in_color = color(0)
     [[
         string as_maya_attribute_name = "color",
-        string label = "Color"
-    ]],
-    float in_inputMin = 0.0
-    [[
-        string as_maya_attribute_name = "inputMin",
-        string label = "Input Min"
-    ]],
-    float in_inputMax = 0.0
-    [[
-        string as_maya_attribute_name = "inputMax",
-        string label = "Input Max"
-    ]],
-    float in_outputMin = 0.0
-    [[
-        string as_maya_attribute_name = "outputMin",
-        string label = "Output Min"
-    ]], 
-    float in_outputMax = 0.0
-    [[
-        string as_maya_attribute_name = "outputMax",
-        string label = "Output Max"
+        string label = "Color",
+        string page = "Remap Color Attributes"
     ]],
     float in_red_Position[] = {0}
     [[
@@ -120,6 +101,30 @@ shader as_maya_remapColor
         string options = "None:0|Linear:1|Smooth:2|Spline:3",
         string label = "Blue Interpolation",
         string page = "Blue"
+    ]],
+    float in_inputMin = 0.0
+    [[
+        string as_maya_attribute_name = "inputMin",
+        string label = "Input Min",
+        string page = "Input And Output Attributes"
+    ]],
+    float in_inputMax = 0.0
+    [[
+        string as_maya_attribute_name = "inputMax",
+        string label = "Input Max",
+        string page = "Input And Output Attributes"
+    ]],
+    float in_outputMin = 0.0
+    [[
+        string as_maya_attribute_name = "outputMin",
+        string label = "Output Min",
+        string page = "Input And Output Attributes"
+    ]], 
+    float in_outputMax = 0.0
+    [[
+        string as_maya_attribute_name = "outputMax",
+        string label = "Output Max",
+        string page = "Input And Output Attributes"
     ]],
 
     output color out_outColor = color(0)

--- a/src/appleseed.shaders/src/maya/as_maya_remapColor.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_remapColor.osl
@@ -57,7 +57,7 @@ shader as_maya_remapColor
     int in_red_Interp[] = {0}
     [[
         string as_maya_attribute_name = "red",
-        string widget = "mapper",
+        //string widget = "mapper",
         string options = "None:0|Linear:1|Smooth:2|Spline:3",
         string label = "Red Interpolation",
         string page = "Red"
@@ -77,7 +77,7 @@ shader as_maya_remapColor
     int in_green_Interp[] = {0}
     [[
         string as_maya_attribute_name = "green",
-        string widget = "mapper",
+        //string widget = "mapper",
         string options = "None:0|Linear:1|Smooth:2|Spline:3",
         string label = "Green Interpolation",
         string page = "Green"
@@ -97,7 +97,7 @@ shader as_maya_remapColor
     int in_blue_Interp[] = {0}
     [[
         string as_maya_attribute_name = "blue",
-        string widget = "mapper",
+        //string widget = "mapper",
         string options = "None:0|Linear:1|Smooth:2|Spline:3",
         string label = "Blue Interpolation",
         string page = "Blue"

--- a/src/appleseed.shaders/src/maya/as_maya_remapHsv.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_remapHsv.osl
@@ -125,7 +125,6 @@ shader as_maya_remapHsv
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_remapHsv.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_remapHsv.osl
@@ -57,7 +57,7 @@ shader as_maya_remapHsv
     int in_hue_Interp[] = {0}
     [[
         string as_maya_attribute_name = "hue",
-        string widget = "mapper",
+        //string widget = "mapper",
         string options = "None:0|Linear:1|Smooth:2|Spline:3",
         string label = "Hue Interpolation",
         string page = "Hue"
@@ -77,7 +77,7 @@ shader as_maya_remapHsv
     int in_saturation_Interp[] = {0}
     [[
         string as_maya_attribute_name = "saturation",
-        string widget = "mapper",
+        //string widget = "mapper",
         string options = "None:0|Linear:1|Smooth:2|Spline:3",
         string label = "Saturation Interpolation",
         string page = "Saturation"
@@ -97,7 +97,7 @@ shader as_maya_remapHsv
     int in_value_Interp[] = {0}
     [[
         string as_maya_attribute_name = "value",
-        string widget = "mapper",
+        //string widget = "mapper",
         string options = "None:0|Linear:1|Smooth:2|Spline:3",
         string label = "Value Interpolation",
         string page = "Value"

--- a/src/appleseed.shaders/src/maya/as_maya_remapHsv.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_remapHsv.osl
@@ -39,27 +39,8 @@ shader as_maya_remapHsv
     color in_color = color(0)
     [[
         string as_maya_attribute_name = "color",
-        string label = "Color"
-    ]],
-    float in_inputMin = 0.0
-    [[
-        string as_maya_attribute_name = "inputMin",
-        string label = "Input Min"
-    ]],
-    float in_inputMax = 0.0
-    [[
-        string as_maya_attribute_name = "inputMax",
-        string label = "Input Max"
-    ]],
-    float in_outputMin = 0.0
-    [[
-        string as_maya_attribute_name = "outputMin",
-        string label = "Output Min"
-    ]], 
-    float in_outputMax = 0.0
-    [[
-        string as_maya_attribute_name = "outputMax",
-        string label = "Output Max"
+        string label = "Color",
+        string page = "Remap HSV Attributes"
     ]],
     float in_hue_Position[] = {0}
     [[
@@ -120,6 +101,30 @@ shader as_maya_remapHsv
         string options = "None:0|Linear:1|Smooth:2|Spline:3",
         string label = "Value Interpolation",
         string page = "Value"
+    ]],
+    float in_inputMin = 0.0
+    [[
+        string as_maya_attribute_name = "inputMin",
+        string label = "Input Min",
+        string page = "Input And Output Attributes"
+    ]],
+    float in_inputMax = 0.0
+    [[
+        string as_maya_attribute_name = "inputMax",
+        string label = "Input Max",
+        string page = "Input And Output Attributes"
+    ]],
+    float in_outputMin = 0.0
+    [[
+        string as_maya_attribute_name = "outputMin",
+        string label = "Output Min",
+        string page = "Input And Output Attributes"
+    ]], 
+    float in_outputMax = 0.0
+    [[
+        string as_maya_attribute_name = "outputMax",
+        string label = "Output Max",
+        string page = "Input And Output Attributes"
     ]],
 
     output color out_outColor = color(0)

--- a/src/appleseed.shaders/src/maya/as_maya_remapValue.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_remapValue.osl
@@ -39,27 +39,8 @@ shader as_maya_remapValue
     float in_inputValue = 0.0
     [[
         string as_maya_attribute_name = "inputValue",
-        string label = "Color"
-    ]],
-    float in_inputMin = 0.0
-    [[
-        string as_maya_attribute_name = "inputMin",
-        string label = "Input Min"
-    ]],
-    float in_inputMax = 0.0
-    [[
-        string as_maya_attribute_name = "inputMax",
-        string label = "Input Max"
-    ]],
-    float in_outputMin = 0.0
-    [[
-        string as_maya_attribute_name = "outputMin",
-        string label = "Output Min"
-    ]], 
-    float in_outputMax = 0.0
-    [[
-        string as_maya_attribute_name = "outputMax",
-        string label = "Output Max"
+        string label = "Color",
+        string page = "Remap Value Attributes"
     ]],
     float in_value_Position[] = {0}
     [[
@@ -100,6 +81,30 @@ shader as_maya_remapValue
         string options = "None:0|Linear:1|Smooth:2|Spline:3",
         string label = "Color Interpolation",
         string page = "Color Attributes"
+    ]],
+    float in_inputMin = 0.0
+    [[
+        string as_maya_attribute_name = "inputMin",
+        string label = "Input Min",
+        string page = "Input And Ouput Attributes"
+    ]],
+    float in_inputMax = 0.0
+    [[
+        string as_maya_attribute_name = "inputMax",
+        string label = "Input Max",
+        string page = "Input And Ouput Attributes"
+    ]],
+    float in_outputMin = 0.0
+    [[
+        string as_maya_attribute_name = "outputMin",
+        string label = "Output Min",
+        string page = "Input And Ouput Attributes"
+    ]], 
+    float in_outputMax = 0.0
+    [[
+        string as_maya_attribute_name = "outputMax",
+        string label = "Output Max",
+        string page = "Input And Ouput Attributes"
     ]],
 
     output float out_outValue = 0.0

--- a/src/appleseed.shaders/src/maya/as_maya_remapValue.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_remapValue.osl
@@ -111,7 +111,6 @@ shader as_maya_remapValue
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]]

--- a/src/appleseed.shaders/src/maya/as_maya_remapValue.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_remapValue.osl
@@ -57,7 +57,7 @@ shader as_maya_remapValue
     int in_value_Interp[] = {0}
     [[
         string as_maya_attribute_name = "value",
-        string widget = "mapper",
+        //string widget = "mapper",
         string options = "None:0|Linear:1|Smooth:2|Spline:3",
         string label = "Value Interpolation",
         string page = "Value"
@@ -77,7 +77,7 @@ shader as_maya_remapValue
     int in_color_Interp[] = {0}
     [[
         string as_maya_attribute_name = "color",
-        string widget = "mapper",
+        //string widget = "mapper",
         string options = "None:0|Linear:1|Smooth:2|Spline:3",
         string label = "Color Interpolation",
         string page = "Color Attributes"

--- a/src/appleseed.shaders/src/maya/as_maya_reverse.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_reverse.osl
@@ -36,7 +36,8 @@ shader as_maya_reverse
     color in_input = color(0)
     [[
         string as_maya_attribute_name = "input",
-        string label = "Input"
+        string label = "Input",
+        string page = "Reverse Attributes"
     ]],
 
     output color out_output = color(0)

--- a/src/appleseed.shaders/src/maya/as_maya_rgbToHsv.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_rgbToHsv.osl
@@ -36,7 +36,8 @@ shader as_maya_rgbToHsv
     color in_inRgb = color(0)
     [[
         string as_maya_attribute_name = "inRgb",
-        string label = "RGB Input"
+        string label = "RGB Input",
+        string page = "RGB To HSV Attributes"
     ]],
 
     output color out_outHsv = color(0)

--- a/src/appleseed.shaders/src/maya/as_maya_setRange.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_setRange.osl
@@ -37,27 +37,32 @@ shader as_maya_setRange
     vector in_value = vector(0)
     [[
         string as_maya_attribute_name = "value",
-        string label = "Input Value"
+        string label = "Input Value",
+        string page = "Set Range Attributes"
     ]],
     vector in_min = vector(0)
     [[
         string as_maya_attribute_name = "min",
-        string label = "Minimum Value"
+        string label = "Minimum Value",
+        string page = "Set Range Attributes"
     ]],
     vector in_max = vector(0)
     [[
         string as_maya_attribute_name = "max",
-        string label = "Maximum Value"
+        string label = "Maximum Value",
+        string page = "Set Range Attributes"
     ]],
     vector in_oldMin = vector(0)
     [[
         string as_maya_attribute_name = "oldMin",
-        string label = "Old Minimum Value"
+        string label = "Old Minimum Value",
+        string page = "Set Range Attributes"
     ]],
     vector in_oldMax = vector(0)
     [[
         string as_maya_attribute_name = "oldMax",
-        string label = "Old Maximum Value"
+        string label = "Old Maximum Value",
+        string page = "Set Range Attributes"
     ]],
 
     output vector out_outValue = vector(0)

--- a/src/appleseed.shaders/src/maya/as_maya_singleShadingSwitch.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_singleShadingSwitch.osl
@@ -36,19 +36,22 @@ shader as_maya_singleShadingSwitch
     float in_inSingle[] = {0.0}
     [[
         string as_maya_attribute_name = "inputs",
-        string label = "Input Value"
+        string label = "Input Value",
+        string page = "Switch Attributes"
     ]],
 
     string in_inShape[] = {""}
     [[
         string as_maya_attribute_name = "inputs",
-        string label = "Input Shape Name"
+        string label = "Input Shape Name",
+        string page = "Switch Attributes"
     ]],
 
     float in_default = 0.0
     [[
         string as_maya_attribute_name = "default",
-        string label = "Default Value"
+        string label = "Default Value",
+        string page = "Switch Attributes"
     ]],
 
     output float out_output = 0.0

--- a/src/appleseed.shaders/src/maya/as_maya_stencil.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_stencil.osl
@@ -96,7 +96,6 @@ shader as_maya_stencil
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],

--- a/src/appleseed.shaders/src/maya/as_maya_stencil.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_stencil.osl
@@ -39,54 +39,64 @@ shader as_maya_stencil
     color in_image = color(0)
     [[
         string as_maya_attribute_name = "image",
-        string label = "Image Input"
-    ]],
-    float in_mask = 0.0
-    [[
-        string as_maya_attribute_name = "mask",
-        string label = "Input Mask"
+        string label = "Image Input",
+        string page = "Stencil Attributes"
     ]],
     float in_edgeBlend = 0.0
     [[
         string as_maya_attribute_name = "edgeBlend",
-        string label = "Edge Blend"
+        string label = "Edge Blend",
+        string page = "Stencil Attributes"
+    ]],
+    float in_mask = 0.0
+    [[
+        string as_maya_attribute_name = "mask",
+        string label = "Input Mask",
+        string page = "Stencil Attributes"
     ]],
     int in_keyMasking = 0
     [[
         string as_maya_attribute_name = "keyMasking",
         string label = "Key Masking",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "HSV Color Key"
     ]],
     int in_positiveKey = 0
     [[
         string as_maya_attribute_name = "positiveKey",
         string label = "Positive Key",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "HSV Color Key"
     ]],
     color in_colorKey = color(0)
     [[
         string as_maya_attribute_name = "colorKey",
-        string label = "Color Key"
+        string label = "Color Key",
+        string page = "HSV Color Key"
     ]],
     float in_hueRange = 0.5
     [[
         string as_maya_attribute_name = "hueRange",
-        string label = "Hue Range"
+        string label = "Hue Range",
+        string page = "HSV Color Key"
     ]],
     float in_saturationRange = 0.5
     [[
         string as_maya_attribute_name = "saturationRange",
-        string label = "Saturation Range"
+        string label = "Saturation Range",
+        string page = "HSV Color Key"
     ]],
     float in_valueRange = 0.5
     [[
         string as_maya_attribute_name = "valueRange",
-        string label = "Value Range"
+        string label = "Value Range",
+        string page = "HSV Color Key"
     ]],
     float in_threshold = 0.5
     [[
         string as_maya_attribute_name = "threshold",
-        string label = "Threshold"
+        string label = "Threshold",
+        string page = "HSV Color Key"
     ]],
 
     MAYA_COLORBALANCE_PARAMETERS,

--- a/src/appleseed.shaders/src/maya/as_maya_tripleShadingSwitch.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_tripleShadingSwitch.osl
@@ -36,17 +36,20 @@ shader as_maya_tripleShadingSwitch
     color in_inTriple[] = {0}
     [[
         string as_maya_attribute_name = "inputs",
-        string label = "Input Value"
+        string label = "Input Value",
+        string page = "Switch Attributes"
     ]],
     string in_inShape[] = {""}
     [[
         string as_maya_attribute_name = "inputs",
-        string label = "Shape Name"
+        string label = "Shape Name",
+        string page = "Switch Attributes"
     ]],
     color in_default = color(0)
     [[
         string as_maya_attribute_name = "default",
-        string label = "Default Color"
+        string label = "Default Color",
+        string page = "Switch Attributes"
     ]],
 
     output color out_output = color(0)

--- a/src/appleseed.shaders/src/maya/as_maya_vectorProduct.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_vectorProduct.osl
@@ -37,30 +37,35 @@ shader as_maya_vectorProduct
     vector in_input1 = vector(0)
     [[
         string as_maya_attribute_name = "input1",
-        string label = "Input Vector 1"
+        string label = "Input Vector 1",
+        string page = "Vector Product Attributes"
     ]],
     vector in_input2 = vector(0)
     [[
         string as_maya_attribute_name = "input2",
-        string label = "Input Vector 2"
+        string label = "Input Vector 2",
+        string page = "Vector Product Attributes"
     ]],
     matrix in_matrix = matrix(1)
     [[
         string as_maya_attribute_name = "matrix",
-        string label = "Input Matrix"
+        string label = "Input Matrix",
+        string page = "Vector Product Attributes"
     ]],
     int in_normalizeOutput = 0
     [[
         string as_maya_attribute_name = "normalizeOutput",
         string label = "Normalize Output",
-        string widget = "checkBox"
+        string widget = "checkBox",
+        string page = "Vector Product Attributes"
     ]],
     int in_operation = 1
     [[
         string as_maya_attribute_name = "operation",
         string label = "Operation",
         string widget = "mapper",
-        string options = "None:0|Dot Product:1|Cross Product:2|Vector Matrix Product:3|Point Matrix Product:4"
+        string options = "None:0|Dot Product:1|Cross Product:2|Vector Matrix Product:3|Point Matrix Product:4",
+        string page = "Vector Product Attributes"
     ]],
 
     // Components = outputX|Y|Z

--- a/src/appleseed.shaders/src/maya/as_maya_water.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_water.osl
@@ -191,14 +191,12 @@ shader as_maya_water
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string widget = "null"
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
-        string as_maya_attribute_short_name = "oa",
         string label = "Output Alpha",
         string widget = "null"
     ]]


### PR DESCRIPTION
While Maya uses its AEtemplates, other apps rely on the metadata. This solves most problems with the UI in for instance, Gaffer. The only remaining issue is support for integer arrays where the widget is a drop-down menu with numerical value (as in an array of enumerators).
Removing the *string widget = "mapper"* token solves the issue, but creates the problem of having no mapping whatsoever for the drop-down menus.