### PR TITLE
LightSamplerBase lambdas

### DIFF
--- a/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
@@ -79,10 +79,19 @@ BackwardLightSampler::BackwardLightSampler(
     collect_non_physical_lights(scene.assembly_instances(), TransformSequence(), light_handling);
     m_non_physical_light_count = m_non_physical_lights.size();
 
+    TriangleHandlingLambda triangle_handling = [&](
+        const Material* material,
+        const float     area,
+        const size_t    emitting_triangle_index)
+    {
+        if (!m_use_light_tree)
+            m_cdf_triangle_handling(material, area, emitting_triangle_index);
+    };
     // Collect all light-emitting triangles.
     collect_emitting_triangles(
         scene.assembly_instances(),
-        TransformSequence());
+        TransformSequence(),
+        triangle_handling);
 
     // Build the hash table of emitting triangles.
     build_emitting_triangle_hash_table();

--- a/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
@@ -32,6 +32,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
+#include "renderer/kernel/lighting/lightsample.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/modeling/edf/edf.h"
 #include "renderer/modeling/light/light.h"
@@ -62,12 +63,10 @@ BackwardLightSampler::BackwardLightSampler(
 
     RENDERER_LOG_INFO("collecting light emitters...");
 
-    LightHandlingLambda light_handling = [&](
-        const NonPhysicalLightInfo& light_info,
-        const Light& light)
+    LightHandlingLambda light_handling = [&](const NonPhysicalLightInfo& light_info)
     {
         if (m_use_light_tree
-            && ((light.get_flags() & Light::LightTreeCompatible) != 0))
+            && ((light_info.m_light->get_flags() & Light::LightTreeCompatible) != 0))
         {
             // Insert into light tree compatible lights.
             m_light_tree_lights.push_back(light_info);
@@ -81,7 +80,7 @@ BackwardLightSampler::BackwardLightSampler(
             // Insert the light into the CDF.
             // todo: compute importance.
             float importance = 1.0f;
-            importance *= light.get_uncached_importance_multiplier();
+            importance *= light_info.m_light->get_uncached_importance_multiplier();
             m_non_physical_lights_cdf.insert(light_index, importance);
         }
     };

--- a/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
@@ -60,9 +60,23 @@ BackwardLightSampler::BackwardLightSampler(
 
     RENDERER_LOG_INFO("collecting light emitters...");
 
+    LightHandlingLambda light_handling = [&](
+        const NonPhysicalLightInfo& light_info,
+        const Light& light)
+    {
+        if (m_use_light_tree
+            && ((light.get_flags() & Light::LightTreeCompatible) != 0))
+        {
+            // Insert into light tree compatible lights.
+            m_light_tree_lights.push_back(light_info);
+        }
+        else
+            m_cdf_light_handling(light_info, light);
+    };
+
     // Collect all non-physical lights and separate them according to their
     // compatibility with the LightTree.
-    collect_non_physical_lights(scene.assembly_instances(), TransformSequence());
+    collect_non_physical_lights(scene.assembly_instances(), TransformSequence(), light_handling);
     m_non_physical_light_count = m_non_physical_lights.size();
 
     // Collect all light-emitting triangles.

--- a/src/appleseed/renderer/kernel/lighting/backwardlightsampler.h
+++ b/src/appleseed/renderer/kernel/lighting/backwardlightsampler.h
@@ -31,7 +31,6 @@
 #define APPLESEED_RENDERER_KERNEL_LIGHTING_BACKWARDLIGHTSAMPLER_H
 
 // appleseed.renderer headers.
-#include "renderer/kernel/lighting/lightsample.h"
 #include "renderer/kernel/lighting/lightsamplerbase.h"
 #include "renderer/kernel/lighting/lighttree.h"
 #include "renderer/kernel/lighting/lighttypes.h"
@@ -47,6 +46,7 @@
 
 // Forward declarations.
 namespace foundation    { class Dictionary; }
+namespace renderer      { class LightSample; }
 namespace renderer      { class Scene; }
 namespace renderer      { class ShadingPoint; }
 

--- a/src/appleseed/renderer/kernel/lighting/backwardlightsampler.h
+++ b/src/appleseed/renderer/kernel/lighting/backwardlightsampler.h
@@ -90,6 +90,9 @@ class BackwardLightSampler
     static foundation::Dictionary get_params_metadata();
 
   private:
+    bool                                    m_use_light_tree;
+    
+    NonPhysicalLightVector                  m_light_tree_lights;
     size_t                                  m_light_tree_light_count;
     std::unique_ptr<LightTree>              m_light_tree;
 

--- a/src/appleseed/renderer/kernel/lighting/forwardlightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/forwardlightsampler.cpp
@@ -58,9 +58,7 @@ ForwardLightSampler::ForwardLightSampler(const Scene& scene, const ParamArray& p
 {
     RENDERER_LOG_INFO("collecting light emitters...");
 
-    LightHandlingLambda light_handling = [&](
-        const NonPhysicalLightInfo& light_info,
-        const Light& light)
+    LightHandlingLambda light_handling = [&](const NonPhysicalLightInfo& light_info)
     {
         // Insert into non physical lights to be evaluated using CDF.
         const size_t light_index = m_non_physical_lights.size();
@@ -69,7 +67,7 @@ ForwardLightSampler::ForwardLightSampler(const Scene& scene, const ParamArray& p
         // Insert the light into the CDF.
         // todo: compute importance.
         float importance = 1.0f;
-        importance *= light.get_uncached_importance_multiplier();
+        importance *= light_info.m_light->get_uncached_importance_multiplier();
         m_non_physical_lights_cdf.insert(light_index, importance);
     };
 

--- a/src/appleseed/renderer/kernel/lighting/forwardlightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/forwardlightsampler.cpp
@@ -75,10 +75,19 @@ ForwardLightSampler::ForwardLightSampler(const Scene& scene, const ParamArray& p
     collect_non_physical_lights(scene.assembly_instances(), TransformSequence(), light_handling);
     m_non_physical_light_count = m_non_physical_lights.size();
 
+    TriangleHandlingLambda triangle_handling = [&](
+        const Material* material,
+        const float     area,
+        const size_t    emitting_triangle_index)
+    {
+        m_cdf_triangle_handling(material, area, emitting_triangle_index);
+    };
+
     // Collect all light-emitting triangles.
     collect_emitting_triangles(
         scene.assembly_instances(),
-        TransformSequence());
+        TransformSequence(),
+        triangle_handling);
 
     // Build the hash table of emitting triangles.
     build_emitting_triangle_hash_table();

--- a/src/appleseed/renderer/kernel/lighting/forwardlightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/forwardlightsampler.cpp
@@ -33,7 +33,9 @@
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
 #include "renderer/kernel/lighting/lightsample.h"
+#include "renderer/modeling/edf/edf.h"
 #include "renderer/modeling/light/light.h"
+#include "renderer/modeling/material/material.h"
 #include "renderer/modeling/scene/assemblyinstance.h"
 #include "renderer/modeling/scene/scene.h"
 
@@ -80,7 +82,17 @@ ForwardLightSampler::ForwardLightSampler(const Scene& scene, const ParamArray& p
         const float     area,
         const size_t    emitting_triangle_index)
     {
-        m_cdf_triangle_handling(material, area, emitting_triangle_index);
+        // Retrieve the EDF and get the importance multiplier.
+        float importance_multiplier = 1.0f;
+        if (const EDF* edf = material->get_uncached_edf())
+            importance_multiplier = edf->get_uncached_importance_multiplier();
+
+        // Compute the probability density of this triangle.
+        const float triangle_importance = m_params.m_importance_sampling ? static_cast<float>(area) : 1.0f;
+        const float triangle_prob = triangle_importance * importance_multiplier;
+
+        // Insert the light-emitting triangle into the CDF.
+        m_emitting_triangles_cdf.insert(emitting_triangle_index, triangle_prob);
     };
 
     // Collect all light-emitting triangles.

--- a/src/appleseed/renderer/kernel/lighting/lightsamplerbase.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lightsamplerbase.cpp
@@ -352,7 +352,7 @@ void LightSamplerBase::collect_non_physical_lights(
         light_info.m_transform_sequence = transform_sequence;
         light_info.m_light = &light;
 
-        light_handling(light_info, light);
+        light_handling(light_info);
     }
 }
 

--- a/src/appleseed/renderer/kernel/lighting/lightsamplerbase.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lightsamplerbase.cpp
@@ -32,9 +32,7 @@
 // appleseed.renderer headers
 #include "renderer/global/globaltypes.h"
 #include "renderer/kernel/intersection/intersector.h"
-#include "renderer/modeling/edf/edf.h"
 #include "renderer/modeling/light/light.h"
-#include "renderer/modeling/material/material.h"
 #include "renderer/modeling/object/iregion.h"
 #include "renderer/modeling/scene/scene.h"
 #include "renderer/modeling/shadergroup/shadergroup.h"
@@ -52,39 +50,6 @@ namespace renderer
 LightSamplerBase::LightSamplerBase(const ParamArray& params)
   : m_params(params)
   , m_emitting_triangle_hash_table(m_triangle_key_hasher)
-  , m_cdf_light_handling(
-        [&](
-            const NonPhysicalLightInfo& light_info,
-            const Light& light)
-        {
-            // Insert into non physical lights to be evaluated using CDF.
-            const size_t light_index = m_non_physical_lights.size();
-            m_non_physical_lights.push_back(light_info);
-
-            // Insert the light into the CDF.
-            // todo: compute importance.
-            float importance = 1.0f;
-            importance *= light.get_uncached_importance_multiplier();
-            m_non_physical_lights_cdf.insert(light_index, importance);
-        })
-  , m_cdf_triangle_handling(
-        [&](
-            const Material* material,
-            const float     area,
-            const size_t    emitting_triangle_index)
-        {
-            // Retrieve the EDF and get the importance multiplier.
-            float importance_multiplier = 1.0f;
-            if (const EDF* edf = material->get_uncached_edf())
-                importance_multiplier = edf->get_uncached_importance_multiplier();
-
-            // Compute the probability density of this triangle.
-            const float triangle_importance = m_params.m_importance_sampling ? static_cast<float>(area) : 1.0f;
-            const float triangle_prob = triangle_importance * importance_multiplier;
-
-            // Insert the light-emitting triangle into the CDF.
-            m_emitting_triangles_cdf.insert(emitting_triangle_index, triangle_prob);
-        })
   {
   }
 

--- a/src/appleseed/renderer/kernel/lighting/lightsamplerbase.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lightsamplerbase.cpp
@@ -52,7 +52,6 @@ namespace renderer
 LightSamplerBase::LightSamplerBase(const ParamArray& params)
   : m_params(params)
   , m_emitting_triangle_hash_table(m_triangle_key_hasher)
-  , m_use_light_tree(false)
   , m_cdf_light_handling(
         [&](
             const NonPhysicalLightInfo& light_info,

--- a/src/appleseed/renderer/kernel/lighting/lightsamplerbase.h
+++ b/src/appleseed/renderer/kernel/lighting/lightsamplerbase.h
@@ -45,6 +45,7 @@
 // Forward declarations.
 namespace renderer  { class Assembly; }
 namespace renderer  { class AssemblyInstance; }
+namespace renderer  { class Material; }
 namespace renderer  { class MaterialArray; }
 
 namespace renderer
@@ -91,7 +92,9 @@ class LightSamplerBase
         const Light&)>                          LightHandlingLambda;
     
     typedef std::function<void (
-        const EmittingTriangle&)>               TriangleHandlingLambda;
+        const Material*,
+        const float,
+        const size_t)>                          TriangleHandlingLambda;
  
     const Parameters                        m_params;
  
@@ -110,6 +113,7 @@ class LightSamplerBase
     bool                                    m_use_light_tree;
 
     LightHandlingLambda                     m_cdf_light_handling;
+    TriangleHandlingLambda                  m_cdf_triangle_handling;
 
     // Build a hash table that allows to find the emitting triangle at a given shading point.
     void build_emitting_triangle_hash_table();
@@ -117,13 +121,15 @@ class LightSamplerBase
     // Recursively collect emitting triangles from a given set of assembly instances.
     void collect_emitting_triangles(
         const AssemblyInstanceContainer&    assembly_instances,
-        const TransformSequence&            parent_transform_seq);
+        const TransformSequence&            parent_transform_seq,
+        const TriangleHandlingLambda&       triangle_handling);
 
     // Collect emitting triangles from a given assembly.
     void collect_emitting_triangles(
         const Assembly&                     assembly,
         const AssemblyInstance&             assembly_instance,
-        const TransformSequence&            transform_sequence);
+        const TransformSequence&            transform_sequence,
+        const TriangleHandlingLambda&       triangle_handling);
 
     // Recursively collect non-physical lights from a given set of assembly instances.
     void collect_non_physical_lights(

--- a/src/appleseed/renderer/kernel/lighting/lightsamplerbase.h
+++ b/src/appleseed/renderer/kernel/lighting/lightsamplerbase.h
@@ -87,10 +87,8 @@ class LightSamplerBase
     typedef std::vector<EmittingTriangle>       EmittingTriangleVector;
     typedef foundation::CDF<size_t, float>      EmitterCDF;
 
-    typedef std::function<void (
-        const NonPhysicalLightInfo&,
-        const Light&)>                          LightHandlingLambda;
-    
+    typedef std::function<void (const NonPhysicalLightInfo&)>
+                                                LightHandlingLambda;
     typedef std::function<void (
         const Material*,
         const float,

--- a/src/appleseed/renderer/kernel/lighting/lightsamplerbase.h
+++ b/src/appleseed/renderer/kernel/lighting/lightsamplerbase.h
@@ -109,9 +109,6 @@ class LightSamplerBase
     EmittingTriangleKeyHasher               m_triangle_key_hasher;
     EmittingTriangleHashTable               m_emitting_triangle_hash_table;
  
-    LightHandlingLambda                     m_cdf_light_handling;
-    TriangleHandlingLambda                  m_cdf_triangle_handling;
-
     // Build a hash table that allows to find the emitting triangle at a given shading point.
     void build_emitting_triangle_hash_table();
 

--- a/src/appleseed/renderer/kernel/lighting/lightsamplerbase.h
+++ b/src/appleseed/renderer/kernel/lighting/lightsamplerbase.h
@@ -39,6 +39,9 @@
 #include "foundation/core/concepts/noncopyable.h"
 #include "foundation/math/cdf.h"
 
+// Standard headers.
+#include <functional>
+
 // Forward declarations.
 namespace renderer  { class Assembly; }
 namespace renderer  { class AssemblyInstance; }
@@ -83,8 +86,15 @@ class LightSamplerBase
     typedef std::vector<EmittingTriangle>       EmittingTriangleVector;
     typedef foundation::CDF<size_t, float>      EmitterCDF;
 
+    typedef std::function<void (
+        const NonPhysicalLightInfo&,
+        const Light&)>                          LightHandlingLambda;
+    
+    typedef std::function<void (
+        const EmittingTriangle&)>               TriangleHandlingLambda;
+ 
     const Parameters                        m_params;
-
+ 
     NonPhysicalLightVector                  m_light_tree_lights;
     NonPhysicalLightVector                  m_non_physical_lights;
     EmittingTriangleVector                  m_emitting_triangles;
@@ -93,11 +103,13 @@ class LightSamplerBase
     
     EmitterCDF                              m_non_physical_lights_cdf;
     EmitterCDF                              m_emitting_triangles_cdf;
-
+ 
     EmittingTriangleKeyHasher               m_triangle_key_hasher;
     EmittingTriangleHashTable               m_emitting_triangle_hash_table;
-
+ 
     bool                                    m_use_light_tree;
+
+    LightHandlingLambda                     m_cdf_light_handling;
 
     // Build a hash table that allows to find the emitting triangle at a given shading point.
     void build_emitting_triangle_hash_table();
@@ -116,12 +128,14 @@ class LightSamplerBase
     // Recursively collect non-physical lights from a given set of assembly instances.
     void collect_non_physical_lights(
         const AssemblyInstanceContainer&    assembly_instances,
-        const TransformSequence&            parent_transform_seq);
+        const TransformSequence&            parent_transform_seq,
+        const LightHandlingLambda&          light_handling);
 
     // Collect non-physical lights from a given assembly.
     void collect_non_physical_lights(
         const Assembly&                     assembly,
-        const TransformSequence&            transform_sequence);
+        const TransformSequence&            transform_sequence,
+        const LightHandlingLambda&          light_handling);
 
     void store_object_area_in_shadergroups(
         const AssemblyInstance*             assembly_instance,

--- a/src/appleseed/renderer/kernel/lighting/lightsamplerbase.h
+++ b/src/appleseed/renderer/kernel/lighting/lightsamplerbase.h
@@ -95,23 +95,20 @@ class LightSamplerBase
         const Material*,
         const float,
         const size_t)>                          TriangleHandlingLambda;
- 
+
     const Parameters                        m_params;
- 
-    NonPhysicalLightVector                  m_light_tree_lights;
+
     NonPhysicalLightVector                  m_non_physical_lights;
     EmittingTriangleVector                  m_emitting_triangles;
-    
+
     size_t                                  m_non_physical_light_count;
     
     EmitterCDF                              m_non_physical_lights_cdf;
     EmitterCDF                              m_emitting_triangles_cdf;
- 
+
     EmittingTriangleKeyHasher               m_triangle_key_hasher;
     EmittingTriangleHashTable               m_emitting_triangle_hash_table;
  
-    bool                                    m_use_light_tree;
-
     LightHandlingLambda                     m_cdf_light_handling;
     TriangleHandlingLambda                  m_cdf_triangle_handling;
 

--- a/src/appleseed/renderer/kernel/lighting/lighttree.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttree.cpp
@@ -82,9 +82,9 @@ vector<size_t> LightTree::build()
                                     .get_local_to_parent()
                                     .extract_translation();
 
-        // Non physical light has no real size - hence some arbitrary small 
+        // Non physical light has no real size - hence some arbitrary small
         // value is assigned.
-        constexpr double BboxSize = 0.001f;
+        const double BboxSize = 0.001f;
         const AABB3d bbox = AABB3d(Vector3d(position[0] - BboxSize,
                                             position[1] - BboxSize,
                                             position[2] - BboxSize),


### PR DESCRIPTION
We created a `LightSamplerBase` to contain overlapping functions used by both `ForwardLightSampler` and `BackwardLightSampler`. However, some of those functions overlap _almost_ completely. It is this _almost_ part that bugged us. In order to avoid duplication, we moved those functions completely to the `LightSamplerBase`, which implied that the `LightSamplerBase` must contain some functions which should logically be only in the `BackwardLightSampler` (i.e. `m_light_tree_lights`, and `m_use_light_tree`).

We wanted to avoid the useless members using lambdas.

If we introduce lambdas to the `LightSamplerBase` there is no duplication whatsoever and useless members are gone...however, I am not so happy with this approach...
I find it hard to follow and way too much complicated for something that we could have avoided just by leaving the things as they are now and using the `m_use_light_tree` flag. In that case, however, we have a useless member m_light_tree_lights within ForwardLightSampler
If I extract the code outside the LightSamplerBase, we will have duplication. To be honest, I don't think we want it even temporarily.

Also, I can remove the emitting triangle lambda and leave only the non physical light lambda.
In that case we would at least avoid having useless m_light_tree_lights but the m_use_light_tree would still stay. But, the code would still be hard to follow. The fact that I dislike the most is the need to write code within the initializer list - it is something I don't find logical when reading the code... Also, within that code, we refer to a piece of code which is waaay lower in the file and the reader must scroll up and down to understand what the heck is going on here.

Anyway, I would really appreciate your thoughts on this.