### PR TITLE
Remove C++03 builds from Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,15 +40,7 @@ matrix:
 
         - os: linux
           compiler: gcc
-          env: GCC_VERSION=5 USE_CPP11=OFF
-
-        - os: linux
-          compiler: gcc
           env: GCC_VERSION=5 USE_CPP11=ON
-
-        - os: linux
-          compiler: gcc
-          env: GCC_VERSION=6 USE_CPP11=OFF
 
         - os: linux
           compiler: gcc


### PR DESCRIPTION
Cuts Travis build time in half.