### PR TITLE
Fix light tree rebuilding

### DIFF
--- a/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
@@ -80,6 +80,11 @@ BackwardLightSampler::BackwardLightSampler(const Scene& scene, const ParamArray&
     // Prepare the CDFs for sampling.
     if (m_non_physical_lights_cdf.valid())
         m_non_physical_lights_cdf.prepare();
+    
+    // Build the light-tree.
+    m_light_tree_light_count = m_light_tree.build(
+        m_light_tree_lights,
+        m_emitting_triangles);
 
    RENDERER_LOG_INFO(
         "found %s %s, %s %s, %s emitting %s.",
@@ -89,14 +94,6 @@ BackwardLightSampler::BackwardLightSampler(const Scene& scene, const ParamArray&
         plural(m_light_tree_light_count, "light-tree compatible light").c_str(),
         pretty_int(m_emitting_triangles.size()).c_str(),
         plural(m_emitting_triangles.size(), "triangle").c_str());
-}
-
-void BackwardLightSampler::on_frame_begin()
-{
-    // Build the light-tree.
-    m_light_tree_light_count = m_light_tree.build(
-        m_light_tree_lights,
-        m_emitting_triangles);
 }
 
 void BackwardLightSampler::collect_non_physical_lights(

--- a/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
@@ -81,7 +81,7 @@ BackwardLightSampler::BackwardLightSampler(const Scene& scene, const ParamArray&
     if (m_non_physical_lights_cdf.valid())
         m_non_physical_lights_cdf.prepare();
     
-    // Build the light-tree.
+    // Build the light tree.
     m_light_tree_light_count = m_light_tree.build(
         m_light_tree_lights,
         m_emitting_triangles);

--- a/src/appleseed/renderer/kernel/lighting/backwardlightsampler.h
+++ b/src/appleseed/renderer/kernel/lighting/backwardlightsampler.h
@@ -72,9 +72,6 @@ class BackwardLightSampler
         const Scene&                        scene,
         const ParamArray&                   params = ParamArray());
 
-    // Build the light tree after the scene is up-to-date.
-    void on_frame_begin();
-
     // Return the number of non-physical lights in the scene.
     size_t get_non_physical_light_count() const;
 

--- a/src/appleseed/renderer/kernel/lighting/lighttree.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttree.cpp
@@ -122,7 +122,7 @@ size_t LightTree::build(
             &ordering[0],
             ordering.size());
 
-        // Set total luminance and level for each node of the LightTree.
+        // Set total node importance and level for each node of the LightTree.
         recursive_node_update(0, 0, 0);
     }
 
@@ -216,24 +216,24 @@ float LightTree::recursive_node_update(
     const size_t node_index, 
     const size_t node_level)
 {
-    float luminance = 0.0f;
+    float importance = 0.0f;
 
     if (!m_nodes[node_index].is_leaf())
     {
         const auto& child1 = m_nodes[node_index].get_child_node_index();
         const auto& child2 = m_nodes[node_index].get_child_node_index() + 1;
 
-        const float luminance1 = recursive_node_update(node_index, child1, node_level + 1);
-        const float luminance2 = recursive_node_update(node_index, child2, node_level + 1);
+        const float importance1 = recursive_node_update(node_index, child1, node_level + 1);
+        const float importance2 = recursive_node_update(node_index, child2, node_level + 1);
 
-        luminance = luminance1 + luminance2;
+        importance = importance1 + importance2;
     }
     else
     {
-        // Access the light intensity value.
+        // Access the light importance value.
         const size_t item_index = m_nodes[node_index].get_item_index();
         const size_t light_source_index = m_items[item_index].m_light_source_index;
-        luminance = m_light_sources[light_source_index]->get_importance();
+        importance = m_light_sources[light_source_index]->get_importance();
 
         // Modify the tree depth if the branch is deeper than the other branches
         // visited so far.
@@ -246,14 +246,14 @@ float LightTree::recursive_node_update(
             m_light_sources[light_source_index]->set_tree_index(node_index);
     }
 
-    m_nodes[node_index].set_luminance(luminance);
+    m_nodes[node_index].set_importance(importance);
     m_nodes[node_index].set_level(node_level);
     if (node_index != 0)
         m_nodes[node_index].set_parent(parent_index);
     else
         m_nodes[node_index].set_root();
 
-    return luminance;
+    return importance;
 }
 
 void LightTree::sample(
@@ -352,7 +352,7 @@ namespace
             static_cast<float>(foundation::square_distance(surface_point, bbox.center()));
         const float inverse_distance_falloff = 1.0f / squared_distance;
 
-        p = node.get_luminance() * inverse_distance_falloff;
+        p = node.get_importance() * inverse_distance_falloff;
     }
 }
 

--- a/src/appleseed/renderer/kernel/lighting/lighttree.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttree.cpp
@@ -233,7 +233,7 @@ float LightTree::recursive_node_update(
         // Access the light intensity value.
         const size_t item_index = m_nodes[node_index].get_item_index();
         const size_t light_source_index = m_items[item_index].m_light_source_index;
-        luminance = m_light_sources[light_source_index]->get_intensity();
+        luminance = m_light_sources[light_source_index]->get_importance();
 
         // Modify the tree depth if the branch is deeper than the other branches
         // visited so far.

--- a/src/appleseed/renderer/kernel/lighting/lighttree.h
+++ b/src/appleseed/renderer/kernel/lighting/lighttree.h
@@ -126,8 +126,8 @@ class LightTree
         const bool                  separate_by_levels = false) const;
 
     // Calculate the tree depth.
-    // Assign total luminance to each node of the tree, where total luminance
-    // represents the sum of all its child nodes luminances.
+    // Assign total importance to each node of the tree, where total importance
+    // represents the sum of all its child nodes importances.
     float recursive_node_update(
         const size_t parent_index,
         const size_t node_index, 

--- a/src/appleseed/renderer/kernel/lighting/lighttree_node.h
+++ b/src/appleseed/renderer/kernel/lighting/lighttree_node.h
@@ -49,15 +49,15 @@ class LightTreeNode
 {
   public:
     LightTreeNode()
-      : m_luminance(0.0f)
+      : m_importance(0.0f)
       , m_root(false)
       , m_parent(0)
     {
     }
 
-    float get_luminance() const
+    float get_importance() const
     {
-        return m_luminance;
+        return m_importance;
     }
 
     size_t get_level() const
@@ -75,9 +75,9 @@ class LightTreeNode
         return m_root;
     }
 
-    void set_luminance(const float luminance)
+    void set_importance(const float importance)
     {
-        m_luminance = luminance;
+        m_importance = importance;
     }
 
     // TODO: set this during the construction
@@ -99,7 +99,7 @@ class LightTreeNode
     }
 
   private:
-    float   m_luminance;
+    float   m_importance;
     size_t  m_tree_level;
     size_t  m_parent;
     bool    m_root;

--- a/src/appleseed/renderer/kernel/lighting/lighttypes.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttypes.cpp
@@ -78,7 +78,7 @@ foundation::AABB3d NonPhysicalLightSource::get_bbox() const
                                      position[2] + 0.001));
 }
 
-float NonPhysicalLightSource::get_intensity() const
+float NonPhysicalLightSource::get_importance() const
 {
     Spectrum spectrum;
     m_light_info->m_light->get_inputs()
@@ -125,11 +125,11 @@ foundation::AABB3d EmittingTriangleLightSource::get_bbox() const
     return bbox;
 }
 
-float EmittingTriangleLightSource::get_intensity() const
+float EmittingTriangleLightSource::get_importance() const
 {
     const EDF* edf = m_triangle->m_material->get_uncached_edf();
     
-    return edf->get_max_contribution() * edf->get_uncached_importance_multiplier();
+    return edf->get_uncached_max_contribution() * edf->get_uncached_importance_multiplier();
 }
 
 int EmittingTriangleLightSource::get_type() const

--- a/src/appleseed/renderer/kernel/lighting/lighttypes.h
+++ b/src/appleseed/renderer/kernel/lighting/lighttypes.h
@@ -111,7 +111,7 @@ class LightSource
     virtual foundation::AABB3d get_bbox() const = 0;
 
     // Get the light intensity.
-    virtual float get_intensity() const = 0;
+    virtual float get_importance() const = 0;
 
     // Get light type.
     virtual int get_type() const = 0;
@@ -133,7 +133,7 @@ class NonPhysicalLightSource
 
     virtual foundation::Vector3d get_position() const override;
     virtual foundation::AABB3d get_bbox() const override;
-    virtual float get_intensity() const override;
+    virtual float get_importance() const override;
     virtual int get_type() const override;
     virtual void set_tree_index(const size_t node_index) const override;
 
@@ -155,7 +155,7 @@ class EmittingTriangleLightSource
 
     virtual foundation::Vector3d get_position() const override;
     virtual foundation::AABB3d get_bbox() const override;
-    virtual float get_intensity() const override;
+    virtual float get_importance() const override;
     virtual int get_type() const override;
     virtual void set_tree_index(const size_t node_index) const override;
 

--- a/src/appleseed/renderer/kernel/lighting/lighttypes.h
+++ b/src/appleseed/renderer/kernel/lighting/lighttypes.h
@@ -110,7 +110,7 @@ class LightSource
     // Get the light source bounding box.
     virtual foundation::AABB3d get_bbox() const = 0;
 
-    // Get the light intensity.
+    // Get the light importance.
     virtual float get_importance() const = 0;
 
     // Get light type.

--- a/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
@@ -292,9 +292,6 @@ IRendererController::Status MasterRenderer::render_frame_sequence(
             return IRendererController::AbortRendering;
         }
 
-        if (components.get_backward_light_sampler())
-            components.get_backward_light_sampler()->on_frame_begin();
-
         // Don't proceed with rendering if scene preparation was aborted.
         if (abort_switch.is_aborted())
         {

--- a/src/appleseed/renderer/kernel/rendering/renderercomponents.h
+++ b/src/appleseed/renderer/kernel/rendering/renderercomponents.h
@@ -85,8 +85,6 @@ class RendererComponents
 
     IFrameRenderer& get_frame_renderer();
 
-    BackwardLightSampler* get_backward_light_sampler() const;
-
   private:
     const Project&              m_project;
     const ParamArray&           m_params;
@@ -134,12 +132,6 @@ inline ShadingEngine& RendererComponents::get_shading_engine()
 inline IFrameRenderer& RendererComponents::get_frame_renderer()
 {
     return *m_frame_renderer.get();
-}
-
-    
-inline BackwardLightSampler* RendererComponents::get_backward_light_sampler() const
-{
-    return m_backward_light_sampler.get();
 }
 
 }       // namespace renderer

--- a/src/appleseed/renderer/modeling/edf/edf.h
+++ b/src/appleseed/renderer/modeling/edf/edf.h
@@ -98,6 +98,9 @@ class APPLESEED_DLLSYMBOL EDF
 
     // Retrieve the light near start value.
     double get_uncached_light_near_start() const;
+    
+    // Retrieve the approximate contribution.
+    virtual float get_uncached_max_contribution() const = 0;
 
     // Get the cached approximate maximum contribution.
     float get_max_contribution() const;
@@ -161,9 +164,6 @@ class APPLESEED_DLLSYMBOL EDF
         const char*                 input_name,
         const char*                 multiplier_name,
         const char*                 exposure_name) const;
-
-    // Retrieve the approximate contribution.
-    virtual float get_uncached_max_contribution() const = 0;
 
   private:
     int    m_flags;


### PR DESCRIPTION
Remove `on_frame_begin()` from the light sampler and build the tree at initialization time.