### PR TITLE
API headers dependencies removal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,22 +29,19 @@ install:
 compiler:
   - gcc
 
-env:
-  - GCC_VERSION=4.8 USE_CPP11=OFF
-
 matrix:
     include:
         - os: linux
           compiler: gcc
-          env: GCC_VERSION=4.8 USE_CPP11=ON
+          env: GCC_VERSION=4.8
 
         - os: linux
           compiler: gcc
-          env: GCC_VERSION=5 USE_CPP11=ON
+          env: GCC_VERSION=5
 
         - os: linux
           compiler: gcc
-          env: GCC_VERSION=6 USE_CPP11=ON
+          env: GCC_VERSION=6
 
 script:
   - ./travis/build.sh

--- a/src/appleseed.studio/mainwindow/rendering/cameracontroller.h
+++ b/src/appleseed.studio/mainwindow/rendering/cameracontroller.h
@@ -32,6 +32,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/api/rendering.h"
+#include "renderer/kernel/rendering/scenepicker.h"
 
 // appleseed.foundation headers.
 #include "foundation/math/vector.h"

--- a/src/appleseed.studio/mainwindow/rendering/scenepickinghandler.h
+++ b/src/appleseed.studio/mainwindow/rendering/scenepickinghandler.h
@@ -32,6 +32,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/api/rendering.h"
+#include "renderer/kernel/rendering/scenepicker.h"
 
 // appleseed.foundation headers.
 #include "foundation/platform/compiler.h"

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -1138,6 +1138,8 @@ set (renderer_kernel_shading_sources
     renderer/kernel/shading/fastambientocclusion.h
     renderer/kernel/shading/oslshadergroupexec.cpp
     renderer/kernel/shading/oslshadergroupexec.h
+    renderer/kernel/shading/oslshadingsystem.cpp
+    renderer/kernel/shading/oslshadingsystem.h
     renderer/kernel/shading/shadingcontext.cpp
     renderer/kernel/shading/shadingcontext.h
     renderer/kernel/shading/shadingengine.cpp

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -1170,6 +1170,8 @@ source_group ("renderer\\kernel\\tessellation" FILES
 )
 
 set (renderer_kernel_texturing_sources
+    renderer/kernel/texturing/oiiotexturesystem.cpp
+    renderer/kernel/texturing/oiiotexturesystem.h
     renderer/kernel/texturing/texturecache.h
     renderer/kernel/texturing/texturestore.cpp
     renderer/kernel/texturing/texturestore.h

--- a/src/appleseed/renderer/api/rendering.h
+++ b/src/appleseed/renderer/api/rendering.h
@@ -45,7 +45,6 @@
 #include "renderer/kernel/rendering/masterrenderer.h"
 #include "renderer/kernel/rendering/nulltilecallback.h"
 #include "renderer/kernel/rendering/progressive/progressiveframerenderer.h"
-#include "renderer/kernel/rendering/scenepicker.h"
 #include "renderer/kernel/rendering/tilecallbackbase.h"
 #include "renderer/kernel/rendering/timedrenderercontroller.h"
 

--- a/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
@@ -43,6 +43,7 @@
 #include "renderer/kernel/rendering/sample.h"
 #include "renderer/kernel/rendering/samplegeneratorbase.h"
 #include "renderer/kernel/shading/oslshadergroupexec.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/kernel/shading/shadingray.h"
@@ -169,7 +170,7 @@ namespace
             const size_t                generator_index,
             const size_t                generator_count,
             OIIOTextureSystem&          oiio_texture_system,
-            OSL::ShadingSystem&         shading_system,
+            OSLShadingSystem&           shading_system,
             const ParamArray&           params)
           : SampleGeneratorBase(generator_index, generator_count)
           , m_params(params)
@@ -870,7 +871,7 @@ LightTracingSampleGeneratorFactory::LightTracingSampleGeneratorFactory(
     TextureStore&           texture_store,
     const LightSampler&     light_sampler,
     OIIOTextureSystem&      oiio_texture_system,
-    OSL::ShadingSystem&     shading_system,
+    OSLShadingSystem&       shading_system,
     const ParamArray&       params)
   : m_project(project)
   , m_frame(frame)

--- a/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
@@ -46,6 +46,7 @@
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/kernel/shading/shadingray.h"
+#include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/kernel/texturing/texturecache.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/camera/camera.h"
@@ -167,7 +168,7 @@ namespace
             const LightSampler&         light_sampler,
             const size_t                generator_index,
             const size_t                generator_count,
-            OIIO::TextureSystem&        oiio_texture_system,
+            OIIOTextureSystem&          oiio_texture_system,
             OSL::ShadingSystem&         shading_system,
             const ParamArray&           params)
           : SampleGeneratorBase(generator_index, generator_count)
@@ -868,7 +869,7 @@ LightTracingSampleGeneratorFactory::LightTracingSampleGeneratorFactory(
     const TraceContext&     trace_context,
     TextureStore&           texture_store,
     const LightSampler&     light_sampler,
-    OIIO::TextureSystem&    oiio_texture_system,
+    OIIOTextureSystem&      oiio_texture_system,
     OSL::ShadingSystem&     shading_system,
     const ParamArray&       params)
   : m_project(project)

--- a/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.h
+++ b/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.h
@@ -42,17 +42,13 @@
 #include "OSL/oslexec.h"
 #include "foundation/platform/_endoslheaders.h"
 
-// OpenImageIO headers.
-#include "foundation/platform/_beginoiioheaders.h"
-#include "OpenImageIO/texture.h"
-#include "foundation/platform/_endoiioheaders.h"
-
 // Standard headers.
 #include <cstddef>
 
 // Forward declarations.
 namespace renderer  { class Frame; }
 namespace renderer  { class LightSampler; }
+namespace renderer  { class OIIOTextureSystem; }
 namespace renderer  { class Project; }
 namespace renderer  { class SampleAccumulationBuffer; }
 namespace renderer  { class TextureStore; }
@@ -72,7 +68,7 @@ class LightTracingSampleGeneratorFactory
         const TraceContext&     trace_context,
         TextureStore&           texture_store,
         const LightSampler&     light_sampler,
-        OIIO::TextureSystem&    oiio_texture_system,
+        OIIOTextureSystem&      oiio_texture_system,
         OSL::ShadingSystem&     shading_system,
         const ParamArray&       params);
 
@@ -93,7 +89,7 @@ class LightTracingSampleGeneratorFactory
     const TraceContext&         m_trace_context;
     TextureStore&               m_texture_store;
     const LightSampler&         m_light_sampler;
-    OIIO::TextureSystem&        m_oiio_texture_system;
+    OIIOTextureSystem&          m_oiio_texture_system;
     OSL::ShadingSystem&         m_shading_system;
     const ParamArray            m_params;
 };

--- a/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.h
+++ b/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.h
@@ -37,11 +37,6 @@
 // appleseed.foundation headers.
 #include "foundation/platform/compiler.h"
 
-// OSL headers.
-#include "foundation/platform/_beginoslheaders.h"
-#include "OSL/oslexec.h"
-#include "foundation/platform/_endoslheaders.h"
-
 // Standard headers.
 #include <cstddef>
 
@@ -49,6 +44,7 @@
 namespace renderer  { class Frame; }
 namespace renderer  { class LightSampler; }
 namespace renderer  { class OIIOTextureSystem; }
+namespace renderer  { class OSLShadingSystem; }
 namespace renderer  { class Project; }
 namespace renderer  { class SampleAccumulationBuffer; }
 namespace renderer  { class TextureStore; }
@@ -69,7 +65,7 @@ class LightTracingSampleGeneratorFactory
         TextureStore&           texture_store,
         const LightSampler&     light_sampler,
         OIIOTextureSystem&      oiio_texture_system,
-        OSL::ShadingSystem&     shading_system,
+        OSLShadingSystem&       shading_system,
         const ParamArray&       params);
 
     // Delete this instance.
@@ -90,7 +86,7 @@ class LightTracingSampleGeneratorFactory
     TextureStore&               m_texture_store;
     const LightSampler&         m_light_sampler;
     OIIOTextureSystem&          m_oiio_texture_system;
-    OSL::ShadingSystem&         m_shading_system;
+    OSLShadingSystem&           m_shading_system;
     const ParamArray            m_params;
 };
 

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmpasscallback.cpp
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmpasscallback.cpp
@@ -33,6 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
 #include "renderer/global/globaltypes.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/modeling/scene/scene.h"
 
@@ -62,7 +63,7 @@ SPPMPassCallback::SPPMPassCallback(
     const TraceContext&     trace_context,
     TextureStore&           texture_store,
     OIIOTextureSystem&      oiio_texture_system,
-    OSL::ShadingSystem&     shading_system,
+    OSLShadingSystem&       shading_system,
     const SPPMParameters&   params)
   : m_params(params)
   , m_photon_tracer(

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmpasscallback.cpp
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmpasscallback.cpp
@@ -33,6 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
 #include "renderer/global/globaltypes.h"
+#include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/modeling/scene/scene.h"
 
 // appleseed.foundation headers.
@@ -60,7 +61,7 @@ SPPMPassCallback::SPPMPassCallback(
     const LightSampler&     light_sampler,
     const TraceContext&     trace_context,
     TextureStore&           texture_store,
-    OIIO::TextureSystem&    oiio_texture_system,
+    OIIOTextureSystem&      oiio_texture_system,
     OSL::ShadingSystem&     shading_system,
     const SPPMParameters&   params)
   : m_params(params)

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmpasscallback.h
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmpasscallback.h
@@ -43,11 +43,6 @@
 #include "foundation/platform/types.h"
 #include "foundation/utility/stopwatch.h"
 
-// OSL headers.
-#include "foundation/platform/_beginoslheaders.h"
-#include "OSL/oslexec.h"
-#include "foundation/platform/_endoslheaders.h"
-
 // Standard headers.
 #include <cstddef>
 #include <memory>
@@ -58,6 +53,7 @@ namespace foundation    { class JobQueue; }
 namespace renderer      { class Frame; }
 namespace renderer      { class LightSampler; }
 namespace renderer      { class OIIOTextureSystem; }
+namespace renderer      { class OSLShadingSystem; }
 namespace renderer      { class Scene; }
 namespace renderer      { class TextureStore; }
 namespace renderer      { class TraceContext; }
@@ -80,7 +76,7 @@ class SPPMPassCallback
         const TraceContext&         trace_context,
         TextureStore&               texture_store,
         OIIOTextureSystem&          oiio_texture_system,
-        OSL::ShadingSystem&         shading_system,
+        OSLShadingSystem&           shading_system,
         const SPPMParameters&       params);
 
     // Delete this instance.

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmpasscallback.h
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmpasscallback.h
@@ -48,11 +48,6 @@
 #include "OSL/oslexec.h"
 #include "foundation/platform/_endoslheaders.h"
 
-// OpenImageIO headers.
-#include "foundation/platform/_beginoiioheaders.h"
-#include "OpenImageIO/texture.h"
-#include "foundation/platform/_endoiioheaders.h"
-
 // Standard headers.
 #include <cstddef>
 #include <memory>
@@ -62,6 +57,7 @@ namespace foundation    { class IAbortSwitch; }
 namespace foundation    { class JobQueue; }
 namespace renderer      { class Frame; }
 namespace renderer      { class LightSampler; }
+namespace renderer      { class OIIOTextureSystem; }
 namespace renderer      { class Scene; }
 namespace renderer      { class TextureStore; }
 namespace renderer      { class TraceContext; }
@@ -83,7 +79,7 @@ class SPPMPassCallback
         const LightSampler&         light_sampler,
         const TraceContext&         trace_context,
         TextureStore&               texture_store,
-        OIIO::TextureSystem&        oiio_texture_system,
+        OIIOTextureSystem&          oiio_texture_system,
         OSL::ShadingSystem&         shading_system,
         const SPPMParameters&       params);
 

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmphotontracer.cpp
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmphotontracer.cpp
@@ -41,6 +41,7 @@
 #include "renderer/kernel/lighting/scatteringmode.h"
 #include "renderer/kernel/lighting/tracer.h"
 #include "renderer/kernel/shading/oslshadergroupexec.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/kernel/shading/shadingray.h"
 #include "renderer/kernel/texturing/oiiotexturesystem.h"
@@ -225,7 +226,7 @@ namespace
             const TraceContext&     trace_context,
             TextureStore&           texture_store,
             OIIOTextureSystem&      oiio_texture_system,
-            OSL::ShadingSystem&     shading_system,
+            OSLShadingSystem&       shading_system,
             const SPPMParameters&   params,
             SPPMPhotonVector&       global_photons,
             const size_t            photon_begin,
@@ -516,7 +517,7 @@ namespace
             const TraceContext&     trace_context,
             TextureStore&           texture_store,
             OIIOTextureSystem&      oiio_texture_system,
-            OSL::ShadingSystem&     shading_system,
+            OSLShadingSystem&       shading_system,
             const SPPMParameters&   params,
             SPPMPhotonVector&       global_photons,
             const size_t            photon_begin,
@@ -715,7 +716,7 @@ SPPMPhotonTracer::SPPMPhotonTracer(
     const TraceContext&     trace_context,
     TextureStore&           texture_store,
     OIIOTextureSystem&      oiio_texture_system,
-    OSL::ShadingSystem&     shading_system,
+    OSLShadingSystem&       shading_system,
     const SPPMParameters&   params)
   : m_params(params)
   , m_scene(scene)

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmphotontracer.cpp
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmphotontracer.cpp
@@ -43,6 +43,7 @@
 #include "renderer/kernel/shading/oslshadergroupexec.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/kernel/shading/shadingray.h"
+#include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/kernel/texturing/texturecache.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/edf/edf.h"
@@ -223,7 +224,7 @@ namespace
             const LightSampler&     light_sampler,
             const TraceContext&     trace_context,
             TextureStore&           texture_store,
-            OIIO::TextureSystem&    oiio_texture_system,
+            OIIOTextureSystem&      oiio_texture_system,
             OSL::ShadingSystem&     shading_system,
             const SPPMParameters&   params,
             SPPMPhotonVector&       global_photons,
@@ -293,7 +294,7 @@ namespace
         const LightSampler&         m_light_sampler;
         TextureCache                m_texture_cache;
         Intersector                 m_intersector;
-        OIIO::TextureSystem&        m_oiio_texture_system;
+        OIIOTextureSystem&          m_oiio_texture_system;
         Arena                       m_arena;
         OSLShaderGroupExec          m_shadergroup_exec;
         const SPPMParameters        m_params;
@@ -514,7 +515,7 @@ namespace
             const LightSampler&     light_sampler,
             const TraceContext&     trace_context,
             TextureStore&           texture_store,
-            OIIO::TextureSystem&    oiio_texture_system,
+            OIIOTextureSystem&      oiio_texture_system,
             OSL::ShadingSystem&     shading_system,
             const SPPMParameters&   params,
             SPPMPhotonVector&       global_photons,
@@ -591,7 +592,7 @@ namespace
         const LightSampler&         m_light_sampler;
         TextureCache                m_texture_cache;
         Intersector                 m_intersector;
-        OIIO::TextureSystem&        m_oiio_texture_system;
+        OIIOTextureSystem&          m_oiio_texture_system;
         Arena                       m_arena;
         OSLShaderGroupExec          m_shadergroup_exec;
         const SPPMParameters        m_params;
@@ -713,7 +714,7 @@ SPPMPhotonTracer::SPPMPhotonTracer(
     const LightSampler&     light_sampler,
     const TraceContext&     trace_context,
     TextureStore&           texture_store,
-    OIIO::TextureSystem&    oiio_texture_system,
+    OIIOTextureSystem&      oiio_texture_system,
     OSL::ShadingSystem&     shading_system,
     const SPPMParameters&   params)
   : m_params(params)

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmphotontracer.h
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmphotontracer.h
@@ -41,11 +41,6 @@
 #include "OSL/oslexec.h"
 #include "foundation/platform/_endoslheaders.h"
 
-// OpenImageIO headers.
-#include "foundation/platform/_beginoiioheaders.h"
-#include "OpenImageIO/texture.h"
-#include "foundation/platform/_endoiioheaders.h"
-
 // Standard headers.
 #include <cstddef>
 
@@ -54,6 +49,7 @@ namespace foundation    { class IAbortSwitch; }
 namespace foundation    { class JobQueue; }
 namespace renderer      { class LightSampler; }
 namespace renderer      { class LightTargetArray; }
+namespace renderer      { class OIIOTextureSystem; }
 namespace renderer      { class Scene; }
 namespace renderer      { class SPPMPhotonVector; }
 namespace renderer      { class TextureStore; }
@@ -71,7 +67,7 @@ class SPPMPhotonTracer
         const LightSampler&         light_sampler,
         const TraceContext&         trace_context,
         TextureStore&               texture_store,
-        OIIO::TextureSystem&        oiio_texture_system,
+        OIIOTextureSystem&          oiio_texture_system,
         OSL::ShadingSystem&         shading_system,
         const SPPMParameters&       params);
 
@@ -89,7 +85,7 @@ class SPPMPhotonTracer
     TextureStore&                   m_texture_store;
     size_t                          m_total_emitted_photon_count;
     size_t                          m_total_stored_photon_count;
-    OIIO::TextureSystem&            m_oiio_texture_system;
+    OIIOTextureSystem&              m_oiio_texture_system;
     OSL::ShadingSystem&             m_shading_system;
 
     void schedule_light_photon_tracing_jobs(

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmphotontracer.h
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmphotontracer.h
@@ -36,11 +36,6 @@
 // appleseed.foundation headers.
 #include "foundation/core/concepts/noncopyable.h"
 
-// OSL headers.
-#include "foundation/platform/_beginoslheaders.h"
-#include "OSL/oslexec.h"
-#include "foundation/platform/_endoslheaders.h"
-
 // Standard headers.
 #include <cstddef>
 
@@ -50,6 +45,7 @@ namespace foundation    { class JobQueue; }
 namespace renderer      { class LightSampler; }
 namespace renderer      { class LightTargetArray; }
 namespace renderer      { class OIIOTextureSystem; }
+namespace renderer      { class OSLShadingSystem; }
 namespace renderer      { class Scene; }
 namespace renderer      { class SPPMPhotonVector; }
 namespace renderer      { class TextureStore; }
@@ -68,7 +64,7 @@ class SPPMPhotonTracer
         const TraceContext&         trace_context,
         TextureStore&               texture_store,
         OIIOTextureSystem&          oiio_texture_system,
-        OSL::ShadingSystem&         shading_system,
+        OSLShadingSystem&           shading_system,
         const SPPMParameters&       params);
 
     void trace_photons(
@@ -86,7 +82,7 @@ class SPPMPhotonTracer
     size_t                          m_total_emitted_photon_count;
     size_t                          m_total_stored_photon_count;
     OIIOTextureSystem&              m_oiio_texture_system;
-    OSL::ShadingSystem&             m_shading_system;
+    OSLShadingSystem&               m_shading_system;
 
     void schedule_light_photon_tracing_jobs(
         const LightTargetArray&     photon_targets,

--- a/src/appleseed/renderer/kernel/rendering/baserenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/baserenderer.cpp
@@ -34,6 +34,7 @@
 #include "renderer/kernel/rendering/oiioerrorhandler.h"
 #include "renderer/kernel/rendering/rendererservices.h"
 #include "renderer/kernel/shading/closures.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/modeling/project/project.h"
 #include "renderer/modeling/scene/scene.h"
@@ -80,7 +81,7 @@ BaseRenderer::BaseRenderer(
         reinterpret_cast<OIIO::TextureSystem&>(*m_texture_system));
 
     RENDERER_LOG_DEBUG("creating osl shading system...");
-    m_shading_system = new OSL::ShadingSystem(
+    m_shading_system = OSLShadingSystemFactory::create(
         m_renderer_services,
         m_texture_system,
         m_error_handler);
@@ -108,7 +109,7 @@ BaseRenderer::~BaseRenderer()
 {
     RENDERER_LOG_DEBUG("destroying osl shading system...");
     m_project.get_scene()->release_optimized_osl_shader_groups();
-    delete m_shading_system;
+    m_shading_system->release();
     delete m_renderer_services;
 
     const string stats = m_texture_system->getstats();

--- a/src/appleseed/renderer/kernel/rendering/baserenderer.h
+++ b/src/appleseed/renderer/kernel/rendering/baserenderer.h
@@ -34,14 +34,10 @@
 
 // appleseed.foundation headers.
 #include "foundation/core/concepts/noncopyable.h"
+#include "foundation/utility/autoreleaseptr.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
-
-// OpenImageIO headers.
-#include "foundation/platform/_beginoiioheaders.h"
-#include "OpenImageIO/texture.h"
-#include "foundation/platform/_endoiioheaders.h"
 
 // OSL headers.
 #include "foundation/platform/_beginoslheaders.h"
@@ -51,6 +47,7 @@
 // Forward declarations.
 namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class OIIOErrorHandler; }
+namespace renderer      { class OIIOTextureSystem; }
 namespace renderer      { class Project; }
 namespace renderer      { class RendererServices; }
 namespace renderer      { class TextureStore; }
@@ -81,7 +78,7 @@ class APPLESEED_DLLSYMBOL BaseRenderer
     Project&                        m_project;
     ParamArray                      m_params;
     OIIOErrorHandler*               m_error_handler;
-    OIIO::TextureSystem*            m_texture_system;
+    OIIOTextureSystem*              m_texture_system;
 
     RendererServices*               m_renderer_services;
     OSL::ShadingSystem*             m_shading_system;

--- a/src/appleseed/renderer/kernel/rendering/baserenderer.h
+++ b/src/appleseed/renderer/kernel/rendering/baserenderer.h
@@ -39,15 +39,11 @@
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
-// OSL headers.
-#include "foundation/platform/_beginoslheaders.h"
-#include "OSL/oslexec.h"
-#include "foundation/platform/_endoslheaders.h"
-
 // Forward declarations.
 namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class OIIOErrorHandler; }
 namespace renderer      { class OIIOTextureSystem; }
+namespace renderer      { class OSLShadingSystem; }
 namespace renderer      { class Project; }
 namespace renderer      { class RendererServices; }
 namespace renderer      { class TextureStore; }
@@ -81,7 +77,7 @@ class APPLESEED_DLLSYMBOL BaseRenderer
     OIIOTextureSystem*              m_texture_system;
 
     RendererServices*               m_renderer_services;
-    OSL::ShadingSystem*             m_shading_system;
+    OSLShadingSystem*               m_shading_system;
 
     // Constructor.
     BaseRenderer(

--- a/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
@@ -40,6 +40,7 @@
 #include "renderer/kernel/lighting/ilightingengine.h"
 #include "renderer/kernel/lighting/tracer.h"
 #include "renderer/kernel/shading/oslshadergroupexec.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingengine.h"
 #include "renderer/kernel/shading/shadingfragment.h"
@@ -99,7 +100,7 @@ namespace
             ILightingEngineFactory* lighting_engine_factory,
             ShadingEngine&          shading_engine,
             OIIOTextureSystem&      oiio_texture_system,
-            OSL::ShadingSystem&     shading_system,
+            OSLShadingSystem&       shading_system,
             const size_t            thread_index,
             const ParamArray&       params)
           : m_params(params)
@@ -357,7 +358,7 @@ GenericSampleRendererFactory::GenericSampleRendererFactory(
     ILightingEngineFactory* lighting_engine_factory,
     ShadingEngine&          shading_engine,
     OIIOTextureSystem&      oiio_texture_system,
-    OSL::ShadingSystem&     shading_system,
+    OSLShadingSystem&       shading_system,
     const ParamArray&       params)
   : m_scene(scene)
   , m_frame(frame)

--- a/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
@@ -46,6 +46,7 @@
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/kernel/shading/shadingray.h"
 #include "renderer/kernel/shading/shadingresult.h"
+#include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/kernel/texturing/texturecache.h"
 #include "renderer/modeling/camera/camera.h"
 #include "renderer/modeling/frame/frame.h"
@@ -97,7 +98,7 @@ namespace
             TextureStore&           texture_store,
             ILightingEngineFactory* lighting_engine_factory,
             ShadingEngine&          shading_engine,
-            OIIO::TextureSystem&    oiio_texture_system,
+            OIIOTextureSystem&      oiio_texture_system,
             OSL::ShadingSystem&     shading_system,
             const size_t            thread_index,
             const ParamArray&       params)
@@ -327,7 +328,7 @@ namespace
         TextureCache                m_texture_cache;
         ILightingEngine*            m_lighting_engine;
         ShadingEngine&              m_shading_engine;
-        OIIO::TextureSystem&        m_oiio_texture_system;
+        OIIOTextureSystem&          m_oiio_texture_system;
         const size_t                m_thread_index;
 
         Arena                       m_arena;
@@ -355,7 +356,7 @@ GenericSampleRendererFactory::GenericSampleRendererFactory(
     TextureStore&           texture_store,
     ILightingEngineFactory* lighting_engine_factory,
     ShadingEngine&          shading_engine,
-    OIIO::TextureSystem&    oiio_texture_system,
+    OIIOTextureSystem&      oiio_texture_system,
     OSL::ShadingSystem&     shading_system,
     const ParamArray&       params)
   : m_scene(scene)

--- a/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.h
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.h
@@ -37,15 +37,11 @@
 // appleseed.foundation headers.
 #include "foundation/platform/compiler.h"
 
-// OSL headers.
-#include "foundation/platform/_beginoslheaders.h"
-#include "OSL/oslexec.h"
-#include "foundation/platform/_endoslheaders.h"
-
 // Forward declarations.
 namespace renderer  { class Frame; }
 namespace renderer  { class ILightingEngineFactory; }
 namespace renderer  { class OIIOTextureSystem; }
+namespace renderer  { class OSLShadingSystem; }
 namespace renderer  { class Scene; }
 namespace renderer  { class ShadingEngine; }
 namespace renderer  { class TextureStore; }
@@ -71,7 +67,7 @@ class GenericSampleRendererFactory
         ILightingEngineFactory* lighting_engine_factory,
         ShadingEngine&          shading_engine,
         OIIOTextureSystem&      oiio_texture_system,
-        OSL::ShadingSystem&     shading_system,
+        OSLShadingSystem&       shading_system,
         const ParamArray&       params);
 
     // Delete this instance.
@@ -89,7 +85,7 @@ class GenericSampleRendererFactory
     ILightingEngineFactory*     m_lighting_engine_factory;
     ShadingEngine&              m_shading_engine;
     OIIOTextureSystem&          m_oiio_texture_system;
-    OSL::ShadingSystem&         m_shading_system;
+    OSLShadingSystem&           m_shading_system;
     const ParamArray            m_params;
 };
 

--- a/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.h
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.h
@@ -42,14 +42,10 @@
 #include "OSL/oslexec.h"
 #include "foundation/platform/_endoslheaders.h"
 
-// OpenImageIO headers.
-#include "foundation/platform/_beginoiioheaders.h"
-#include "OpenImageIO/texture.h"
-#include "foundation/platform/_endoiioheaders.h"
-
 // Forward declarations.
 namespace renderer  { class Frame; }
 namespace renderer  { class ILightingEngineFactory; }
+namespace renderer  { class OIIOTextureSystem; }
 namespace renderer  { class Scene; }
 namespace renderer  { class ShadingEngine; }
 namespace renderer  { class TextureStore; }
@@ -74,7 +70,7 @@ class GenericSampleRendererFactory
         TextureStore&           texture_store,
         ILightingEngineFactory* lighting_engine_factory,
         ShadingEngine&          shading_engine,
-        OIIO::TextureSystem&    oiio_texture_system,
+        OIIOTextureSystem&      oiio_texture_system,
         OSL::ShadingSystem&     shading_system,
         const ParamArray&       params);
 
@@ -92,7 +88,7 @@ class GenericSampleRendererFactory
     TextureStore&               m_texture_store;
     ILightingEngineFactory*     m_lighting_engine_factory;
     ShadingEngine&              m_shading_engine;
-    OIIO::TextureSystem&        m_oiio_texture_system;
+    OIIOTextureSystem&          m_oiio_texture_system;
     OSL::ShadingSystem&         m_shading_system;
     const ParamArray            m_params;
 };

--- a/src/appleseed/renderer/kernel/rendering/renderercomponents.cpp
+++ b/src/appleseed/renderer/kernel/rendering/renderercomponents.cpp
@@ -49,6 +49,7 @@
 #include "renderer/kernel/rendering/generic/generictilerenderer.h"
 #include "renderer/kernel/rendering/permanentshadingresultframebufferfactory.h"
 #include "renderer/kernel/rendering/progressive/progressiveframerenderer.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/modeling/project/project.h"
 #include "renderer/utility/paramarray.h"
@@ -93,7 +94,7 @@ RendererComponents::RendererComponents(
     ITileCallbackFactory*   tile_callback_factory,
     TextureStore&           texture_store,
     OIIOTextureSystem&      texture_system,
-    OSL::ShadingSystem&     shading_system)
+    OSLShadingSystem&       shading_system)
   : m_project(project)
   , m_params(params)
   , m_tile_callback_factory(tile_callback_factory)

--- a/src/appleseed/renderer/kernel/rendering/renderercomponents.cpp
+++ b/src/appleseed/renderer/kernel/rendering/renderercomponents.cpp
@@ -49,6 +49,7 @@
 #include "renderer/kernel/rendering/generic/generictilerenderer.h"
 #include "renderer/kernel/rendering/permanentshadingresultframebufferfactory.h"
 #include "renderer/kernel/rendering/progressive/progressiveframerenderer.h"
+#include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/modeling/project/project.h"
 #include "renderer/utility/paramarray.h"
 
@@ -91,7 +92,7 @@ RendererComponents::RendererComponents(
     const ParamArray&       params,
     ITileCallbackFactory*   tile_callback_factory,
     TextureStore&           texture_store,
-    OIIO::TextureSystem&    texture_system,
+    OIIOTextureSystem&      texture_system,
     OSL::ShadingSystem&     shading_system)
   : m_project(project)
   , m_params(params)

--- a/src/appleseed/renderer/kernel/rendering/renderercomponents.h
+++ b/src/appleseed/renderer/kernel/rendering/renderercomponents.h
@@ -44,11 +44,6 @@
 // appleseed.foundation headers.
 #include "foundation/utility/autoreleaseptr.h"
 
-// OSL headers.
-#include "foundation/platform/_beginoslheaders.h"
-#include "OSL/oslexec.h"
-#include "foundation/platform/_endoslheaders.h"
-
 // Standard headers.
 #include <memory>
 
@@ -57,6 +52,7 @@ namespace renderer  { class Frame; }
 namespace renderer  { class IFrameRenderer; }
 namespace renderer  { class ITileCallbackFactory; }
 namespace renderer  { class OIIOTextureSystem; }
+namespace renderer  { class OSLShadingSystem; }
 namespace renderer  { class ParamArray; }
 namespace renderer  { class Project; }
 namespace renderer  { class Scene; }
@@ -80,7 +76,7 @@ class RendererComponents
         ITileCallbackFactory*   tile_callback_factory,
         TextureStore&           texture_store,
         OIIOTextureSystem&      texture_system,
-        OSL::ShadingSystem&     shading_system);
+        OSLShadingSystem&       shading_system);
 
     bool create();
 
@@ -99,7 +95,7 @@ class RendererComponents
     ShadingEngine               m_shading_engine;
     TextureStore&               m_texture_store;
     OIIOTextureSystem&          m_texture_system;
-    OSL::ShadingSystem&         m_shading_system;
+    OSLShadingSystem&           m_shading_system;
 
     std::auto_ptr<ILightingEngineFactory>               m_lighting_engine_factory;
     std::auto_ptr<ISampleRendererFactory>               m_sample_renderer_factory;

--- a/src/appleseed/renderer/kernel/rendering/renderercomponents.h
+++ b/src/appleseed/renderer/kernel/rendering/renderercomponents.h
@@ -44,11 +44,6 @@
 // appleseed.foundation headers.
 #include "foundation/utility/autoreleaseptr.h"
 
-// OpenImageIO headers.
-#include "foundation/platform/_beginoiioheaders.h"
-#include "OpenImageIO/texture.h"
-#include "foundation/platform/_endoiioheaders.h"
-
 // OSL headers.
 #include "foundation/platform/_beginoslheaders.h"
 #include "OSL/oslexec.h"
@@ -61,6 +56,7 @@
 namespace renderer  { class Frame; }
 namespace renderer  { class IFrameRenderer; }
 namespace renderer  { class ITileCallbackFactory; }
+namespace renderer  { class OIIOTextureSystem; }
 namespace renderer  { class ParamArray; }
 namespace renderer  { class Project; }
 namespace renderer  { class Scene; }
@@ -83,7 +79,7 @@ class RendererComponents
         const ParamArray&       params,
         ITileCallbackFactory*   tile_callback_factory,
         TextureStore&           texture_store,
-        OIIO::TextureSystem&    texture_system,
+        OIIOTextureSystem&      texture_system,
         OSL::ShadingSystem&     shading_system);
 
     bool create();
@@ -102,7 +98,7 @@ class RendererComponents
     LightSampler                m_light_sampler;
     ShadingEngine               m_shading_engine;
     TextureStore&               m_texture_store;
-    OIIO::TextureSystem&        m_texture_system;
+    OIIOTextureSystem&          m_texture_system;
     OSL::ShadingSystem&         m_shading_system;
 
     std::auto_ptr<ILightingEngineFactory>               m_lighting_engine_factory;

--- a/src/appleseed/renderer/kernel/shading/closures.cpp
+++ b/src/appleseed/renderer/kernel/shading/closures.cpp
@@ -31,6 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/modeling/bsdf/ashikhminbrdf.h"
 #include "renderer/modeling/bsdf/blinnbrdf.h"
 #include "renderer/modeling/bsdf/diffusebtdf.h"
@@ -151,7 +152,7 @@ namespace
             return ScatteringMode::Diffuse | ScatteringMode::Glossy;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -215,7 +216,7 @@ namespace
             return BackgroundID;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -250,7 +251,7 @@ namespace
             return ScatteringMode::Glossy;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -305,7 +306,7 @@ namespace
             return DebugID;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -339,7 +340,7 @@ namespace
             return ScatteringMode::Diffuse;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -410,7 +411,7 @@ namespace
             return ScatteringMode::Diffuse | ScatteringMode::Glossy;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -484,7 +485,7 @@ namespace
             return EmissionID;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -548,7 +549,7 @@ namespace
             return ScatteringMode::Glossy | ScatteringMode::Specular;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -653,7 +654,7 @@ namespace
             return ScatteringMode::Glossy | ScatteringMode::Specular;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -736,7 +737,7 @@ namespace
             return HoldoutID;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -776,7 +777,7 @@ namespace
             return ScatteringMode::Glossy | ScatteringMode::Specular;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -867,7 +868,7 @@ namespace
             return ScatteringMode::Diffuse;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -928,7 +929,7 @@ namespace
             return ScatteringMode::Glossy;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -993,7 +994,7 @@ namespace
             return ScatteringMode::Specular;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -1055,7 +1056,7 @@ namespace
             return ScatteringMode::Diffuse;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -1123,7 +1124,7 @@ namespace
             params->fresnel_weight = 1.0f;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -1254,7 +1255,7 @@ namespace
             return ScatteringMode::Diffuse;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -1306,7 +1307,7 @@ namespace
             return TransparentID;
         }
 
-        static void register_closure(OSL::ShadingSystem& shading_system)
+        static void register_closure(OSLShadingSystem& shading_system)
         {
             const OSL::ClosureParam params[] =
             {
@@ -1850,14 +1851,14 @@ Color3f process_background_tree(const OSL::ClosureColor* ci)
 namespace
 {
     template <typename ClosureType>
-    void register_closure(OSL::ShadingSystem& shading_system)
+    void register_closure(OSLShadingSystem& shading_system)
     {
         ClosureType::register_closure(shading_system);
         RENDERER_LOG_DEBUG("registered osl closure %s.", ClosureType::name());
     }
 }
 
-void register_closures(OSL::ShadingSystem& shading_system)
+void register_closures(OSLShadingSystem& shading_system)
 {
     for (size_t i = 0; i < NumClosuresIDs; ++i)
     {

--- a/src/appleseed/renderer/kernel/shading/closures.h
+++ b/src/appleseed/renderer/kernel/shading/closures.h
@@ -53,6 +53,7 @@
 // Forward declarations.
 namespace foundation    { class Arena; }
 namespace renderer      { class BSDF; }
+namespace renderer      { class OSLShadingSystem; }
 
 namespace renderer
 {
@@ -306,7 +307,7 @@ void process_transparency_tree(const OSL::ClosureColor* ci, Alpha& alpha);
 float process_holdout_tree(const OSL::ClosureColor* ci);
 foundation::Color3f process_background_tree(const OSL::ClosureColor* ci);
 
-void register_closures(OSL::ShadingSystem& shading_system);
+void register_closures(OSLShadingSystem& shading_system);
 
 
 //

--- a/src/appleseed/renderer/kernel/shading/oslshadergroupexec.cpp
+++ b/src/appleseed/renderer/kernel/shading/oslshadergroupexec.cpp
@@ -31,6 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/shading/closures.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/kernel/shading/shadingray.h"
 #include "renderer/modeling/bsdf/bsdf.h"
@@ -48,7 +49,7 @@ namespace renderer
 // OSLShaderGroupExec class implementation.
 //
 
-OSLShaderGroupExec::OSLShaderGroupExec(OSL::ShadingSystem& shading_system, Arena& arena)
+OSLShaderGroupExec::OSLShaderGroupExec(OSLShadingSystem& shading_system, Arena& arena)
   : m_osl_shading_system(shading_system)
   , m_arena(arena)
   , m_osl_thread_info(shading_system.create_thread_info())
@@ -177,7 +178,7 @@ Color3f OSLShaderGroupExec::execute_background(
 
     m_osl_shading_system.execute(
         m_osl_shading_context,
-        *shader_group.shader_group_ref(),
+        *reinterpret_cast<OSL::ShaderGroup*>(shader_group.osl_shader_group()),
         sg);
 
     return process_background_tree(sg.Ci);
@@ -198,7 +199,7 @@ void OSLShaderGroupExec::do_execute(
 
     m_osl_shading_system.execute(
         m_osl_shading_context,
-        *shader_group.shader_group_ref(),
+        *reinterpret_cast<OSL::ShaderGroup*>(shader_group.osl_shader_group()),
         shading_point.get_osl_shader_globals());
 }
 

--- a/src/appleseed/renderer/kernel/shading/oslshadergroupexec.h
+++ b/src/appleseed/renderer/kernel/shading/oslshadergroupexec.h
@@ -46,6 +46,7 @@
 
 // Forward declarations.
 namespace foundation    { class Arena; }
+namespace renderer      { class OSLShadingSystem; }
 namespace renderer      { class ShaderGroup; }
 namespace renderer      { class ShadingContext; }
 namespace renderer      { class ShadingPoint; }
@@ -59,7 +60,7 @@ class OSLShaderGroupExec
 {
   public:
     OSLShaderGroupExec(
-        OSL::ShadingSystem&             shading_system,
+        OSLShadingSystem&               shading_system,
         foundation::Arena&              arena);
 
     ~OSLShaderGroupExec();
@@ -68,7 +69,7 @@ class OSLShaderGroupExec
     friend class ShadingContext;
     friend class Tracer;
 
-    OSL::ShadingSystem&                 m_osl_shading_system;
+    OSLShadingSystem&                   m_osl_shading_system;
     foundation::Arena&                  m_arena;
 
     OSL::PerThreadInfo*                 m_osl_thread_info;

--- a/src/appleseed/renderer/kernel/shading/oslshadingsystem.cpp
+++ b/src/appleseed/renderer/kernel/shading/oslshadingsystem.cpp
@@ -1,0 +1,61 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "oslshadingsystem.h"
+
+// appleseed.renderer headers.
+#include "renderer/kernel/rendering/oiioerrorhandler.h"
+#include "renderer/kernel/rendering/rendererservices.h"
+#include "renderer/kernel/texturing/oiiotexturesystem.h"
+
+namespace renderer
+{
+
+OSLShadingSystem::OSLShadingSystem(
+    RendererServices* renderer,
+    OIIOTextureSystem* texturesystem,
+    OIIOErrorHandler* err)
+  : OSL::ShadingSystem(renderer, texturesystem, err)
+{
+}
+
+void OSLShadingSystem::release()
+{
+    delete this;
+}
+
+OSLShadingSystem* OSLShadingSystemFactory::create(
+    RendererServices* renderer,
+    OIIOTextureSystem* texturesystem,
+    OIIOErrorHandler* err)
+{
+    return new OSLShadingSystem(renderer, texturesystem, err);
+}
+
+}   // namespace renderer

--- a/src/appleseed/renderer/kernel/shading/oslshadingsystem.h
+++ b/src/appleseed/renderer/kernel/shading/oslshadingsystem.h
@@ -1,0 +1,72 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef APPLESEED_RENDERER_KERNEL_SHADING_OSLSHADINGSYSTEM_H
+#define APPLESEED_RENDERER_KERNEL_SHADING_OSLSHADINGSYSTEM_H
+
+// OSL headers.
+#include "foundation/platform/_beginoslheaders.h"
+#include "OSL/oslexec.h"
+#include "OSL/oslversion.h"
+#include "foundation/platform/_endoslheaders.h"
+
+// Forward declarations.
+namespace renderer { class OIIOErrorHandler; }
+namespace renderer { class OIIOTextureSystem; }
+namespace renderer { class RendererServices; }
+
+namespace renderer
+{
+
+class OSLShadingSystem
+  : public OSL::ShadingSystem
+{
+  public:
+    void release();
+
+  private:
+    friend class OSLShadingSystemFactory;
+
+    OSLShadingSystem(
+        RendererServices* renderer = 0,
+        OIIOTextureSystem* texturesystem = 0,
+        OIIOErrorHandler* err = 0);
+};
+
+class OSLShadingSystemFactory
+{
+  public:
+    static OSLShadingSystem* create(
+        RendererServices* renderer = 0,
+        OIIOTextureSystem* texturesystem = 0,
+        OIIOErrorHandler* err = 0);
+};
+
+}       // namespace renderer
+
+#endif  // !APPLESEED_RENDERER_KERNEL_SHADING_OSLSHADINGSYSTEM_H

--- a/src/appleseed/renderer/kernel/shading/shadingcontext.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingcontext.cpp
@@ -33,6 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/kernel/shading/closures.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/modeling/shadergroup/shadergroup.h"
 
@@ -74,7 +75,7 @@ OIIOTextureSystem&   ShadingContext::get_oiio_texture_system() const
     return m_oiio_texture_system;
 }
 
-OSL::ShadingSystem& ShadingContext::get_osl_shading_system() const
+OSLShadingSystem& ShadingContext::get_osl_shading_system() const
 {
     return m_shadergroup_exec.m_osl_shading_system;
 }

--- a/src/appleseed/renderer/kernel/shading/shadingcontext.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingcontext.cpp
@@ -33,6 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/kernel/shading/closures.h"
+#include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/modeling/shadergroup/shadergroup.h"
 
 using namespace foundation;
@@ -48,7 +49,7 @@ ShadingContext::ShadingContext(
     const Intersector&      intersector,
     Tracer&                 tracer,
     TextureCache&           texture_cache,
-    OIIO::TextureSystem&    oiio_texture_system,
+    OIIOTextureSystem&      oiio_texture_system,
     OSLShaderGroupExec&     osl_shadergroup_exec,
     Arena&                  arena,
     const size_t            thread_index,
@@ -68,7 +69,7 @@ ShadingContext::ShadingContext(
 {
 }
 
-OIIO::TextureSystem& ShadingContext::get_oiio_texture_system() const
+OIIOTextureSystem&   ShadingContext::get_oiio_texture_system() const
 {
     return m_oiio_texture_system;
 }

--- a/src/appleseed/renderer/kernel/shading/shadingcontext.h
+++ b/src/appleseed/renderer/kernel/shading/shadingcontext.h
@@ -45,6 +45,7 @@ namespace foundation    { class Arena; }
 namespace renderer      { class ILightingEngine; }
 namespace renderer      { class Intersector; }
 namespace renderer      { class OIIOTextureSystem; }
+namespace renderer      { class OSLShadingSystem; }
 namespace renderer      { class ShadingPoint; }
 namespace renderer      { class TextureCache; }
 namespace renderer      { class Tracer; }
@@ -94,7 +95,7 @@ class ShadingContext
     // Return the maximum number of iterations in ray/path tracing loops.
     size_t get_max_iterations() const;
 
-    OSL::ShadingSystem& get_osl_shading_system() const;
+    OSLShadingSystem& get_osl_shading_system() const;
     OSL::ShadingContext* get_osl_shading_context() const;
 
     void execute_osl_shading(

--- a/src/appleseed/renderer/kernel/shading/shadingcontext.h
+++ b/src/appleseed/renderer/kernel/shading/shadingcontext.h
@@ -37,11 +37,6 @@
 #include "foundation/core/concepts/noncopyable.h"
 #include "foundation/math/vector.h"
 
-// OpenImageIO headers.
-#include "foundation/platform/_beginoiioheaders.h"
-#include "OpenImageIO/texture.h"
-#include "foundation/platform/_endoiioheaders.h"
-
 // Standard headers.
 #include <cstddef>
 
@@ -49,6 +44,7 @@
 namespace foundation    { class Arena; }
 namespace renderer      { class ILightingEngine; }
 namespace renderer      { class Intersector; }
+namespace renderer      { class OIIOTextureSystem; }
 namespace renderer      { class ShadingPoint; }
 namespace renderer      { class TextureCache; }
 namespace renderer      { class Tracer; }
@@ -69,7 +65,7 @@ class ShadingContext
         const Intersector&          intersector,
         Tracer&                     tracer,
         TextureCache&               texture_cache,
-        OIIO::TextureSystem&        oiio_texture_system,
+        OIIOTextureSystem&          oiio_texture_system,
         OSLShaderGroupExec&         osl_shadergroup_exec,
         foundation::Arena&          arena,
         const size_t                thread_index,
@@ -83,7 +79,7 @@ class ShadingContext
 
     TextureCache& get_texture_cache() const;
 
-    OIIO::TextureSystem& get_oiio_texture_system() const;
+    OIIOTextureSystem&   get_oiio_texture_system() const;
 
     ILightingEngine* get_lighting_engine() const;
 
@@ -140,7 +136,7 @@ class ShadingContext
     const Intersector&              m_intersector;
     Tracer&                         m_tracer;
     TextureCache&                   m_texture_cache;
-    OIIO::TextureSystem&            m_oiio_texture_system;
+    OIIOTextureSystem&              m_oiio_texture_system;
     OSLShaderGroupExec&             m_shadergroup_exec;
     foundation::Arena&              m_arena;
     const size_t                    m_thread_index;

--- a/src/appleseed/renderer/kernel/texturing/oiiotexturesystem.cpp
+++ b/src/appleseed/renderer/kernel/texturing/oiiotexturesystem.cpp
@@ -1,0 +1,46 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "oiiotexturesystem.h"
+
+namespace renderer
+{
+
+void OIIOTextureSystem::release()
+{
+    OIIO::TextureSystem::destroy(
+        reinterpret_cast<OIIO::TextureSystem*>(this));
+}
+
+OIIOTextureSystem* OIIOTextureSystemFactory::create(const bool shared)
+{
+    return reinterpret_cast<OIIOTextureSystem*>(OIIO::TextureSystem::create(shared));
+}
+
+}   // namespace renderer

--- a/src/appleseed/renderer/kernel/texturing/oiiotexturesystem.h
+++ b/src/appleseed/renderer/kernel/texturing/oiiotexturesystem.h
@@ -1,0 +1,58 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef APPLESEED_RENDERER_KERNEL_TEXTURING_OIIOTEXTURESYSTEM_H
+#define APPLESEED_RENDERER_KERNEL_TEXTURING_OIIOTEXTURESYSTEM_H
+
+// OpenImageIO headers.
+#include "foundation/platform/_beginoiioheaders.h"
+#include "OpenImageIO/texture.h"
+#include "foundation/platform/_endoiioheaders.h"
+
+namespace renderer
+{
+
+class OIIOTextureSystem
+  : public OIIO::TextureSystem
+{
+  public:
+    void release();
+
+  private:
+    virtual ~OIIOTextureSystem();
+};
+
+class OIIOTextureSystemFactory
+{
+  public:
+    static OIIOTextureSystem* create(const bool shared = true);
+};
+
+}       // namespace renderer
+
+#endif  // !APPLESEED_RENDERER_KERNEL_TEXTURING_OIIOTEXTURESYSTEM_H

--- a/src/appleseed/renderer/meta/tests/test_environmentedf.cpp
+++ b/src/appleseed/renderer/meta/tests/test_environmentedf.cpp
@@ -73,9 +73,6 @@
 #include "OpenImageIO/texture.h"
 #include "foundation/platform/_endoiioheaders.h"
 
-// Boost headers.
-#include "boost/shared_ptr.hpp"
-
 // Standard headers.
 #include <cassert>
 #include <cstddef>
@@ -192,7 +189,7 @@ TEST_SUITE(Renderer_Modeling_EnvironmentEDF)
             TextureStore texture_store(m_scene);
             TextureCache texture_cache(texture_store);
 
-            boost::shared_ptr<OIIOTextureSystem> texture_system(
+            std::shared_ptr<OIIOTextureSystem> texture_system(
                 OIIOTextureSystemFactory::create(),
                 [](OIIOTextureSystem* object) { object->release(); });
 
@@ -200,7 +197,7 @@ TEST_SUITE(Renderer_Modeling_EnvironmentEDF)
                 m_project,
                 *texture_system);
 
-            boost::shared_ptr<OSLShadingSystem> shading_system(
+            std::shared_ptr<OSLShadingSystem> shading_system(
                 OSLShadingSystemFactory::create(&renderer_services, texture_system.get()),
                 [](OSLShadingSystem* object) { object->release(); });
 

--- a/src/appleseed/renderer/meta/tests/test_environmentedf.cpp
+++ b/src/appleseed/renderer/meta/tests/test_environmentedf.cpp
@@ -34,6 +34,7 @@
 #include "renderer/kernel/rendering/rendererservices.h"
 #include "renderer/kernel/shading/oslshadergroupexec.h"
 #include "renderer/kernel/shading/shadingcontext.h"
+#include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/kernel/texturing/texturecache.h"
 #include "renderer/kernel/texturing/texturestore.h"
 #include "renderer/modeling/entity/onframebeginrecorder.h"
@@ -191,9 +192,9 @@ TEST_SUITE(Renderer_Modeling_EnvironmentEDF)
             TextureStore texture_store(m_scene);
             TextureCache texture_cache(texture_store);
 
-            boost::shared_ptr<OIIO::TextureSystem> texture_system(
-                OIIO::TextureSystem::create(),
-                boost::bind(&OIIO::TextureSystem::destroy, _1));
+            boost::shared_ptr<OIIOTextureSystem> texture_system(
+                OIIOTextureSystemFactory::create(),
+                boost::bind(&OIIOTextureSystem::release, _1));
 
             RendererServices renderer_services(
                 m_project,

--- a/src/appleseed/renderer/meta/tests/test_environmentedf.cpp
+++ b/src/appleseed/renderer/meta/tests/test_environmentedf.cpp
@@ -33,6 +33,7 @@
 #include "renderer/kernel/lighting/tracer.h"
 #include "renderer/kernel/rendering/rendererservices.h"
 #include "renderer/kernel/shading/oslshadergroupexec.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/kernel/texturing/texturecache.h"
@@ -73,7 +74,6 @@
 #include "foundation/platform/_endoiioheaders.h"
 
 // Boost headers.
-#include "boost/bind.hpp"
 #include "boost/shared_ptr.hpp"
 
 // Standard headers.
@@ -194,14 +194,15 @@ TEST_SUITE(Renderer_Modeling_EnvironmentEDF)
 
             boost::shared_ptr<OIIOTextureSystem> texture_system(
                 OIIOTextureSystemFactory::create(),
-                boost::bind(&OIIOTextureSystem::release, _1));
+                [](OIIOTextureSystem* object) { object->release(); });
 
             RendererServices renderer_services(
                 m_project,
                 *texture_system);
 
-            boost::shared_ptr<OSL::ShadingSystem> shading_system(
-                new OSL::ShadingSystem(&renderer_services, texture_system.get()));
+            boost::shared_ptr<OSLShadingSystem> shading_system(
+                OSLShadingSystemFactory::create(&renderer_services, texture_system.get()),
+                [](OSLShadingSystem* object) { object->release(); });
 
             Intersector intersector(
                 m_project.get_trace_context(),

--- a/src/appleseed/renderer/meta/tests/test_phasefunction.cpp
+++ b/src/appleseed/renderer/meta/tests/test_phasefunction.cpp
@@ -36,6 +36,7 @@
 #include "renderer/kernel/lighting/tracer.h"
 #include "renderer/kernel/rendering/rendererservices.h"
 #include "renderer/kernel/shading/oslshadergroupexec.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/kernel/texturing/texturecache.h"
@@ -98,8 +99,9 @@ TEST_SUITE(Renderer_Modeling_PhaseFunction)
                 m_project,
                 *texture_system);
 
-            std::shared_ptr<OSL::ShadingSystem> shading_system(
-                new OSL::ShadingSystem(&renderer_services, texture_system.get()));
+            std::shared_ptr<OSLShadingSystem> shading_system(
+                OSLShadingSystemFactory::create(&renderer_services, texture_system.get()),
+                [](OSLShadingSystem* object) { object->release(); });
 
             Intersector intersector(
                 m_project.get_trace_context(),

--- a/src/appleseed/renderer/meta/tests/test_phasefunction.cpp
+++ b/src/appleseed/renderer/meta/tests/test_phasefunction.cpp
@@ -37,6 +37,7 @@
 #include "renderer/kernel/rendering/rendererservices.h"
 #include "renderer/kernel/shading/oslshadergroupexec.h"
 #include "renderer/kernel/shading/shadingcontext.h"
+#include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/kernel/texturing/texturecache.h"
 #include "renderer/kernel/texturing/texturestore.h"
 #include "renderer/modeling/entity/onframebeginrecorder.h"
@@ -89,9 +90,9 @@ TEST_SUITE(Renderer_Modeling_PhaseFunction)
             TextureStore texture_store(m_scene);
             TextureCache texture_cache(texture_store);
 
-            std::shared_ptr<OIIO::TextureSystem> texture_system(
-                OIIO::TextureSystem::create(),
-                [](OIIO::TextureSystem* object) { OIIO::TextureSystem::destroy(object); });
+            std::shared_ptr<OIIOTextureSystem> texture_system(
+                OIIOTextureSystemFactory::create(),
+                [](OIIOTextureSystem* object) { object->release(); });
 
             RendererServices renderer_services(
                 m_project,

--- a/src/appleseed/renderer/meta/tests/test_tracer.cpp
+++ b/src/appleseed/renderer/meta/tests/test_tracer.cpp
@@ -34,6 +34,7 @@
 #include "renderer/kernel/lighting/tracer.h"
 #include "renderer/kernel/rendering/rendererservices.h"
 #include "renderer/kernel/shading/oslshadergroupexec.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/kernel/shading/shadingray.h"
 #include "renderer/kernel/texturing/oiiotexturesystem.h"
@@ -217,7 +218,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         Intersector                             m_intersector;
         boost::shared_ptr<OIIOTextureSystem>    m_texture_system;
         boost::shared_ptr<RendererServices>     m_renderer_services;
-        boost::shared_ptr<OSL::ShadingSystem>   m_shading_system;
+        boost::shared_ptr<OSLShadingSystem>     m_shading_system;
         Arena                                   m_arena;
         boost::shared_ptr<OSLShaderGroupExec>   m_shading_group_exec;
         OnFrameBeginRecorder                    m_recorder;
@@ -236,9 +237,8 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
                     *Base::m_project,
                     reinterpret_cast<OIIO::TextureSystem&>(*m_texture_system)));
             m_shading_system.reset(
-                new OSL::ShadingSystem(
-                    m_renderer_services.get(),
-                    m_texture_system.get()));
+                OSLShadingSystemFactory::create(m_renderer_services.get(), m_texture_system.get()),
+                [](OSLShadingSystem* object) { object->release(); });
             m_shading_group_exec.reset(new OSLShaderGroupExec(*m_shading_system, m_arena));
 
             Base::m_scene->on_frame_begin(Base::m_project.ref(), 0, m_recorder);

--- a/src/appleseed/renderer/meta/tests/test_tracer.cpp
+++ b/src/appleseed/renderer/meta/tests/test_tracer.cpp
@@ -74,11 +74,9 @@
 #include "OpenImageIO/texture.h"
 #include "foundation/platform/_endoiioheaders.h"
 
-// Boost headers.
-#include "boost/shared_ptr.hpp"
-
 // Standard headers.
 #include <cstddef>
+#include <memory>
 #include <string>
 
 using namespace foundation;
@@ -216,11 +214,11 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         TextureStore                            m_texture_store;
         TextureCache                            m_texture_cache;
         Intersector                             m_intersector;
-        boost::shared_ptr<OIIOTextureSystem>    m_texture_system;
-        boost::shared_ptr<RendererServices>     m_renderer_services;
-        boost::shared_ptr<OSLShadingSystem>     m_shading_system;
+        std::shared_ptr<OIIOTextureSystem>      m_texture_system;
+        std::shared_ptr<RendererServices>       m_renderer_services;
+        std::shared_ptr<OSLShadingSystem>       m_shading_system;
         Arena                                   m_arena;
-        boost::shared_ptr<OSLShaderGroupExec>   m_shading_group_exec;
+        std::shared_ptr<OSLShaderGroupExec>     m_shading_group_exec;
         OnFrameBeginRecorder                    m_recorder;
 
         Fixture()

--- a/src/appleseed/renderer/modeling/material/disneymaterial.cpp
+++ b/src/appleseed/renderer/modeling/material/disneymaterial.cpp
@@ -31,6 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/shading/shadingpoint.h"
+#include "renderer/kernel/texturing/oiiotexturesystem.h"
 #include "renderer/modeling/bsdf/disneybrdf.h"
 #include "renderer/modeling/bsdf/disneylayeredbrdf.h"
 #include "renderer/modeling/scene/containers.h"
@@ -164,7 +165,7 @@ namespace
 
         Color3f evaluate(
             const ShadingPoint&     shading_point,
-            OIIO::TextureSystem&    texture_system) const
+            OIIOTextureSystem&      texture_system) const
         {
             if (m_is_constant)
                 return m_constant_value;
@@ -330,7 +331,7 @@ bool DisneyMaterialLayer::prepare_expressions() const
 
 void DisneyMaterialLayer::evaluate_expressions(
     const ShadingPoint&     shading_point,
-    OIIO::TextureSystem&    texture_system,
+    OIIOTextureSystem&      texture_system,
     Color3f&                base_color,
     DisneyBRDFInputValues&  values) const
 {

--- a/src/appleseed/renderer/modeling/material/disneymaterial.h
+++ b/src/appleseed/renderer/modeling/material/disneymaterial.h
@@ -42,11 +42,6 @@
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
-// OpenImageIO headers.
-#include "foundation/platform/_beginoiioheaders.h"
-#include "OpenImageIO/texture.h"
-#include "foundation/platform/_endoiioheaders.h"
-
 // Forward declarations.
 namespace foundation    { class Dictionary; }
 namespace foundation    { class DictionaryArray; }
@@ -54,6 +49,7 @@ namespace foundation    { class StringArray; }
 namespace foundation    { class StringDictionary; }
 namespace renderer      { class BaseGroup; }
 namespace renderer      { class MessageContext; }
+namespace renderer      { class OIIOTextureSystem; }
 namespace renderer      { class OnFrameBeginRecorder; }
 namespace renderer      { class ParamArray; }
 namespace renderer      { class ShadingContext; }
@@ -88,7 +84,7 @@ class APPLESEED_DLLSYMBOL DisneyMaterialLayer
 
     void evaluate_expressions(
         const ShadingPoint&             shading_point,
-        OIIO::TextureSystem&            texture_system,
+        OIIOTextureSystem&              texture_system,
         foundation::Color3f&            base_color,
         DisneyBRDFInputValues&          values) const;
 

--- a/src/appleseed/renderer/modeling/scene/basegroup.cpp
+++ b/src/appleseed/renderer/modeling/scene/basegroup.cpp
@@ -31,6 +31,7 @@
 #include "basegroup.h"
 
 // appleseed.renderer headers.
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/modeling/color/colorentity.h"
 #include "renderer/modeling/scene/assembly.h"
 #include "renderer/modeling/scene/assemblyinstance.h"
@@ -98,7 +99,7 @@ ShaderGroupContainer& BaseGroup::shader_groups() const
 }
 
 bool BaseGroup::create_optimized_osl_shader_groups(
-    OSL::ShadingSystem& shading_system,
+    OSLShadingSystem&   shading_system,
     IAbortSwitch*       abort_switch)
 {
     bool success = true;

--- a/src/appleseed/renderer/modeling/scene/basegroup.h
+++ b/src/appleseed/renderer/modeling/scene/basegroup.h
@@ -36,16 +36,12 @@
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
-// OSL headers.
-#include "foundation/platform/_beginoslheaders.h"
-#include "OSL/oslexec.h"
-#include "foundation/platform/_endoslheaders.h"
-
 // Forward declarations.
 namespace foundation    { class IAbortSwitch; }
 namespace foundation    { class StringArray; }
 namespace foundation    { class StringDictionary; }
 namespace renderer      { class Entity; }
+namespace renderer      { class OSLShadingSystem; }
 
 namespace renderer
 {
@@ -77,7 +73,7 @@ class APPLESEED_DLLSYMBOL BaseGroup
 
     // Create OSL shader groups and optimize them.
     bool create_optimized_osl_shader_groups(
-        OSL::ShadingSystem&         shading_system,
+        OSLShadingSystem&           shading_system,
         foundation::IAbortSwitch*   abort_switch = 0);
 
     // Release internal OSL shader groups.

--- a/src/appleseed/renderer/modeling/shadergroup/shader.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shader.cpp
@@ -31,6 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/modeling/shadergroup/shaderparamparser.h"
 #include "renderer/utility/paramarray.h"
 
@@ -261,7 +262,7 @@ const ShaderParamContainer& Shader::shader_params() const
     return impl->m_params;
 }
 
-bool Shader::add(OSL::ShadingSystem& shading_system)
+bool Shader::add(OSLShadingSystem& shading_system)
 {
     for (each<ShaderParamContainer> i = impl->m_params; i; ++i)
     {

--- a/src/appleseed/renderer/modeling/shadergroup/shader.h
+++ b/src/appleseed/renderer/modeling/shadergroup/shader.h
@@ -40,17 +40,13 @@
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
-// OSL headers.
-#include "foundation/platform/_beginoslheaders.h"
-#include "OSL/oslexec.h"
-#include "foundation/platform/_endoslheaders.h"
-
 // Standard headers.
 #include <cstddef>
 
 // Forward declarations.
 namespace foundation    { class SearchPaths; }
 namespace renderer      { class Assembly; }
+namespace renderer      { class OSLShadingSystem; }
 namespace renderer      { class ParamArray; }
 namespace renderer      { class Project; }
 namespace renderer      { class ShaderGroup; }
@@ -91,7 +87,7 @@ class APPLESEED_DLLSYMBOL Shader
     // Destructor.
     ~Shader();
 
-    bool add(OSL::ShadingSystem& shading_system);
+    bool add(OSLShadingSystem& shading_system);
 };
 
 }       // namespace renderer

--- a/src/appleseed/renderer/modeling/shadergroup/shaderconnection.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderconnection.cpp
@@ -31,6 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 
 // appleseed.foundation headers.
 #include "foundation/utility/uid.h"
@@ -110,7 +111,7 @@ const char *ShaderConnection::get_dst_param() const
     return impl->m_dst_param.c_str();
 }
 
-bool ShaderConnection::add(OSL::ShadingSystem& shading_system)
+bool ShaderConnection::add(OSLShadingSystem& shading_system)
 {
     if (!shading_system.ConnectShaders(
             get_src_layer(),

--- a/src/appleseed/renderer/modeling/shadergroup/shaderconnection.h
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderconnection.h
@@ -38,12 +38,8 @@
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
-// OSL headers.
-#include "foundation/platform/_beginoslheaders.h"
-#include "OSL/oslexec.h"
-#include "foundation/platform/_endoslheaders.h"
-
 // Forward declarations.
+namespace renderer  { class OSLShadingSystem; }
 namespace renderer  { class ShaderGroup; }
 
 namespace renderer
@@ -89,7 +85,7 @@ class APPLESEED_DLLSYMBOL ShaderConnection
     ~ShaderConnection();
 
     // Add this connection to OSL's shading system.
-    bool add(OSL::ShadingSystem& shading_system);
+    bool add(OSLShadingSystem& shading_system);
 };
 
 }       // namespace renderer

--- a/src/appleseed/renderer/modeling/shadergroup/shadergroup.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shadergroup.cpp
@@ -31,6 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 #include "renderer/modeling/project/project.h"
 #include "renderer/modeling/shadergroup/shader.h"
 #include "renderer/modeling/shadergroup/shaderconnection.h"
@@ -80,8 +81,6 @@ struct ShaderGroup::Impl
     ShaderConnectionContainer   m_connections;
     mutable OSL::ShaderGroupRef m_shader_group_ref;
     mutable SurfaceAreaMap      m_surface_areas;
-    const OSL::ShaderSymbol*    m_surface_shader_color_sym;
-    const OSL::ShaderSymbol*    m_surface_shader_alpha_sym;
 };
 
 ShaderGroup::ShaderGroup(const char* name)
@@ -113,8 +112,6 @@ void ShaderGroup::clear()
     impl->m_connections.clear();
     impl->m_shader_group_ref.reset();
     m_flags = 0;
-    impl->m_surface_shader_color_sym = 0;
-    impl->m_surface_shader_alpha_sym = 0;
 }
 
 void ShaderGroup::add_shader(
@@ -159,7 +156,7 @@ void ShaderGroup::add_connection(
 }
 
 bool ShaderGroup::create_optimized_osl_shader_group(
-    OSL::ShadingSystem& shading_system,
+    OSLShadingSystem&   shading_system,
     IAbortSwitch*       abort_switch)
 {
     if (is_valid())
@@ -209,49 +206,6 @@ bool ShaderGroup::create_optimized_osl_shader_group(
 
         impl->m_shader_group_ref = shader_group_ref;
 
-        // Set the shadergroup outputs and get symbols if needed.
-        for (each<ShaderContainer> i = impl->m_shaders; i; ++i)
-        {
-            if (strcmp(i->get_type(), "surface_shader") == 0)
-            {
-                // Renderer outputs.
-                const char* renderer_outputs[] =
-                {
-                    "Cout",
-                    "Aout",
-                };
-
-                if (shading_system.attribute(
-                        impl->m_shader_group_ref.get(),
-                        "renderer_outputs",
-                        OIIO::TypeDesc(OIIO::TypeDesc::STRING, 2),
-                        &renderer_outputs[0]))
-                {
-                    OSL::ShadingContext *ctx = shading_system.get_context();
-                    OSL::ShaderGlobals sg;
-                    memset(&sg, 0, sizeof(OSL::ShaderGlobals));
-
-                    if (shading_system.execute(
-                            ctx,
-                            *impl->m_shader_group_ref,
-                            sg,
-                            false))
-                    {
-                        impl->m_surface_shader_color_sym =
-                            shading_system.find_symbol(
-                                *impl->m_shader_group_ref,
-                                OIIO::ustring("Cout"));
-
-                        impl->m_surface_shader_alpha_sym =
-                            shading_system.find_symbol(
-                                *impl->m_shader_group_ref,
-                                OIIO::ustring("Aout"));
-                    }
-                }
-                break;
-            }
-        }
-
         get_shadergroup_closures_info(shading_system);
         report_has_closure("bsdf", HasBSDFs);
         report_has_closure("emission", HasEmission);
@@ -298,22 +252,12 @@ float ShaderGroup::get_surface_area(const AssemblyInstance* ass, const ObjectIns
     return impl->m_surface_areas[Impl::SurfaceAreaKey(ass, obj)];
 }
 
-OSL::ShaderGroupRef& ShaderGroup::shader_group_ref() const
+void* ShaderGroup::osl_shader_group() const
 {
-    return impl->m_shader_group_ref;
+    return impl->m_shader_group_ref.get();
 }
 
-const OSL::ShaderSymbol* ShaderGroup::surface_shader_color_symbol() const
-{
-    return impl->m_surface_shader_color_sym;
-}
-
-const OSL::ShaderSymbol* ShaderGroup::surface_shader_alpha_symbol() const
-{
-    return impl->m_surface_shader_alpha_sym;
-}
-
-void ShaderGroup::get_shadergroup_closures_info(OSL::ShadingSystem& shading_system)
+void ShaderGroup::get_shadergroup_closures_info(OSLShadingSystem& shading_system)
 {
     // Assume the shader group has all closure types.
     m_flags |= HasAllClosures;
@@ -413,7 +357,7 @@ void ShaderGroup::report_has_closure(const char* closure_name, const Flags flag)
     }
 }
 
-void ShaderGroup::get_shadergroup_globals_info(OSL::ShadingSystem& shading_system)
+void ShaderGroup::get_shadergroup_globals_info(OSLShadingSystem& shading_system)
 {
     // Assume the shader group uses all globals.
     m_flags |= UsesAllGlobals;

--- a/src/appleseed/renderer/modeling/shadergroup/shadergroup.h
+++ b/src/appleseed/renderer/modeling/shadergroup/shadergroup.h
@@ -41,14 +41,10 @@
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
-// OSL headers.
-#include "foundation/platform/_beginoslheaders.h"
-#include "OSL/oslexec.h"
-#include "foundation/platform/_endoslheaders.h"
-
 // Forward declarations.
 namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class AssemblyInstance; }
+namespace renderer      { class OSLShadingSystem; }
 namespace renderer      { class ParamArray; }
 namespace renderer      { class ObjectInstance; }
 
@@ -88,7 +84,7 @@ class APPLESEED_DLLSYMBOL ShaderGroup
 
     // Create OSL shader group.
     bool create_optimized_osl_shader_group(
-        OSL::ShadingSystem&         shading_system,
+        OSLShadingSystem&           shading_system,
         foundation::IAbortSwitch*   abort_switch = 0);
 
     // Release internal OSL shader group.
@@ -128,12 +124,8 @@ class APPLESEED_DLLSYMBOL ShaderGroup
     // Can only be called if the shader group has emission closures.
     float get_surface_area(const AssemblyInstance* ass, const ObjectInstance* obj) const;
 
-    // Return a reference-counted (but opaque) reference to the internal OSL shader group.
-    OSL::ShaderGroupRef& shader_group_ref() const;
-
-    // OSL symbols.
-    const OSL::ShaderSymbol* surface_shader_color_symbol() const;
-    const OSL::ShaderSymbol* surface_shader_alpha_symbol() const;
+    // Return an opaque pointer to the internal OSL shader group.
+    void* osl_shader_group() const;
 
   private:
     friend class LightSampler;
@@ -171,10 +163,10 @@ class APPLESEED_DLLSYMBOL ShaderGroup
     // Destructor.
     ~ShaderGroup();
 
-    void get_shadergroup_closures_info(OSL::ShadingSystem& shading_system);
+    void get_shadergroup_closures_info(OSLShadingSystem& shading_system);
     void report_has_closure(const char* closure_name, const Flags flag) const;
 
-    void get_shadergroup_globals_info(OSL::ShadingSystem& shading_system);
+    void get_shadergroup_globals_info(OSLShadingSystem& shading_system);
     void report_uses_global(const char* global_name, const Flags flag) const;
 
     void set_surface_area(

--- a/src/appleseed/renderer/modeling/shadergroup/shaderparam.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderparam.cpp
@@ -31,6 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
+#include "renderer/kernel/shading/oslshadingsystem.h"
 
 // appleseed.foundation headers.
 #include "foundation/utility/api/apistring.h"
@@ -347,7 +348,7 @@ auto_release_ptr<ShaderParam> ShaderParam::create_string_param(
     return p;
 }
 
-bool ShaderParam::add(OSL::ShadingSystem& shading_system)
+bool ShaderParam::add(OSLShadingSystem& shading_system)
 {
     if (!shading_system.Parameter(get_name(), impl->m_type_desc, get_value()))
     {

--- a/src/appleseed/renderer/modeling/shadergroup/shaderparam.h
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderparam.h
@@ -44,12 +44,8 @@
 #include <string>
 #include <vector>
 
-// OSL headers.
-#include "foundation/platform/_beginoslheaders.h"
-#include "OSL/oslexec.h"
-#include "foundation/platform/_endoslheaders.h"
-
 // Forward declarations.
+namespace renderer  { class OSLShadingSystem; }
 namespace renderer  { class Shader; }
 
 namespace renderer
@@ -192,7 +188,7 @@ class APPLESEED_DLLSYMBOL ShaderParam
     const void* get_value() const;
 
     // Add this param to OSL's shading system.
-    bool add(OSL::ShadingSystem& shading_system);
+    bool add(OSLShadingSystem& shading_system);
 };
 
 }       // namespace renderer

--- a/src/appleseed/renderer/utility/seexpr.h
+++ b/src/appleseed/renderer/utility/seexpr.h
@@ -32,6 +32,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
 #include "renderer/kernel/shading/shadingpoint.h"
+#include "renderer/kernel/texturing/oiiotexturesystem.h"
 
 // appleseed.foundation headers.
 #include "foundation/image/color.h"
@@ -48,12 +49,6 @@
 #include "SeExprFunc.h"
 #include "SeExprNode.h"
 #pragma warning (pop)
-
-// OpenImageIO headers.
-#include "foundation/platform/_beginoiioheaders.h"
-#include "OpenImageIO/texture.h"
-#include "OpenImageIO/ustring.h"
-#include "foundation/platform/_endoiioheaders.h"
 
 // Boost headers.
 #include "boost/ptr_container/ptr_vector.hpp"
@@ -88,7 +83,7 @@ class TextureSeExprFunc
         m_texture_options.twrap = OIIO::TextureOpt::WrapPeriodic;
     }
 
-    void set_texture_system(OIIO::TextureSystem* texture_system)
+    void set_texture_system(OIIOTextureSystem* texture_system)
     {
         m_texture_system = texture_system;
     }
@@ -165,7 +160,7 @@ class TextureSeExprFunc
     }
 
   private:
-    OIIO::TextureSystem*        m_texture_system;
+    OIIOTextureSystem*          m_texture_system;
     OIIO::ustring               m_texture_filename;
     mutable OIIO::TextureOpt    m_texture_options;
     bool                        m_texture_is_srgb;
@@ -225,7 +220,7 @@ class SeAppleseedExpr
 
     foundation::Color3d update_and_evaluate(
         const ShadingPoint&     shading_point,
-        OIIO::TextureSystem&    texture_system)
+        OIIOTextureSystem&      texture_system)
     {
         for (foundation::each<boost::ptr_vector<TextureSeExprFunc>> i = m_functions_x; i; ++i)
             i->set_texture_system(&texture_system);

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -15,7 +15,6 @@ cd build
 
 cmake --version
 cmake \
-    -D USE_CPP11=$USE_CPP11 \
     -D WITH_CLI=ON \
     -D WITH_STUDIO=OFF \
     -D WITH_TOOLS=OFF \


### PR DESCRIPTION
Wrap OIIO and OSL classes used in API headers, replace OSL and OIIO includes in public headers by forward declarations.

With these changes, OIIO and OSL headers are not required anymore to build appleseed.maya.
