### PR TITLE
Fix CIE Lab,Luv,LCh, remapping, glass, see notes

### DIFF
--- a/src/appleseed.shaders/include/appleseed/color/as_color_transforms.h
+++ b/src/appleseed.shaders/include/appleseed/color/as_color_transforms.h
@@ -996,6 +996,71 @@ color transform_RGB_to_HSV(color C)
     }
 }
 
+//
+// Reference:
+//
+//      http://www.easyrgb.com/en/math.php#text21
+//
+
+color transform_HSV_to_RGB(color C)
+{
+    if (C != color(0) || C[2] > 0.0)
+    {
+        float hue = C[0], saturation = C[1], value = C[2], r, g, b;
+
+        hue *= 6.0;
+        if (hue == 6.0) hue = 0.0;
+
+        int i = (int) floor(hue);
+
+        float j = value * (1.0 - saturation);
+        float k = value * (1.0 - saturation * (hue - (float) i));
+        float l = value * (1.0 - saturation * (1.0 - (hue - (float) i)));
+
+        if (i == 0)
+        {
+            r = value;
+            g = l;
+            b = j;
+        }
+        else if (i == 1)
+        {
+            r = k;
+            g = value;
+            b = j;
+        }
+        else if (i == 2)
+        {
+            r = j;
+            g = value;
+            b = l;
+        }
+        else if (i == 3)
+        {
+            r = j;
+            g = k;
+            b = value;
+        }
+        else if (i == 4)
+        {
+            r = l;
+            g = j;
+            b = value;
+        }
+        else
+        {
+            r = value;
+            g = j;
+            b = k;
+        }
+        return color(r, g, b);
+    }
+    else
+    {
+        return color(0);
+    }
+}
+
 color transform_RGB_to_HSL(color C)
 {
     if (C != color(0))
@@ -1034,6 +1099,63 @@ color transform_RGB_to_HSL(color C)
     else
     {
         return color(0);
+    }
+}
+
+//
+// Reference:
+//
+//      http://www.easyrgb.com/en/math.php#text21
+//
+
+color transform_HSL_to_RGB(color C)
+{
+    float hue_to_rgb(float v1, float v2, float vH)
+    {
+        float vh = mod(vH, 1.0), out = 0.0;
+
+        if (vh * 6.0 < 1.0)
+        {
+            out = v1 + (v2 - v1) * 6.0 * vh;
+        }
+        else if (vh * 2.0 < 1.0)
+        {
+            out = v2;
+        }
+        else if (vh * 3.0 < 2.0)
+        {
+            out = v1 + (v2 - v1) * ((2.0 / 3.0) - vh) * 6.0;
+        }
+        else
+        {
+            out = v1;
+        }
+        return out;
+    }
+
+    float hue = C[0], saturation = C[1], lightness = C[2];
+
+    if (C == color(0) || lightness == 0.0)
+    {
+        return color(0);
+    }
+    else if (saturation == 0.0)
+    {
+        return color(lightness);
+    }
+    else
+    {
+        float var_2 = (lightness < 0.5)
+            ? lightness * (1.0 + saturation)
+            : (lightness + saturation) - (saturation * lightness);
+
+        float var_1 = 2.0 * lightness - var_2;
+
+        float r = hue_to_rgb(var_1, var_2, hue + (1.0 / 3.0));
+        float g = hue_to_rgb(var_1, var_2, hue);
+        float b = hue_to_rgb(var_1, var_2, hue - (1.0 / 3.0));
+
+        return color(r, g, b);
     }
 }
 

--- a/src/appleseed.shaders/include/appleseed/color/as_color_transforms.h
+++ b/src/appleseed.shaders/include/appleseed/color/as_color_transforms.h
@@ -986,10 +986,50 @@ color transform_RGB_to_HSV(color C)
             hue = delta_b - delta_g;
             hue = (g == maximum) ? (1.0 / 3.0) + delta_r - delta_b : hue;
             hue = (b == maximum) ? (2.0 / 3.0) + delta_g - delta_r : hue;
-
             hue = mod(hue, 1.0);
         }
         return color(hue, saturation, value);
+    }
+    else
+    {
+        return color(0);
+    }
+}
+
+color transform_RGB_to_HSL(color C)
+{
+    if (C != color(0))
+    {
+        float r = C[0], g = C[1], b = C[2];
+        float hue, saturation, lightness;
+
+        float maximum = max(r, max(g, b));
+        float minimum = min(r, min(g, b));
+
+        lightness = (maximum + minimum) / 2.0;
+
+        float delta = max(0.0, maximum - minimum);        
+
+        if (delta == 0.0 || lightness == 0.0)
+        {
+            hue = saturation = 0.0;
+        }
+        else
+        {
+            saturation = (lightness < 0.5)
+                ? delta / (maximum + minimum)
+                : delta / (2.0 - maximum - minimum);
+
+            float delta_r = (((maximum - r) / 6.0) + (delta / 2.0)) / delta;
+            float delta_g = (((maximum - g) / 6.0) + (delta / 2.0)) / delta;
+            float delta_b = (((maximum - b) / 6.0) + (delta / 2.0)) / delta;
+
+            hue = delta_b - delta_g;
+            hue = (g == maximum) ? (1.0 / 3.0) + delta_r - delta_b : hue;
+            hue = (b == maximum) ? (2.0 / 3.0) + delta_g - delta_r : hue;
+            hue = mod(hue, 1.0);
+        }
+        return color(hue, saturation, lightness);
     }
     else
     {

--- a/src/appleseed.shaders/include/appleseed/color/as_color_transforms.h
+++ b/src/appleseed.shaders/include/appleseed/color/as_color_transforms.h
@@ -555,6 +555,25 @@ void transform_XYZ_to_uv(color XYZ, output float uv[2])
 }
 
 //
+// CIE L*a*b* and CIE L*u*v* have L in [0,100] range, and a,b and u,v
+// in [-100,100] range. Remap to [0,1].
+//
+
+color remap_CIELab(color Lab)
+{
+    float L = Lab[0] * 0.01;
+    float a = (Lab[1] + 100.0) * 0.005;
+    float b = (Lab[2] + 100.0) * 0.005;
+
+    return color(L, a, b);
+}
+
+color remap_CIELuv(color Luv)
+{
+    return remap_CIELab(Luv);
+}
+
+//
 // Reference:
 //
 //      RGB to XYZ to Lab equations
@@ -575,7 +594,7 @@ color transform_XYZ_to_Lab(color XYZ_color, color reference_white_xyY)
             : (CIE_K * XYZ_f[i] + 16) / 116;
     }
 
-    float L  = 116 * XYZ[1] - 16;
+    float L = 116 * XYZ[1] - 16;
     float a = 500 * (XYZ[0] - XYZ[1]);
     float b = 200 * (XYZ[1] - XYZ[2]);
 

--- a/src/appleseed.shaders/include/appleseed/color/as_color_transforms.h
+++ b/src/appleseed.shaders/include/appleseed/color/as_color_transforms.h
@@ -1145,15 +1145,15 @@ color transform_HSL_to_RGB(color C)
     }
     else
     {
-        float var_2 = (lightness < 0.5)
+        float v2 = (lightness < 0.5)
             ? lightness * (1.0 + saturation)
             : (lightness + saturation) - (saturation * lightness);
 
-        float var_1 = 2.0 * lightness - var_2;
+        float v1 = 2.0 * lightness - v2;
 
-        float r = hue_to_rgb(var_1, var_2, hue + (1.0 / 3.0));
-        float g = hue_to_rgb(var_1, var_2, hue);
-        float b = hue_to_rgb(var_1, var_2, hue - (1.0 / 3.0));
+        float r = hue_to_rgb(v1, v2, hue + (1.0 / 3.0));
+        float g = hue_to_rgb(v1, v2, hue);
+        float b = hue_to_rgb(v1, v2, hue - (1.0 / 3.0));
 
         return color(r, g, b);
     }

--- a/src/appleseed.shaders/include/appleseed/color/as_color_transforms.h
+++ b/src/appleseed.shaders/include/appleseed/color/as_color_transforms.h
@@ -947,6 +947,59 @@ color transform_LCh_uv_to_linear_RGB(
 //
 // Reference:
 //
+//      http://colour-science.org/
+//      colour/colour/models/rgb/deprecated.py
+//
+//      Handbook of Digital Image Synthesis: Scientific Foundations of
+//      Rendering, Vincent Pegoraro, CRC Press, 2016
+//      ISBN 1315395215, 9781315395210
+//      (chapter 20: color science, page 707)
+//
+
+color transform_RGB_to_HSV(color C)
+{
+    if (C != color(0))
+    {
+        float r = C[0], g = C[1], b = C[2];
+
+        float maximum = max(r, max(g, b));
+        float minimum = min(r, min(g, b));
+
+        float delta = max(0.0, maximum - minimum);
+
+        float value = maximum, hue;
+
+        float saturation = (delta == 0.0 || maximum == 0.0)
+            ? 0.0
+            : delta / maximum;
+
+        if (delta == 0.0 || saturation == 0.0)
+        {
+            hue = 0.0;
+        }
+        else
+        {
+            float delta_r = (((maximum - r) / 6.0) + (delta / 2.0)) / delta;
+            float delta_g = (((maximum - g) / 6.0) + (delta / 2.0)) / delta;
+            float delta_b = (((maximum - b) / 6.0) + (delta / 2.0)) / delta;
+
+            hue = delta_b - delta_g;
+            hue = (g == maximum) ? (1.0 / 3.0) + delta_r - delta_b : hue;
+            hue = (b == maximum) ? (2.0 / 3.0) + delta_g - delta_r : hue;
+
+            hue = mod(hue, 1.0);
+        }
+        return color(hue, saturation, value);
+    }
+    else
+    {
+        return color(0);
+    }
+}
+
+//
+// Reference:
+//
 //      Delta E (CIEDE2000)
 //
 //      https://en.wikipedia.org/wiki/Color_difference

--- a/src/appleseed.shaders/include/appleseed/color/as_colorimetry.h
+++ b/src/appleseed.shaders/include/appleseed/color/as_colorimetry.h
@@ -37,8 +37,8 @@
 //      http://www.brucelindbloom.com/index.html?ColorDifferenceCalcHelp.html
 //
 
-#define CIE_E   903.29629629629629
-#define CIE_K   0.0088564516790356
+#define CIE_E   (216.0 / 24389.0)
+#define CIE_K   (24389.0 / 27.0)
 
 //
 // Reference:

--- a/src/appleseed.shaders/src/appleseed/as_color_transform.osl
+++ b/src/appleseed.shaders/src/appleseed/as_color_transform.osl
@@ -51,7 +51,7 @@ shader as_color_transform
         string as_maya_attribute_short_name = "is",
         int as_maya_attribute_keyable = 0,
         string widget = "mapper",
-        string options = "RGB:0|HSV:1|HSL:2|XYZ:3|xyY:4|CIE L*a*b*:5|CIE L*u*v*:6|LCHab:7|LCHuv:8|CIE UCS:9",
+        string options = "RGB:0|HSV:1|HSL:2|XYZ:3|xyY:4|CIE L*a*b*:5|CIE L*u*v*:6|CIE Lch_ab:7|CIE Lch_uv:8|CIE UCS 1960:9",
         string label = "Input Space",
         string page = "Color Attributes"
     ]],
@@ -61,7 +61,7 @@ shader as_color_transform
         string as_maya_attribute_short_name = "os",
         int as_maya_attribute_keyable = 0,
         string widget = "mapper",
-        string options = "RGB:0|HSV:1|HSL:2|XYZ:3|xyY:4|CIE L*a*b*:5|CIE L*u*v*:6|LCHab:7|LCHuv:8|CIE UCS:9",
+        string options = "RGB:0|HSV:1|HSL:2|XYZ:3|xyY:4|CIE L*a*b*:5|CIE L*u*v*:6|CIE Lch_ab:7|CIE Lch_uv:8|CIE UCS 1960:9",
         string label = "Output Space",
         string page = "Color Attributes"
     ]],
@@ -134,20 +134,24 @@ shader as_color_transform
         }
         else if (in_inputSpace == 5)
         {
-            XYZ = transform_Lab_to_XYZ(in_color, illuminant);
+            color Lab = inverse_remap_CIELab(in_color);
+            XYZ = transform_Lab_to_XYZ(Lab, illuminant);
         }
         else if (in_inputSpace == 6)
         {
-            XYZ = transform_Luv_to_XYZ(in_color, illuminant);
+            color Luv = inverse_remap_CIELuv(in_color);
+            XYZ = transform_Luv_to_XYZ(Luv, illuminant);
         }
         else if (in_inputSpace == 7)
         {
-            color Lab = transform_LCh_ab_to_Lab(in_color);
+            color LCh_ab = inverse_remap_CIELCh(in_color);
+            color Lab = transform_LCh_ab_to_Lab(LCh_ab);
             XYZ = transform_Lab_to_XYZ(Lab, illuminant);
         }
         else if (in_inputSpace == 8)
         {
-            color Luv = transform_LCh_uv_to_Luv(in_color);
+            color LCh_uv = inverse_remap_CIELCh(in_color);
+            color Luv = transform_LCh_uv_to_Luv(LCh_uv);
             XYZ = transform_Luv_to_XYZ(Luv, illuminant);
         }
         else if (in_inputSpace == 9)
@@ -194,20 +198,24 @@ shader as_color_transform
         else if (in_outputSpace == 5)
         {
             out = transform_XYZ_to_Lab(XYZ, illuminant);
+            out = remap_CIELab(out);
         }
         else if (in_outputSpace == 6)
         {
             out = transform_XYZ_to_Luv(XYZ, illuminant);
+            out = remap_CIELuv(out);
         }
         else if (in_outputSpace == 7)
         {
             color Lab = transform_XYZ_to_Lab(XYZ, illuminant);
             out = transform_Lab_to_LCh_ab(Lab);
+            out = remap_CIELCh(out);
         }
         else if (in_outputSpace == 8)
         {
             color Luv = transform_XYZ_to_Luv(XYZ, illuminant);
             out = transform_Luv_to_LCh_uv(Luv);
+            out = remap_CIELCh(out);
         }
         else if (in_outputSpace == 9)
         {

--- a/src/appleseed.shaders/src/appleseed/as_color_transform.osl
+++ b/src/appleseed.shaders/src/appleseed/as_color_transform.osl
@@ -185,7 +185,7 @@ shader as_color_transform
         else if (in_outputSpace == 2)
         {
             color RGB = transform_XYZ_to_linear_RGB(XYZ, space, illuminant);
-            out = transformc("rgb", "hsl", RGB);
+            out = transform_RGB_to_HSL(RGB);
         }
         else if (in_outputSpace == 3)
         {

--- a/src/appleseed.shaders/src/appleseed/as_color_transform.osl
+++ b/src/appleseed.shaders/src/appleseed/as_color_transform.osl
@@ -116,12 +116,12 @@ shader as_color_transform
         }
         else if (in_inputSpace == 1)
         {
-            color RGB = transformc("hsv", "rgb", in_color);
+            color RGB = transform_HSV_to_RGB(in_color);
             XYZ = transform_linear_RGB_to_XYZ(RGB, space, illuminant);
         }
         else if (in_inputSpace == 2)
         {
-            color RGB = transformc("hsl", "rgb", in_color);
+            color RGB = transform_HSL_to_RGB(in_color);
             XYZ = transform_linear_RGB_to_XYZ(RGB, space, illuminant);
         }
         else if (in_inputSpace == 3)

--- a/src/appleseed.shaders/src/appleseed/as_color_transform.osl
+++ b/src/appleseed.shaders/src/appleseed/as_color_transform.osl
@@ -180,7 +180,7 @@ shader as_color_transform
         else if (in_outputSpace == 1)
         {
             color RGB = transform_XYZ_to_linear_RGB(XYZ, space, illuminant);
-            out = transformc("rgb", "hsv", RGB);
+            out = transform_RGB_to_HSV(RGB);
         }
         else if (in_outputSpace == 2)
         {

--- a/src/appleseed.shaders/src/appleseed/as_glass.osl
+++ b/src/appleseed.shaders/src/appleseed/as_glass.osl
@@ -182,20 +182,6 @@ shader as_glass
         string label = "Matte Opacity",
         string page = "Matte Opacity Parameters"
     ]],
-    int in_maximumRayDepth = 4
-    [[
-        string as_maya_attribute_name = "maximumRayDepth",
-        int as_maya_attribute_connectable = 0,
-        int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1,
-        int min = 0,
-        int max = 32,
-        int softmin = 0,
-        int softmax = 8,
-        string widget = "slider",
-        string label = "Ray Depth",
-        string page = "Advanced Parameters"
-    ]],
 
     output closure color out_outColor = 0
     [[
@@ -215,10 +201,7 @@ shader as_glass
     ]]
 )
 {
-    int ray_depth = 0;
-    int status = getattribute("path:ray_depth", ray_depth);
-
-    if (status && ray_depth <= in_maximumRayDepth)
+    if (!raytype("shadow") && !raytype("transparency"))
     {
         normal Nn = normalize(in_normalCamera);
         vector tangent;


### PR DESCRIPTION
CIE L*a*b* and CIE L*u*v* return values with L in [0,100] range, and a,b
and u,v in [-100,100] range. Color samples however were discarded for
being negative, and it's not really easy to adjust this in a normal
workflow, so CIELAB, CIELUV are mapped to [0,1] overall.
The same applies to CIE LCh, and a minor bug.