### PR TITLE
Add gaffer node metadata, fix bump space scaling

### DIFF
--- a/src/appleseed.shaders/include/appleseed/maya/as_maya_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/maya/as_maya_helpers.h
@@ -44,35 +44,40 @@
         string as_maya_attribute_name = "defaultColor",                     \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Default Color",                                     \
-        string page = "Color Balance"                                       \
+        string page = "Color Balance",                                      \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]],                                                                     \
     color in_colorGain = color(1.0)                                         \
     [[                                                                      \
         string as_maya_attribute_name = "colorGain",                        \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Color Gain",                                        \
-        string page = "Color Balance"                                       \
+        string page = "Color Balance",                                      \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]],                                                                     \
     color in_colorOffset = color(0.0)                                       \
     [[                                                                      \
         string as_maya_attribute_name = "colorOffset",                      \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Color Offset",                                      \
-        string page = "Color Balance"                                       \
+        string page = "Color Balance",                                      \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]],                                                                     \
     float in_alphaGain = 1.0                                                \
     [[                                                                      \
         string as_maya_attribute_name = "alphaGain",                        \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Alpha Gain",                                        \
-        string page = "Color Balance"                                       \
+        string page = "Color Balance",                                      \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]],                                                                     \
     float in_alphaOffset = 0.0                                              \
     [[                                                                      \
         string as_maya_attribute_name = "alphaOffset",                      \
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Alpha Offset",                                      \
-        string page = "Color Balance"                                       \
+        string page = "Color Balance",                                      \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]],                                                                     \
     int in_alphaIsLuminance = 1                                             \
     [[                                                                      \
@@ -80,7 +85,8 @@
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Alpha Is Luminance",                                \
         string widget = "checkBox",                                         \
-        string page = "Color Balance"                                       \
+        string page = "Color Balance",                                      \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]]
 
 #define MAYA_EFFECTS_PARAMETERS                                             \
@@ -91,7 +97,8 @@
         float min = 0.0,                                                    \
         float softmax = 1.0,                                                \
         string label = "Filter",                                            \
-        string page = "Effects"                                             \
+        string page = "Effects",                                            \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]],                                                                     \
     float in_filterOffset = 0.0                                             \
     [[                                                                      \
@@ -100,7 +107,8 @@
         float softmin = 0.0,                                                \
         float softmax = 1.0,                                                \
         string label = "Filter Offset",                                     \
-        string page = "Effects"                                             \
+        string page = "Effects",                                            \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]],                                                                     \
     int in_invert = 0                                                       \
     [[                                                                      \
@@ -108,7 +116,8 @@
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Invert",                                            \
         string widget = "checkBox",                                         \
-        string page = "Effects"                                             \
+        string page = "Effects",                                            \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]]
 
 #define MAYA_EFFECTS_3DTEX_PARAMETERS                                       \
@@ -118,7 +127,8 @@
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Wrap",                                              \
         string widget = "checkBox",                                         \
-        string page = "Effects"                                             \
+        string page = "Effects",                                            \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]],                                                                     \
     int in_local = 0                                                        \
     [[                                                                      \
@@ -126,7 +136,8 @@
         int as_maya_attribute_hidden = 1,                                   \
         string label = "Local",                                             \
         string widget = "checkBox",                                         \
-        string page = "Effects"                                             \
+        string page = "Effects",                                            \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]],                                                                     \
     float in_blend = 0.0                                                    \
     [[                                                                      \
@@ -135,7 +146,8 @@
         string label = "Blend",                                             \
         float min = 0.0,                                                    \
         float max = 1.0,                                                    \
-        string page = "Effects"                                             \
+        string page = "Effects",                                            \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]]
 
 #define MAYA_UV_PARAMETERS                                                  \
@@ -161,20 +173,23 @@
         int as_maya_attribute_hidden = 1,                                   \
         string widget = "null",                                             \
         string label = "Color Profile",                                     \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]],                                                                     \
     int in_ignoreColorSpaceFileRules = 0                                    \
     [[                                                                      \
         string as_maya_attribute_name = "ignoreColorSpaceFileRules",        \
         int as_maya_attribute_hidden = 1,                                   \
         string widget = "null",                                             \
-        string label = "Ignore Color Space File Rules"                      \
+        string label = "Ignore Color Space File Rules",                     \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]],                                                                     \
     string in_colorSpace = ""                                               \
     [[                                                                      \
         string as_maya_attribute_name = "colorSpace",                       \
         int as_maya_attribute_hidden = 1,                                   \
         string widget = "null",                                             \
-        string label = "Color Space"                                        \
+        string label = "Color Space",                                       \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]],                                                                     \
     string in_workingSpace = ""                                             \
     [[                                                                      \
@@ -188,21 +203,24 @@
         string as_maya_attribute_name = "colorManagementEnabled",           \
         int as_maya_attribute_hidden = 1,                                   \
         string widget = "null",                                             \
-        string label = "Color Management Enabled"                           \
+        string label = "Color Management Enabled",                          \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]],                                                                     \
     int in_colorManagementConfigFileEnabled = 0                             \
     [[                                                                      \
         string as_maya_attribute_name = "colorManagementConfigFileEnabled", \
         int as_maya_attribute_hidden = 1,                                   \
         string widget = "null",                                             \
-        string label = "Enable CMS Config"                                  \
+        string label = "Enable CMS Config",                                 \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]],                                                                     \
     string in_colorManagementConfigFilePath = ""                            \
     [[                                                                      \
         string as_maya_attribute_name = "colorManagementConfigFilePath",    \
         int as_maya_attribute_hidden = 1,                                   \
         string widget = "null",                                             \
-        string label = "Color Management Config File Path"                  \
+        string label = "Color Management Config File Path",                 \
+        int gafferNoduleLayoutVisible = 0                                   \
     ]]
 
 float maya_luminance(color in_C)

--- a/src/appleseed.shaders/src/appleseed/as_disney_material.osl
+++ b/src/appleseed.shaders/src/appleseed/as_disney_material.osl
@@ -171,7 +171,8 @@ shader as_disney_material
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
-        int divider = 1
+        int divider = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     float in_matte_opacity = 0.0
     [[
@@ -180,14 +181,16 @@ shader as_disney_material
         float min = 0.0,
         float max = 1.0,
         string label = "Matte Opacity",
-        string page = "Matte Opacity Parameters"
+        string page = "Matte Opacity Parameters",
+        int gafferNoduleLayoutVisible = 0
     ]],
     color in_matte_opacity_color = color(1, 0.5, 0)
     [[
         string as_maya_attribute_name = "matteOpacityColor",
         string as_maya_attribute_short_name = "mac",
         string label = "Matte Opacity Color",
-        string page = "Matte Opacity Parameters"
+        string page = "Matte Opacity Parameters",
+        int gafferNoduleLayoutVisible = 0
     ]], 
     int in_maximum_ray_depth = 4
     [[
@@ -200,19 +203,23 @@ shader as_disney_material
         string page = "Advanced Parameters",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     vector Tn = vector(0)
     [[
         int lockgeom = 0,
         int as_maya_attribute_hidden = 1,
-        string widget = "null"
+        string widget = "null",
+        int gafferNoduleLayoutVisible = 0
     ]],
     vector Bn = vector(0)
     [[
         int lockgeom = 0,
         int as_maya_attribute_hidden = 1,
-        string widget = "null"
+        string widget = "null",
+        int gafferNoduleLayoutVisible = 0
+        
     ]],
 
     output closure color out_outColor = 0
@@ -232,7 +239,8 @@ shader as_disney_material
         string as_maya_attribute_name = "outMatteOpacity",
         string as_maya_attribute_short_name = "om",
         string widget = "null",
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_glass.osl
+++ b/src/appleseed.shaders/src/appleseed/as_glass.osl
@@ -75,7 +75,8 @@ shader as_glass
         string page = "Specular Parameters",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_hidden = 1,
-        int divider = 1
+        int divider = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     string in_distribution = "ggx"
     [[
@@ -87,7 +88,8 @@ shader as_glass
         string page = "Specular Parameters",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     float in_roughness = 0.1
     [[
@@ -96,6 +98,15 @@ shader as_glass
         float min = 0.001,
         float max = 1.0,
         string label = "Roughness",
+        string page = "Specular Parameters"
+    ]],
+    float in_specular_spread = 0.5
+    [[
+        string as_maya_attribute_name = "specularSpread",
+        string as_maya_attribute_short_name = "ss",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Specular Spread",
         string page = "Specular Parameters",
         int divider = 1
     ]],
@@ -140,7 +151,8 @@ shader as_glass
         float min = 0.0,
         float max = 1e+9,
         string label = "Transmittance Distance",
-        string page = "Volume Material Parameters"
+        string page = "Volume Material Parameters",
+        int gafferNoduleLayoutVisible = 0
     ]],
     normal in_bump_normal = N
     [[
@@ -159,7 +171,8 @@ shader as_glass
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
-        int divider = 1
+        int divider = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     float in_matte_opacity = 0.0
     [[
@@ -168,14 +181,16 @@ shader as_glass
         float min = 0.0,
         float max = 1.0,
         string label = "Matte Opacity",
-        string page = "Matte Opacity Parameters"
+        string page = "Matte Opacity Parameters",
+        int gafferNoduleLayoutVisible = 0
     ]],
     color in_matte_opacity_color = color(1,0.5,0)
     [[
         string as_maya_attribute_name = "matteOpacityColor",
         string as_maya_attribute_short_name = "mac",
         string label = "Matte Opacity Color",
-        string page = "Matte Opacity Parameters"
+        string page = "Matte Opacity Parameters",
+        int gafferNoduleLayoutVisible = 0
     ]],
     int in_maximum_ray_depth= 4
     [[
@@ -188,19 +203,22 @@ shader as_glass
         string page = "Advanced Parameters",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     vector Tn = vector(0)
     [[
         int lockgeom = 0,
         int as_maya_attribute_hidden = 1,
-        string widget = "null"
+        string widget = "null",
+        int gafferNoduleLayoutVisible = 0
     ]],
     vector Bn = vector(0)
     [[
         int lockgeom = 0,
         int as_maya_attribute_hidden = 1,
-        string widget = "null"
+        string widget = "null",
+        int gafferNoduleLayoutVisible = 0
     ]],
 
     output closure color out_outColor = 0
@@ -220,7 +238,8 @@ shader as_glass
         string as_maya_attribute_name = "outMatteOpacity",
         string as_maya_attribute_short_name = "om",
         string widget = "null",
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]]
 )
 {
@@ -283,7 +302,7 @@ shader as_glass
         in_reflection_tint,
         in_refraction_tint,
         in_roughness,
-        0.5, // highlight falloff
+        in_specular_spread,
         in_anisotropy_amount,
         in_ior,
         in_volume_transmittance,

--- a/src/appleseed.shaders/src/appleseed/as_luminance.osl
+++ b/src/appleseed.shaders/src/appleseed/as_luminance.osl
@@ -52,7 +52,8 @@ shader as_luminance
         string widget = "checkBox",
         string label = "Use Maya CMS",
         string page = "Color Space",
-        int divider = 1
+        int divider = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     int in_inputColorSpace = 0
     [[
@@ -63,7 +64,8 @@ shader as_luminance
         string options = "ACES 2065-1 AP0:0|ACEScg AP1:1|Rec.2020:2|DCI-P3:3|Rec.709/sRGB:4|Chromaticity Coordinates:5",
         string label = "Input Color Space",
         string page = "Color Space",
-        int divider = 1
+        int divider = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     float in_chromaticityCoordsR[2] = {0.317, 0.329}
     [[
@@ -106,7 +108,8 @@ shader as_luminance
         string label = "Illuminants",
         string page = "Color Space",
         string help = "Preset illuminants, correlated color temperature or explicit white point xy chromaticity coordinates.",
-        int divider = 1
+        int divider = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     int in_colorTemperature = 6504
     [[

--- a/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
@@ -33,7 +33,7 @@ shader as_standard_surface
 [[
     string as_maya_node_name = "asStandardSurface",
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
-    string help = "Primaries and illuminants aware relative luminance node",
+    string help = "Standard Surface Shader",
     int as_maya_type_id = 1210836
 ]]
 (
@@ -90,7 +90,8 @@ shader as_standard_surface
         string page = "Subsurface Parameters",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 1,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     float in_translucency_weight = 0.0
     [[
@@ -146,7 +147,8 @@ shader as_standard_surface
         string help = "In dielectric mode, set IOR explicitly, and in conductor mode, set face and edge refletance.",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     float in_ior = 1.37
     [[
@@ -160,7 +162,8 @@ shader as_standard_surface
         string help = "IOR, only active if Fresnel is set to dielectric.",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 1,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     color in_face_tint = color(0.85, 0.21, 0.05)
     [[
@@ -171,7 +174,8 @@ shader as_standard_surface
         string help = "Reflectance at facing angle, for conductor Fresnel.",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     color in_edge_tint = color(1)
     [[
@@ -183,7 +187,8 @@ shader as_standard_surface
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
-        int divider = 1
+        int divider = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     float in_anisotropy_amount = 0.0
     [[
@@ -241,7 +246,8 @@ shader as_standard_surface
         string page = "Refraction Parameters",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     color in_absorption_color = color(1)
     [[
@@ -282,7 +288,8 @@ shader as_standard_surface
         int divider = 1,
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 1,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     float in_coating_depth = 0.0
     [[
@@ -323,7 +330,8 @@ shader as_standard_surface
         int divider = 1,
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     color in_incandescence_color = color(0)
     [[
@@ -347,7 +355,8 @@ shader as_standard_surface
         int divider = 1,
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
 
     int in_area_normalize_edf = 0
@@ -359,7 +368,8 @@ shader as_standard_surface
         string page = "Incandescence Parameters",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     int in_tonemap_edf = 1
     [[
@@ -371,7 +381,8 @@ shader as_standard_surface
         string help = "Tonemap incandescence, only valid for physically based mode",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     color in_transparency = color(0)
     [[
@@ -406,7 +417,8 @@ shader as_standard_surface
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
-        int divider = 1
+        int divider = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     float in_matte_opacity = 0.0
     [[
@@ -415,14 +427,16 @@ shader as_standard_surface
         float min = 0.0,
         float max = 1.0,
         string label = "Matte Opacity",
-        string page = "Matte Opacity Parameters"
+        string page = "Matte Opacity Parameters",
+        int gafferNoduleLayoutVisible = 0
     ]],
     color in_matte_opacity_color = color(1,0.5,0)
     [[
         string as_maya_attribute_name = "matteOpacityColor",
         string as_maya_attribute_short_name = "mac",
         string label = "Matte Opacity Color",
-        string page = "Matte Opacity Parameters"
+        string page = "Matte Opacity Parameters",
+        int gafferNoduleLayoutVisible = 0
     ]],
     int in_sss_maximum_ray_depth = 2
     [[
@@ -435,7 +449,8 @@ shader as_standard_surface
         string page = "Advanced Parameters",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     float in_sss_threshold = 0.001
     [[
@@ -449,7 +464,8 @@ shader as_standard_surface
         string help = "Threshold at which SSS is replaced by a diffuse term",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     int in_maximum_ray_depth = 8
     [[
@@ -462,19 +478,22 @@ shader as_standard_surface
         string page = "Advanced Parameters",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     vector Tn = vector(0)
     [[
         int lockgeom = 0,
         int as_maya_attribute_hidden = 1,
-        string widget = "null"
+        string widget = "null",
+        int gafferNoduleLayoutVisible = 0
     ]],
     vector Bn = vector(0)
     [[
         int lockgeom = 0,
         int as_maya_attribute_hidden = 1,
-        string widget = "null"
+        string widget = "null",
+        int gafferNoduleLayoutVisible = 0
     ]],
     output closure color out_outColor = 0
     [[
@@ -493,7 +512,8 @@ shader as_standard_surface
         string as_maya_attribute_name = "outMatteOpacity",
         string as_maya_attribute_short_name = "om",
         string widget = "null",
-        int as_maya_attribute_hidden = 1
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_voronoi2d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_voronoi2d.osl
@@ -136,7 +136,8 @@ shader as_voronoi2d
         string options = "Euclidian Distance:0|Sum of Square Difference:1|Tchebychev Distance:2|Sum of Absolute Difference:3|Akritean Distance:4|Minkowski Metric:5|Karlsruhe Metric:6",
         string label = "Metric",
         string page = "Cell Parameters",
-        int divider = 1
+        int divider = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     float in_Minkowski_p = 5.0
     [[
@@ -167,7 +168,8 @@ shader as_voronoi2d
         string widget = "mapper",
         string options = "Feature 1:0|Feature 2:1|Feature 3:2|Feature 4:3|F1 + F2:4|F2 - F1:5|F1 * F2:6|F1 / F2:7|F1 ^ F2:8|Pebbles:9|Cell ID 1:10|Cell ID 2:11|Cell ID 3:12|Cell ID 4:13",
         string label = "Features Mode",
-        string page = "Cell Parameters"
+        string page = "Cell Parameters",
+        int gafferNoduleLayoutVisible = 0
     ]],
 
     MAYA_COLORBALANCE_PARAMETERS,

--- a/src/appleseed.shaders/src/appleseed/as_voronoi3d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_voronoi3d.osl
@@ -136,7 +136,8 @@ shader as_voronoi3d
         string options = "Euclidian Distance:0|Sum of Square Difference:1|Tchebychev Distance:2|Sum of Absolute Difference:3|Akritean Distance:4|Minkowski Metric:5|Karlsruhe Metric:6",
         string label = "Metric",
         string page = "Cell Parameters",
-        int divider = 1
+        int divider = 1,
+        int gafferNoduleLayoutVisible = 0
     ]],
     float in_Minkowski_p = 5.0
     [[
@@ -167,7 +168,8 @@ shader as_voronoi3d
         string widget = "mapper",
         string options = "Feature 1:0|Feature 2:1|Feature 3:2|Feature 4:3|F1 + F2:4|F2 - F1:5|F1 * F2:6|F1 / F2:7|F1 ^ F2:8|Pebbles:9|Cell ID 1:10|Cell ID 2:11|Cell ID 3:12|Cell ID 4:13",
         string label = "Features Mode",
-        string page = "Cell Parameters"
+        string page = "Cell Parameters",
+        int gafferNoduleLayoutVisible = 0
     ]],
     int in_softEdges = 1
     [[
@@ -175,13 +177,15 @@ shader as_voronoi3d
         int as_maya_attribute_hidden = 1,
         string label = "Soft Edges",
         string widget = "checkBox",
-        string page = "Placement Parameters"
+        string page = "Placement Parameters",
+        int gafferNoduleLayoutVisible = 0
     ]],
     matrix in_placementMatrix = matrix(1)
     [[
         string as_maya_attribute_name = "placementMatrix",
         string label = "Placement Matrix",
-        string page = "Placement Parameters"
+        string page = "Placement Parameters",
+        int gafferNoduleLayoutVisible = 0
     ]],
     point in_surfacePoint = P
     [[
@@ -189,7 +193,8 @@ shader as_voronoi3d
         int as_maya_attribute_hidden = 1,
         string label = "Surface Point",
         string page = "Cell Parameters",
-        string widget = "null"
+        string widget = "null",
+        int gafferNoduleLayoutVisible = 0
     ]],
 
     MAYA_COLORBALANCE_PARAMETERS,

--- a/src/appleseed.shaders/src/maya/as_maya_bump2d.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_bump2d.osl
@@ -154,8 +154,6 @@ shader as_maya_bump2d
 
         if (in_bumpInterp == 0)
         {
-            bump_offset /= length(transform("object", surface_normal));
-
             out_outNormal = normalize(calculatenormal(
                 in_pointCamera + (vector) surface_normal * bump_offset));
         }

--- a/src/appleseed.shaders/src/maya/as_maya_bump3d.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_bump3d.osl
@@ -94,8 +94,6 @@ shader as_maya_bump3d
 
         normal surface_normal = normalize(in_normalCamera);
 
-        bump_offset /= length(transform("world", surface_normal));
-
         out_outNormal = normalize(calculatenormal(
             in_pointCamera + (vector) surface_normal * bump_offset));
     }


### PR DESCRIPTION
The asGlass shader can use the Student T MDF as well, so specular spread was added.