### PR TITLE
True branchless orthonormal basis construction

### DIFF
--- a/src/appleseed/foundation/math/basis.h
+++ b/src/appleseed/foundation/math/basis.h
@@ -188,7 +188,7 @@ inline void Basis3<T>::build(const VectorType& normal)
 
     m_n = normal;
 
-    const T sign = m_n[2] < T(0.0) ? T(-1.0) : T(1.0);
+    const T sign = copysign(T(1.0), m_n[2]);
 
     const T a = T(-1.0) / (sign + m_n[2]);
     const T b = m_n[0] * m_n[1] * a;


### PR DESCRIPTION
Now that we are switching to C++ 11, we should be able use copysign safely. However, In OIIO's `missing_math` header, copysign is directed to  the native _copysign function via a macro, which is not properly overloaded. How should we handle this?