### PR TITLE
Fix most of the warnings in appleseed GCC 7 build 

### DIFF
--- a/src/appleseed/foundation/platform/_beginoslheaders.h
+++ b/src/appleseed/foundation/platform/_beginoslheaders.h
@@ -34,3 +34,10 @@
     #pragma warning (disable: 4290)     // C++ exception specification ignored except to indicate a function is not __declspec(nothrow)
 
 #endif
+
+#if __GNUC__ >= 7
+
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdeprecated"	// dynamic exception specifications are deprecated in C++11
+
+#endif

--- a/src/appleseed/foundation/platform/_endoslheaders.h
+++ b/src/appleseed/foundation/platform/_endoslheaders.h
@@ -32,4 +32,10 @@
 
 #endif
 
+#if __GNUC__ >= 7
+
+    #pragma GCC diagnostic pop
+
+#endif
+
 #include "foundation/platform/_endoiioheaders.h"


### PR DESCRIPTION
by omitting gcc warning 'dynamic exception specifications are deprecated' in OSL headers.