### PR TITLE
platform/thread.h: Correct spinlock initialisation with C++11

### DIFF
--- a/src/appleseed/foundation/platform/thread.h
+++ b/src/appleseed/foundation/platform/thread.h
@@ -296,9 +296,8 @@ class APPLESEED_DLLSYMBOL ThreadFlag
 
 inline Spinlock::Spinlock()
 {
-    // todo: is there a simpler way to initialize m_sp in a platform-independent manner?
     boost::detail::spinlock initialized_sp = BOOST_DETAIL_SPINLOCK_INIT;
-    m_sp = initialized_sp;
+    std::memcpy(&m_sp, &initialized_sp, sizeof(initialized_sp));
 }
 
 inline bool Spinlock::try_lock()


### PR DESCRIPTION
This matches the way it's initialised internally by Boost.  The previous initialisation method broke compilation with Clang/LLVM 4.0.0 on FreeBSD with C++11 enabled; copy and assignment operators are deleted, which this logic was attempting to use (in fact, it's surprising that it was working before because it was most likely not possible even with C++98, unless it's a very recent Boost change).

See [Boost smart_ptr atomic_shared_ptr](https://github.com/boostorg/smart_ptr/blob/a054a570c11bd1ac9e89b849cd7636f4b3341e4c/include/boost/smart_ptr/atomic_shared_ptr.hpp#L71) for details.