### PR TITLE
Get rid of templates in Tracer and fix bug in distance sampling

### DIFF
--- a/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
@@ -332,7 +332,7 @@ namespace
                 // Compute the transmission factor between the light vertex and the camera.
                 // Prevent self-intersections by letting the ray originate from the camera.
                 Spectrum radiance;
-                m_shading_context.get_tracer().trace_between(
+                m_shading_context.get_tracer().trace_between_simple(
                     m_shading_context,
                     light_sample.m_point - camera_outgoing,
                     light_sample.m_point,
@@ -375,7 +375,7 @@ namespace
 
                 // Compute the transmission factor between the light vertex and the camera.
                 Spectrum radiance;
-                m_shading_context.get_tracer().trace_between(
+                m_shading_context.get_tracer().trace_between_simple(
                     m_shading_context,
                     light_vertex - camera_outgoing,
                     light_vertex,
@@ -426,7 +426,7 @@ namespace
                 // Compute the transmission factor between the path vertex and the camera.
                 // Prevent self-intersections by letting the ray originate from the camera.
                 Spectrum transmission;
-                m_shading_context.get_tracer().trace_between(
+                m_shading_context.get_tracer().trace_between_simple(
                     m_shading_context,
                     vertex.get_point() - camera_outgoing,
                     vertex.get_point(),

--- a/src/appleseed/renderer/kernel/lighting/materialsamplers.cpp
+++ b/src/appleseed/renderer/kernel/lighting/materialsamplers.cpp
@@ -131,14 +131,15 @@ const ShadingPoint& BSDFSampler::trace(
         m_shading_point.get_ray().m_depth + 1);
     ray.copy_media_from(m_shading_point.get_ray());
 
-    const ShadingPoint& shading_point =
-        shading_context.get_tracer().trace<const ShadingPoint&>(
-            shading_context,
-            m_shading_point,
-            ray,
-            transmission);
-    if (shading_point.hit()) transmission.set(0.0f);
-    return shading_point;
+    const ShadingPoint* shading_point;
+    shading_context.get_tracer().trace(
+        shading_context,
+        m_shading_point,
+        ray,
+        transmission,
+        shading_point);
+    if (shading_point->hit()) transmission.set(0.0f);
+    return *shading_point;
 }
 
 void BSDFSampler::trace_between(
@@ -258,13 +259,14 @@ const ShadingPoint& PhaseFunctionSampler::trace(
         m_volume_ray.m_depth + 1);
     ray.copy_media_from(m_volume_ray);
 
-    const ShadingPoint& shading_point =
-        shading_context.get_tracer().trace<const ShadingPoint&>(
-            shading_context,
-            ray,
-            transmission);
-    if (shading_point.hit()) transmission.set(0.0f);
-    return shading_point;
+    const ShadingPoint* shading_point;
+    shading_context.get_tracer().trace(
+        shading_context,
+        ray,
+        transmission,
+        shading_point);
+    if (shading_point->hit()) transmission.set(0.0f);
+    return *shading_point;
 }
 
 void PhaseFunctionSampler::trace_between(

--- a/src/appleseed/renderer/kernel/lighting/materialsamplers.cpp
+++ b/src/appleseed/renderer/kernel/lighting/materialsamplers.cpp
@@ -131,15 +131,14 @@ const ShadingPoint& BSDFSampler::trace(
         m_shading_point.get_ray().m_depth + 1);
     ray.copy_media_from(m_shading_point.get_ray());
 
-    const ShadingPoint* shading_point;
-    shading_context.get_tracer().trace(
-        shading_context,
-        m_shading_point,
-        ray,
-        transmission,
-        shading_point);
-    if (shading_point->hit()) transmission.set(0.0f);
-    return *shading_point;
+    const ShadingPoint& shading_point =
+        shading_context.get_tracer().trace_full(
+            shading_context,
+            m_shading_point,
+            ray,
+            transmission);
+    if (shading_point.hit()) transmission.set(0.0f);
+    return shading_point;
 }
 
 void BSDFSampler::trace_between(
@@ -147,7 +146,7 @@ void BSDFSampler::trace_between(
     const Vector3d&         target_position,
     Spectrum&               transmission) const
 {
-    shading_context.get_tracer().trace_between(
+    shading_context.get_tracer().trace_between_simple(
         shading_context,
         m_shading_point,
         target_position,
@@ -259,14 +258,13 @@ const ShadingPoint& PhaseFunctionSampler::trace(
         m_volume_ray.m_depth + 1);
     ray.copy_media_from(m_volume_ray);
 
-    const ShadingPoint* shading_point;
-    shading_context.get_tracer().trace(
-        shading_context,
-        ray,
-        transmission,
-        shading_point);
-    if (shading_point->hit()) transmission.set(0.0f);
-    return *shading_point;
+    const ShadingPoint& shading_point =
+        shading_context.get_tracer().trace_full(
+            shading_context,
+            ray,
+            transmission);
+    if (shading_point.hit()) transmission.set(0.0f);
+    return shading_point;
 }
 
 void PhaseFunctionSampler::trace_between(
@@ -274,7 +272,7 @@ void PhaseFunctionSampler::trace_between(
     const Vector3d&         target_position,
     Spectrum&               transmission) const
 {
-    shading_context.get_tracer().trace_between(
+    shading_context.get_tracer().trace_between_simple(
         shading_context,
         m_point,
         target_position,

--- a/src/appleseed/renderer/meta/tests/test_tracer.cpp
+++ b/src/appleseed/renderer/meta/tests/test_tracer.cpp
@@ -276,13 +276,14 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             ShadingRay::Time(),
             VisibilityFlags::ShadowRay,
             0);
-        const ShadingPoint& shading_point =
-            m_tracer.trace<const ShadingPoint&>(
-                *m_shading_context,
-                ray,
-                transmission);
+        const ShadingPoint* shading_point;
+        m_tracer.trace(
+            *m_shading_context,
+            ray,
+            transmission,
+            shading_point);
 
-        EXPECT_FALSE(shading_point.hit());
+        EXPECT_FALSE(shading_point->hit());
         EXPECT_EQ(Spectrum(1.0f), transmission);
     }
 
@@ -306,17 +307,18 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
     TEST_CASE_F(TraceBetween_GivenNoOccluder, Fixture<EmptyScene>)
     {
         Spectrum transmission;
-        const ShadingPoint& shading_point =
-            m_tracer.trace_between<const ShadingPoint&>(
-                *m_shading_context,
-                Vector3d(0.0, 0.0, 0.0),
-                Vector3d(5.0, 0.0, 0.0),
-                ShadingRay::Time(),
-                VisibilityFlags::ShadowRay,
-                0,
-                transmission);
+        const ShadingPoint* shading_point;
+        m_tracer.trace_between(
+            *m_shading_context,
+            Vector3d(0.0, 0.0, 0.0),
+            Vector3d(5.0, 0.0, 0.0),
+            ShadingRay::Time(),
+            VisibilityFlags::ShadowRay,
+            0,
+            transmission,
+            shading_point);
 
-        EXPECT_FALSE(shading_point.hit());
+        EXPECT_FALSE(shading_point->hit());
         EXPECT_EQ(Spectrum(1.0f), transmission);
     }
 
@@ -353,14 +355,15 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             ShadingRay::Time(),
             VisibilityFlags::ShadowRay,
             0);
-        const ShadingPoint& shading_point =
-            m_tracer.trace<const ShadingPoint&>(
-                *m_shading_context,
-                ray,
-                transmission);
+        const ShadingPoint* shading_point;
+        m_tracer.trace(
+            *m_shading_context,
+            ray,
+            transmission,
+            shading_point);
 
-        ASSERT_TRUE(shading_point.hit());
-        EXPECT_FEQ(Vector3d(2.0, 0.0, 0.0), shading_point.get_point());
+        ASSERT_TRUE(shading_point->hit());
+        EXPECT_FEQ(Vector3d(2.0, 0.0, 0.0), shading_point->get_point());
         EXPECT_EQ(Spectrum(1.0f), transmission);
     }
 
@@ -384,18 +387,19 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
     TEST_CASE_F(TraceBetween_GivenSingleOpaqueOccluder, Fixture<SceneWithSingleOpaqueOccluder>)
     {
         Spectrum transmission;
-        const ShadingPoint& shading_point =
-            m_tracer.trace_between<const ShadingPoint&>(
-                *m_shading_context,
-                Vector3d(0.0, 0.0, 0.0),
-                Vector3d(5.0, 0.0, 0.0),
-                ShadingRay::Time(),
-                VisibilityFlags::ShadowRay,
-                0,
-                transmission);
+        const ShadingPoint* shading_point;
+        m_tracer.trace_between(
+            *m_shading_context,
+            Vector3d(0.0, 0.0, 0.0),
+            Vector3d(5.0, 0.0, 0.0),
+            ShadingRay::Time(),
+            VisibilityFlags::ShadowRay,
+            0,
+            transmission,
+            shading_point);
 
-        ASSERT_TRUE(shading_point.hit());
-        EXPECT_FEQ(Vector3d(2.0, 0.0, 0.0), shading_point.get_point());
+        ASSERT_TRUE(shading_point->hit());
+        EXPECT_FEQ(Vector3d(2.0, 0.0, 0.0), shading_point->get_point());
         EXPECT_EQ(Spectrum(1.0f), transmission);
     }
 
@@ -432,13 +436,14 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             ShadingRay::Time(),
             VisibilityFlags::ShadowRay,
             0);
-        const ShadingPoint& shading_point =
-            m_tracer.trace<const ShadingPoint&>(
-                *m_shading_context,
-                ray,
-                transmission);
+        const ShadingPoint* shading_point;
+        m_tracer.trace(
+            *m_shading_context,
+            ray,
+            transmission,
+            shading_point);
 
-        ASSERT_FALSE(shading_point.hit());
+        ASSERT_FALSE(shading_point->hit());
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
@@ -462,17 +467,18 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
     TEST_CASE_F(TraceBetween_GivenSingleTransparentOccluder, Fixture<SceneWithSingleTransparentOccluder>)
     {
         Spectrum transmission;
-        const ShadingPoint& shading_point =
-            m_tracer.trace_between<const ShadingPoint&>(
-                *m_shading_context,
-                Vector3d(0.0, 0.0, 0.0),
-                Vector3d(5.0, 0.0, 0.0),
-                ShadingRay::Time(),
-                VisibilityFlags::ShadowRay,
-                0,
-                transmission);
+        const ShadingPoint* shading_point;
+        m_tracer.trace_between(
+            *m_shading_context,
+            Vector3d(0.0, 0.0, 0.0),
+            Vector3d(5.0, 0.0, 0.0),
+            ShadingRay::Time(),
+            VisibilityFlags::ShadowRay,
+            0,
+            transmission,
+            shading_point);
 
-        ASSERT_FALSE(shading_point.hit());
+        ASSERT_FALSE(shading_point->hit());
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
@@ -510,14 +516,15 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             ShadingRay::Time(),
             VisibilityFlags::ShadowRay,
             0);
-        const ShadingPoint& shading_point =
-            m_tracer.trace<const ShadingPoint&>(
-                *m_shading_context,
-                ray,
-                transmission);
+        const ShadingPoint* shading_point;
+        m_tracer.trace(
+            *m_shading_context,
+            ray,
+            transmission,
+            shading_point);
 
-        ASSERT_TRUE(shading_point.hit());
-        EXPECT_FEQ(Vector3d(4.0, 0.0, 0.0), shading_point.get_point());
+        ASSERT_TRUE(shading_point->hit());
+        EXPECT_FEQ(Vector3d(4.0, 0.0, 0.0), shading_point->get_point());
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
@@ -541,18 +548,19 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
     TEST_CASE_F(TraceBetween_GivenTransparentThenOpaqueOccluders_GivenTargetPastOpaqueOccluder, Fixture<SceneWithTransparentThenOpaqueOccluders>)
     {
         Spectrum transmission;
-        const ShadingPoint& shading_point =
-            m_tracer.trace_between<const ShadingPoint&>(
-                *m_shading_context,
-                Vector3d(0.0, 0.0, 0.0),
-                Vector3d(5.0, 0.0, 0.0),
-                ShadingRay::Time(),
-                VisibilityFlags::ShadowRay,
-                0,
-                transmission);
+        const ShadingPoint* shading_point;
+        m_tracer.trace_between(
+            *m_shading_context,
+            Vector3d(0.0, 0.0, 0.0),
+            Vector3d(5.0, 0.0, 0.0),
+            ShadingRay::Time(),
+            VisibilityFlags::ShadowRay,
+            0,
+            transmission,
+            shading_point);
 
-        ASSERT_TRUE(shading_point.hit());
-        EXPECT_FEQ(Vector3d(4.0, 0.0, 0.0), shading_point.get_point());
+        ASSERT_TRUE(shading_point->hit());
+        EXPECT_FEQ(Vector3d(4.0, 0.0, 0.0), shading_point->get_point());
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
@@ -574,17 +582,18 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
     TEST_CASE_F(TraceBetween_GivenTransparentThenOpaqueOccluders_GivenTargetOnOpaqueOccluder, Fixture<SceneWithTransparentThenOpaqueOccluders>)
     {
         Spectrum transmission;
-        const ShadingPoint& shading_point =
-            m_tracer.trace_between<const ShadingPoint&>(
-                *m_shading_context,
-                Vector3d(0.0, 0.0, 0.0),
-                Vector3d(4.0, 0.0, 0.0),
-                ShadingRay::Time(),
-                VisibilityFlags::ShadowRay,
-                0,
-                transmission);
+        const ShadingPoint* shading_point;
+        m_tracer.trace_between(
+            *m_shading_context,
+            Vector3d(0.0, 0.0, 0.0),
+            Vector3d(4.0, 0.0, 0.0),
+            ShadingRay::Time(),
+            VisibilityFlags::ShadowRay,
+            0,
+            transmission,
+            shading_point);
 
-        ASSERT_FALSE(shading_point.hit());
+        ASSERT_FALSE(shading_point->hit());
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
@@ -622,19 +631,20 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             VisibilityFlags::ShadowRay,
             0);
         Spectrum parent_transmission;
-        const ShadingPoint& parent_shading_point =
-            m_tracer.trace<const ShadingPoint&>(
-                *m_shading_context,
-                ray,
-                parent_transmission);
+        const ShadingPoint* parent_shading_point;
+        m_tracer.trace(
+            *m_shading_context,
+            ray,
+            parent_transmission,
+            parent_shading_point);
 
-        ASSERT_TRUE(parent_shading_point.hit());
-        ASSERT_FEQ(2.0, parent_shading_point.get_distance());
+        ASSERT_TRUE(parent_shading_point->hit());
+        ASSERT_FEQ(2.0, parent_shading_point->get_distance());
 
         Spectrum transmission;
         m_tracer.trace_between(
             *m_shading_context,
-            parent_shading_point,
+            *parent_shading_point,
             Vector3d(4.0, 0.0, 0.0),
             VisibilityFlags::ShadowRay,
             transmission);
@@ -663,19 +673,20 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             VisibilityFlags::ShadowRay,
             0);
         Spectrum parent_transmission;
-        const ShadingPoint& parent_shading_point =
-            m_tracer.trace<const ShadingPoint&>(
-                *m_shading_context,
-                ray,
-                parent_transmission);
+        const ShadingPoint* parent_shading_point;
+        m_tracer.trace(
+            *m_shading_context,
+            ray,
+            parent_transmission,
+            parent_shading_point);
 
-        ASSERT_TRUE(parent_shading_point.hit());
-        ASSERT_FEQ(1.0, parent_shading_point.get_distance());
+        ASSERT_TRUE(parent_shading_point->hit());
+        ASSERT_FEQ(1.0, parent_shading_point->get_distance());
 
         Spectrum transmission;
         m_tracer.trace_between(
             *m_shading_context,
-            parent_shading_point,
+            *parent_shading_point,
             Vector3d(2.0, 0.0, 0.0),
             VisibilityFlags::ShadowRay,
             transmission);

--- a/src/appleseed/renderer/meta/tests/test_tracer.cpp
+++ b/src/appleseed/renderer/meta/tests/test_tracer.cpp
@@ -276,14 +276,13 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             ShadingRay::Time(),
             VisibilityFlags::ShadowRay,
             0);
-        const ShadingPoint* shading_point;
-        m_tracer.trace(
-            *m_shading_context,
-            ray,
-            transmission,
-            shading_point);
+        const ShadingPoint& shading_point =
+            m_tracer.trace_full(
+                *m_shading_context,
+                ray,
+                transmission);
 
-        EXPECT_FALSE(shading_point->hit());
+        EXPECT_FALSE(shading_point.hit());
         EXPECT_EQ(Spectrum(1.0f), transmission);
     }
 
@@ -296,7 +295,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             VisibilityFlags::ShadowRay,
             0);
         Spectrum transmission;
-        m_tracer.trace(
+        m_tracer.trace_simple(
             *m_shading_context,
             ray,
             transmission);
@@ -307,25 +306,24 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
     TEST_CASE_F(TraceBetween_GivenNoOccluder, Fixture<EmptyScene>)
     {
         Spectrum transmission;
-        const ShadingPoint* shading_point;
-        m_tracer.trace_between(
-            *m_shading_context,
-            Vector3d(0.0, 0.0, 0.0),
-            Vector3d(5.0, 0.0, 0.0),
-            ShadingRay::Time(),
-            VisibilityFlags::ShadowRay,
-            0,
-            transmission,
-            shading_point);
+        const ShadingPoint& shading_point =
+            m_tracer.trace_between_full(
+                *m_shading_context,
+                Vector3d(0.0, 0.0, 0.0),
+                Vector3d(5.0, 0.0, 0.0),
+                ShadingRay::Time(),
+                VisibilityFlags::ShadowRay,
+                0,
+                transmission);
 
-        EXPECT_FALSE(shading_point->hit());
+        EXPECT_FALSE(shading_point.hit());
         EXPECT_EQ(Spectrum(1.0f), transmission);
     }
 
     TEST_CASE_F(TraceBetween_QuickVariant_GivenNoOccluder, Fixture<EmptyScene>)
     {
         Spectrum transmission;
-        m_tracer.trace_between(
+        m_tracer.trace_between_simple(
             *m_shading_context,
             Vector3d(0.0, 0.0, 0.0),
             Vector3d(5.0, 0.0, 0.0),
@@ -355,15 +353,14 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             ShadingRay::Time(),
             VisibilityFlags::ShadowRay,
             0);
-        const ShadingPoint* shading_point;
-        m_tracer.trace(
-            *m_shading_context,
-            ray,
-            transmission,
-            shading_point);
+        const ShadingPoint& shading_point =
+            m_tracer.trace_full(
+                *m_shading_context,
+                ray,
+                transmission);
 
-        ASSERT_TRUE(shading_point->hit());
-        EXPECT_FEQ(Vector3d(2.0, 0.0, 0.0), shading_point->get_point());
+        ASSERT_TRUE(shading_point.hit());
+        EXPECT_FEQ(Vector3d(2.0, 0.0, 0.0), shading_point.get_point());
         EXPECT_EQ(Spectrum(1.0f), transmission);
     }
 
@@ -376,7 +373,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             ShadingRay::Time(),
             VisibilityFlags::ShadowRay,
             0);
-        m_tracer.trace(
+        m_tracer.trace_simple(
             *m_shading_context,
             ray,
             transmission);
@@ -387,26 +384,25 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
     TEST_CASE_F(TraceBetween_GivenSingleOpaqueOccluder, Fixture<SceneWithSingleOpaqueOccluder>)
     {
         Spectrum transmission;
-        const ShadingPoint* shading_point;
-        m_tracer.trace_between(
-            *m_shading_context,
-            Vector3d(0.0, 0.0, 0.0),
-            Vector3d(5.0, 0.0, 0.0),
-            ShadingRay::Time(),
-            VisibilityFlags::ShadowRay,
-            0,
-            transmission,
-            shading_point);
+        const ShadingPoint& shading_point =
+            m_tracer.trace_between_full(
+                *m_shading_context,
+                Vector3d(0.0, 0.0, 0.0),
+                Vector3d(5.0, 0.0, 0.0),
+                ShadingRay::Time(),
+                VisibilityFlags::ShadowRay,
+                0,
+                transmission);
 
-        ASSERT_TRUE(shading_point->hit());
-        EXPECT_FEQ(Vector3d(2.0, 0.0, 0.0), shading_point->get_point());
+        ASSERT_TRUE(shading_point.hit());
+        EXPECT_FEQ(Vector3d(2.0, 0.0, 0.0), shading_point.get_point());
         EXPECT_EQ(Spectrum(1.0f), transmission);
     }
 
     TEST_CASE_F(TraceBetween_QuickVariant_GivenSingleOpaqueOccluder, Fixture<SceneWithSingleOpaqueOccluder>)
     {
         Spectrum transmission;
-        m_tracer.trace_between(
+        m_tracer.trace_between_simple(
             *m_shading_context,
             Vector3d(0.0, 0.0, 0.0),
             Vector3d(5.0, 0.0, 0.0),
@@ -436,14 +432,13 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             ShadingRay::Time(),
             VisibilityFlags::ShadowRay,
             0);
-        const ShadingPoint* shading_point;
-        m_tracer.trace(
-            *m_shading_context,
-            ray,
-            transmission,
-            shading_point);
+        const ShadingPoint& shading_point =
+            m_tracer.trace_full(
+                *m_shading_context,
+                ray,
+                transmission);
 
-        ASSERT_FALSE(shading_point->hit());
+        ASSERT_FALSE(shading_point.hit());
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
@@ -456,7 +451,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             ShadingRay::Time(),
             VisibilityFlags::ShadowRay,
             0);
-        m_tracer.trace(
+        m_tracer.trace_simple(
             *m_shading_context,
             ray,
             transmission);
@@ -467,25 +462,24 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
     TEST_CASE_F(TraceBetween_GivenSingleTransparentOccluder, Fixture<SceneWithSingleTransparentOccluder>)
     {
         Spectrum transmission;
-        const ShadingPoint* shading_point;
-        m_tracer.trace_between(
-            *m_shading_context,
-            Vector3d(0.0, 0.0, 0.0),
-            Vector3d(5.0, 0.0, 0.0),
-            ShadingRay::Time(),
-            VisibilityFlags::ShadowRay,
-            0,
-            transmission,
-            shading_point);
+        const ShadingPoint& shading_point =
+            m_tracer.trace_between_full(
+                *m_shading_context,
+                Vector3d(0.0, 0.0, 0.0),
+                Vector3d(5.0, 0.0, 0.0),
+                ShadingRay::Time(),
+                VisibilityFlags::ShadowRay,
+                0,
+                transmission);
 
-        ASSERT_FALSE(shading_point->hit());
+        ASSERT_FALSE(shading_point.hit());
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
     TEST_CASE_F(TraceBetween_QuickVariant_GivenSingleTransparentOccluder, Fixture<SceneWithSingleTransparentOccluder>)
     {
         Spectrum transmission;
-        m_tracer.trace_between(
+        m_tracer.trace_between_simple(
             *m_shading_context,
             Vector3d(0.0, 0.0, 0.0),
             Vector3d(5.0, 0.0, 0.0),
@@ -516,15 +510,14 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             ShadingRay::Time(),
             VisibilityFlags::ShadowRay,
             0);
-        const ShadingPoint* shading_point;
-        m_tracer.trace(
-            *m_shading_context,
-            ray,
-            transmission,
-            shading_point);
+        const ShadingPoint& shading_point =
+            m_tracer.trace_full(
+                *m_shading_context,
+                ray,
+                transmission);
 
-        ASSERT_TRUE(shading_point->hit());
-        EXPECT_FEQ(Vector3d(4.0, 0.0, 0.0), shading_point->get_point());
+        ASSERT_TRUE(shading_point.hit());
+        EXPECT_FEQ(Vector3d(4.0, 0.0, 0.0), shading_point.get_point());
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
@@ -537,7 +530,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             ShadingRay::Time(),
             VisibilityFlags::ShadowRay,
             0);
-        m_tracer.trace(
+        m_tracer.trace_simple(
             *m_shading_context,
             ray,
             transmission);
@@ -548,26 +541,25 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
     TEST_CASE_F(TraceBetween_GivenTransparentThenOpaqueOccluders_GivenTargetPastOpaqueOccluder, Fixture<SceneWithTransparentThenOpaqueOccluders>)
     {
         Spectrum transmission;
-        const ShadingPoint* shading_point;
-        m_tracer.trace_between(
-            *m_shading_context,
-            Vector3d(0.0, 0.0, 0.0),
-            Vector3d(5.0, 0.0, 0.0),
-            ShadingRay::Time(),
-            VisibilityFlags::ShadowRay,
-            0,
-            transmission,
-            shading_point);
+        const ShadingPoint& shading_point =
+            m_tracer.trace_between_full(
+                *m_shading_context,
+                Vector3d(0.0, 0.0, 0.0),
+                Vector3d(5.0, 0.0, 0.0),
+                ShadingRay::Time(),
+                VisibilityFlags::ShadowRay,
+                0,
+                transmission);
 
-        ASSERT_TRUE(shading_point->hit());
-        EXPECT_FEQ(Vector3d(4.0, 0.0, 0.0), shading_point->get_point());
+        ASSERT_TRUE(shading_point.hit());
+        EXPECT_FEQ(Vector3d(4.0, 0.0, 0.0), shading_point.get_point());
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
     TEST_CASE_F(TraceBetween_QuickVariant_GivenTransparentThenOpaqueOccluders_GivenTargetPastOpaqueOccluder, Fixture<SceneWithTransparentThenOpaqueOccluders>)
     {
         Spectrum transmission;
-        m_tracer.trace_between(
+        m_tracer.trace_between_simple(
             *m_shading_context,
             Vector3d(0.0, 0.0, 0.0),
             Vector3d(5.0, 0.0, 0.0),
@@ -582,25 +574,24 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
     TEST_CASE_F(TraceBetween_GivenTransparentThenOpaqueOccluders_GivenTargetOnOpaqueOccluder, Fixture<SceneWithTransparentThenOpaqueOccluders>)
     {
         Spectrum transmission;
-        const ShadingPoint* shading_point;
-        m_tracer.trace_between(
-            *m_shading_context,
-            Vector3d(0.0, 0.0, 0.0),
-            Vector3d(4.0, 0.0, 0.0),
-            ShadingRay::Time(),
-            VisibilityFlags::ShadowRay,
-            0,
-            transmission,
-            shading_point);
+        const ShadingPoint& shading_point =
+            m_tracer.trace_between_full(
+                *m_shading_context,
+                Vector3d(0.0, 0.0, 0.0),
+                Vector3d(4.0, 0.0, 0.0),
+                ShadingRay::Time(),
+                VisibilityFlags::ShadowRay,
+                0,
+                transmission);
 
-        ASSERT_FALSE(shading_point->hit());
+        ASSERT_FALSE(shading_point.hit());
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
     TEST_CASE_F(TraceBetween_QuickVariant_GivenTransparentThenOpaqueOccluders_GivenTargetOnOpaqueOccluder, Fixture<SceneWithTransparentThenOpaqueOccluders>)
     {
         Spectrum transmission;
-        m_tracer.trace_between(
+        m_tracer.trace_between_simple(
             *m_shading_context,
             Vector3d(0.0, 0.0, 0.0),
             Vector3d(4.0, 0.0, 0.0),
@@ -631,20 +622,19 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             VisibilityFlags::ShadowRay,
             0);
         Spectrum parent_transmission;
-        const ShadingPoint* parent_shading_point;
-        m_tracer.trace(
-            *m_shading_context,
-            ray,
-            parent_transmission,
-            parent_shading_point);
+        const ShadingPoint& parent_shading_point =
+            m_tracer.trace_full(
+                *m_shading_context,
+                ray,
+                parent_transmission);
 
-        ASSERT_TRUE(parent_shading_point->hit());
-        ASSERT_FEQ(2.0, parent_shading_point->get_distance());
+        ASSERT_TRUE(parent_shading_point.hit());
+        ASSERT_FEQ(2.0, parent_shading_point.get_distance());
 
         Spectrum transmission;
-        m_tracer.trace_between(
+        m_tracer.trace_between_simple(
             *m_shading_context,
-            *parent_shading_point,
+            parent_shading_point,
             Vector3d(4.0, 0.0, 0.0),
             VisibilityFlags::ShadowRay,
             transmission);
@@ -673,20 +663,19 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
             VisibilityFlags::ShadowRay,
             0);
         Spectrum parent_transmission;
-        const ShadingPoint* parent_shading_point;
-        m_tracer.trace(
-            *m_shading_context,
-            ray,
-            parent_transmission,
-            parent_shading_point);
+        const ShadingPoint& parent_shading_point =
+            m_tracer.trace_full(
+                *m_shading_context,
+                ray,
+                parent_transmission);
 
-        ASSERT_TRUE(parent_shading_point->hit());
-        ASSERT_FEQ(1.0, parent_shading_point->get_distance());
+        ASSERT_TRUE(parent_shading_point.hit());
+        ASSERT_FEQ(1.0, parent_shading_point.get_distance());
 
         Spectrum transmission;
-        m_tracer.trace_between(
+        m_tracer.trace_between_simple(
             *m_shading_context,
-            *parent_shading_point,
+            parent_shading_point,
             Vector3d(2.0, 0.0, 0.0),
             VisibilityFlags::ShadowRay,
             transmission);

--- a/src/appleseed/renderer/meta/tests/test_tracer.cpp
+++ b/src/appleseed/renderer/meta/tests/test_tracer.cpp
@@ -267,7 +267,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
     {
     };
 
-    TEST_CASE_F(Trace_GivenNoOccluder, Fixture<EmptyScene>)
+    TEST_CASE_F(TraceFull_GivenNoOccluder, Fixture<EmptyScene>)
     {
         Spectrum transmission;
         ShadingRay ray(
@@ -286,7 +286,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         EXPECT_EQ(Spectrum(1.0f), transmission);
     }
 
-    TEST_CASE_F(Trace_QuickVariant_GivenNoOccluder, Fixture<EmptyScene>)
+    TEST_CASE_F(TraceSimple_GivenNoOccluder, Fixture<EmptyScene>)
     {
         ShadingRay ray(
             Vector3d(0.0),
@@ -303,7 +303,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         EXPECT_EQ(Spectrum(1.0f), transmission);
     }
 
-    TEST_CASE_F(TraceBetween_GivenNoOccluder, Fixture<EmptyScene>)
+    TEST_CASE_F(TraceBetweenFull_GivenNoOccluder, Fixture<EmptyScene>)
     {
         Spectrum transmission;
         const ShadingPoint& shading_point =
@@ -320,7 +320,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         EXPECT_EQ(Spectrum(1.0f), transmission);
     }
 
-    TEST_CASE_F(TraceBetween_QuickVariant_GivenNoOccluder, Fixture<EmptyScene>)
+    TEST_CASE_F(TraceBetweenSimple_GivenNoOccluder, Fixture<EmptyScene>)
     {
         Spectrum transmission;
         m_tracer.trace_between_simple(
@@ -344,7 +344,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         }
     };
 
-    TEST_CASE_F(Trace_GivenSingleOpaqueOccluder, Fixture<SceneWithSingleOpaqueOccluder>)
+    TEST_CASE_F(TraceFull_GivenSingleOpaqueOccluder, Fixture<SceneWithSingleOpaqueOccluder>)
     {
         Spectrum transmission;
         ShadingRay ray(
@@ -364,7 +364,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         EXPECT_EQ(Spectrum(1.0f), transmission);
     }
 
-    TEST_CASE_F(Trace_QuickVariant_GivenSingleOpaqueOccluder, Fixture<SceneWithSingleOpaqueOccluder>)
+    TEST_CASE_F(TraceSimple_GivenSingleOpaqueOccluder, Fixture<SceneWithSingleOpaqueOccluder>)
     {
         Spectrum transmission;
         ShadingRay ray(
@@ -381,7 +381,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         EXPECT_EQ(Spectrum(0.0f), transmission);
     }
 
-    TEST_CASE_F(TraceBetween_GivenSingleOpaqueOccluder, Fixture<SceneWithSingleOpaqueOccluder>)
+    TEST_CASE_F(TraceBetweenFull_GivenSingleOpaqueOccluder, Fixture<SceneWithSingleOpaqueOccluder>)
     {
         Spectrum transmission;
         const ShadingPoint& shading_point =
@@ -399,7 +399,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         EXPECT_EQ(Spectrum(1.0f), transmission);
     }
 
-    TEST_CASE_F(TraceBetween_QuickVariant_GivenSingleOpaqueOccluder, Fixture<SceneWithSingleOpaqueOccluder>)
+    TEST_CASE_F(TraceBetweenSimple_GivenSingleOpaqueOccluder, Fixture<SceneWithSingleOpaqueOccluder>)
     {
         Spectrum transmission;
         m_tracer.trace_between_simple(
@@ -423,7 +423,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         }
     };
 
-    TEST_CASE_F(Trace_GivenSingleTransparentOccluder, Fixture<SceneWithSingleTransparentOccluder>)
+    TEST_CASE_F(TraceFull_GivenSingleTransparentOccluder, Fixture<SceneWithSingleTransparentOccluder>)
     {
         Spectrum transmission;
         ShadingRay ray(
@@ -442,7 +442,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
-    TEST_CASE_F(Trace_QuickVariant_GivenSingleTransparentOccluder, Fixture<SceneWithSingleTransparentOccluder>)
+    TEST_CASE_F(TraceSimple_GivenSingleTransparentOccluder, Fixture<SceneWithSingleTransparentOccluder>)
     {
         Spectrum transmission;
         ShadingRay ray(
@@ -459,7 +459,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
-    TEST_CASE_F(TraceBetween_GivenSingleTransparentOccluder, Fixture<SceneWithSingleTransparentOccluder>)
+    TEST_CASE_F(TraceBetweenFull_GivenSingleTransparentOccluder, Fixture<SceneWithSingleTransparentOccluder>)
     {
         Spectrum transmission;
         const ShadingPoint& shading_point =
@@ -476,7 +476,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
-    TEST_CASE_F(TraceBetween_QuickVariant_GivenSingleTransparentOccluder, Fixture<SceneWithSingleTransparentOccluder>)
+    TEST_CASE_F(TraceBetweenSimple_GivenSingleTransparentOccluder, Fixture<SceneWithSingleTransparentOccluder>)
     {
         Spectrum transmission;
         m_tracer.trace_between_simple(
@@ -501,7 +501,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         }
     };
 
-    TEST_CASE_F(Trace_GivenTransparentThenOpaqueOccluders, Fixture<SceneWithTransparentThenOpaqueOccluders>)
+    TEST_CASE_F(TraceFull_GivenTransparentThenOpaqueOccluders, Fixture<SceneWithTransparentThenOpaqueOccluders>)
     {
         Spectrum transmission;
         ShadingRay ray(
@@ -521,7 +521,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
-    TEST_CASE_F(Trace_QuickVariant_GivenTransparentThenOpaqueOccluders, Fixture<SceneWithTransparentThenOpaqueOccluders>)
+    TEST_CASE_F(TraceSimple_GivenTransparentThenOpaqueOccluders, Fixture<SceneWithTransparentThenOpaqueOccluders>)
     {
         Spectrum transmission;
         ShadingRay ray(
@@ -538,7 +538,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         EXPECT_FEQ(Spectrum(0.0f), transmission);
     }
 
-    TEST_CASE_F(TraceBetween_GivenTransparentThenOpaqueOccluders_GivenTargetPastOpaqueOccluder, Fixture<SceneWithTransparentThenOpaqueOccluders>)
+    TEST_CASE_F(TraceBetweenFull_GivenTransparentThenOpaqueOccluders_GivenTargetPastOpaqueOccluder, Fixture<SceneWithTransparentThenOpaqueOccluders>)
     {
         Spectrum transmission;
         const ShadingPoint& shading_point =
@@ -556,7 +556,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
-    TEST_CASE_F(TraceBetween_QuickVariant_GivenTransparentThenOpaqueOccluders_GivenTargetPastOpaqueOccluder, Fixture<SceneWithTransparentThenOpaqueOccluders>)
+    TEST_CASE_F(TraceBetweenSimple_GivenTransparentThenOpaqueOccluders_GivenTargetPastOpaqueOccluder, Fixture<SceneWithTransparentThenOpaqueOccluders>)
     {
         Spectrum transmission;
         m_tracer.trace_between_simple(
@@ -571,7 +571,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         EXPECT_FEQ(Spectrum(0.0f), transmission);
     }
 
-    TEST_CASE_F(TraceBetween_GivenTransparentThenOpaqueOccluders_GivenTargetOnOpaqueOccluder, Fixture<SceneWithTransparentThenOpaqueOccluders>)
+    TEST_CASE_F(TraceBetweenFull_GivenTransparentThenOpaqueOccluders_GivenTargetOnOpaqueOccluder, Fixture<SceneWithTransparentThenOpaqueOccluders>)
     {
         Spectrum transmission;
         const ShadingPoint& shading_point =
@@ -588,7 +588,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         EXPECT_FEQ(Spectrum(0.5f), transmission);
     }
 
-    TEST_CASE_F(TraceBetween_QuickVariant_GivenTransparentThenOpaqueOccluders_GivenTargetOnOpaqueOccluder, Fixture<SceneWithTransparentThenOpaqueOccluders>)
+    TEST_CASE_F(TraceBetweenSimple_GivenTransparentThenOpaqueOccluders_GivenTargetOnOpaqueOccluder, Fixture<SceneWithTransparentThenOpaqueOccluders>)
     {
         Spectrum transmission;
         m_tracer.trace_between_simple(
@@ -613,7 +613,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         }
     };
 
-    TEST_CASE_F(TraceBetween_ComputeVisibilityBetweenTwoOpaqueOccluders_ReturnsOne, Fixture<SceneWithTwoOpaqueOccluders>)
+    TEST_CASE_F(TraceBetweenSimple_ComputeVisibilityBetweenTwoOpaqueOccluders_ReturnsOne, Fixture<SceneWithTwoOpaqueOccluders>)
     {
         ShadingRay ray(
             Vector3d(0.0, 0.0, 0.0),
@@ -654,7 +654,7 @@ TEST_SUITE(Renderer_Kernel_Lighting_Tracer)
         }
     };
 
-    TEST_CASE_F(TraceBetween_ComputeVisibilityBetweenTwoOpaqueOccludersAndScaledAssemblyInstance_ReturnsOne, Fixture<SceneWithTwoOpaqueOccludersAndScaledAssemblyInstance>)
+    TEST_CASE_F(TraceBetweenSimple_ComputeVisibilityBetweenTwoOpaqueOccludersAndScaledAssemblyInstance_ReturnsOne, Fixture<SceneWithTwoOpaqueOccludersAndScaledAssemblyInstance>)
     {
         ShadingRay ray(
             Vector3d(0.0, 0.0, 0.0),

--- a/src/appleseed/renderer/modeling/phasefunction/henyeyphasefunction.cpp
+++ b/src/appleseed/renderer/modeling/phasefunction/henyeyphasefunction.cpp
@@ -110,28 +110,6 @@ class HenyeyPhaseFunction
         values->m_precomputed.m_extinction = values->m_absorption + values->m_scattering;
     }
 
-    virtual float sample_distance(
-        SamplingContext&    sampling_context,
-        const void*         data,
-        const ShadingRay&   volume_ray,
-        const size_t        channel,
-        float&              distance) const override
-    {
-        const InputValues* values = static_cast<const InputValues*>(data);
-
-        const float ray_length = static_cast<float>(volume_ray.get_length());
-
-        // Sample distance.
-        sampling_context.split_in_place(1, 1);
-        const float s = sampling_context.next2<float>();
-        distance = sample_exponential_distribution_on_segment(
-            s, values->m_precomputed.m_extinction[channel], 0.0f, ray_length);
-
-        // Return corresponding PDF value.
-        return exponential_distribution_on_segment_pdf(
-            distance, values->m_precomputed.m_extinction[channel], 0.0f, ray_length);
-    }
-
     virtual float sample(
         SamplingContext&    sampling_context,
         const void*         data,

--- a/src/appleseed/renderer/modeling/phasefunction/isotropicphasefunction.cpp
+++ b/src/appleseed/renderer/modeling/phasefunction/isotropicphasefunction.cpp
@@ -101,28 +101,6 @@ class IsotropicPhaseFunction
         values->m_precomputed.m_extinction = values->m_absorption + values->m_scattering;
     }
 
-    virtual float sample_distance(
-        SamplingContext&    sampling_context,
-        const void*         data,
-        const ShadingRay&   volume_ray,
-        const size_t        channel,
-        float&              distance) const override
-    {
-        const InputValues* values = static_cast<const InputValues*>(data);
-
-        const float ray_length = static_cast<float>(volume_ray.get_length());
-
-        // Sample distance.
-        sampling_context.split_in_place(1, 1);
-        const float s = sampling_context.next2<float>();
-        distance = sample_exponential_distribution_on_segment(
-            s, values->m_precomputed.m_extinction[channel], 0.0f, ray_length);
-
-        // Return corresponding PDF value.
-        return exponential_distribution_on_segment_pdf(
-            distance, values->m_precomputed.m_extinction[channel], 0.0f, ray_length);
-    }
-
     virtual float sample(
         SamplingContext&    sampling_context,
         const void*         data,

--- a/src/appleseed/renderer/modeling/phasefunction/phasefunction.h
+++ b/src/appleseed/renderer/modeling/phasefunction/phasefunction.h
@@ -89,14 +89,6 @@ class APPLESEED_DLLSYMBOL PhaseFunction
         const ShadingRay&           volume_ray,
         void*                       data) const;
 
-    // Sample distance before the ray is extincted. Return corresponding PDF value.
-    virtual float sample_distance(
-        SamplingContext&            sampling_context,
-        const void*                 data,                       // input values
-        const ShadingRay&           volume_ray,                 // ray used for marching inside the volume
-        const size_t                channel,                    // index of the chroma that is used for sampling
-        float&                      distance) const = 0;        // resulting distance
-
     // Sample phase function in a given point on the ray. Return the PDF value.
     virtual float sample(
         SamplingContext&            sampling_context,


### PR DESCRIPTION
- Get rid of templates in Tracer (Simple overloading instead: now can pass `const ShadingPoint*&` as last argument for the full tracing)
- Fix bug with bad sampling when `vertex.throughput` has more components than `extinction` of phase function.