### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -326,6 +326,7 @@ source_group ("foundation\\mesh" FILES
 )
 
 set (foundation_meta_benchmarks_sources
+    foundation/meta/benchmarks/benchmark_basis.cpp
     foundation/meta/benchmarks/benchmark_cache.cpp
     foundation/meta/benchmarks/benchmark_cdf.cpp
     foundation/meta/benchmarks/benchmark_colorspace.cpp


### PR DESCRIPTION
Just noticed that we haven't added the `benchmark_basis.cpp` to the CMakeLists.txt.