### PR TITLE
AOVs work

### DIFF
--- a/sandbox/tests/unit tests/inputs/test_projectfilereader_configurationblocks.appleseed
+++ b/sandbox/tests/unit tests/inputs/test_projectfilereader_configurationblocks.appleseed
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project format_revision="19">
+<project format_revision="20">
     <scene>
         <camera name="camera" model="pinhole_camera">
             <parameter name="film_dimensions" value="0.025 0.025" />

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -1160,6 +1160,8 @@ set (renderer_kernel_shading_sources
     renderer/kernel/shading/ambientocclusion.h
     renderer/kernel/shading/closures.cpp
     renderer/kernel/shading/closures.h
+    renderer/kernel/shading/directshadingcomponents.cpp
+    renderer/kernel/shading/directshadingcomponents.h
     renderer/kernel/shading/fastambientocclusion.cpp
     renderer/kernel/shading/fastambientocclusion.h
     renderer/kernel/shading/oslshadercompiler.cpp
@@ -1168,8 +1170,6 @@ set (renderer_kernel_shading_sources
     renderer/kernel/shading/oslshadergroupexec.h
     renderer/kernel/shading/oslshadingsystem.cpp
     renderer/kernel/shading/oslshadingsystem.h
-    renderer/kernel/shading/shadingcomponents.cpp
-    renderer/kernel/shading/shadingcomponents.h
     renderer/kernel/shading/shadingcontext.cpp
     renderer/kernel/shading/shadingcontext.h
     renderer/kernel/shading/shadingengine.cpp

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -1170,6 +1170,8 @@ set (renderer_kernel_shading_sources
     renderer/kernel/shading/oslshadergroupexec.h
     renderer/kernel/shading/oslshadingsystem.cpp
     renderer/kernel/shading/oslshadingsystem.h
+    renderer/kernel/shading/shadingcomponents.cpp
+    renderer/kernel/shading/shadingcomponents.h
     renderer/kernel/shading/shadingcontext.cpp
     renderer/kernel/shading/shadingcontext.h
     renderer/kernel/shading/shadingengine.cpp

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
@@ -30,7 +30,7 @@
 #include "aovaccumulator.h"
 
 // appleseed.renderer headers.
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/kernel/shading/shadingresult.h"
 #include "renderer/modeling/aov/aov.h"
@@ -65,14 +65,14 @@ void AOVAccumulator::release()
 }
 
 void AOVAccumulator::write(
-    const ShadingComponents&    shading_components,
-    const float                 multiplier)
+    const DirectShadingComponents&  shading_components,
+    const float                     multiplier)
 {
 }
 
 void AOVAccumulator::write(
-    const ShadingPoint&         shading_point,
-    const Camera&               camera)
+    const ShadingPoint&             shading_point,
+    const Camera&                   camera)
 {
 }
 
@@ -112,8 +112,8 @@ void BeautyAOVAccumulator::reset()
 }
 
 void BeautyAOVAccumulator::write(
-    const ShadingComponents&    shading_components,
-    const float                 multiplier)
+    const DirectShadingComponents&  shading_components,
+    const float                     multiplier)
 {
     m_color = shading_components.m_beauty.to_rgb(g_std_lighting_conditions);
     m_color *= multiplier;
@@ -193,16 +193,16 @@ void AOVAccumulatorContainer::reset()
 }
 
 void AOVAccumulatorContainer::write(
-    const ShadingComponents&    shading_components,
-    const float                 multiplier)
+    const DirectShadingComponents&  shading_components,
+    const float                     multiplier)
 {
     for (size_t i = 0, e = m_size; i < e; ++i)
         m_accumulators[i]->write(shading_components, multiplier);
 }
 
 void AOVAccumulatorContainer::write(
-    const ShadingPoint&         shading_point,
-    const Camera&               camera)
+    const ShadingPoint&             shading_point,
+    const Camera&                   camera)
 {
     for (size_t i = 0, e = m_size; i < e; ++i)
         m_accumulators[i]->write(shading_point, camera);

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
@@ -78,6 +78,31 @@ void AOVAccumulator::write(
 
 
 //
+// ColorAOVAccumulator class implementation.
+//
+
+ColorAOVAccumulator::ColorAOVAccumulator(const size_t index)
+  : AOVAccumulator(index)
+{
+}
+
+ColorAOVAccumulator::~ColorAOVAccumulator()
+{
+}
+
+void ColorAOVAccumulator::reset()
+{
+    m_color.set(0.0f);
+}
+
+void ColorAOVAccumulator::flush(ShadingResult& result)
+{
+    result.m_aovs[m_index].rgb() = m_color;
+    result.m_aovs[m_index].a = result.m_main.a;
+}
+
+
+//
 // BeautyAOVAccumulator class implementation.
 //
 

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
@@ -30,7 +30,7 @@
 #include "aovaccumulator.h"
 
 // appleseed.renderer headers.
-#include "renderer/kernel/shading/directshadingcomponents.h"
+#include "renderer/kernel/shading/shadingcomponents.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/kernel/shading/shadingresult.h"
 #include "renderer/modeling/aov/aov.h"
@@ -65,14 +65,14 @@ void AOVAccumulator::release()
 }
 
 void AOVAccumulator::write(
-    const DirectShadingComponents&  shading_components,
-    const float                     multiplier)
+    const ShadingComponents&    shading_components,
+    const float                 multiplier)
 {
 }
 
 void AOVAccumulator::write(
-    const ShadingPoint&             shading_point,
-    const Camera&                   camera)
+    const ShadingPoint&         shading_point,
+    const Camera&               camera)
 {
 }
 
@@ -112,8 +112,8 @@ void BeautyAOVAccumulator::reset()
 }
 
 void BeautyAOVAccumulator::write(
-    const DirectShadingComponents&  shading_components,
-    const float                     multiplier)
+    const ShadingComponents&    shading_components,
+    const float                 multiplier)
 {
     m_color = shading_components.m_beauty.to_rgb(g_std_lighting_conditions);
     m_color *= multiplier;
@@ -193,16 +193,16 @@ void AOVAccumulatorContainer::reset()
 }
 
 void AOVAccumulatorContainer::write(
-    const DirectShadingComponents&  shading_components,
-    const float                     multiplier)
+    const ShadingComponents&    shading_components,
+    const float                 multiplier)
 {
     for (size_t i = 0, e = m_size; i < e; ++i)
         m_accumulators[i]->write(shading_components, multiplier);
 }
 
 void AOVAccumulatorContainer::write(
-    const ShadingPoint&             shading_point,
-    const Camera&                   camera)
+    const ShadingPoint&         shading_point,
+    const Camera&               camera)
 {
     for (size_t i = 0, e = m_size; i < e; ++i)
         m_accumulators[i]->write(shading_point, camera);

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
@@ -159,7 +159,7 @@ void AlphaAOVAccumulator::flush(ShadingResult& result)
 // AOVAccumulatorContainer class implementation.
 //
 
-AOVAccumulatorContainer::AOVAccumulatorContainer(const AOVContainer& aovs)
+AOVAccumulatorContainer::AOVAccumulatorContainer()
   : m_size(0)
 {
     memset(m_accumulators, 0, MaxAovAccumulators * sizeof(AOVAccumulator*));
@@ -167,7 +167,11 @@ AOVAccumulatorContainer::AOVAccumulatorContainer(const AOVContainer& aovs)
     // Create beauty and alpha accumulators.
     insert(auto_release_ptr<AOVAccumulator>(new BeautyAOVAccumulator()));
     insert(auto_release_ptr<AOVAccumulator>(new AlphaAOVAccumulator()));
+}
 
+AOVAccumulatorContainer::AOVAccumulatorContainer(const AOVContainer& aovs)
+  : AOVAccumulatorContainer()
+{
     // Create the remaining accumulators.
     for (size_t i = 0, e = aovs.size(); i < e; ++i)
     {

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.h
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.h
@@ -63,7 +63,7 @@ class AOVAccumulator
     virtual ~AOVAccumulator();
 
     // Delete this instance.
-    virtual void release();
+    void release();
 
     // Reset the accumulator.
     virtual void reset() = 0;
@@ -88,6 +88,31 @@ class AOVAccumulator
     explicit AOVAccumulator(const size_t index);
 
     const size_t m_index;
+};
+
+
+//
+// Color AOV accumulator base class.
+//
+
+class ColorAOVAccumulator
+  : public AOVAccumulator
+{
+  public:
+    // Destructor.
+    ~ColorAOVAccumulator() override;
+
+    // Reset the accumulator.
+    void reset() override;
+
+    // Flush the result.
+    void flush(ShadingResult& result) override;
+
+  protected:
+    // Constructor.
+    explicit ColorAOVAccumulator(const size_t index);
+
+    foundation::Color3f m_color;
 };
 
 

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.h
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.h
@@ -44,7 +44,7 @@
 
 // Forward declarations.
 namespace renderer  { class Camera; }
-namespace renderer  { class ShadingComponents; }
+namespace renderer  { class DirectShadingComponents; }
 namespace renderer  { class ShadingPoint; }
 namespace renderer  { class ShadingResult; }
 
@@ -71,14 +71,14 @@ class AOVAccumulator
     // Write a value to the accumulator.
     // Normally, this is used for shading AOVs like diffuse, glossy...
     virtual void write(
-        const ShadingComponents&    shading_components,
-        const float                 multiplier);
+        const DirectShadingComponents&  shading_components,
+        const float                     multiplier);
 
     // Write a value to the accumulator.
     // Normally, this is used for geometry AOVs like normals, velocity...
     virtual void write(
-        const ShadingPoint&         shading_point,
-        const Camera&               camera);
+        const ShadingPoint&             shading_point,
+        const Camera&                   camera);
 
     // Flush the result.
     virtual void flush(ShadingResult& result) = 0;
@@ -111,8 +111,8 @@ class BeautyAOVAccumulator
     virtual void reset() override;
 
     virtual void write(
-        const ShadingComponents&    shading_components,
-        const float                 multiplier) override;
+        const DirectShadingComponents&  shading_components,
+        const float                     multiplier) override;
 
     virtual void flush(ShadingResult& result) override;
 
@@ -168,13 +168,13 @@ class AOVAccumulatorContainer
 
     // Write a sample to all accumulators.
     void write(
-        const ShadingComponents&    shading_components,
-        const float                 multiplier);
+        const DirectShadingComponents&  shading_components,
+        const float                     multiplier);
 
     // Write a sample to all accumulators.
     void write(
-        const ShadingPoint&         shading_point,
-        const Camera&               camera);
+        const ShadingPoint&             shading_point,
+        const Camera&                   camera);
 
     // Flush all the accumulators.
     void flush(ShadingResult& result);

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.h
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.h
@@ -44,7 +44,7 @@
 
 // Forward declarations.
 namespace renderer  { class Camera; }
-namespace renderer  { class DirectShadingComponents; }
+namespace renderer  { class ShadingComponents; }
 namespace renderer  { class ShadingPoint; }
 namespace renderer  { class ShadingResult; }
 
@@ -71,14 +71,14 @@ class AOVAccumulator
     // Write a value to the accumulator.
     // Normally, this is used for shading AOVs like diffuse, glossy...
     virtual void write(
-        const DirectShadingComponents&  shading_components,
-        const float                     multiplier);
+        const ShadingComponents&    shading_components,
+        const float                 multiplier);
 
     // Write a value to the accumulator.
     // Normally, this is used for geometry AOVs like normals, velocity...
     virtual void write(
-        const ShadingPoint&             shading_point,
-        const Camera&                   camera);
+        const ShadingPoint&         shading_point,
+        const Camera&               camera);
 
     // Flush the result.
     virtual void flush(ShadingResult& result) = 0;
@@ -111,8 +111,8 @@ class BeautyAOVAccumulator
     virtual void reset() override;
 
     virtual void write(
-        const DirectShadingComponents&  shading_components,
-        const float                     multiplier) override;
+        const ShadingComponents&    shading_components,
+        const float                 multiplier) override;
 
     virtual void flush(ShadingResult& result) override;
 
@@ -168,13 +168,13 @@ class AOVAccumulatorContainer
 
     // Write a sample to all accumulators.
     void write(
-        const DirectShadingComponents&  shading_components,
-        const float                     multiplier);
+        const ShadingComponents&    shading_components,
+        const float                 multiplier);
 
     // Write a sample to all accumulators.
     void write(
-        const ShadingPoint&             shading_point,
-        const Camera&                   camera);
+        const ShadingPoint&         shading_point,
+        const Camera&               camera);
 
     // Flush all the accumulators.
     void flush(ShadingResult& result);

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.h
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.h
@@ -155,6 +155,9 @@ class AOVAccumulatorContainer
 {
   public:
     // Constructor.
+    AOVAccumulatorContainer();
+
+    // Constructor.
     explicit AOVAccumulatorContainer(const AOVContainer& aovs);
 
     // Destructor.

--- a/src/appleseed/renderer/kernel/intersection/intersectionfilter.cpp
+++ b/src/appleseed/renderer/kernel/intersection/intersectionfilter.cpp
@@ -160,11 +160,6 @@ void IntersectionFilter::do_update(
     IntersectionFilter::AlphaMask*& mask,
     uint64&                         signature)
 {
-    // Intersection filters would prevent shading fully transparent shading points,
-    // so don't create one if shading fully transparent shading points is enabled.
-    if (entity.shade_alpha_cutouts())
-        delete_and_clear(mask);
-
     // Use the uncached version of get_alpha_map() since at this point
     // on_frame_begin() hasn't been called on the materials, when
     // intersection filters are updated on existing triangle trees

--- a/src/appleseed/renderer/kernel/lighting/bdpt/bdptlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/bdpt/bdptlightingengine.cpp
@@ -43,14 +43,13 @@ namespace
     // Bidirectional Path Tracing lighting engine.
     //
 
-    class BDPTLightingEngine 
+    class BDPTLightingEngine
       : public ILightingEngine
     {
       public:
         struct Parameters
         {
-            explicit Parameters(
-                const ParamArray&   params)
+            explicit Parameters(const ParamArray& params)
             {
 
             }
@@ -62,8 +61,7 @@ namespace
             }
         };
 
-        BDPTLightingEngine(
-            const ParamArray&   params)
+        BDPTLightingEngine(const ParamArray& params)
           : m_params(params)
         {
         }
@@ -74,11 +72,11 @@ namespace
         }
 
         virtual void compute_lighting(
-            SamplingContext&        sampling_context,
-            const PixelContext&     pixel_context,
-            const ShadingContext&   shading_context,
-            const ShadingPoint&     shading_point,
-            ShadingComponents&      radiance) override      // output radiance, in W.sr^-1.m^-2
+            SamplingContext&            sampling_context,
+            const PixelContext&         pixel_context,
+            const ShadingContext&       shading_context,
+            const ShadingPoint&         shading_point,
+            DirectShadingComponents&    radiance) override      // output radiance, in W.sr^-1.m^-2
         {
         }
 

--- a/src/appleseed/renderer/kernel/lighting/bdpt/bdptlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/bdpt/bdptlightingengine.cpp
@@ -72,11 +72,11 @@ namespace
         }
 
         virtual void compute_lighting(
-            SamplingContext&            sampling_context,
-            const PixelContext&         pixel_context,
-            const ShadingContext&       shading_context,
-            const ShadingPoint&         shading_point,
-            DirectShadingComponents&    radiance) override      // output radiance, in W.sr^-1.m^-2
+            SamplingContext&        sampling_context,
+            const PixelContext&     pixel_context,
+            const ShadingContext&   shading_context,
+            const ShadingPoint&     shading_point,
+            ShadingComponents&      radiance) override      // output radiance, in W.sr^-1.m^-2
         {
         }
 

--- a/src/appleseed/renderer/kernel/lighting/directlightingintegrator.cpp
+++ b/src/appleseed/renderer/kernel/lighting/directlightingintegrator.cpp
@@ -33,7 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/backwardlightsampler.h"
 #include "renderer/kernel/lighting/tracer.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/modeling/bsdf/bsdf.h"
@@ -101,7 +101,7 @@ void DirectLightingIntegrator::compute_outgoing_radiance_material_sampling(
     SamplingContext&            sampling_context,
     const MISHeuristic          mis_heuristic,
     const Dual3d&               outgoing,
-    ShadingComponents&          radiance) const
+    DirectShadingComponents&    radiance) const
 {
     radiance.set(0.0f);
 
@@ -126,7 +126,7 @@ void DirectLightingIntegrator::compute_outgoing_radiance_light_sampling_low_vari
     SamplingContext&            sampling_context,
     const MISHeuristic          mis_heuristic,
     const Dual3d&               outgoing,
-    ShadingComponents&          radiance) const
+    DirectShadingComponents&    radiance) const
 {
     radiance.set(0.0f);
 
@@ -158,7 +158,7 @@ void DirectLightingIntegrator::compute_outgoing_radiance_light_sampling_low_vari
     // Add contributions from the light set.
     if (m_light_sampler.has_lightset())
     {
-        ShadingComponents lightset_radiance;
+        DirectShadingComponents lightset_radiance;
 
         sampling_context.split_in_place(3, m_light_sample_count);
 
@@ -202,7 +202,7 @@ void DirectLightingIntegrator::compute_outgoing_radiance_light_sampling_low_vari
 void DirectLightingIntegrator::compute_outgoing_radiance_combined_sampling_low_variance(
     SamplingContext&            sampling_context,
     const Dual3d&               outgoing,
-    ShadingComponents&          radiance) const
+    DirectShadingComponents&    radiance) const
 {
     compute_outgoing_radiance_material_sampling(
         sampling_context,
@@ -210,8 +210,7 @@ void DirectLightingIntegrator::compute_outgoing_radiance_combined_sampling_low_v
         outgoing,
         radiance);
 
-    ShadingComponents radiance_light_sampling;
-
+    DirectShadingComponents radiance_light_sampling;
     compute_outgoing_radiance_light_sampling_low_variance(
         sampling_context,
         MISPower2,
@@ -225,13 +224,13 @@ void DirectLightingIntegrator::take_single_material_sample(
     SamplingContext&            sampling_context,
     const MISHeuristic          mis_heuristic,
     const Dual3d&               outgoing,
-    ShadingComponents&          radiance) const
+    DirectShadingComponents&    radiance) const
 {
     assert(m_light_sampler.has_hittable_lights());
 
     // Sample material.
     Dual3f incoming;
-    ShadingComponents sample_value;
+    DirectShadingComponents sample_value;
     float sample_probability;
     if (!m_material_sampler.sample(
             sampling_context,
@@ -334,7 +333,7 @@ void DirectLightingIntegrator::add_emitting_triangle_sample_contribution(
     const LightSample&          sample,
     const MISHeuristic          mis_heuristic,
     const Dual3d&               outgoing,
-    ShadingComponents&          radiance) const
+    DirectShadingComponents&    radiance) const
 {
     const Material* material = sample.m_triangle->m_material;
     const Material::RenderData& material_data = material->get_render_data();
@@ -409,7 +408,7 @@ void DirectLightingIntegrator::add_emitting_triangle_sample_contribution(
         return;
 
     // Evaluate the BSDF (or volume).
-    ShadingComponents material_value;
+    DirectShadingComponents material_value;
     const float material_probability =
         m_material_sampler.evaluate(
             m_light_sampling_modes,
@@ -461,7 +460,7 @@ void DirectLightingIntegrator::add_non_physical_light_sample_contribution(
     SamplingContext&            sampling_context,
     const LightSample&          sample,
     const Dual3d&               outgoing,
-    ShadingComponents&          radiance) const
+    DirectShadingComponents&    radiance) const
 {
     const Light* light = sample.m_light;
 
@@ -505,7 +504,7 @@ void DirectLightingIntegrator::add_non_physical_light_sample_contribution(
         return;
 
     // Evaluate the BSDF (or volume).
-    ShadingComponents material_value;
+    DirectShadingComponents material_value;
     const float material_probability =
         m_material_sampler.evaluate(
             m_light_sampling_modes,

--- a/src/appleseed/renderer/kernel/lighting/directlightingintegrator.h
+++ b/src/appleseed/renderer/kernel/lighting/directlightingintegrator.h
@@ -47,7 +47,7 @@
 // Forward declarations.
 namespace renderer  { class BackwardLightSampler; }
 namespace renderer  { class LightSample; }
-namespace renderer  { class ShadingComponents; }
+namespace renderer  { class DirectShadingComponents; }
 namespace renderer  { class ShadingContext; }
 namespace renderer  { class ShadingPoint; }
 
@@ -89,21 +89,21 @@ class DirectLightingIntegrator
     void compute_outgoing_radiance_combined_sampling_low_variance(
         SamplingContext&                sampling_context,
         const foundation::Dual3d&       outgoing,                   // world space outgoing direction, unit-length
-        ShadingComponents&              radiance) const;
+        DirectShadingComponents&        radiance) const;
 
     // Compute outgoing radiance due to direct lighting via BSDF sampling only.
     void compute_outgoing_radiance_material_sampling(
         SamplingContext&                sampling_context,
         const foundation::MISHeuristic  mis_heuristic,
         const foundation::Dual3d&       outgoing,                   // world space outgoing direction, unit-length
-        ShadingComponents&              radiance) const;
+        DirectShadingComponents&        radiance) const;
 
     // Compute outgoing radiance due to direct lighting via light sampling only.
     void compute_outgoing_radiance_light_sampling_low_variance(
         SamplingContext&                sampling_context,
         const foundation::MISHeuristic  mis_heuristic,
         const foundation::Dual3d&       outgoing,                   // world space outgoing direction, unit-length
-        ShadingComponents&              radiance) const;
+        DirectShadingComponents&        radiance) const;
 
   private:
     const ShadingContext&               m_shading_context;
@@ -121,20 +121,20 @@ class DirectLightingIntegrator
         SamplingContext&                sampling_context,
         const foundation::MISHeuristic  mis_heuristic,
         const foundation::Dual3d&       outgoing,
-        ShadingComponents&              radiance) const;
+        DirectShadingComponents&        radiance) const;
 
     void add_emitting_triangle_sample_contribution(
         SamplingContext&                sampling_context,
         const LightSample&              sample,
         const foundation::MISHeuristic  mis_heuristic,
         const foundation::Dual3d&       outgoing,
-        ShadingComponents&              radiance) const;
+        DirectShadingComponents&        radiance) const;
 
     void add_non_physical_light_sample_contribution(
         SamplingContext&                sampling_context,
         const LightSample&              sample,
         const foundation::Dual3d&       outgoing,
-        ShadingComponents&              radiance) const;
+        DirectShadingComponents&        radiance) const;
 };
 
 }       // namespace renderer

--- a/src/appleseed/renderer/kernel/lighting/ilightingengine.h
+++ b/src/appleseed/renderer/kernel/lighting/ilightingengine.h
@@ -40,7 +40,7 @@
 namespace foundation    { class Dictionary; }
 namespace foundation    { class StatisticsVector; }
 namespace renderer      { class PixelContext; }
-namespace renderer      { class ShadingComponents; }
+namespace renderer      { class DirectShadingComponents; }
 namespace renderer      { class ShadingContext; }
 namespace renderer      { class ShadingPoint; }
 
@@ -57,11 +57,11 @@ class ILightingEngine
   public:
     // Compute the lighting at a given point of the scene.
     virtual void compute_lighting(
-        SamplingContext&        sampling_context,
-        const PixelContext&     pixel_context,
-        const ShadingContext&   shading_context,
-        const ShadingPoint&     shading_point,
-        ShadingComponents&      radiance) = 0;      // output radiance, in W.sr^-1.m^-2
+        SamplingContext&          sampling_context,
+        const PixelContext&       pixel_context,
+        const ShadingContext&     shading_context,
+        const ShadingPoint&       shading_point,
+        DirectShadingComponents&  radiance) = 0;      // output radiance, in W.sr^-1.m^-2
 
     // Retrieve performance statistics.
     virtual foundation::StatisticsVector get_statistics() const = 0;
@@ -81,8 +81,8 @@ class ILightingEngineFactory
 
   protected:
     static void add_common_params_metadata(
-        foundation::Dictionary& metadata,
-        const bool              add_lighting_samples);
+        foundation::Dictionary&   metadata,
+        const bool                add_lighting_samples);
 };
 
 }       // namespace renderer

--- a/src/appleseed/renderer/kernel/lighting/ilightingengine.h
+++ b/src/appleseed/renderer/kernel/lighting/ilightingengine.h
@@ -40,7 +40,7 @@
 namespace foundation    { class Dictionary; }
 namespace foundation    { class StatisticsVector; }
 namespace renderer      { class PixelContext; }
-namespace renderer      { class DirectShadingComponents; }
+namespace renderer      { class ShadingComponents; }
 namespace renderer      { class ShadingContext; }
 namespace renderer      { class ShadingPoint; }
 
@@ -61,7 +61,7 @@ class ILightingEngine
         const PixelContext&       pixel_context,
         const ShadingContext&     shading_context,
         const ShadingPoint&       shading_point,
-        DirectShadingComponents&  radiance) = 0;      // output radiance, in W.sr^-1.m^-2
+        ShadingComponents&        radiance) = 0;      // output radiance, in W.sr^-1.m^-2
 
     // Retrieve performance statistics.
     virtual foundation::StatisticsVector get_statistics() const = 0;

--- a/src/appleseed/renderer/kernel/lighting/imagebasedlighting.cpp
+++ b/src/appleseed/renderer/kernel/lighting/imagebasedlighting.cpp
@@ -33,7 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/materialsamplers.h"
 #include "renderer/kernel/lighting/tracer.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/modeling/bsdf/bsdf.h"
@@ -62,7 +62,7 @@ void compute_ibl_combined_sampling(
     const int                   env_sampling_modes,
     const size_t                material_sample_count,
     const size_t                env_sample_count,
-    ShadingComponents&          radiance)
+    DirectShadingComponents&    radiance)
 {
     assert(is_normalized(outgoing.get_value()));
 
@@ -78,7 +78,7 @@ void compute_ibl_combined_sampling(
         radiance);
 
     // Compute IBL by sampling the environment.
-    ShadingComponents radiance_env_sampling;
+    DirectShadingComponents radiance_env_sampling;
     compute_ibl_environment_sampling(
         sampling_context,
         shading_context,
@@ -100,7 +100,7 @@ void compute_ibl_material_sampling(
     const IMaterialSampler&     material_sampler,
     const size_t                bsdf_sample_count,
     const size_t                env_sample_count,
-    ShadingComponents&          radiance)
+    DirectShadingComponents&    radiance)
 {
     assert(is_normalized(outgoing.get_value()));
 
@@ -114,7 +114,7 @@ void compute_ibl_material_sampling(
         // afterward. We need a mechanism to indicate that we want the contribution of some of
         // the components only.
         Dual3f incoming;
-        ShadingComponents material_value;
+        DirectShadingComponents material_value;
         float material_prob;
         if (!material_sampler.sample(
                 sampling_context,
@@ -172,7 +172,7 @@ void compute_ibl_environment_sampling(
     const int                   env_sampling_modes,
     const size_t                material_sample_count,
     const size_t                env_sample_count,
-    ShadingComponents&          radiance)
+    DirectShadingComponents&    radiance)
 {
     assert(is_normalized(outgoing.get_value()));
 
@@ -212,7 +212,7 @@ void compute_ibl_environment_sampling(
             continue;
 
         // Evaluate the BSDF.
-        ShadingComponents material_value;
+        DirectShadingComponents material_value;
         const float material_prob = material_sampler.evaluate(
             env_sampling_modes,
             Vector3f(outgoing.get_value()),

--- a/src/appleseed/renderer/kernel/lighting/imagebasedlighting.h
+++ b/src/appleseed/renderer/kernel/lighting/imagebasedlighting.h
@@ -44,7 +44,7 @@
 namespace renderer  { class BSDF; }
 namespace renderer  { class EnvironmentEDF; }
 namespace renderer  { class IMaterialSampler; }
-namespace renderer  { class ShadingComponents; }
+namespace renderer  { class DirectShadingComponents; }
 namespace renderer  { class ShadingContext; }
 namespace renderer  { class ShadingPoint; }
 
@@ -65,7 +65,7 @@ void compute_ibl_combined_sampling(
     const int                       env_sampling_modes,     // permitted scattering modes during environment sampling
     const size_t                    material_sample_count,  // number of samples in BSDF sampling
     const size_t                    env_sample_count,       // number of samples in environment sampling
-    ShadingComponents&              radiance);
+    DirectShadingComponents&        radiance);
 
 // Compute outgoing radiance due to image-based lighting via BSDF sampling only.
 void compute_ibl_material_sampling(
@@ -76,7 +76,7 @@ void compute_ibl_material_sampling(
     const IMaterialSampler&         material_sampler,
     const size_t                    material_sample_count,  // number of samples in BSDF sampling
     const size_t                    env_sample_count,       // number of samples in environment sampling
-    ShadingComponents&              radiance);
+    DirectShadingComponents&        radiance);
 
 // Compute outgoing radiance due to image-based lighting via environment sampling only.
 void compute_ibl_environment_sampling(
@@ -88,7 +88,7 @@ void compute_ibl_environment_sampling(
     const int                       env_sampling_modes,     // permitted scattering modes during environment sampling
     const size_t                    material_sample_count,
     const size_t                    env_sample_count,       // number of samples in environment sampling
-    ShadingComponents&              radiance);
+    DirectShadingComponents&        radiance);
 
 }       // namespace renderer
 

--- a/src/appleseed/renderer/kernel/lighting/imagebasedlighting.h
+++ b/src/appleseed/renderer/kernel/lighting/imagebasedlighting.h
@@ -42,9 +42,9 @@
 
 // Forward declarations.
 namespace renderer  { class BSDF; }
+namespace renderer  { class DirectShadingComponents; }
 namespace renderer  { class EnvironmentEDF; }
 namespace renderer  { class IMaterialSampler; }
-namespace renderer  { class DirectShadingComponents; }
 namespace renderer  { class ShadingContext; }
 namespace renderer  { class ShadingPoint; }
 

--- a/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
@@ -457,7 +457,7 @@ namespace
                         shading_normal);
 
                 // Evaluate the BSDF at the vertex position.
-                ShadingComponents bsdf_value;
+                DirectShadingComponents bsdf_value;
                 const float bsdf_prob =
                     vertex.m_bsdf->evaluate(
                         vertex.m_bsdf_data,

--- a/src/appleseed/renderer/kernel/lighting/materialsamplers.cpp
+++ b/src/appleseed/renderer/kernel/lighting/materialsamplers.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/tracer.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/modeling/bsdf/bsdf.h"
@@ -49,10 +49,10 @@ namespace renderer
 //
 
 BSDFSampler::BSDFSampler(
-    const BSDF&             bsdf,
-    const void*             bsdf_data,
-    const int               bsdf_sampling_modes,
-    const ShadingPoint&     shading_point)
+    const BSDF&                 bsdf,
+    const void*                 bsdf_data,
+    const int                   bsdf_sampling_modes,
+    const ShadingPoint&         shading_point)
   : m_bsdf(bsdf)
   , m_bsdf_data(bsdf_data)
   , m_bsdf_sampling_modes(bsdf_sampling_modes)
@@ -74,11 +74,11 @@ bool BSDFSampler::contributes_to_light_sampling() const
 }
 
 bool BSDFSampler::sample(
-    SamplingContext&        sampling_context,
-    const Dual3d&           outgoing,
-    Dual3f&                 incoming,
-    ShadingComponents&      value,
-    float&                  pdf) const
+    SamplingContext&            sampling_context,
+    const Dual3d&               outgoing,
+    Dual3f&                     incoming,
+    DirectShadingComponents&    value,
+    float&                      pdf) const
 {
     BSDFSample sample(&m_shading_point, Dual3f(outgoing));
     m_bsdf.sample(
@@ -100,10 +100,10 @@ bool BSDFSampler::sample(
 }
 
 float BSDFSampler::evaluate(
-    const int               light_sampling_modes,
-    const Vector3f&         outgoing,
-    const Vector3f&         incoming,
-    ShadingComponents&      value) const
+    const int                   light_sampling_modes,
+    const Vector3f&             outgoing,
+    const Vector3f&             incoming,
+    DirectShadingComponents&    value) const
 {
     return
         m_bsdf.evaluate(
@@ -119,9 +119,9 @@ float BSDFSampler::evaluate(
 }
 
 const ShadingPoint& BSDFSampler::trace(
-    const ShadingContext&   shading_context,
-    const Vector3f&         direction,
-    Spectrum&               transmission) const
+    const ShadingContext&       shading_context,
+    const Vector3f&             direction,
+    Spectrum&                   transmission) const
 {
     ShadingRay ray(
         m_shading_point.get_point(),
@@ -142,9 +142,9 @@ const ShadingPoint& BSDFSampler::trace(
 }
 
 void BSDFSampler::trace_between(
-    const ShadingContext&   shading_context,
-    const Vector3d&         target_position,
-    Spectrum&               transmission) const
+    const ShadingContext&       shading_context,
+    const Vector3d&             target_position,
+    Spectrum&                   transmission) const
 {
     shading_context.get_tracer().trace_between_simple(
         shading_context,
@@ -176,10 +176,10 @@ bool BSDFSampler::cull_incoming_direction(const Vector3d& incoming) const
 //
 
 VolumeSampler::VolumeSampler(
-    const ShadingRay&       volume_ray,
-    const Volume&           volume,
-    const void*             volume_data,
-    const float             distance)
+    const ShadingRay&           volume_ray,
+    const Volume&               volume,
+    const void*                 volume_data,
+    const float                 distance)
   : m_volume_ray(volume_ray)
   , m_volume(volume)
   , m_volume_data(volume_data)
@@ -199,11 +199,11 @@ bool VolumeSampler::contributes_to_light_sampling() const
 }
 
 bool VolumeSampler::sample(
-    SamplingContext&        sampling_context,
-    const Dual3d&           outgoing,
-    Dual3f&                 incoming,
-    ShadingComponents&      value,
-    float&                  pdf) const
+    SamplingContext&            sampling_context,
+    const Dual3d&               outgoing,
+    Dual3f&                     incoming,
+    DirectShadingComponents&    value,
+    float&                      pdf) const
 {
     Vector3f incoming_direction;
 
@@ -225,10 +225,10 @@ bool VolumeSampler::sample(
 }
 
 float VolumeSampler::evaluate(
-    const int               light_sampling_modes,
-    const Vector3f&         outgoing,
-    const Vector3f&         incoming,
-    ShadingComponents&      value) const
+    const int                   light_sampling_modes,
+    const Vector3f&             outgoing,
+    const Vector3f&             incoming,
+    DirectShadingComponents&    value) const
 {
     const float pdf =
         m_volume.evaluate(
@@ -246,9 +246,9 @@ float VolumeSampler::evaluate(
 }
 
 const ShadingPoint& VolumeSampler::trace(
-    const ShadingContext&   shading_context,
-    const Vector3f&         direction,
-    Spectrum&               transmission) const
+    const ShadingContext&       shading_context,
+    const Vector3f&             direction,
+    Spectrum&                   transmission) const
 {
     ShadingRay ray(
         m_point,
@@ -268,9 +268,9 @@ const ShadingPoint& VolumeSampler::trace(
 }
 
 void VolumeSampler::trace_between(
-    const ShadingContext&   shading_context,
-    const Vector3d&         target_position,
-    Spectrum&               transmission) const
+    const ShadingContext&       shading_context,
+    const Vector3d&             target_position,
+    Spectrum&                   transmission) const
 {
     shading_context.get_tracer().trace_between_simple(
         shading_context,

--- a/src/appleseed/renderer/kernel/lighting/materialsamplers.h
+++ b/src/appleseed/renderer/kernel/lighting/materialsamplers.h
@@ -40,7 +40,7 @@
 
 // Forward declarations.
 namespace renderer  { class BSDF; }
-namespace renderer  { class ShadingComponents; }
+namespace renderer  { class DirectShadingComponents; }
 namespace renderer  { class ShadingContext; }
 namespace renderer  { class ShadingPoint; }
 
@@ -74,14 +74,14 @@ class IMaterialSampler
         SamplingContext&                sampling_context,
         const foundation::Dual3d&       outgoing,
         foundation::Dual3f&             incoming,
-        ShadingComponents&              value,
+        DirectShadingComponents&        value,
         float&                          pdf) const = 0;
 
     virtual float evaluate(
         const int                       light_sampling_modes,
         const foundation::Vector3f&     outgoing,
         const foundation::Vector3f&     incoming,
-        ShadingComponents&              value) const = 0;
+        DirectShadingComponents&        value) const = 0;
 
     virtual bool cull_incoming_direction(
         const foundation::Vector3d&     incoming) const = 0;
@@ -115,14 +115,14 @@ class BSDFSampler
         SamplingContext&                sampling_context,
         const foundation::Dual3d&       outgoing,
         foundation::Dual3f&             incoming,
-        ShadingComponents&              value,
+        DirectShadingComponents&        value,
         float&                          pdf) const override;
 
     virtual float evaluate(
         const int                       light_sampling_modes,
         const foundation::Vector3f&     outgoing,
         const foundation::Vector3f&     incoming,
-        ShadingComponents&              value) const override;
+        DirectShadingComponents&        value) const override;
 
     virtual bool cull_incoming_direction(
         const foundation::Vector3d&  incoming) const override;
@@ -164,14 +164,14 @@ class VolumeSampler
         SamplingContext&                sampling_context,
         const foundation::Dual3d&       outgoing,
         foundation::Dual3f&             incoming,
-        ShadingComponents&              value,
+        DirectShadingComponents&        value,
         float&                          pdf) const override;
 
     virtual float evaluate(
         const int                       light_sampling_modes,
         const foundation::Vector3f&     outgoing,
         const foundation::Vector3f&     incoming,
-        ShadingComponents&              value) const override;
+        DirectShadingComponents&        value) const override;
 
     virtual bool cull_incoming_direction(
         const foundation::Vector3d&     incoming) const override;

--- a/src/appleseed/renderer/kernel/lighting/null/nulllightingengine.h
+++ b/src/appleseed/renderer/kernel/lighting/null/nulllightingengine.h
@@ -39,7 +39,7 @@
 
 // Forward declarations.
 namespace renderer  { class PixelContext; }
-namespace renderer  { class ShadingComponents; }
+namespace renderer  { class DirectShadingComponents; }
 namespace renderer  { class ShadingContext; }
 namespace renderer  { class ShadingPoint; }
 
@@ -62,11 +62,11 @@ class NullLightingEngine
 
     // Compute the lighting at a given point of the scene.
     virtual void compute_lighting(
-        SamplingContext&        sampling_context,
-        const PixelContext&     pixel_context,
-        const ShadingContext&   shading_context,
-        const ShadingPoint&     shading_point,
-        ShadingComponents&      radiance) override
+        SamplingContext&            sampling_context,
+        const PixelContext&         pixel_context,
+        const ShadingContext&       shading_context,
+        const ShadingPoint&         shading_point,
+        DirectShadingComponents&    radiance) override
     {
     }
 };

--- a/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.cpp
@@ -1110,13 +1110,9 @@ namespace
                     }
 
                     radiance *= vertex.m_throughput;
-
-                    const float scalar_weight = current_mis_weight /
-                        (distance_sample_count_float * distance_prob);
-                    radiance *= transmission * scalar_weight;
-
-                    m_path_radiance.add(
-                        vertex.m_path_length, vertex.m_aov_mode, radiance);
+                    radiance *= transmission;
+                    radiance *= current_mis_weight / (distance_sample_count_float * distance_prob);
+                    m_path_radiance.add(vertex.m_path_length, vertex.m_aov_mode, radiance);
                 }
             }
         };

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmlightingengine.cpp
@@ -39,7 +39,7 @@
 #include "renderer/kernel/lighting/sppm/sppmpasscallback.h"
 #include "renderer/kernel/lighting/sppm/sppmphoton.h"
 #include "renderer/kernel/lighting/sppm/sppmphotonmap.h"
-#include "renderer/kernel/shading/directshadingcomponents.h"
+#include "renderer/kernel/shading/shadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/modeling/bsdf/bsdf.h"
@@ -148,7 +148,7 @@ namespace
             const PixelContext&         pixel_context,
             const ShadingContext&       shading_context,
             const ShadingPoint&         shading_point,
-            DirectShadingComponents&    radiance) override      // output radiance, in W.sr^-1.m^-2
+            ShadingComponents&          radiance) override      // output radiance, in W.sr^-1.m^-2
         {
             if (m_params.m_view_photons)
             {
@@ -219,7 +219,7 @@ namespace
             const ShadingContext&           m_shading_context;
             const EnvironmentEDF*           m_env_edf;
             knn::Answer<float>&             m_answer;
-            DirectShadingComponents&        m_path_radiance;
+            ShadingComponents&              m_path_radiance;
 
             PathVisitor(
                 const SPPMParameters&           params,
@@ -230,7 +230,7 @@ namespace
                 const ShadingContext&           shading_context,
                 const Scene&                    scene,
                 knn::Answer<float>&             answer,
-                DirectShadingComponents&        path_radiance)
+                ShadingComponents&              path_radiance)
               : m_params(params)
               , m_pass_callback(pass_callback)
               , m_forward_light_sampler(forward_light_sampler)
@@ -313,11 +313,7 @@ namespace
 
                 // Update the path radiance.
                 vertex_radiance *= vertex.m_throughput;
-
-                if (vertex.m_path_length == 1)
-                    m_path_radiance += vertex_radiance;
-                else
-                    m_path_radiance.add_to_component(vertex.m_aov_mode, vertex_radiance);
+                m_path_radiance.add(vertex.m_path_length, vertex.m_aov_mode, vertex_radiance);
             }
 
             void on_scatter(const PathVertex& vertex)

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmlightingengine.cpp
@@ -39,7 +39,7 @@
 #include "renderer/kernel/lighting/sppm/sppmpasscallback.h"
 #include "renderer/kernel/lighting/sppm/sppmphoton.h"
 #include "renderer/kernel/lighting/sppm/sppmphotonmap.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/modeling/bsdf/bsdf.h"
@@ -144,11 +144,11 @@ namespace
         }
 
         virtual void compute_lighting(
-            SamplingContext&        sampling_context,
-            const PixelContext&     pixel_context,
-            const ShadingContext&   shading_context,
-            const ShadingPoint&     shading_point,
-            ShadingComponents&      radiance) override      // output radiance, in W.sr^-1.m^-2
+            SamplingContext&            sampling_context,
+            const PixelContext&         pixel_context,
+            const ShadingContext&       shading_context,
+            const ShadingPoint&         shading_point,
+            DirectShadingComponents&    radiance) override      // output radiance, in W.sr^-1.m^-2
         {
             if (m_params.m_view_photons)
             {
@@ -219,7 +219,7 @@ namespace
             const ShadingContext&           m_shading_context;
             const EnvironmentEDF*           m_env_edf;
             knn::Answer<float>&             m_answer;
-            ShadingComponents&              m_path_radiance;
+            DirectShadingComponents&        m_path_radiance;
 
             PathVisitor(
                 const SPPMParameters&           params,
@@ -230,7 +230,7 @@ namespace
                 const ShadingContext&           shading_context,
                 const Scene&                    scene,
                 knn::Answer<float>&             answer,
-                ShadingComponents&              path_radiance)
+                DirectShadingComponents&        path_radiance)
               : m_params(params)
               , m_pass_callback(pass_callback)
               , m_forward_light_sampler(forward_light_sampler)
@@ -287,7 +287,7 @@ namespace
 
             void on_hit(const PathVertex& vertex)
             {
-                ShadingComponents vertex_radiance;
+                DirectShadingComponents vertex_radiance;
 
                 if (vertex.m_bsdf)
                 {
@@ -325,10 +325,10 @@ namespace
             }
 
             void add_direct_lighting_contribution(
-                const PathVertex&       vertex,
-                ShadingComponents&      vertex_radiance)
+                const PathVertex&           vertex,
+                DirectShadingComponents&    vertex_radiance)
             {
-                ShadingComponents dl_radiance;
+                DirectShadingComponents dl_radiance;
 
                 const size_t light_sample_count =
                     stochastic_cast<size_t>(
@@ -375,8 +375,8 @@ namespace
             }
 
             void add_photon_map_lighting_contribution(
-                const PathVertex&       vertex,
-                ShadingComponents&      vertex_radiance)
+                const PathVertex&           vertex,
+                DirectShadingComponents&    vertex_radiance)
             {
                 const SPPMPhotonMap& photon_map = m_pass_callback.get_photon_map();
 
@@ -479,7 +479,7 @@ namespace
 #endif
 
                     // Evaluate the BSDF for this photon.
-                    ShadingComponents bsdf_value;
+                    DirectShadingComponents bsdf_value;
                     const float bsdf_prob =
                         vertex.m_bsdf->evaluate(
                             vertex.m_bsdf_data,
@@ -551,7 +551,7 @@ namespace
 #endif
 
                     // Evaluate the BSDF for this photon.
-                    ShadingComponents bsdf_value;
+                    DirectShadingComponents bsdf_value;
                     const float bsdf_prob =
                         vertex.m_bsdf->evaluate(
                             vertex.m_bsdf_data,

--- a/src/appleseed/renderer/kernel/rendering/debug/blanksamplerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/debug/blanksamplerenderer.cpp
@@ -62,10 +62,11 @@ namespace
         }
 
         virtual void render_sample(
-            SamplingContext&    sampling_context,
-            const PixelContext& pixel_context,
-            const Vector2d&     image_point,
-            ShadingResult&      shading_result) override
+            SamplingContext&            sampling_context,
+            const PixelContext&         pixel_context,
+            const Vector2d&             image_point,
+            AOVAccumulatorContainer&    aov_accumulators,
+            ShadingResult&              shading_result) override
         {
             shading_result.m_main.set(0.0f);
         }

--- a/src/appleseed/renderer/kernel/rendering/debug/debugsamplerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/debug/debugsamplerenderer.cpp
@@ -67,10 +67,11 @@ namespace
         }
 
         virtual void render_sample(
-            SamplingContext&    sampling_context,
-            const PixelContext& pixel_context,
-            const Vector2d&     image_point,
-            ShadingResult&      shading_result) override
+            SamplingContext&            sampling_context,
+            const PixelContext&         pixel_context,
+            const Vector2d&             image_point,
+            AOVAccumulatorContainer&    aov_accumulators,
+            ShadingResult&              shading_result) override
         {
             const Vector2d v = Vector2d(0.5) - image_point;
             const double d = norm(v) * 2.0;

--- a/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
@@ -162,6 +162,7 @@ namespace
             const size_t                pass_hash,
             const Vector2i&             pi,
             const Vector2i&             pt,
+            AOVAccumulatorContainer&    aov_accumulators,
             ShadingResultFrameBuffer&   framebuffer) override
         {
             const size_t aov_count = frame.aov_images().size();
@@ -217,6 +218,7 @@ namespace
                         child_sampling_context,
                         pixel_context,
                         sample_position,
+                        aov_accumulators,
                         shading_result);
 
                     // Ignore invalid samples.

--- a/src/appleseed/renderer/kernel/rendering/final/uniformpixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/uniformpixelrenderer.cpp
@@ -118,6 +118,7 @@ namespace
             const size_t                pass_hash,
             const Vector2i&             pi,
             const Vector2i&             pt,
+            AOVAccumulatorContainer&    aov_accumulators,
             ShadingResultFrameBuffer&   framebuffer) override
         {
             const size_t aov_count = frame.aov_images().size();
@@ -159,6 +160,7 @@ namespace
                         child_sampling_context,
                         pixel_context,
                         sample_position,
+                        aov_accumulators,
                         shading_result);
 
                     // Update sampling statistics.
@@ -216,6 +218,7 @@ namespace
                             sampling_context,
                             pixel_context,
                             sample_position,
+                            aov_accumulators,
                             shading_result);
 
                         // Update sampling statistics.

--- a/src/appleseed/renderer/kernel/rendering/generic/genericsamplegenerator.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericsamplegenerator.cpp
@@ -32,6 +32,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
+#include "renderer/kernel/aov/aovaccumulator.h"
 #include "renderer/kernel/rendering/isamplerenderer.h"
 #include "renderer/kernel/rendering/localsampleaccumulationbuffer.h"
 #include "renderer/kernel/rendering/pixelcontext.h"
@@ -139,6 +140,8 @@ namespace
 
         Population<uint64>                  m_total_sampling_dim;
 
+        AOVAccumulatorContainer             m_aov_accumulators;
+
         virtual size_t generate_samples(
             const size_t                    sequence_index,
             SampleVector&                   samples) override
@@ -182,6 +185,7 @@ namespace
                 sampling_context,
                 pixel_context,
                 sample_position,
+                m_aov_accumulators,
                 shading_result);
 
             // Update sampling statistics.

--- a/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
@@ -132,7 +132,6 @@ namespace
                 m_lighting_engine,
                 m_params.m_transparency_threshold,
                 m_params.m_max_iterations)
-          , m_aov_accumulators(frame.aovs())
         {
             // 1/4 of a pixel, like in RenderMan RIS.
             const CanvasProperties& c = frame.image().properties();
@@ -151,10 +150,11 @@ namespace
         }
 
         virtual void render_sample(
-            SamplingContext&        sampling_context,
-            const PixelContext&     pixel_context,
-            const Vector2d&         image_point,
-            ShadingResult&          shading_result) override
+            SamplingContext&            sampling_context,
+            const PixelContext&         pixel_context,
+            const Vector2d&             image_point,
+            AOVAccumulatorContainer&    aov_accumulators,
+            ShadingResult&              shading_result) override
         {
 #ifdef DEBUG_DISPLAY_TEXTURE_CACHE_PERFORMANCES
 
@@ -199,7 +199,7 @@ namespace
                 shading_point_ptr = &shading_points[shading_point_index];
                 shading_point_index = 1 - shading_point_index;
 
-                m_aov_accumulators.reset();
+                aov_accumulators.reset();
 
                 if (iterations == 1)
                 {
@@ -209,13 +209,13 @@ namespace
                         pixel_context,
                         m_shading_context,
                         *shading_point_ptr,
-                        m_aov_accumulators);
+                        aov_accumulators);
 
-                    m_aov_accumulators.write(
+                    aov_accumulators.write(
                         *shading_point_ptr,
                         *m_scene.get_active_camera());
 
-                    m_aov_accumulators.flush(shading_result);
+                    aov_accumulators.flush(shading_result);
 
                     // Apply alpha premultiplication.
                     if (shading_point_ptr->hit())
@@ -230,13 +230,13 @@ namespace
                         pixel_context,
                         m_shading_context,
                         *shading_point_ptr,
-                        m_aov_accumulators);
+                        aov_accumulators);
 
-                    m_aov_accumulators.write(
+                    aov_accumulators.write(
                         *shading_point_ptr,
                         *m_scene.get_active_camera());
 
-                    m_aov_accumulators.flush(local_result);
+                    aov_accumulators.flush(local_result);
 
                     // Apply alpha premultiplication.
                     if (shading_point_ptr->hit())
@@ -329,8 +329,6 @@ namespace
 
         Vector2d                    m_image_point_dx;
         Vector2d                    m_image_point_dy;
-
-        AOVAccumulatorContainer     m_aov_accumulators;
     };
 }
 

--- a/src/appleseed/renderer/kernel/rendering/generic/generictilerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/generictilerenderer.cpp
@@ -33,6 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
 #include "renderer/global/globaltypes.h"
+#include "renderer/kernel/aov/aovaccumulator.h"
 #include "renderer/kernel/aov/imagestack.h"
 #include "renderer/kernel/aov/tilestack.h"
 #include "renderer/kernel/rendering/ipixelrenderer.h"
@@ -98,6 +99,7 @@ namespace
             const ParamArray&                   params,
             const size_t                        thread_index)
           : m_pixel_renderer(pixel_renderer_factory->create(thread_index))
+          , m_aov_accumulators(frame.aovs())
           , m_framebuffer_factory(framebuffer_factory)
         {
             compute_tile_margins(frame, thread_index == 0);
@@ -195,6 +197,7 @@ namespace
                     pass_hash,
                     pi,
                     pt,
+                    m_aov_accumulators,
                     *framebuffer);
             }
 
@@ -215,6 +218,7 @@ namespace
 
       protected:
         auto_release_ptr<IPixelRenderer>    m_pixel_renderer;
+        AOVAccumulatorContainer             m_aov_accumulators;
         IShadingResultFrameBufferFactory*   m_framebuffer_factory;
         int                                 m_margin_width;
         int                                 m_margin_height;

--- a/src/appleseed/renderer/kernel/rendering/ipixelrenderer.h
+++ b/src/appleseed/renderer/kernel/rendering/ipixelrenderer.h
@@ -41,6 +41,7 @@
 // Forward declarations.
 namespace foundation    { class StatisticsVector; }
 namespace foundation    { class Tile; }
+namespace renderer      { class AOVAccumulatorContainer; }
 namespace renderer      { class Frame; }
 namespace renderer      { class ShadingResultFrameBuffer; }
 namespace renderer      { class TileStack; }
@@ -75,8 +76,9 @@ class IPixelRenderer
         TileStack&                  aov_tiles,
         const foundation::AABB2i&   tile_bbox,
         const size_t                pass_hash,
-        const foundation::Vector2i& pi,             // image-space pixel coordinates
-        const foundation::Vector2i& pt,             // tile-space pixel coordinates
+        const foundation::Vector2i& pi,               // image-space pixel coordinates
+        const foundation::Vector2i& pt,               // tile-space pixel coordinates
+        AOVAccumulatorContainer&    aov_accumulators,
         ShadingResultFrameBuffer&   framebuffer) = 0;
 
     // Retrieve performance statistics.

--- a/src/appleseed/renderer/kernel/rendering/isamplerenderer.h
+++ b/src/appleseed/renderer/kernel/rendering/isamplerenderer.h
@@ -42,6 +42,7 @@
 
 // Forward declarations.
 namespace foundation    { class StatisticsVector; }
+namespace renderer      { class AOVAccumulatorContainer; }
 namespace renderer      { class PixelContext; }
 namespace renderer      { class ShadingResult; }
 
@@ -62,6 +63,7 @@ class ISampleRenderer
         SamplingContext&                sampling_context,
         const PixelContext&             pixel_context,
         const foundation::Vector2d&     image_point,
+        AOVAccumulatorContainer&        aov_accumulators,
         ShadingResult&                  shading_result) = 0;
 
     // Retrieve performance statistics.

--- a/src/appleseed/renderer/kernel/shading/directshadingcomponents.cpp
+++ b/src/appleseed/renderer/kernel/shading/directshadingcomponents.cpp
@@ -27,7 +27,7 @@
 //
 
 // Interface header.
-#include "shadingcomponents.h"
+#include "directshadingcomponents.h"
 
 // appleseed.foundation headers.
 #include "foundation/utility/otherwise.h"
@@ -36,15 +36,15 @@ namespace renderer
 {
 
 //
-// ShadingComponents class implementation.
+// DirectShadingComponents class implementation.
 //
 
-ShadingComponents::ShadingComponents()
+DirectShadingComponents::DirectShadingComponents()
 {
     set(0.0f);
 }
 
-void ShadingComponents::set(const float val)
+void DirectShadingComponents::set(const float val)
 {
     m_beauty.set(0.0f);
     m_diffuse.set(0.0f);
@@ -53,9 +53,9 @@ void ShadingComponents::set(const float val)
     m_emission.set(0.0f);
 }
 
-void ShadingComponents::add_to_component(
-    const ScatteringMode::Mode  scattering_mode,
-    const Spectrum&             value)
+void DirectShadingComponents::add_to_component(
+    const ScatteringMode::Mode      scattering_mode,
+    const Spectrum&                 value)
 {
     switch (scattering_mode)
     {
@@ -76,18 +76,18 @@ void ShadingComponents::add_to_component(
     }
 }
 
-void ShadingComponents::add_to_component(
-    const ScatteringMode::Mode  scattering_mode,
-    const ShadingComponents&    value)
+void DirectShadingComponents::add_to_component(
+    const ScatteringMode::Mode      scattering_mode,
+    const DirectShadingComponents&  value)
 {
     m_beauty += value.m_beauty;
     add_to_component(scattering_mode, value.m_beauty);
 }
 
-void ShadingComponents::add_emission(
-    const size_t                path_length,
-    const ScatteringMode::Mode  scattering_mode,
-    const Spectrum&             value)
+void DirectShadingComponents::add_emission(
+    const size_t                    path_length,
+    const ScatteringMode::Mode      scattering_mode,
+    const Spectrum&                 value)
 {
     m_beauty += value;
 
@@ -97,7 +97,7 @@ void ShadingComponents::add_emission(
         add_to_component(scattering_mode, value);
 }
 
-ShadingComponents& operator+=(ShadingComponents& lhs, const ShadingComponents& rhs)
+DirectShadingComponents& operator+=(DirectShadingComponents& lhs, const DirectShadingComponents& rhs)
 {
     lhs.m_beauty += rhs.m_beauty;
     lhs.m_diffuse += rhs.m_diffuse;
@@ -107,7 +107,7 @@ ShadingComponents& operator+=(ShadingComponents& lhs, const ShadingComponents& r
     return lhs;
 }
 
-ShadingComponents& operator*=(ShadingComponents& lhs, const float rhs)
+DirectShadingComponents& operator*=(DirectShadingComponents& lhs, const float rhs)
 {
     lhs.m_beauty *= rhs;
     lhs.m_diffuse *= rhs;
@@ -117,14 +117,14 @@ ShadingComponents& operator*=(ShadingComponents& lhs, const float rhs)
     return lhs;
 }
 
-ShadingComponents& operator/=(ShadingComponents& lhs, const float rhs)
+DirectShadingComponents& operator/=(DirectShadingComponents& lhs, const float rhs)
 {
     const float rcp_rhs = 1.0f / rhs;
     lhs *= rcp_rhs;
     return lhs;
 }
 
-ShadingComponents& operator*=(ShadingComponents& lhs, const Spectrum& rhs)
+DirectShadingComponents& operator*=(DirectShadingComponents& lhs, const Spectrum& rhs)
 {
     lhs.m_beauty *= rhs;
     lhs.m_diffuse *= rhs;
@@ -134,7 +134,7 @@ ShadingComponents& operator*=(ShadingComponents& lhs, const Spectrum& rhs)
     return lhs;
 }
 
-void madd(ShadingComponents& a, const ShadingComponents& b, const float c)
+void madd(DirectShadingComponents& a, const DirectShadingComponents& b, const float c)
 {
     madd(a.m_beauty, b.m_beauty, c);
     madd(a.m_diffuse, b.m_diffuse, c);
@@ -143,7 +143,7 @@ void madd(ShadingComponents& a, const ShadingComponents& b, const float c)
     madd(a.m_emission, b.m_emission, c);
 }
 
-void madd(ShadingComponents& a, const ShadingComponents& b, const Spectrum& c)
+void madd(DirectShadingComponents& a, const DirectShadingComponents& b, const Spectrum& c)
 {
     madd(a.m_beauty, b.m_beauty, c);
     madd(a.m_diffuse, b.m_diffuse, c);

--- a/src/appleseed/renderer/kernel/shading/directshadingcomponents.cpp
+++ b/src/appleseed/renderer/kernel/shading/directshadingcomponents.cpp
@@ -53,50 +53,6 @@ void DirectShadingComponents::set(const float val)
     m_emission.set(0.0f);
 }
 
-void DirectShadingComponents::add_to_component(
-    const ScatteringMode::Mode      scattering_mode,
-    const Spectrum&                 value)
-{
-    switch (scattering_mode)
-    {
-      case ScatteringMode::Diffuse:
-        m_diffuse += value;
-        break;
-
-      case ScatteringMode::Glossy:
-      case ScatteringMode::Specular:
-        m_glossy += value;
-        break;
-
-      case ScatteringMode::Volumetric:
-        m_volume += value;
-        break;
-
-      assert_otherwise;
-    }
-}
-
-void DirectShadingComponents::add_to_component(
-    const ScatteringMode::Mode      scattering_mode,
-    const DirectShadingComponents&  value)
-{
-    m_beauty += value.m_beauty;
-    add_to_component(scattering_mode, value.m_beauty);
-}
-
-void DirectShadingComponents::add_emission(
-    const size_t                    path_length,
-    const ScatteringMode::Mode      scattering_mode,
-    const Spectrum&                 value)
-{
-    m_beauty += value;
-
-    if (path_length == 1)
-        m_emission += value;
-    else
-        add_to_component(scattering_mode, value);
-}
-
 DirectShadingComponents& operator+=(DirectShadingComponents& lhs, const DirectShadingComponents& rhs)
 {
     lhs.m_beauty += rhs.m_beauty;

--- a/src/appleseed/renderer/kernel/shading/directshadingcomponents.h
+++ b/src/appleseed/renderer/kernel/shading/directshadingcomponents.h
@@ -26,8 +26,8 @@
 // THE SOFTWARE.
 //
 
-#ifndef APPLESEED_RENDERER_KERNEL_SHADING_SHADINGCOMPONENTS_H
-#define APPLESEED_RENDERER_KERNEL_SHADING_SHADINGCOMPONENTS_H
+#ifndef APPLESEED_RENDERER_KERNEL_SHADING_DIRECTSHADINGCOMPONENTS_H
+#define APPLESEED_RENDERER_KERNEL_SHADING_DIRECTSHADINGCOMPONENTS_H
 
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
@@ -38,7 +38,7 @@
 namespace renderer
 {
 
-class ShadingComponents
+class DirectShadingComponents
 {
   public:
     Spectrum m_beauty;
@@ -48,34 +48,34 @@ class ShadingComponents
     Spectrum m_emission;
 
     // Constructor. Clears all components to 0.
-    ShadingComponents();
+    DirectShadingComponents();
 
     void set(const float val);
 
     void add_to_component(
-        const ScatteringMode::Mode  scattering_mode,
-        const Spectrum&             value);
+        const ScatteringMode::Mode      scattering_mode,
+        const Spectrum&                 value);
 
     void add_to_component(
-        const ScatteringMode::Mode  scattering_mode,
-        const ShadingComponents&    value);
+        const ScatteringMode::Mode      scattering_mode,
+        const DirectShadingComponents&  value);
 
     void add_emission(
-        const size_t                path_length,
-        const ScatteringMode::Mode  scattering_mode,
-        const Spectrum&             value);
+        const size_t                    path_length,
+        const ScatteringMode::Mode      scattering_mode,
+        const Spectrum&                 value);
 };
 
-ShadingComponents& operator+=(ShadingComponents& lhs, const ShadingComponents& rhs);
+DirectShadingComponents& operator+=(DirectShadingComponents& lhs, const DirectShadingComponents& rhs);
 
-ShadingComponents& operator*=(ShadingComponents& lhs, const float rhs);
-ShadingComponents& operator/=(ShadingComponents& lhs, const float rhs);
+DirectShadingComponents& operator*=(DirectShadingComponents& lhs, const float rhs);
+DirectShadingComponents& operator/=(DirectShadingComponents& lhs, const float rhs);
 
-ShadingComponents& operator*=(ShadingComponents& lhs, const Spectrum& rhs);
+DirectShadingComponents& operator*=(DirectShadingComponents& lhs, const Spectrum& rhs);
 
-void madd(ShadingComponents& a, const ShadingComponents& b, const float c);
-void madd(ShadingComponents& a, const ShadingComponents& b, const Spectrum& c);
+void madd(DirectShadingComponents& a, const DirectShadingComponents& b, const float c);
+void madd(DirectShadingComponents& a, const DirectShadingComponents& b, const Spectrum& c);
 
 }       // namespace renderer
 
-#endif  // !APPLESEED_RENDERER_KERNEL_SHADING_SHADINGCOMPONENTS_H
+#endif  // !APPLESEED_RENDERER_KERNEL_SHADING_DIRECTSHADINGCOMPONENTS_H

--- a/src/appleseed/renderer/kernel/shading/directshadingcomponents.h
+++ b/src/appleseed/renderer/kernel/shading/directshadingcomponents.h
@@ -51,19 +51,6 @@ class DirectShadingComponents
     DirectShadingComponents();
 
     void set(const float val);
-
-    void add_to_component(
-        const ScatteringMode::Mode      scattering_mode,
-        const Spectrum&                 value);
-
-    void add_to_component(
-        const ScatteringMode::Mode      scattering_mode,
-        const DirectShadingComponents&  value);
-
-    void add_emission(
-        const size_t                    path_length,
-        const ScatteringMode::Mode      scattering_mode,
-        const Spectrum&                 value);
 };
 
 DirectShadingComponents& operator+=(DirectShadingComponents& lhs, const DirectShadingComponents& rhs);

--- a/src/appleseed/renderer/kernel/shading/shadingcomponents.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingcomponents.cpp
@@ -1,0 +1,142 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "shadingcomponents.h"
+
+// appleseed.renderer headers.
+#include "renderer/kernel/shading/directshadingcomponents.h"
+
+namespace renderer
+{
+
+//
+// ShadingComponents class implementation.
+//
+
+ShadingComponents::ShadingComponents()
+  : m_beauty(0.0f)
+  , m_diffuse(0.0f)
+  , m_glossy(0.0f)
+  , m_volume(0.0f)
+  , m_emission(0.0f)
+  , m_indirect_diffuse(0.0f)
+  , m_indirect_glossy(0.0f)
+  , m_indirect_volume(0.0f)
+{
+}
+
+void ShadingComponents::add_emission(
+    const size_t                path_length,
+    const ScatteringMode::Mode  scattering_mode,
+    const Spectrum&             value)
+{
+    m_beauty += value;
+
+    if (path_length == 1)
+        m_emission += value;
+    else
+    {
+        switch (scattering_mode)
+        {
+          case ScatteringMode::Diffuse:
+            m_indirect_diffuse += value;
+            break;
+
+          case ScatteringMode::Glossy:
+          case ScatteringMode::Specular:
+            m_indirect_glossy += value;
+            break;
+
+          case ScatteringMode::Volumetric:
+            m_indirect_volume += value;
+            break;
+
+          assert_otherwise;
+        }
+    }
+}
+
+void ShadingComponents::add(
+    const size_t                    path_length,
+    const ScatteringMode::Mode      scattering_mode,
+    const DirectShadingComponents&  value)
+{
+    m_beauty += value.m_beauty;
+
+    if (path_length == 1)
+    {
+        m_diffuse += value.m_diffuse;
+        m_glossy += value.m_glossy;
+        m_volume += value.m_volume;
+        m_emission += value.m_emission;
+    }
+    else
+    {
+        switch (scattering_mode)
+        {
+          case ScatteringMode::Diffuse:
+            m_indirect_diffuse += value.m_beauty;
+            break;
+
+          case ScatteringMode::Glossy:
+          case ScatteringMode::Specular:
+            m_indirect_glossy += value.m_beauty;
+            break;
+
+          case ScatteringMode::Volumetric:
+            m_indirect_volume += value.m_beauty;
+            break;
+
+          assert_otherwise;
+        }
+    }
+}
+
+
+ShadingComponents& operator*=(ShadingComponents& lhs, const float rhs)
+{
+    lhs.m_beauty *= rhs;
+    lhs.m_diffuse *= rhs;
+    lhs.m_glossy *= rhs;
+    lhs.m_volume *= rhs;
+    lhs.m_emission *= rhs;
+    lhs.m_indirect_diffuse *= rhs;
+    lhs.m_indirect_glossy *= rhs;
+    lhs.m_indirect_volume *= rhs;
+    return lhs;
+}
+
+ShadingComponents& operator/=(ShadingComponents& lhs, const float rhs)
+{
+    const float rcp_rhs = 1.0f / rhs;
+    lhs *= rcp_rhs;
+    return lhs;
+}
+
+}   // namespace renderer

--- a/src/appleseed/renderer/kernel/shading/shadingcomponents.h
+++ b/src/appleseed/renderer/kernel/shading/shadingcomponents.h
@@ -5,8 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2010-2013 Francois Beaune, Jupiter Jazz Limited
-// Copyright (c) 2014-2017 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2017 Esteban Tovagliari, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -27,50 +26,53 @@
 // THE SOFTWARE.
 //
 
-#ifndef APPLESEED_RENDERER_KERNEL_LIGHTING_NULL_NULLLIGHTINGENGINE_H
-#define APPLESEED_RENDERER_KERNEL_LIGHTING_NULL_NULLLIGHTINGENGINE_H
+#ifndef APPLESEED_RENDERER_KERNEL_SHADING_SHADINGCOMPONENTS_H
+#define APPLESEED_RENDERER_KERNEL_SHADING_SHADINGCOMPONENTS_H
 
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
-#include "renderer/kernel/lighting/ilightingengine.h"
 
-// appleseed.foundation headers.
-#include "foundation/platform/compiler.h"
+// appleseed.renderer headers.
+#include "renderer/kernel/lighting/scatteringmode.h"
 
 // Forward declarations.
-namespace renderer  { class PixelContext; }
-namespace renderer  { class ShadingComponents; }
-namespace renderer  { class ShadingContext; }
-namespace renderer  { class ShadingPoint; }
+namespace renderer    { class DirectShadingComponents; }
 
 namespace renderer
 {
 
-//
-// A lighting engine that always returns zero.
-//
-
-class NullLightingEngine
-  : public ILightingEngine
+class ShadingComponents
 {
   public:
-    // Delete this instance.
-    virtual void release() override
-    {
-        delete this;
-    }
+    // Direct components.
+    Spectrum m_beauty;
+    Spectrum m_diffuse;
+    Spectrum m_glossy;
+    Spectrum m_volume;
+    Spectrum m_emission;
 
-    // Compute the lighting at a given point of the scene.
-    virtual void compute_lighting(
-        SamplingContext&        sampling_context,
-        const PixelContext&     pixel_context,
-        const ShadingContext&   shading_context,
-        const ShadingPoint&     shading_point,
-        ShadingComponents&      radiance) override
-    {
-    }
+    // Indirect components.
+    Spectrum m_indirect_diffuse;
+    Spectrum m_indirect_glossy;
+    Spectrum m_indirect_volume;
+
+    // Constructor. Clears all components to 0.
+    ShadingComponents();
+
+    void add_emission(
+        const size_t                path_length,
+        const ScatteringMode::Mode  scattering_mode,
+        const Spectrum&             value);
+
+    void add(
+        const size_t                    path_length,
+        const ScatteringMode::Mode      scattering_mode,
+        const DirectShadingComponents&  value);
 };
+
+ShadingComponents& operator*=(ShadingComponents& lhs, const float rhs);
+ShadingComponents& operator/=(ShadingComponents& lhs, const float rhs);
 
 }       // namespace renderer
 
-#endif  // !APPLESEED_RENDERER_KERNEL_LIGHTING_NULL_NULLLIGHTINGENGINE_H
+#endif  // !APPLESEED_RENDERER_KERNEL_SHADING_SHADINGCOMPONENTS_H

--- a/src/appleseed/renderer/kernel/shading/shadingengine.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingengine.cpp
@@ -32,7 +32,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/aov/aovaccumulator.h"
-#include "renderer/kernel/shading/directshadingcomponents.h"
+#include "renderer/kernel/shading/shadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingray.h"
 #include "renderer/modeling/environment/environment.h"
@@ -169,7 +169,7 @@ void ShadingEngine::shade_environment(
         // There is an environment shader: execute it.
         const ShadingRay& ray = shading_point.get_ray();
         const Vector3d direction = normalize(ray.m_dir);
-        DirectShadingComponents value;
+        ShadingComponents value;
         Alpha alpha;
         environment_shader->evaluate(
             shading_context,

--- a/src/appleseed/renderer/kernel/shading/shadingengine.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingengine.cpp
@@ -32,7 +32,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/aov/aovaccumulator.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingray.h"
 #include "renderer/modeling/environment/environment.h"
@@ -169,7 +169,7 @@ void ShadingEngine::shade_environment(
         // There is an environment shader: execute it.
         const ShadingRay& ray = shading_point.get_ray();
         const Vector3d direction = normalize(ray.m_dir);
-        ShadingComponents value;
+        DirectShadingComponents value;
         Alpha alpha;
         environment_shader->evaluate(
             shading_context,

--- a/src/appleseed/renderer/kernel/shading/shadingengine.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingengine.cpp
@@ -116,7 +116,7 @@ void ShadingEngine::shade_hit_point(
     }
 
     // Shade the sample if it isn't fully transparent.
-    if (aov_accumulators.alpha().get()[0] > 0.0f || shading_point.shade_alpha_cutouts())
+    if (aov_accumulators.alpha().get()[0] > 0.0f)
     {
         // Use the diagnostic surface shader if there is one.
         const SurfaceShader* surface_shader = m_diagnostic_surface_shader.get();

--- a/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
@@ -1140,7 +1140,6 @@ void PoisonImpl<renderer::ShadingPoint>::do_poison(renderer::ShadingPoint& point
     poison(point.m_material);
     poison(point.m_opposite_material);
     poison(point.m_alpha);
-    poison(point.m_shade_alpha_cutouts);
 
     poison(point.m_asm_geo_normal);
     poison(point.m_front_point);

--- a/src/appleseed/renderer/kernel/shading/shadingpoint.h
+++ b/src/appleseed/renderer/kernel/shading/shadingpoint.h
@@ -224,9 +224,6 @@ class ShadingPoint
     // Return the opacity at the intersection point.
     const Alpha& get_alpha() const;
 
-    // Return whether surface shaders should be invoked for fully transparent shading points.
-    bool shade_alpha_cutouts() const;
-
     OSL::ShaderGlobals& get_osl_shader_globals() const;
 
     struct OSLObjectTransformInfo
@@ -339,7 +336,6 @@ class ShadingPoint
     mutable const Material*             m_material;                     // material at intersection point
     mutable const Material*             m_opposite_material;            // opposite material at intersection point
     mutable Alpha                       m_alpha;                        // opacity at intersection point
-    mutable bool                        m_shade_alpha_cutouts;
 
     // Data required to avoid self-intersections.
     mutable foundation::Vector3d        m_asm_geo_normal;               // assembly instance space geometric normal to hit triangle
@@ -867,12 +863,6 @@ inline const Alpha& ShadingPoint::get_alpha() const
     return m_alpha;
 }
 
-inline bool ShadingPoint::shade_alpha_cutouts() const
-{
-    get_material();
-    return m_shade_alpha_cutouts;
-}
-
 inline OSL::ShaderGlobals& ShadingPoint::get_osl_shader_globals() const
 {
     assert(hit());
@@ -920,11 +910,6 @@ inline void ShadingPoint::fetch_materials() const
         if (static_cast<size_t>(m_primitive_pa) < opposite_materials->size())
             m_opposite_material = (*opposite_materials)[m_primitive_pa];
     }
-
-    m_shade_alpha_cutouts = m_object->shade_alpha_cutouts();
-
-    if (m_material && m_material->shade_alpha_cutouts())
-        m_shade_alpha_cutouts = true;
 }
 
 }       // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/aov.cpp
+++ b/src/appleseed/renderer/modeling/aov/aov.cpp
@@ -61,4 +61,30 @@ void AOV::release()
     delete this;
 }
 
+
+//
+// ColorAOV class implementation.
+//
+
+ColorAOV::ColorAOV(const char* name, const ParamArray& params)
+  : AOV(name, params)
+{
+}
+
+size_t ColorAOV::get_channel_count() const
+{
+    return 3;
+}
+
+const char** ColorAOV::get_channel_names() const
+{
+    static const char* ChannelNames[] = {"R", "G", "B"};
+    return ChannelNames;
+}
+
+bool ColorAOV::has_color_data() const
+{
+    return true;
+}
+
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/aov.h
+++ b/src/appleseed/renderer/modeling/aov/aov.h
@@ -50,6 +50,10 @@ namespace renderer      { class ParamArray; }
 namespace renderer
 {
 
+//
+// AOV base class.
+//
+
 class APPLESEED_DLLSYMBOL AOV
   : public Entity
 {
@@ -78,6 +82,28 @@ class APPLESEED_DLLSYMBOL AOV
     // Create an accumulator for this AOV.
     virtual foundation::auto_release_ptr<AOVAccumulator> create_accumulator(
         const size_t index) const = 0;
+};
+
+
+//
+// ColorAOV base class.
+//
+
+class ColorAOV
+  : public AOV
+{
+  public:
+    // Constructor.
+    ColorAOV(const char* name, const ParamArray& params);
+
+    // Return the number of channels of this AOV.
+    size_t get_channel_count() const override;
+
+    // Return the AOV channel names.
+    const char** get_channel_names() const override;
+
+    // Return true if this AOV contains color data.
+    bool has_color_data() const override;
 };
 
 }       // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/aovfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/aov/aovfactoryregistrar.cpp
@@ -64,8 +64,12 @@ AOVFactoryRegistrar::AOVFactoryRegistrar()
 {
     register_factory(auto_ptr<FactoryType>(new DepthAOVFactory()));
     register_factory(auto_ptr<FactoryType>(new DiffuseAOVFactory()));
+    register_factory(auto_ptr<FactoryType>(new DirectDiffuseAOVFactory()));
+    register_factory(auto_ptr<FactoryType>(new DirectGlossyAOVFactory()));
     register_factory(auto_ptr<FactoryType>(new EmissionAOVFactory()));
     register_factory(auto_ptr<FactoryType>(new GlossyAOVFactory()));
+    register_factory(auto_ptr<FactoryType>(new IndirectDiffuseAOVFactory()));
+    register_factory(auto_ptr<FactoryType>(new IndirectGlossyAOVFactory()));
     register_factory(auto_ptr<FactoryType>(new NormalAOVFactory()));
     register_factory(auto_ptr<FactoryType>(new UVAOVFactory()));
 }

--- a/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/aov/aovaccumulator.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingresult.h"
 #include "renderer/modeling/aov/aov.h"
 #include "renderer/modeling/color/colorspace.h"
@@ -72,8 +72,8 @@ namespace
         }
 
         virtual void write(
-            const ShadingComponents&    shading_components,
-            const float                 multiplier) override
+            const DirectShadingComponents&  shading_components,
+            const float                     multiplier) override
         {
             m_color = shading_components.m_diffuse.to_rgb(g_std_lighting_conditions);
             m_color *= multiplier;

--- a/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
@@ -78,10 +78,56 @@ namespace
 
 
     //
+    // DirectDiffuse AOV accumulator.
+    //
+
+    class DirectDiffuseAOVAccumulator
+      : public ColorAOVAccumulator
+    {
+      public:
+        explicit DirectDiffuseAOVAccumulator(const size_t index)
+          : ColorAOVAccumulator(index)
+        {
+        }
+
+        virtual void write(
+            const ShadingComponents&    shading_components,
+            const float                 multiplier) override
+        {
+            m_color = shading_components.m_diffuse.to_rgb(g_std_lighting_conditions);
+            m_color *= multiplier;
+        }
+    };
+
+
+    //
+    // IndirectDiffuse AOV accumulator.
+    //
+
+    class IndirectDiffuseAOVAccumulator
+      : public ColorAOVAccumulator
+    {
+      public:
+        explicit IndirectDiffuseAOVAccumulator(const size_t index)
+          : ColorAOVAccumulator(index)
+        {
+        }
+
+        virtual void write(
+            const ShadingComponents&    shading_components,
+            const float                 multiplier) override
+        {
+            m_color = shading_components.m_indirect_diffuse.to_rgb(g_std_lighting_conditions);
+            m_color *= multiplier;
+        }
+    };
+
+
+    //
     // Diffuse AOV.
     //
 
-    const char* Model = "diffuse_aov";
+    const char* DiffuseModel = "diffuse_aov";
 
     class DiffuseAOV
       : public ColorAOV
@@ -99,13 +145,79 @@ namespace
 
         virtual const char* get_model() const override
         {
-            return Model;
+            return DiffuseModel;
         }
 
         virtual auto_release_ptr<AOVAccumulator> create_accumulator(
             const size_t index) const override
         {
             return auto_release_ptr<AOVAccumulator>(new DiffuseAOVAccumulator(index));
+        }
+    };
+
+
+    //
+    // DirectDiffuse AOV.
+    //
+
+    const char* DirectDiffuseModel = "direct_diffuse_aov";
+
+    class DirectDiffuseAOV
+      : public ColorAOV
+    {
+      public:
+        DirectDiffuseAOV(const char* name, const ParamArray& params)
+          : ColorAOV(name, params)
+        {
+        }
+
+        virtual void release() override
+        {
+            delete this;
+        }
+
+        virtual const char* get_model() const override
+        {
+            return DirectDiffuseModel;
+        }
+
+        virtual auto_release_ptr<AOVAccumulator> create_accumulator(
+            const size_t index) const override
+        {
+            return auto_release_ptr<AOVAccumulator>(new DirectDiffuseAOVAccumulator(index));
+        }
+    };
+
+
+    //
+    // IndirectDiffuse AOV.
+    //
+
+    const char* IndirectDiffuseModel = "indirect_diffuse_aov";
+
+    class IndirectDiffuseAOV
+      : public ColorAOV
+    {
+      public:
+        IndirectDiffuseAOV(const char* name, const ParamArray& params)
+          : ColorAOV(name, params)
+        {
+        }
+
+        virtual void release() override
+        {
+            delete this;
+        }
+
+        virtual const char* get_model() const override
+        {
+            return IndirectDiffuseModel;
+        }
+
+        virtual auto_release_ptr<AOVAccumulator> create_accumulator(
+            const size_t index) const override
+        {
+            return auto_release_ptr<AOVAccumulator>(new IndirectDiffuseAOVAccumulator(index));
         }
     };
 }
@@ -117,14 +229,14 @@ namespace
 
 const char* DiffuseAOVFactory::get_model() const
 {
-    return Model;
+    return DiffuseModel;
 }
 
 Dictionary DiffuseAOVFactory::get_model_metadata() const
 {
     return
         Dictionary()
-            .insert("name", Model)
+            .insert("name", get_model())
             .insert("label", "Diffuse")
             .insert("default_model", "false");
 }
@@ -148,9 +260,85 @@ auto_release_ptr<AOV> DiffuseAOVFactory::static_create(
     const char*         name,
     const ParamArray&   params)
 {
+    return auto_release_ptr<AOV>(new DiffuseAOV(name, params));
+}
+
+
+//
+// DirectDiffuseAOVFactory class implementation.
+//
+
+const char* DirectDiffuseAOVFactory::get_model() const
+{
+    return DirectDiffuseModel;
+}
+
+Dictionary DirectDiffuseAOVFactory::get_model_metadata() const
+{
     return
-        auto_release_ptr<AOV>(
-            new DiffuseAOV(name, params));
+        Dictionary()
+            .insert("name", get_model())
+            .insert("label", "Direct Diffuse")
+            .insert("default_model", "false");
+}
+
+DictionaryArray DirectDiffuseAOVFactory::get_input_metadata() const
+{
+    DictionaryArray metadata;
+    return metadata;
+}
+
+auto_release_ptr<AOV> DirectDiffuseAOVFactory::create(
+    const char*         name,
+    const ParamArray&   params) const
+{
+    return auto_release_ptr<AOV>(new DirectDiffuseAOV(name, params));
+}
+
+auto_release_ptr<AOV> DirectDiffuseAOVFactory::static_create(
+    const char*         name,
+    const ParamArray&   params)
+{
+    return auto_release_ptr<AOV>(new DirectDiffuseAOV(name, params));
+}
+
+
+//
+// IndirectDiffuseAOVFactory class implementation.
+//
+
+const char* IndirectDiffuseAOVFactory::get_model() const
+{
+    return IndirectDiffuseModel;
+}
+
+Dictionary IndirectDiffuseAOVFactory::get_model_metadata() const
+{
+    return
+        Dictionary()
+            .insert("name", get_model())
+            .insert("label", "Indirect Diffuse")
+            .insert("default_model", "false");
+}
+
+DictionaryArray IndirectDiffuseAOVFactory::get_input_metadata() const
+{
+    DictionaryArray metadata;
+    return metadata;
+}
+
+auto_release_ptr<AOV> IndirectDiffuseAOVFactory::create(
+    const char*         name,
+    const ParamArray&   params) const
+{
+    return auto_release_ptr<AOV>(new IndirectDiffuseAOV(name, params));
+}
+
+auto_release_ptr<AOV> IndirectDiffuseAOVFactory::static_create(
+    const char*         name,
+    const ParamArray&   params)
+{
+    return auto_release_ptr<AOV>(new IndirectDiffuseAOV(name, params));
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
@@ -58,17 +58,12 @@ namespace
     //
 
     class DiffuseAOVAccumulator
-      : public AOVAccumulator
+      : public ColorAOVAccumulator
     {
       public:
         explicit DiffuseAOVAccumulator(const size_t index)
-          : AOVAccumulator(index)
+          : ColorAOVAccumulator(index)
         {
-        }
-
-        virtual void reset() override
-        {
-            m_color.set(0.0f);
         }
 
         virtual void write(
@@ -79,15 +74,6 @@ namespace
             m_color += shading_components.m_indirect_diffuse.to_rgb(g_std_lighting_conditions);
             m_color *= multiplier;
         }
-
-        virtual void flush(ShadingResult& result) override
-        {
-            result.m_aovs[m_index].rgb() = m_color;
-            result.m_aovs[m_index].a = result.m_main.a;
-        }
-
-        private:
-          Color3f m_color;
     };
 
 
@@ -98,11 +84,11 @@ namespace
     const char* Model = "diffuse_aov";
 
     class DiffuseAOV
-      : public AOV
+      : public ColorAOV
     {
       public:
         DiffuseAOV(const char* name, const ParamArray& params)
-          : AOV(name, params)
+          : ColorAOV(name, params)
         {
         }
 
@@ -114,22 +100,6 @@ namespace
         virtual const char* get_model() const override
         {
             return Model;
-        }
-
-        virtual size_t get_channel_count() const override
-        {
-            return 3;
-        }
-
-        virtual const char** get_channel_names() const override
-        {
-            static const char* ChannelNames[] = {"R", "G", "B"};
-            return ChannelNames;
-        }
-
-        virtual bool has_color_data() const override
-        {
-            return true;
         }
 
         virtual auto_release_ptr<AOVAccumulator> create_accumulator(

--- a/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/aov/aovaccumulator.h"
-#include "renderer/kernel/shading/directshadingcomponents.h"
+#include "renderer/kernel/shading/shadingcomponents.h"
 #include "renderer/kernel/shading/shadingresult.h"
 #include "renderer/modeling/aov/aov.h"
 #include "renderer/modeling/color/colorspace.h"
@@ -72,10 +72,11 @@ namespace
         }
 
         virtual void write(
-            const DirectShadingComponents&  shading_components,
-            const float                     multiplier) override
+            const ShadingComponents&    shading_components,
+            const float                 multiplier) override
         {
             m_color = shading_components.m_diffuse.to_rgb(g_std_lighting_conditions);
+            m_color += shading_components.m_indirect_diffuse.to_rgb(g_std_lighting_conditions);
             m_color *= multiplier;
         }
 
@@ -85,8 +86,8 @@ namespace
             result.m_aovs[m_index].a = result.m_main.a;
         }
 
-      private:
-        Color3f m_color;
+        private:
+          Color3f m_color;
     };
 
 

--- a/src/appleseed/renderer/modeling/aov/diffuseaov.h
+++ b/src/appleseed/renderer/modeling/aov/diffuseaov.h
@@ -75,6 +75,64 @@ class APPLESEED_DLLSYMBOL DiffuseAOVFactory
         const ParamArray&   params);
 };
 
+
+//
+// A factory for direct diffuse AOVs.
+//
+
+class APPLESEED_DLLSYMBOL DirectDiffuseAOVFactory
+  : public IAOVFactory
+{
+  public:
+    // Return a string identifying this AOV model.
+    virtual const char* get_model() const override;
+
+    // Return metadata for this AOV model.
+    virtual foundation::Dictionary get_model_metadata() const override;
+
+    // Return metadata for the inputs of this AOV model.
+    virtual foundation::DictionaryArray get_input_metadata() const override;
+
+    // Create a new AOV instance.
+    virtual foundation::auto_release_ptr<AOV> create(
+        const char*         name,
+        const ParamArray&   params) const override;
+
+    // Static variant of the create() method above.
+    static foundation::auto_release_ptr<AOV> static_create(
+        const char*         name,
+        const ParamArray&   params);
+};
+
+
+//
+// A factory for indirect diffuse AOVs.
+//
+
+class APPLESEED_DLLSYMBOL IndirectDiffuseAOVFactory
+  : public IAOVFactory
+{
+  public:
+    // Return a string identifying this AOV model.
+    virtual const char* get_model() const override;
+
+    // Return metadata for this AOV model.
+    virtual foundation::Dictionary get_model_metadata() const override;
+
+    // Return metadata for the inputs of this AOV model.
+    virtual foundation::DictionaryArray get_input_metadata() const override;
+
+    // Create a new AOV instance.
+    virtual foundation::auto_release_ptr<AOV> create(
+        const char*         name,
+        const ParamArray&   params) const override;
+
+    // Static variant of the create() method above.
+    static foundation::auto_release_ptr<AOV> static_create(
+        const char*         name,
+        const ParamArray&   params);
+};
+
 }       // namespace renderer
 
 #endif  // !APPLESEED_RENDERER_MODELING_AOV_DIFFUSEAOV_H

--- a/src/appleseed/renderer/modeling/aov/emissionaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/emissionaov.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/aov/aovaccumulator.h"
-#include "renderer/kernel/shading/directshadingcomponents.h"
+#include "renderer/kernel/shading/shadingcomponents.h"
 #include "renderer/kernel/shading/shadingresult.h"
 #include "renderer/modeling/aov/aov.h"
 #include "renderer/modeling/color/colorspace.h"
@@ -72,8 +72,8 @@ namespace
         }
 
         virtual void write(
-            const DirectShadingComponents&  shading_components,
-            const float                     multiplier) override
+            const ShadingComponents&    shading_components,
+            const float                 multiplier) override
         {
             m_color = shading_components.m_emission.to_rgb(g_std_lighting_conditions);
             m_color *= multiplier;

--- a/src/appleseed/renderer/modeling/aov/emissionaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/emissionaov.cpp
@@ -58,17 +58,12 @@ namespace
     //
 
     class EmissionAOVAccumulator
-      : public AOVAccumulator
+      : public ColorAOVAccumulator
     {
       public:
         explicit EmissionAOVAccumulator(const size_t index)
-          : AOVAccumulator(index)
+          : ColorAOVAccumulator(index)
         {
-        }
-
-        virtual void reset() override
-        {
-            m_color.set(0.0f);
         }
 
         virtual void write(
@@ -78,15 +73,6 @@ namespace
             m_color = shading_components.m_emission.to_rgb(g_std_lighting_conditions);
             m_color *= multiplier;
         }
-
-        virtual void flush(ShadingResult& result) override
-        {
-            result.m_aovs[m_index].rgb() = m_color;
-            result.m_aovs[m_index].a = result.m_main.a;
-        }
-
-      private:
-        Color3f m_color;
     };
 
 
@@ -97,11 +83,11 @@ namespace
     const char* Model = "emission_aov";
 
     class EmissionAOV
-      : public AOV
+      : public ColorAOV
     {
       public:
         EmissionAOV(const char* name, const ParamArray& params)
-          : AOV(name, params)
+          : ColorAOV(name, params)
         {
         }
 
@@ -113,22 +99,6 @@ namespace
         virtual const char* get_model() const override
         {
             return Model;
-        }
-
-        virtual size_t get_channel_count() const override
-        {
-            return 3;
-        }
-
-        virtual const char** get_channel_names() const override
-        {
-            static const char* ChannelNames[] = {"R", "G", "B"};
-            return ChannelNames;
-        }
-
-        virtual bool has_color_data() const override
-        {
-            return true;
         }
 
         virtual auto_release_ptr<AOVAccumulator> create_accumulator(

--- a/src/appleseed/renderer/modeling/aov/emissionaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/emissionaov.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/aov/aovaccumulator.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingresult.h"
 #include "renderer/modeling/aov/aov.h"
 #include "renderer/modeling/color/colorspace.h"
@@ -72,8 +72,8 @@ namespace
         }
 
         virtual void write(
-            const ShadingComponents&    shading_components,
-            const float                 multiplier) override
+            const DirectShadingComponents&  shading_components,
+            const float                     multiplier) override
         {
             m_color = shading_components.m_emission.to_rgb(g_std_lighting_conditions);
             m_color *= multiplier;

--- a/src/appleseed/renderer/modeling/aov/glossyaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/glossyaov.cpp
@@ -74,7 +74,52 @@ namespace
             m_color += shading_components.m_indirect_glossy.to_rgb(g_std_lighting_conditions);
             m_color *= multiplier;
         }
+    };
 
+
+    //
+    // DirectGlossy AOV accumulator.
+    //
+
+    class DirectGlossyAOVAccumulator
+      : public ColorAOVAccumulator
+    {
+      public:
+        explicit DirectGlossyAOVAccumulator(const size_t index)
+          : ColorAOVAccumulator(index)
+        {
+        }
+
+        virtual void write(
+            const ShadingComponents&    shading_components,
+            const float                 multiplier) override
+        {
+            m_color = shading_components.m_glossy.to_rgb(g_std_lighting_conditions);
+            m_color *= multiplier;
+        }
+    };
+
+
+    //
+    // IndirectGlossy AOV accumulator.
+    //
+
+    class IndirectGlossyAOVAccumulator
+      : public ColorAOVAccumulator
+    {
+      public:
+        explicit IndirectGlossyAOVAccumulator(const size_t index)
+          : ColorAOVAccumulator(index)
+        {
+        }
+
+        virtual void write(
+            const ShadingComponents&    shading_components,
+            const float                 multiplier) override
+        {
+            m_color = shading_components.m_indirect_glossy.to_rgb(g_std_lighting_conditions);
+            m_color *= multiplier;
+        }
     };
 
 
@@ -82,7 +127,7 @@ namespace
     // Glossy AOV.
     //
 
-    const char* Model = "glossy_aov";
+    const char* GlossyModel = "glossy_aov";
 
     class GlossyAOV
       : public ColorAOV
@@ -100,13 +145,79 @@ namespace
 
         virtual const char* get_model() const override
         {
-            return Model;
+            return GlossyModel;
         }
 
         virtual auto_release_ptr<AOVAccumulator> create_accumulator(
             const size_t index) const override
         {
             return auto_release_ptr<AOVAccumulator>(new GlossyAOVAccumulator(index));
+        }
+    };
+
+
+    //
+    // Direct Glossy AOV.
+    //
+
+    const char* DirectGlossyModel = "direct_glossy_aov";
+
+    class DirectGlossyAOV
+      : public ColorAOV
+    {
+      public:
+        DirectGlossyAOV(const char* name, const ParamArray& params)
+          : ColorAOV(name, params)
+        {
+        }
+
+        virtual void release() override
+        {
+            delete this;
+        }
+
+        virtual const char* get_model() const override
+        {
+            return DirectGlossyModel;
+        }
+
+        virtual auto_release_ptr<AOVAccumulator> create_accumulator(
+            const size_t index) const override
+        {
+            return auto_release_ptr<AOVAccumulator>(new DirectGlossyAOVAccumulator(index));
+        }
+    };
+
+
+    //
+    // Indirect Glossy AOV.
+    //
+
+    const char* IndirectGlossyModel = "indirect_glossy_aov";
+
+    class IndirectGlossyAOV
+      : public ColorAOV
+    {
+      public:
+        IndirectGlossyAOV(const char* name, const ParamArray& params)
+          : ColorAOV(name, params)
+        {
+        }
+
+        virtual void release() override
+        {
+            delete this;
+        }
+
+        virtual const char* get_model() const override
+        {
+            return IndirectGlossyModel;
+        }
+
+        virtual auto_release_ptr<AOVAccumulator> create_accumulator(
+            const size_t index) const override
+        {
+            return auto_release_ptr<AOVAccumulator>(new IndirectGlossyAOVAccumulator(index));
         }
     };
 }
@@ -118,14 +229,14 @@ namespace
 
 const char* GlossyAOVFactory::get_model() const
 {
-    return Model;
+    return GlossyModel;
 }
 
 Dictionary GlossyAOVFactory::get_model_metadata() const
 {
     return
         Dictionary()
-            .insert("name", Model)
+            .insert("name", get_model())
             .insert("label", "Glossy")
             .insert("default_model", "false");
 }
@@ -140,18 +251,92 @@ auto_release_ptr<AOV> GlossyAOVFactory::create(
     const char*         name,
     const ParamArray&   params) const
 {
-    return
-        auto_release_ptr<AOV>(
-            new GlossyAOV(name, params));
+    return auto_release_ptr<AOV>(new GlossyAOV(name, params));
 }
 
 auto_release_ptr<AOV> GlossyAOVFactory::static_create(
     const char*         name,
     const ParamArray&   params)
 {
+    return auto_release_ptr<AOV>(new GlossyAOV(name, params));
+}
+
+
+//
+// DirectGlossyAOVFactory class implementation.
+//
+
+const char* DirectGlossyAOVFactory::get_model() const
+{
+    return DirectGlossyModel;
+}
+
+Dictionary DirectGlossyAOVFactory::get_model_metadata() const
+{
     return
-        auto_release_ptr<AOV>(
-            new GlossyAOV(name, params));
+        Dictionary()
+            .insert("name", get_model())
+            .insert("label", "Direct Glossy")
+            .insert("default_model", "false");
+}
+
+DictionaryArray DirectGlossyAOVFactory::get_input_metadata() const
+{
+    DictionaryArray metadata;
+    return metadata;
+}
+
+auto_release_ptr<AOV> DirectGlossyAOVFactory::create(
+    const char*         name,
+    const ParamArray&   params) const
+{
+    return auto_release_ptr<AOV>(new DirectGlossyAOV(name, params));
+}
+
+auto_release_ptr<AOV> DirectGlossyAOVFactory::static_create(
+    const char*         name,
+    const ParamArray&   params)
+{
+    return auto_release_ptr<AOV>(new DirectGlossyAOV(name, params));
+}
+
+
+//
+// IndirectGlossyAOVFactory class implementation.
+//
+
+const char* IndirectGlossyAOVFactory::get_model() const
+{
+    return IndirectGlossyModel;
+}
+
+Dictionary IndirectGlossyAOVFactory::get_model_metadata() const
+{
+    return
+        Dictionary()
+            .insert("name", get_model())
+            .insert("label", "Indirect Glossy")
+            .insert("default_model", "false");
+}
+
+DictionaryArray IndirectGlossyAOVFactory::get_input_metadata() const
+{
+    DictionaryArray metadata;
+    return metadata;
+}
+
+auto_release_ptr<AOV> IndirectGlossyAOVFactory::create(
+    const char*         name,
+    const ParamArray&   params) const
+{
+    return auto_release_ptr<AOV>(new IndirectGlossyAOV(name, params));
+}
+
+auto_release_ptr<AOV> IndirectGlossyAOVFactory::static_create(
+    const char*         name,
+    const ParamArray&   params)
+{
+    return auto_release_ptr<AOV>(new IndirectGlossyAOV(name, params));
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/glossyaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/glossyaov.cpp
@@ -58,17 +58,12 @@ namespace
     //
 
     class GlossyAOVAccumulator
-      : public AOVAccumulator
+      : public ColorAOVAccumulator
     {
       public:
         explicit GlossyAOVAccumulator(const size_t index)
-          : AOVAccumulator(index)
+          : ColorAOVAccumulator(index)
         {
-        }
-
-        virtual void reset() override
-        {
-            m_color.set(0.0f);
         }
 
         virtual void write(
@@ -80,14 +75,6 @@ namespace
             m_color *= multiplier;
         }
 
-        virtual void flush(ShadingResult& result) override
-        {
-            result.m_aovs[m_index].rgb() = m_color;
-            result.m_aovs[m_index].a = result.m_main.a;
-        }
-
-      private:
-        Color3f m_color;
     };
 
 
@@ -98,11 +85,11 @@ namespace
     const char* Model = "glossy_aov";
 
     class GlossyAOV
-      : public AOV
+      : public ColorAOV
     {
       public:
         GlossyAOV(const char* name, const ParamArray& params)
-          : AOV(name, params)
+          : ColorAOV(name, params)
         {
         }
 
@@ -114,22 +101,6 @@ namespace
         virtual const char* get_model() const override
         {
             return Model;
-        }
-
-        virtual size_t get_channel_count() const override
-        {
-            return 3;
-        }
-
-        virtual const char** get_channel_names() const override
-        {
-            static const char* ChannelNames[] = {"R", "G", "B"};
-            return ChannelNames;
-        }
-
-        virtual bool has_color_data() const override
-        {
-            return true;
         }
 
         virtual auto_release_ptr<AOVAccumulator> create_accumulator(

--- a/src/appleseed/renderer/modeling/aov/glossyaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/glossyaov.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/aov/aovaccumulator.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingresult.h"
 #include "renderer/modeling/aov/aov.h"
 #include "renderer/modeling/color/colorspace.h"
@@ -72,8 +72,8 @@ namespace
         }
 
         virtual void write(
-            const ShadingComponents&    shading_components,
-            const float                 multiplier) override
+            const DirectShadingComponents&  shading_components,
+            const float                     multiplier) override
         {
             m_color = shading_components.m_glossy.to_rgb(g_std_lighting_conditions);
             m_color *= multiplier;

--- a/src/appleseed/renderer/modeling/aov/glossyaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/glossyaov.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/aov/aovaccumulator.h"
-#include "renderer/kernel/shading/directshadingcomponents.h"
+#include "renderer/kernel/shading/shadingcomponents.h"
 #include "renderer/kernel/shading/shadingresult.h"
 #include "renderer/modeling/aov/aov.h"
 #include "renderer/modeling/color/colorspace.h"
@@ -72,10 +72,11 @@ namespace
         }
 
         virtual void write(
-            const DirectShadingComponents&  shading_components,
-            const float                     multiplier) override
+            const ShadingComponents&    shading_components,
+            const float                 multiplier) override
         {
             m_color = shading_components.m_glossy.to_rgb(g_std_lighting_conditions);
+            m_color += shading_components.m_indirect_glossy.to_rgb(g_std_lighting_conditions);
             m_color *= multiplier;
         }
 

--- a/src/appleseed/renderer/modeling/aov/glossyaov.h
+++ b/src/appleseed/renderer/modeling/aov/glossyaov.h
@@ -75,6 +75,64 @@ class APPLESEED_DLLSYMBOL GlossyAOVFactory
         const ParamArray&   params);
 };
 
+
+//
+// A factory for direct glossy AOVs.
+//
+
+class APPLESEED_DLLSYMBOL DirectGlossyAOVFactory
+  : public IAOVFactory
+{
+  public:
+    // Return a string identifying this AOV model.
+    virtual const char* get_model() const override;
+
+    // Return metadata for this AOV model.
+    virtual foundation::Dictionary get_model_metadata() const override;
+
+    // Return metadata for the inputs of this AOV model.
+    virtual foundation::DictionaryArray get_input_metadata() const override;
+
+    // Create a new AOV instance.
+    virtual foundation::auto_release_ptr<AOV> create(
+        const char*         name,
+        const ParamArray&   params) const override;
+
+    // Static variant of the create() method above.
+    static foundation::auto_release_ptr<AOV> static_create(
+        const char*         name,
+        const ParamArray&   params);
+};
+
+
+//
+// A factory for indirect glossy AOVs.
+//
+
+class APPLESEED_DLLSYMBOL IndirectGlossyAOVFactory
+  : public IAOVFactory
+{
+  public:
+    // Return a string identifying this AOV model.
+    virtual const char* get_model() const override;
+
+    // Return metadata for this AOV model.
+    virtual foundation::Dictionary get_model_metadata() const override;
+
+    // Return metadata for the inputs of this AOV model.
+    virtual foundation::DictionaryArray get_input_metadata() const override;
+
+    // Create a new AOV instance.
+    virtual foundation::auto_release_ptr<AOV> create(
+        const char*         name,
+        const ParamArray&   params) const override;
+
+    // Static variant of the create() method above.
+    static foundation::auto_release_ptr<AOV> static_create(
+        const char*         name,
+        const ParamArray&   params);
+};
+
 }       // namespace renderer
 
 #endif  // !APPLESEED_RENDERER_MODELING_AOV_GLOSSYAOV_H

--- a/src/appleseed/renderer/modeling/bsdf/ashikhminbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/ashikhminbrdf.cpp
@@ -32,7 +32,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 
@@ -78,8 +78,8 @@ namespace
     {
       public:
         AshikhminBRDFImpl(
-            const char*         name,
-            const ParamArray&   params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Diffuse | ScatteringMode::Glossy, params)
         {
             m_inputs.declare("diffuse_reflectance", InputFormatSpectralReflectance);
@@ -102,12 +102,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&    sampling_context,
-            const void*         data,
-            const bool          adjoint,
-            const bool          cosine_mult,
-            const int           modes,
-            BSDFSample&         sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             // No reflection below the shading surface.
             const float cos_on = dot(sample.m_outgoing.get_value(), sample.m_shading_basis.get_normal());
@@ -253,15 +253,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*         data,
-            const bool          adjoint,
-            const bool          cosine_mult,
-            const Vector3f&     geometric_normal,
-            const Basis3f&      shading_basis,
-            const Vector3f&     outgoing,
-            const Vector3f&     incoming,
-            const int           modes,
-            ShadingComponents&  value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             // No reflection below the shading surface.
             const Vector3f& shading_normal = shading_basis.get_normal();
@@ -339,12 +339,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*         data,
-            const Vector3f&     geometric_normal,
-            const Basis3f&      shading_basis,
-            const Vector3f&     outgoing,
-            const Vector3f&     incoming,
-            const int           modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             // No reflection below the shading surface.
             const Vector3f& shading_normal = shading_basis.get_normal();

--- a/src/appleseed/renderer/modeling/bsdf/blinnbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/blinnbrdf.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 #include "renderer/modeling/bsdf/fresnel.h"
@@ -107,8 +107,8 @@ namespace
     {
       public:
         BlinnBRDFImpl(
-            const char*             name,
-            const ParamArray&       params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Glossy, params)
         {
         }
@@ -129,9 +129,9 @@ namespace
         }
 
         virtual void prepare_inputs(
-            Arena&                  arena,
-            const ShadingPoint&     shading_point,
-            void*                   data) const override
+            Arena&                      arena,
+            const ShadingPoint&         shading_point,
+            void*                       data) const override
         {
             InputValues* values = static_cast<InputValues*>(data);
             new (&values->m_precomputed) InputValues::Precomputed();
@@ -139,12 +139,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&        sampling_context,
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const int               modes,
-            BSDFSample&             sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             if (!ScatteringMode::has_glossy(modes))
                 return;
@@ -171,15 +171,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes,
-            ShadingComponents&      value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             if (!ScatteringMode::has_glossy(modes))
                 return 0.0f;
@@ -213,12 +213,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*             data,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             if (!ScatteringMode::has_glossy(modes))
                 return 0.0f;

--- a/src/appleseed/renderer/modeling/bsdf/bsdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdf.h
@@ -50,7 +50,7 @@
 namespace foundation    { class Arena; }
 namespace renderer      { class BSDFSample; }
 namespace renderer      { class ParamArray; }
-namespace renderer      { class ShadingComponents; }
+namespace renderer      { class DirectShadingComponents; }
 namespace renderer      { class ShadingContext; }
 namespace renderer      { class ShadingPoint; }
 
@@ -165,7 +165,7 @@ class APPLESEED_DLLSYMBOL BSDF
         const foundation::Vector3f& outgoing,                   // world space outgoing direction, unit-length
         const foundation::Vector3f& incoming,                   // world space incoming direction, unit-length
         const int                   modes,                      // enabled scattering modes
-        ShadingComponents&          value) const = 0;           // BSDF value, or BSDF value * |cos(incoming, normal)|
+        DirectShadingComponents&    value) const = 0;           // BSDF value, or BSDF value * |cos(incoming, normal)|
 
     // Evaluate the PDF for a given pair of directions.
     virtual float evaluate_pdf(

--- a/src/appleseed/renderer/modeling/bsdf/bsdfblend.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfblend.cpp
@@ -33,7 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
 #include "renderer/global/globaltypes.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
@@ -76,8 +76,8 @@ namespace
     {
       public:
         BSDFBlendImpl(
-            const char*             name,
-            const ParamArray&       params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::All, params)
         {
             m_inputs.declare("weight", InputFormatFloat);
@@ -94,10 +94,10 @@ namespace
         }
 
         virtual bool on_frame_begin(
-            const Project&          project,
-            const BaseGroup*        parent,
-            OnFrameBeginRecorder&   recorder,
-            IAbortSwitch*           abort_switch) override
+            const Project&              project,
+            const BaseGroup*            parent,
+            OnFrameBeginRecorder&       recorder,
+            IAbortSwitch*               abort_switch) override
         {
             if (!BSDF::on_frame_begin(project, parent, recorder, abort_switch))
                 return false;
@@ -114,8 +114,8 @@ namespace
         }
 
         virtual void* evaluate_inputs(
-            const ShadingContext&   shading_context,
-            const ShadingPoint&     shading_point) const override
+            const ShadingContext&       shading_context,
+            const ShadingPoint&         shading_point) const override
         {
             assert(m_bsdf[0] && m_bsdf[1]);
 
@@ -132,12 +132,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&        sampling_context,
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const int               modes,
-            BSDFSample&             sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             assert(m_bsdf[0] && m_bsdf[1]);
 
@@ -159,15 +159,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes,
-            ShadingComponents&      value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             assert(m_bsdf[0] && m_bsdf[1]);
 
@@ -178,7 +178,7 @@ namespace
             const float w1 = 1.0f - w0;
 
             // Evaluate the first BSDF.
-            ShadingComponents bsdf0_value;
+            DirectShadingComponents bsdf0_value;
             const float bsdf0_prob =
                 w0 > 0.0f
                     ? m_bsdf[0]->evaluate(
@@ -194,7 +194,7 @@ namespace
                     : 0.0f;
 
             // Evaluate the second BSDF.
-            ShadingComponents bsdf1_value;
+            DirectShadingComponents bsdf1_value;
             const float bsdf1_prob =
                 w1 > 0.0f
                     ? m_bsdf[1]->evaluate(
@@ -219,12 +219,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*             data,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             assert(m_bsdf[0] && m_bsdf[1]);
 

--- a/src/appleseed/renderer/modeling/bsdf/bsdfmix.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfmix.cpp
@@ -33,7 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
 #include "renderer/global/globaltypes.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
@@ -76,8 +76,8 @@ namespace
     {
       public:
         BSDFMixImpl(
-            const char*             name,
-            const ParamArray&       params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::All, params)
         {
             m_inputs.declare("weight0", InputFormatFloat);
@@ -95,10 +95,10 @@ namespace
         }
 
         virtual bool on_frame_begin(
-            const Project&          project,
-            const BaseGroup*        parent,
-            OnFrameBeginRecorder&   recorder,
-            IAbortSwitch*           abort_switch) override
+            const Project&              project,
+            const BaseGroup*            parent,
+            OnFrameBeginRecorder&       recorder,
+            IAbortSwitch*               abort_switch) override
         {
             if (!BSDF::on_frame_begin(project, parent, recorder, abort_switch))
                 return false;
@@ -115,8 +115,8 @@ namespace
         }
 
         virtual void* evaluate_inputs(
-            const ShadingContext&   shading_context,
-            const ShadingPoint&     shading_point) const override
+            const ShadingContext&       shading_context,
+            const ShadingPoint&         shading_point) const override
         {
             assert(m_bsdf[0] && m_bsdf[1]);
 
@@ -133,12 +133,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&        sampling_context,
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const int               modes,
-            BSDFSample&             sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             assert(m_bsdf[0] && m_bsdf[1]);
 
@@ -165,15 +165,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes,
-            ShadingComponents&      value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             assert(m_bsdf[0] && m_bsdf[1]);
 
@@ -194,7 +194,7 @@ namespace
             w1 *= rcp_total_weight;
 
             // Evaluate the first BSDF.
-            ShadingComponents bsdf0_value;
+            DirectShadingComponents bsdf0_value;
             const float bsdf0_prob =
                 w0 > 0.0f
                     ? m_bsdf[0]->evaluate(
@@ -210,7 +210,7 @@ namespace
                     : 0.0f;
 
             // Evaluate the second BSDF.
-            ShadingComponents bsdf1_value;
+            DirectShadingComponents bsdf1_value;
             const float bsdf1_prob =
                 w1 > 0.0f
                     ? m_bsdf[1]->evaluate(
@@ -235,12 +235,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*             data,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             assert(m_bsdf[0] && m_bsdf[1]);
 

--- a/src/appleseed/renderer/modeling/bsdf/bsdfsample.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfsample.h
@@ -32,7 +32,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 
 // appleseed.foundation headers.
@@ -61,7 +61,7 @@ class BSDFSample
     ScatteringMode::Mode            m_mode;                 // scattering mode
     foundation::Dual3f              m_incoming;             // world space incoming direction, unit-length, defined only if m_mode != None
     float                           m_probability;          // PDF value, defined only if m_mode != None
-    ShadingComponents               m_value;                // BSDF value, defined only if m_mode != None
+    DirectShadingComponents         m_value;                // BSDF value, defined only if m_mode != None
 
     // Constructor.
     BSDFSample(

--- a/src/appleseed/renderer/modeling/bsdf/bsdfwrapper.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfwrapper.h
@@ -32,7 +32,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdfsample.h"
 
 // appleseed.foundation headers.
@@ -81,7 +81,7 @@ class BSDFWrapper
         const foundation::Vector3f&     outgoing,
         const foundation::Vector3f&     incoming,
         const int                       modes,
-        ShadingComponents&              value) const override;
+        DirectShadingComponents&        value) const override;
 
     virtual float evaluate_pdf(
         const void*                     data,
@@ -158,7 +158,7 @@ float BSDFWrapper<BSDFImpl>::evaluate(
     const foundation::Vector3f&         outgoing,
     const foundation::Vector3f&         incoming,
     const int                           modes,
-    ShadingComponents&                  value) const
+    DirectShadingComponents&            value) const
 {
     assert(foundation::is_normalized(geometric_normal));
     assert(foundation::is_normalized(outgoing));

--- a/src/appleseed/renderer/modeling/bsdf/diffusebtdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/diffusebtdf.cpp
@@ -32,7 +32,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/backfacingpolicy.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
@@ -70,8 +70,8 @@ namespace
     {
       public:
         DiffuseBTDFImpl(
-            const char*             name,
-            const ParamArray&       params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Transmissive, ScatteringMode::Diffuse, params)
         {
             m_inputs.declare("transmittance", InputFormatSpectralReflectance);
@@ -94,9 +94,9 @@ namespace
         }
 
         virtual void prepare_inputs(
-            Arena&                  arena,
-            const ShadingPoint&     shading_point,
-            void*                   data) const override
+            Arena&                      arena,
+            const ShadingPoint&         shading_point,
+            void*                       data) const override
         {
             InputValues* values = static_cast<InputValues*>(data);
             new (&values->m_precomputed) InputValues::Precomputed();
@@ -104,12 +104,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&        sampling_context,
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const int               modes,
-            BSDFSample&             sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             if (!ScatteringMode::has_diffuse(modes))
                 return;
@@ -143,15 +143,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes,
-            ShadingComponents&      value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             if (!ScatteringMode::has_diffuse(modes))
                 return 0.0f;
@@ -182,12 +182,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*             data,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             if (!ScatteringMode::has_diffuse(modes))
                 return 0.0f;

--- a/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 #include "renderer/modeling/bsdf/microfacethelper.h"
 #include "renderer/modeling/color/colorspace.h"
@@ -336,8 +336,8 @@ namespace
         };
 
         DisneyBRDFImpl(
-            const char*             name,
-            const ParamArray&       params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Diffuse | ScatteringMode::Glossy, params)
         {
             m_inputs.declare("base_color", InputFormatSpectralReflectance);
@@ -369,9 +369,9 @@ namespace
         }
 
         virtual void prepare_inputs(
-            Arena&                  arena,
-            const ShadingPoint&     shading_point,
-            void*                   data) const override
+            Arena&                      arena,
+            const ShadingPoint&         shading_point,
+            void*                       data) const override
         {
             InputValues* values = static_cast<InputValues*>(data);
 
@@ -391,12 +391,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&        sampling_context,
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const int               modes,
-            BSDFSample&             sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             // No reflection below the shading surface.
             const Vector3f& outgoing = sample.m_outgoing.get_value();
@@ -562,15 +562,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes,
-            ShadingComponents&      value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             // No reflection below the shading surface.
             const Vector3f& n = shading_basis.get_normal();
@@ -667,12 +667,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*             data,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             // No reflection below the shading surface.
             const Vector3f& n = shading_basis.get_normal();
@@ -747,9 +747,9 @@ namespace
         typedef DisneyBRDFInputValues InputValues;
 
         static bool compute_component_weights(
-            const InputValues*      values,
-            const int               modes,
-            float                   weights[NumComponents])
+            const InputValues*          values,
+            const int                   modes,
+            float                       weights[NumComponents])
         {
             if (ScatteringMode::has_diffuse(modes))
             {

--- a/src/appleseed/renderer/modeling/bsdf/disneylayeredbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/disneylayeredbrdf.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/modeling/bsdf/disneybrdf.h"
 #include "renderer/modeling/color/colorspace.h"
@@ -169,7 +169,7 @@ float DisneyLayeredBRDF::evaluate(
     const Vector3f&             outgoing,
     const Vector3f&             incoming,
     const int                   modes,
-    ShadingComponents&          value) const
+    DirectShadingComponents&    value) const
 {
     if (m_parent->get_layer_count() == 0)
     {

--- a/src/appleseed/renderer/modeling/bsdf/disneylayeredbrdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/disneylayeredbrdf.h
@@ -97,7 +97,7 @@ class DisneyLayeredBRDF
         const foundation::Vector3f&     outgoing,
         const foundation::Vector3f&     incoming,
         const int                       modes,
-        ShadingComponents&              value) const override;
+        DirectShadingComponents&        value) const override;
 
     virtual float evaluate_pdf(
         const void*                     data,

--- a/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/backfacingpolicy.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
@@ -90,8 +90,8 @@ namespace
     {
       public:
         GlassBSDFImpl(
-            const char*             name,
-            const ParamArray&       params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, AllBSDFTypes, ScatteringMode::Glossy, params)
         {
             m_inputs.declare("surface_transmittance", InputFormatSpectralReflectance);
@@ -125,10 +125,10 @@ namespace
         }
 
         virtual bool on_frame_begin(
-            const Project&          project,
-            const BaseGroup*        parent,
-            OnFrameBeginRecorder&   recorder,
-            IAbortSwitch*           abort_switch) override
+            const Project&              project,
+            const BaseGroup*            parent,
+            OnFrameBeginRecorder&       recorder,
+            IAbortSwitch*               abort_switch) override
         {
             if (!BSDF::on_frame_begin(project, parent, recorder, abort_switch))
                 return false;
@@ -167,9 +167,9 @@ namespace
         }
 
         virtual void prepare_inputs(
-            Arena&                  arena,
-            const ShadingPoint&     shading_point,
-            void*                   data) const override
+            Arena&                      arena,
+            const ShadingPoint&         shading_point,
+            void*                       data) const override
         {
             InputValues* values = static_cast<InputValues*>(data);
 
@@ -202,12 +202,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&        sampling_context,
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const int               modes,
-            BSDFSample&             sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             if (!ScatteringMode::has_glossy(modes))
                 return;
@@ -316,15 +316,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes,
-            ShadingComponents&      value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             if (!ScatteringMode::has_glossy(modes))
                 return 0.0f;
@@ -399,12 +399,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*             data,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             if (!ScatteringMode::has_glossy(modes))
                 return 0.0f;
@@ -448,16 +448,16 @@ namespace
         }
 
         virtual float sample_ior(
-            SamplingContext&        sampling_context,
-            const void*             data) const override
+            SamplingContext&            sampling_context,
+            const void*                 data) const override
         {
             return static_cast<const InputValues*>(data)->m_ior;
         }
 
         virtual void compute_absorption(
-            const void*             data,
-            const float             distance,
-            Spectrum&               absorption) const override
+            const void*                 data,
+            const float                 distance,
+            Spectrum&                   absorption) const override
         {
             const InputValues* values = static_cast<const InputValues*>(data);
 

--- a/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 #include "renderer/modeling/bsdf/fresnel.h"
@@ -89,8 +89,8 @@ namespace
     {
       public:
         GlossyBRDFImpl(
-            const char*             name,
-            const ParamArray&       params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Glossy | ScatteringMode::Specular, params)
         {
             m_inputs.declare("reflectance", InputFormatSpectralReflectance);
@@ -117,9 +117,9 @@ namespace
         }
 
         virtual void prepare_inputs(
-            Arena&                  arena,
-            const ShadingPoint&     shading_point,
-            void*                   data) const override
+            Arena&                      arena,
+            const ShadingPoint&         shading_point,
+            void*                       data) const override
         {
             InputValues* values = static_cast<InputValues*>(data);
             new (&values->m_precomputed) InputValues::Precomputed();
@@ -127,10 +127,10 @@ namespace
         }
 
         virtual bool on_frame_begin(
-            const Project&          project,
-            const BaseGroup*        parent,
-            OnFrameBeginRecorder&   recorder,
-            IAbortSwitch*           abort_switch) override
+            const Project&              project,
+            const BaseGroup*            parent,
+            OnFrameBeginRecorder&       recorder,
+            IAbortSwitch*               abort_switch) override
         {
             if (!BSDF::on_frame_begin(project, parent, recorder, abort_switch))
                 return false;
@@ -155,12 +155,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&        sampling_context,
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const int               modes,
-            BSDFSample&             sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             const Vector3f& n = sample.m_shading_basis.get_normal();
             const Vector3f& outgoing = sample.m_outgoing.get_value();
@@ -210,15 +210,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes,
-            ShadingComponents&      value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             if (!ScatteringMode::has_glossy(modes))
                 return 0.0f;
@@ -264,12 +264,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*             data,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             if (!ScatteringMode::has_glossy(modes))
                 return 0.0f;

--- a/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.cpp
@@ -33,7 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 #include "renderer/modeling/input/inputarray.h"
@@ -211,8 +211,8 @@ namespace
         }
 
         virtual void on_frame_end(
-            const Project&          project,
-            const BaseGroup*        parent) override
+            const Project&              project,
+            const BaseGroup*            parent) override
         {
             m_mdf.reset();
 
@@ -220,12 +220,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&        sampling_context,
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const int               modes,
-            BSDFSample&             sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             // Define aliases to match the notations in the paper.
             const Vector3f& V = sample.m_outgoing.get_value();
@@ -349,15 +349,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes,
-            ShadingComponents&      value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             // Define aliases to match the notations in the paper.
             const Vector3f& V = outgoing;
@@ -437,12 +437,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*             data,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             // Define aliases to match the notations in the paper.
             const Vector3f& V = outgoing;

--- a/src/appleseed/renderer/modeling/bsdf/lambertianbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/lambertianbrdf.cpp
@@ -32,7 +32,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 
@@ -71,8 +71,8 @@ namespace
     {
       public:
         LambertianBRDFImpl(
-            const char*         name,
-            const ParamArray&   params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Diffuse, params)
         {
             m_inputs.declare("reflectance", InputFormatSpectralReflectance);
@@ -90,12 +90,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&    sampling_context,
-            const void*         data,
-            const bool          adjoint,
-            const bool          cosine_mult,
-            const int           modes,
-            BSDFSample&         sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             if (!ScatteringMode::has_diffuse(modes))
                 return;
@@ -125,15 +125,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*         data,
-            const bool          adjoint,
-            const bool          cosine_mult,
-            const Vector3f&     geometric_normal,
-            const Basis3f&      shading_basis,
-            const Vector3f&     outgoing,
-            const Vector3f&     incoming,
-            const int           modes,
-            ShadingComponents&  value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             if (!ScatteringMode::has_diffuse(modes))
                 return 0.0f;
@@ -155,12 +155,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*         data,
-            const Vector3f&     geometric_normal,
-            const Basis3f&      shading_basis,
-            const Vector3f&     outgoing,
-            const Vector3f&     incoming,
-            const int           modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             if (!ScatteringMode::has_diffuse(modes))
                 return 0.0f;

--- a/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 #include "renderer/modeling/bsdf/fresnel.h"
@@ -93,8 +93,8 @@ namespace
     {
       public:
         MetalBRDFImpl(
-            const char*             name,
-            const ParamArray&       params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Glossy | ScatteringMode::Specular, params)
         {
             m_inputs.declare("normal_reflectance", InputFormatSpectralReflectance);
@@ -121,9 +121,9 @@ namespace
         }
 
         virtual void prepare_inputs(
-            Arena&                  arena,
-            const ShadingPoint&     shading_point,
-            void*                   data) const override
+            Arena&                      arena,
+            const ShadingPoint&         shading_point,
+            void*                       data) const override
         {
             InputValues* values = static_cast<InputValues*>(data);
             new (&values->m_precomputed) InputValues::Precomputed();
@@ -137,10 +137,10 @@ namespace
         }
 
         virtual bool on_frame_begin(
-            const Project&          project,
-            const BaseGroup*        parent,
-            OnFrameBeginRecorder&   recorder,
-            IAbortSwitch*           abort_switch) override
+            const Project&              project,
+            const BaseGroup*            parent,
+            OnFrameBeginRecorder&       recorder,
+            IAbortSwitch*               abort_switch) override
         {
             if (!BSDF::on_frame_begin(project, parent, recorder, abort_switch))
                 return false;
@@ -165,12 +165,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&        sampling_context,
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const int               modes,
-            BSDFSample&             sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             const Vector3f& n = sample.m_shading_basis.get_normal();
             const Vector3f& outgoing = sample.m_outgoing.get_value();
@@ -221,15 +221,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes,
-            ShadingComponents&      value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             if (!ScatteringMode::has_glossy(modes))
                 return 0.0f;
@@ -276,12 +276,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*             data,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             if (!ScatteringMode::has_glossy(modes))
                 return 0.0f;

--- a/src/appleseed/renderer/modeling/bsdf/microfacetbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/microfacetbrdf.cpp
@@ -33,7 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 #include "renderer/modeling/bsdf/microfacethelper.h"
@@ -111,8 +111,8 @@ namespace
     {
       public:
         MicrofacetBRDFImpl(
-            const char*             name,
-            const ParamArray&       params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Glossy, params)
         {
             m_inputs.declare("glossiness", InputFormatFloat);
@@ -133,10 +133,10 @@ namespace
         }
 
         virtual bool on_frame_begin(
-            const Project&          project,
-            const BaseGroup*        parent,
-            OnFrameBeginRecorder&   recorder,
-            IAbortSwitch*           abort_switch) override
+            const Project&              project,
+            const BaseGroup*            parent,
+            OnFrameBeginRecorder&       recorder,
+            IAbortSwitch*               abort_switch) override
         {
             if (!BSDF::on_frame_begin(project, parent, recorder, abort_switch))
                 return false;
@@ -161,12 +161,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&        sampling_context,
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const int               modes,
-            BSDFSample&             sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             if (!ScatteringMode::has_glossy(modes))
                 return;
@@ -253,15 +253,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes,
-            ShadingComponents&      value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             if (!ScatteringMode::has_glossy(modes))
                 return 0.0f;
@@ -366,12 +366,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*             data,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             if (!ScatteringMode::has_glossy(modes))
                 return 0.0f;

--- a/src/appleseed/renderer/modeling/bsdf/microfacethelper.h
+++ b/src/appleseed/renderer/modeling/bsdf/microfacethelper.h
@@ -34,7 +34,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdfsample.h"
 
 // appleseed.foundation headers.

--- a/src/appleseed/renderer/modeling/bsdf/nullbsdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/nullbsdf.h
@@ -33,7 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 
 // appleseed.foundation headers.
@@ -86,7 +86,7 @@ class NullBSDF
         const foundation::Vector3f&     outgoing,
         const foundation::Vector3f&     incoming,
         const int                       modes,
-        ShadingComponents&              value) const override
+        DirectShadingComponents&        value) const override
     {
         return 0.0f;
     }

--- a/src/appleseed/renderer/modeling/bsdf/orennayarbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/orennayarbrdf.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 
@@ -76,8 +76,8 @@ namespace
     {
       public:
         OrenNayarBRDFImpl(
-            const char*         name,
-            const ParamArray&   params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Diffuse, params)
         {
             m_inputs.declare("reflectance", InputFormatSpectralReflectance);
@@ -96,12 +96,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&    sampling_context,
-            const void*         data,
-            const bool          adjoint,
-            const bool          cosine_mult,
-            const int           modes,
-            BSDFSample&         sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             if (!ScatteringMode::has_diffuse(modes))
                 return;
@@ -162,15 +162,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*         data,
-            const bool          adjoint,
-            const bool          cosine_mult,
-            const Vector3f&     geometric_normal,
-            const Basis3f&      shading_basis,
-            const Vector3f&     outgoing,
-            const Vector3f&     incoming,
-            const int           modes,
-            ShadingComponents&  value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             if (!ScatteringMode::has_diffuse(modes))
                 return 0.0f;
@@ -217,12 +217,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*         data,
-            const Vector3f&     geometric_normal,
-            const Basis3f&      shading_basis,
-            const Vector3f&     outgoing,
-            const Vector3f&     incoming,
-            const int           modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             if (!ScatteringMode::has_diffuse(modes))
                 return 0.0f;
@@ -249,15 +249,15 @@ namespace
         typedef OrenNayarBRDFInputValues InputValues;
 
         static void oren_nayar_qualitative(
-            const float         cos_on,
-            const float         cos_in,
-            const float         roughness,
-            const Spectrum&     reflectance,
-            const float         reflectance_multiplier,
-            const Vector3f&     outgoing,
-            const Vector3f&     incoming,
-            const Vector3f&     n,
-            Spectrum&           value)
+            const float                 cos_on,
+            const float                 cos_in,
+            const float                 roughness,
+            const Spectrum&             reflectance,
+            const float                 reflectance_multiplier,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const Vector3f&             n,
+            Spectrum&                   value)
         {
             const float sigma2 = square(roughness);
             const float theta_r = min(acos(cos_on), HalfPi<float>());

--- a/src/appleseed/renderer/modeling/bsdf/oslbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/oslbsdf.cpp
@@ -33,7 +33,7 @@
 #include "renderer/global/globallogger.h"
 #include "renderer/global/globaltypes.h"
 #include "renderer/kernel/shading/closures.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/modeling/bsdf/blinnbrdf.h"
@@ -82,8 +82,8 @@ namespace
     {
       public:
         OSLBSDFImpl(
-            const char*             name,
-            const ParamArray&       params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, AllBSDFTypes, ScatteringMode::All, params)
         {
             memset(m_all_bsdfs, 0, sizeof(BSDF*) * NumClosuresIDs);
@@ -143,10 +143,10 @@ namespace
         }
 
         virtual bool on_frame_begin(
-            const Project&          project,
-            const BaseGroup*        parent,
-            OnFrameBeginRecorder&   recorder,
-            IAbortSwitch*           abort_switch) override
+            const Project&              project,
+            const BaseGroup*            parent,
+            OnFrameBeginRecorder&       recorder,
+            IAbortSwitch*               abort_switch) override
         {
             if (!BSDF::on_frame_begin(project, parent, recorder, abort_switch))
                 return false;
@@ -164,8 +164,8 @@ namespace
         }
 
         virtual void* evaluate_inputs(
-            const ShadingContext&   shading_context,
-            const ShadingPoint&     shading_point) const override
+            const ShadingContext&       shading_context,
+            const ShadingPoint&         shading_point) const override
         {
             Arena& arena = shading_context.get_arena();
 
@@ -190,12 +190,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&        sampling_context,
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const int               modes,
-            BSDFSample&             sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             const CompositeSurfaceClosure* c = static_cast<const CompositeSurfaceClosure*>(data);
 
@@ -236,7 +236,7 @@ namespace
             {
                 if (pdfs[i] > 0.0f)
                 {
-                    ShadingComponents s;
+                    DirectShadingComponents s;
                     const float pdf =
                         bsdf_from_closure_id(c->get_closure_type(i))
                             .evaluate(
@@ -260,15 +260,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes,
-            ShadingComponents&      value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             const CompositeSurfaceClosure* c = static_cast<const CompositeSurfaceClosure*>(data);
 
@@ -282,7 +282,7 @@ namespace
             {
                 if (pdfs[i] > 0.0f)
                 {
-                    ShadingComponents s;
+                    DirectShadingComponents s;
                     const float pdf =
                         bsdf_from_closure_id(c->get_closure_type(i))
                             .evaluate(
@@ -308,12 +308,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*             data,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             const CompositeSurfaceClosure* c = static_cast<const CompositeSurfaceClosure*>(data);
 
@@ -342,8 +342,8 @@ namespace
         }
 
         virtual float sample_ior(
-            SamplingContext&        sampling_context,
-            const void*             data) const override
+            SamplingContext&            sampling_context,
+            const void*                 data) const override
         {
             const CompositeSurfaceClosure* c = static_cast<const CompositeSurfaceClosure*>(data);
             sampling_context.split_in_place(1, 1);
@@ -351,9 +351,9 @@ namespace
         }
 
         virtual void compute_absorption(
-            const void*             data,
-            const float             distance,
-            Spectrum&               absorption) const override
+            const void*                 data,
+            const float                 distance,
+            Spectrum&                   absorption) const override
         {
             const CompositeSurfaceClosure* c = static_cast<const CompositeSurfaceClosure*>(data);
 

--- a/src/appleseed/renderer/modeling/bsdf/plasticbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/plasticbrdf.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 #include "renderer/modeling/bsdf/fresnel.h"
@@ -90,8 +90,8 @@ namespace
     {
       public:
         PlasticBRDFImpl(
-            const char*             name,
-            const ParamArray&       params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::All, params)
         {
             m_inputs.declare("specular_reflectance", InputFormatSpectralReflectance);
@@ -115,10 +115,10 @@ namespace
         }
 
         virtual bool on_frame_begin(
-            const Project&          project,
-            const BaseGroup*        parent,
-            OnFrameBeginRecorder&   recorder,
-            IAbortSwitch*           abort_switch) override
+            const Project&              project,
+            const BaseGroup*            parent,
+            OnFrameBeginRecorder&       recorder,
+            IAbortSwitch*               abort_switch) override
         {
             if (!BSDF::on_frame_begin(project, parent, recorder, abort_switch))
                 return false;
@@ -150,9 +150,9 @@ namespace
         }
 
         virtual void prepare_inputs(
-            Arena&                  arena,
-            const ShadingPoint&     shading_point,
-            void*                   data) const override
+            Arena&                      arena,
+            const ShadingPoint&         shading_point,
+            void*                       data) const override
         {
             InputValues* values = static_cast<InputValues*>(data);
 
@@ -169,12 +169,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&        sampling_context,
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const int               modes,
-            BSDFSample&             sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             const Basis3f& shading_basis(sample.m_shading_basis);
             const Vector3f& n = shading_basis.get_normal();
@@ -261,15 +261,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes,
-            ShadingComponents&      value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             // No reflection below the shading surface.
             const Vector3f& n = shading_basis.get_normal();
@@ -337,12 +337,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*             data,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             // No reflection below the shading surface.
             const Vector3f& n = shading_basis.get_normal();
@@ -383,8 +383,8 @@ namespace
         typedef PlasticBRDFInputValues InputValues;
 
         static float choose_specular_probability(
-            const InputValues&      values,
-            const float             F)
+            const InputValues&          values,
+            const float                 F)
         {
             const float specular_weight = F * values.m_precomputed.m_specular_weight;
             const float diffuse_weight = (1.0f - F) * values.m_precomputed.m_diffuse_weight;
@@ -399,9 +399,9 @@ namespace
         }
 
         static float fresnel_reflectance(
-            const Vector3f&         w,
-            const Vector3f&         m,
-            const float             eta)
+            const Vector3f&             w,
+            const Vector3f&             m,
+            const float                 eta)
         {
             const float cos_wm(dot(w, m));
 
@@ -417,15 +417,15 @@ namespace
         }
 
         static void evaluate_specular(
-            const Spectrum&         specular_reflectance,
-            const MDF&              mdf,
-            const float             alpha,
-            const float             gamma,
-            const Vector3f&         wi,
-            const Vector3f&         wo,
-            const Vector3f&         m,
-            const float             F,
-            Spectrum&               value)
+            const Spectrum&             specular_reflectance,
+            const MDF&                  mdf,
+            const float                 alpha,
+            const float                 gamma,
+            const Vector3f&             wi,
+            const Vector3f&             wo,
+            const Vector3f&             m,
+            const float                 F,
+            Spectrum&                   value)
         {
             if (alpha == 0.0f)
                 return;
@@ -444,11 +444,11 @@ namespace
         }
 
         static float specular_pdf(
-            const MDF&              mdf,
-            const float             alpha,
-            const float             gamma,
-            const Vector3f&         wo,
-            const Vector3f&         m)
+            const MDF&                  mdf,
+            const float                 alpha,
+            const float                 gamma,
+            const Vector3f&             wo,
+            const Vector3f&             m)
         {
             if (alpha == 0.0f)
                 return 0.0f;
@@ -462,12 +462,12 @@ namespace
         }
 
         static void evaluate_diffuse(
-            const Spectrum&         diffuse_reflectance,
-            const float             eta,
-            const float             internal_scattering,
-            const float             Fo,
-            const float             Fi,
-            Spectrum&               value)
+            const Spectrum&             diffuse_reflectance,
+            const float                 eta,
+            const float                 internal_scattering,
+            const float                 Fo,
+            const float                 Fi,
+            Spectrum&                   value)
         {
             const float eta2 = square(eta);
             const float fdr = fresnel_internal_diffuse_reflectance(1.0f / eta);

--- a/src/appleseed/renderer/modeling/bsdf/sheenbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/sheenbrdf.cpp
@@ -31,7 +31,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 
@@ -74,8 +74,8 @@ namespace
     {
       public:
         SheenBRDFImpl(
-            const char*         name,
-            const ParamArray&   params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Diffuse, params)
         {
             m_inputs.declare("reflectance", InputFormatSpectralReflectance);
@@ -93,12 +93,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&    sampling_context,
-            const void*         data,
-            const bool          adjoint,
-            const bool          cosine_mult,
-            const int           modes,
-            BSDFSample&         sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             if (!ScatteringMode::has_diffuse(modes))
                 return;
@@ -133,15 +133,15 @@ namespace
         }
 
         virtual float evaluate(
-            const void*         data,
-            const bool          adjoint,
-            const bool          cosine_mult,
-            const Vector3f&     geometric_normal,
-            const Basis3f&      shading_basis,
-            const Vector3f&     outgoing,
-            const Vector3f&     incoming,
-            const int           modes,
-            ShadingComponents&  value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             if (!ScatteringMode::has_diffuse(modes))
                 return 0.0f;
@@ -169,12 +169,12 @@ namespace
         }
 
         virtual float evaluate_pdf(
-            const void*         data,
-            const Vector3f&     geometric_normal,
-            const Basis3f&      shading_basis,
-            const Vector3f&     outgoing,
-            const Vector3f&     incoming,
-            const int           modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             if (!ScatteringMode::has_diffuse(modes))
                 return 0.0f;

--- a/src/appleseed/renderer/modeling/bsdf/specularbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/specularbrdf.cpp
@@ -32,7 +32,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 #include "renderer/modeling/bsdf/fresnel.h"
@@ -63,8 +63,8 @@ namespace
     {
       public:
         SpecularBRDFImpl(
-            const char*         name,
-            const ParamArray&   params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Specular, params)
         {
             m_inputs.declare("reflectance", InputFormatSpectralReflectance);
@@ -82,12 +82,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&    sampling_context,
-            const void*         data,
-            const bool          adjoint,
-            const bool          cosine_mult,
-            const int           modes,
-            BSDFSample&         sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             if (!ScatteringMode::has_specular(modes))
                 return;
@@ -109,26 +109,26 @@ namespace
         }
 
         virtual float evaluate(
-            const void*         data,
-            const bool          adjoint,
-            const bool          cosine_mult,
-            const Vector3f&     geometric_normal,
-            const Basis3f&      shading_basis,
-            const Vector3f&     outgoing,
-            const Vector3f&     incoming,
-            const int           modes,
-            ShadingComponents&  value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             return 0.0f;
         }
 
         virtual float evaluate_pdf(
-            const void*         data,
-            const Vector3f&     geometric_normal,
-            const Basis3f&      shading_basis,
-            const Vector3f&     outgoing,
-            const Vector3f&     incoming,
-            const int           modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             return 0.0f;
         }

--- a/src/appleseed/renderer/modeling/bsdf/specularbtdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/specularbtdf.cpp
@@ -32,7 +32,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 
@@ -67,8 +67,8 @@ namespace
     {
       public:
         SpecularBTDFImpl(
-            const char*             name,
-            const ParamArray&       params)
+            const char*                 name,
+            const ParamArray&           params)
           : BSDF(name, Transmissive, ScatteringMode::Specular, params)
         {
             m_inputs.declare("reflectance", InputFormatSpectralReflectance);
@@ -97,9 +97,9 @@ namespace
         }
 
         virtual void prepare_inputs(
-            Arena&                  arena,
-            const ShadingPoint&     shading_point,
-            void*                   data) const override
+            Arena&                      arena,
+            const ShadingPoint&         shading_point,
+            void*                       data) const override
         {
             InputValues* values = static_cast<InputValues*>(data);
             new (&values->m_precomputed) InputValues::Precomputed();
@@ -110,12 +110,12 @@ namespace
         }
 
         virtual void sample(
-            SamplingContext&        sampling_context,
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const int               modes,
-            BSDFSample&             sample) const override
+            SamplingContext&            sampling_context,
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const int                   modes,
+            BSDFSample&                 sample) const override
         {
             if (!ScatteringMode::has_specular(modes))
                 return;
@@ -202,41 +202,41 @@ namespace
         }
 
         virtual float evaluate(
-            const void*             data,
-            const bool              adjoint,
-            const bool              cosine_mult,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes,
-            ShadingComponents&      value) const override
+            const void*                 data,
+            const bool                  adjoint,
+            const bool                  cosine_mult,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes,
+            DirectShadingComponents&    value) const override
         {
             return 0.0f;
         }
 
         virtual float evaluate_pdf(
-            const void*             data,
-            const Vector3f&         geometric_normal,
-            const Basis3f&          shading_basis,
-            const Vector3f&         outgoing,
-            const Vector3f&         incoming,
-            const int               modes) const override
+            const void*                 data,
+            const Vector3f&             geometric_normal,
+            const Basis3f&              shading_basis,
+            const Vector3f&             outgoing,
+            const Vector3f&             incoming,
+            const int                   modes) const override
         {
             return 0.0f;
         }
 
         virtual float sample_ior(
-            SamplingContext&        sampling_context,
-            const void*             data) const override
+            SamplingContext&            sampling_context,
+            const void*                 data) const override
         {
             return static_cast<const InputValues*>(data)->m_ior;
         }
 
         void compute_absorption(
-            const void*             data,
-            const float             distance,
-            Spectrum&               absorption) const override
+            const void*                 data,
+            const float                 distance,
+            Spectrum&                   absorption) const override
         {
             const InputValues* values = static_cast<const InputValues*>(data);
             const float d = values->m_volume_density * values->m_volume_scale * distance;

--- a/src/appleseed/renderer/modeling/bsdf/specularhelper.h
+++ b/src/appleseed/renderer/modeling/bsdf/specularhelper.h
@@ -32,7 +32,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
 #include "renderer/kernel/lighting/scatteringmode.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfsample.h"
 

--- a/src/appleseed/renderer/modeling/material/imaterialfactory.cpp
+++ b/src/appleseed/renderer/modeling/material/imaterialfactory.cpp
@@ -43,14 +43,6 @@ void IMaterialFactory::add_surface_shader_metadata(DictionaryArray& metadata)
 {
     metadata.push_back(
         Dictionary()
-            .insert("name", "shade_alpha_cutouts")
-            .insert("label", "Shade Alpha Cutouts")
-            .insert("type", "boolean")
-            .insert("use", "optional")
-            .insert("default", "false"));
-
-    metadata.push_back(
-        Dictionary()
             .insert("name", "surface_shader")
             .insert("label", "Surface Shader")
             .insert("type", "entity")

--- a/src/appleseed/renderer/modeling/material/material.cpp
+++ b/src/appleseed/renderer/modeling/material/material.cpp
@@ -82,7 +82,6 @@ Material::Material(
     const char*             name,
     const ParamArray&       params)
   : ConnectableEntity(g_class_uid, params)
-  , m_shade_alpha_cutouts(params.get_optional<bool>("shade_alpha_cutouts", false))
   , m_has_render_data(false)
 {
     set_name(name);

--- a/src/appleseed/renderer/modeling/material/material.h
+++ b/src/appleseed/renderer/modeling/material/material.h
@@ -77,9 +77,6 @@ class APPLESEED_DLLSYMBOL Material
     // Return a string identifying the model of this material.
     virtual const char* get_model() const = 0;
 
-    // Return whether surface shaders should be invoked for fully transparent shading points.
-    bool shade_alpha_cutouts() const;
-
     // Return true if this material has an alpha map.
     bool has_alpha_map() const;
 
@@ -155,7 +152,6 @@ class APPLESEED_DLLSYMBOL Material
     const RenderData& get_render_data() const;
 
   protected:
-    bool        m_shade_alpha_cutouts;
     bool        m_has_render_data;
     RenderData  m_render_data;
 
@@ -173,11 +169,6 @@ class APPLESEED_DLLSYMBOL Material
 //
 // Material class implementation.
 //
-
-inline bool Material::shade_alpha_cutouts() const
-{
-    return m_shade_alpha_cutouts;
-}
 
 inline const Material::RenderData& Material::get_render_data() const
 {

--- a/src/appleseed/renderer/modeling/object/meshobject.cpp
+++ b/src/appleseed/renderer/modeling/object/meshobject.cpp
@@ -135,8 +135,6 @@ bool MeshObject::on_frame_begin(
         return false;
 
     m_alpha_map = get_uncached_alpha_map();
-    m_shade_alpha_cutouts = m_params.get_optional<bool>("shade_alpha_cutouts", false);
-
     return true;
 }
 
@@ -145,8 +143,6 @@ void MeshObject::on_frame_end(
     const BaseGroup*        parent)
 {
     m_alpha_map = 0;
-    m_shade_alpha_cutouts = false;
-
     Object::on_frame_end(project, parent);
 }
 

--- a/src/appleseed/renderer/modeling/object/object.cpp
+++ b/src/appleseed/renderer/modeling/object/object.cpp
@@ -54,7 +54,6 @@ Object::Object(
     const ParamArray&   params)
   : ConnectableEntity(g_class_uid, params)
   , m_alpha_map(0)
-  , m_shade_alpha_cutouts(false)
 {
     set_name(name);
 }

--- a/src/appleseed/renderer/modeling/object/object.h
+++ b/src/appleseed/renderer/modeling/object/object.h
@@ -89,12 +89,8 @@ class APPLESEED_DLLSYMBOL Object
     const Source* get_alpha_map() const;
     virtual const Source* get_uncached_alpha_map() const;
 
-    // Return whether surface shaders should be invoked for fully transparent shading points.
-    bool shade_alpha_cutouts() const;
-
   protected:
     const Source* m_alpha_map;
-    bool          m_shade_alpha_cutouts;
 };
 
 
@@ -105,11 +101,6 @@ class APPLESEED_DLLSYMBOL Object
 inline const Source* Object::get_alpha_map() const
 {
     return m_alpha_map;
-}
-
-inline bool Object::shade_alpha_cutouts() const
-{
-    return m_shade_alpha_cutouts;
 }
 
 }       // namespace renderer

--- a/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
@@ -1493,6 +1493,53 @@ namespace
             params.remove_path("premultiplied_alpha");
         }
     };
+
+    //
+    // Update from revision 19 to revision 20.
+    //
+
+    class UpdateFromRevision_19
+      : public Updater
+    {
+      public:
+        explicit UpdateFromRevision_19(Project& project)
+            : Updater(project, 19)
+        {
+        }
+
+        virtual void update() override
+        {
+            if (Scene* scene = m_project.get_scene())
+                update_material_and_object_inputs(scene->assemblies());
+        }
+
+      private:
+        static void update_material_and_object_inputs(AssemblyContainer& assemblies)
+        {
+            for (each<AssemblyContainer> i = assemblies; i; ++i)
+            {
+                update_material_and_object_inputs(*i);
+                update_material_and_object_inputs(i->assemblies());
+            }
+        }
+
+        static void update_material_and_object_inputs(Assembly& assembly)
+        {
+            for (each<MaterialContainer> i = assembly.materials(); i; ++i)
+                remove_shade_alpha_cutouts(*i);
+
+            for (each<ObjectContainer> i = assembly.objects(); i; ++i)
+                remove_shade_alpha_cutouts(*i);
+        }
+
+        template <typename EntityType>
+        static void remove_shade_alpha_cutouts(EntityType& entity)
+        {
+            ParamArray& params = entity.get_parameters();
+            params.remove_path("shade_alpha_cutouts");
+        }
+    };
+
 }
 
 bool ProjectFileUpdater::update(
@@ -1544,6 +1591,7 @@ void ProjectFileUpdater::update(
       CASE_UPDATE_FROM_REVISION(16);
       CASE_UPDATE_FROM_REVISION(17);
       CASE_UPDATE_FROM_REVISION(18);
+      CASE_UPDATE_FROM_REVISION(19);
 
       case ProjectFormatRevision:
         // Project is up-to-date.

--- a/src/appleseed/renderer/modeling/project/projectformatrevision.h
+++ b/src/appleseed/renderer/modeling/project/projectformatrevision.h
@@ -39,7 +39,7 @@ namespace renderer
 // when you increment this value.
 //
 
-const size_t ProjectFormatRevision = 19;
+const size_t ProjectFormatRevision = 20;
 
 }       // namespace renderer
 

--- a/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
@@ -33,7 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/kernel/aov/aovaccumulator.h"
 #include "renderer/kernel/shading/ambientocclusion.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/modeling/bsdf/bsdf.h"
@@ -245,7 +245,7 @@ void DiagnosticSurfaceShader::evaluate(
                 {
                     const Vector3f direction = -normalize(Vector3f(shading_point.get_ray().m_dir));
 
-                    ShadingComponents value;
+                    DirectShadingComponents value;
                     material_data.m_bsdf->evaluate(
                         material_data.m_bsdf->evaluate_inputs(shading_context, shading_point),
                         false,

--- a/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
@@ -33,7 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/kernel/aov/aovaccumulator.h"
 #include "renderer/kernel/lighting/ilightingengine.h"
-#include "renderer/kernel/shading/directshadingcomponents.h"
+#include "renderer/kernel/shading/shadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/modeling/input/inputarray.h"
@@ -113,7 +113,7 @@ namespace
                 &values);
 
             // Compute lighting.
-            DirectShadingComponents radiance;
+            ShadingComponents radiance;
             for (size_t i = 0, e = m_lighting_samples; i < e; ++i)
             {
                 shading_context.get_lighting_engine()->compute_lighting(

--- a/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
@@ -33,7 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/kernel/aov/aovaccumulator.h"
 #include "renderer/kernel/lighting/ilightingengine.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/modeling/input/inputarray.h"
@@ -113,7 +113,7 @@ namespace
                 &values);
 
             // Compute lighting.
-            ShadingComponents radiance;
+            DirectShadingComponents radiance;
             for (size_t i = 0, e = m_lighting_samples; i < e; ++i)
             {
                 shading_context.get_lighting_engine()->compute_lighting(


### PR DESCRIPTION
- Removed shade alpha cutouts. Does not make sense after unpremultiplied rendering was removed.
- Use only the beauty and alpha accumulators for progressive rendering.
- Added direct and indirect diffuse and glossy AOVs.
- AOV related classes refactors.
