### PR TITLE
Fix PyQt,PySide load preference

### DIFF
--- a/src/appleseed.python/studio/__init__.py
+++ b/src/appleseed.python/studio/__init__.py
@@ -26,4 +26,10 @@
 # THE SOFTWARE.
 #
 
+import os
+
+# Prevent Qt.py importing PySide2 and PyQt5.
+if not os.getenv("QT_PREFERRED_BINDING"):
+    os.environ["QT_PREFERRED_BINDING"] = "PyQt4"
+
 from _appleseedstudio import *


### PR DESCRIPTION
Which results in a crash in Fedora22, 23. Use PyQt4, Pyside first.