### PR TITLE
AOV cleanups

### DIFF
--- a/src/appleseed.python/bindaov.cpp
+++ b/src/appleseed.python/bindaov.cpp
@@ -54,14 +54,13 @@ namespace
 {
     auto_release_ptr<AOV> create_aov(
         const string&      model,
-        const string&      name,
         const bpy::dict&   params)
     {
         AOVFactoryRegistrar factories;
         const IAOVFactory* factory = factories.lookup(model.c_str());
 
         if (factory)
-            return factory->create(name.c_str(), bpy_dict_to_param_array(params));
+            return factory->create(bpy_dict_to_param_array(params));
         else
         {
             PyErr_SetString(PyExc_RuntimeError, "AOV model not found");

--- a/src/appleseed.python/bindframe.cpp
+++ b/src/appleseed.python/bindframe.cpp
@@ -62,6 +62,14 @@ namespace
         return FrameFactory::create(name.c_str(), bpy_dict_to_param_array(params));
     }
 
+    auto_release_ptr<Frame> create_frame_with_aovs(
+        const string&       name,
+        const bpy::dict&    params,
+        const AOVContainer& aovs)
+    {
+        return FrameFactory::create(name.c_str(), bpy_dict_to_param_array(params), aovs);
+    }
+
     bpy::object archive_frame(const Frame* frame, const char* directory)
     {
         char* output = 0;
@@ -124,6 +132,7 @@ void bind_frame()
 {
     bpy::class_<Frame, auto_release_ptr<Frame>, bpy::bases<Entity>, boost::noncopyable>("Frame", bpy::no_init)
         .def("__init__", bpy::make_constructor(create_frame))
+        .def("__init__", bpy::make_constructor(create_frame_with_aovs))
 
         .def("reset_crop_window", &Frame::reset_crop_window)
         .def("has_crop_window", &Frame::has_crop_window)
@@ -140,8 +149,6 @@ void bind_frame()
         .def("write_image_and_aovs_to_multipart_exr", &Frame::write_image_and_aovs_to_multipart_exr)
         .def("archive", archive_frame)
 
-        .def("add_aov", &Frame::add_aov)
-        .def("transfer_aovs", &Frame::transfer_aovs)
         .def("aovs", &Frame::aovs, bpy::return_value_policy<bpy::reference_existing_object>())
         ;
 }

--- a/src/appleseed.studio/mainwindow/project/projectbuilder.cpp
+++ b/src/appleseed.studio/mainwindow/project/projectbuilder.cpp
@@ -71,9 +71,8 @@ Frame* ProjectBuilder::edit_frame(
     const size_t old_canvas_width = old_frame->image().properties().m_canvas_width;
     const size_t old_canvas_height = old_frame->image().properties().m_canvas_height;
 
-    auto_release_ptr<Frame> new_frame = FrameFactory::create(name.c_str(), clean_values);
-    new_frame->transfer_aovs(old_frame->aovs());
-    m_project.set_frame(new_frame);
+    m_project.set_frame(
+        FrameFactory::create(name.c_str(), clean_values, old_frame->aovs()));
 
     const size_t new_canvas_width = m_project.get_frame()->image().properties().m_canvas_width;
     const size_t new_canvas_height = m_project.get_frame()->image().properties().m_canvas_height;

--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -99,8 +99,8 @@ namespace
       : public AOV
     {
       public:
-        DepthAOV(const char* name, const ParamArray& params)
-          : AOV(name, params)
+        explicit DepthAOV(const ParamArray& params)
+          : AOV("depth", params)
         {
         }
 
@@ -164,21 +164,15 @@ DictionaryArray DepthAOVFactory::get_input_metadata() const
 }
 
 auto_release_ptr<AOV> DepthAOVFactory::create(
-    const char*         name,
     const ParamArray&   params) const
 {
-    return
-        auto_release_ptr<AOV>(
-            new DepthAOV(name, params));
+    return auto_release_ptr<AOV>(new DepthAOV(params));
 }
 
 auto_release_ptr<AOV> DepthAOVFactory::static_create(
-    const char*         name,
     const ParamArray&   params)
 {
-    return
-        auto_release_ptr<AOV>(
-            new DepthAOV(name, params));
+    return auto_release_ptr<AOV>(new DepthAOV(params));
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/depthaov.h
+++ b/src/appleseed/renderer/modeling/aov/depthaov.h
@@ -66,12 +66,10 @@ class APPLESEED_DLLSYMBOL DepthAOVFactory
 
     // Create a new AOV instance.
     virtual foundation::auto_release_ptr<AOV> create(
-        const char*         name,
         const ParamArray&   params) const override;
 
     // Static variant of the create() method above.
     static foundation::auto_release_ptr<AOV> static_create(
-        const char*         name,
         const ParamArray&   params);
 };
 

--- a/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
@@ -133,8 +133,8 @@ namespace
       : public ColorAOV
     {
       public:
-        DiffuseAOV(const char* name, const ParamArray& params)
-          : ColorAOV(name, params)
+        explicit DiffuseAOV(const ParamArray& params)
+          : ColorAOV("diffuse", params)
         {
         }
 
@@ -166,8 +166,8 @@ namespace
       : public ColorAOV
     {
       public:
-        DirectDiffuseAOV(const char* name, const ParamArray& params)
-          : ColorAOV(name, params)
+        explicit DirectDiffuseAOV(const ParamArray& params)
+          : ColorAOV("direct_diffuse", params)
         {
         }
 
@@ -199,8 +199,8 @@ namespace
       : public ColorAOV
     {
       public:
-        IndirectDiffuseAOV(const char* name, const ParamArray& params)
-          : ColorAOV(name, params)
+        explicit IndirectDiffuseAOV(const ParamArray& params)
+          : ColorAOV("indirect_diffuse", params)
         {
         }
 
@@ -248,19 +248,15 @@ DictionaryArray DiffuseAOVFactory::get_input_metadata() const
 }
 
 auto_release_ptr<AOV> DiffuseAOVFactory::create(
-    const char*         name,
     const ParamArray&   params) const
 {
-    return
-        auto_release_ptr<AOV>(
-            new DiffuseAOV(name, params));
+    return auto_release_ptr<AOV>(new DiffuseAOV(params));
 }
 
 auto_release_ptr<AOV> DiffuseAOVFactory::static_create(
-    const char*         name,
     const ParamArray&   params)
 {
-    return auto_release_ptr<AOV>(new DiffuseAOV(name, params));
+    return auto_release_ptr<AOV>(new DiffuseAOV(params));
 }
 
 
@@ -289,17 +285,15 @@ DictionaryArray DirectDiffuseAOVFactory::get_input_metadata() const
 }
 
 auto_release_ptr<AOV> DirectDiffuseAOVFactory::create(
-    const char*         name,
     const ParamArray&   params) const
 {
-    return auto_release_ptr<AOV>(new DirectDiffuseAOV(name, params));
+    return auto_release_ptr<AOV>(new DirectDiffuseAOV(params));
 }
 
 auto_release_ptr<AOV> DirectDiffuseAOVFactory::static_create(
-    const char*         name,
     const ParamArray&   params)
 {
-    return auto_release_ptr<AOV>(new DirectDiffuseAOV(name, params));
+    return auto_release_ptr<AOV>(new DirectDiffuseAOV(params));
 }
 
 
@@ -328,17 +322,15 @@ DictionaryArray IndirectDiffuseAOVFactory::get_input_metadata() const
 }
 
 auto_release_ptr<AOV> IndirectDiffuseAOVFactory::create(
-    const char*         name,
     const ParamArray&   params) const
 {
-    return auto_release_ptr<AOV>(new IndirectDiffuseAOV(name, params));
+    return auto_release_ptr<AOV>(new IndirectDiffuseAOV(params));
 }
 
 auto_release_ptr<AOV> IndirectDiffuseAOVFactory::static_create(
-    const char*         name,
     const ParamArray&   params)
 {
-    return auto_release_ptr<AOV>(new IndirectDiffuseAOV(name, params));
+    return auto_release_ptr<AOV>(new IndirectDiffuseAOV(params));
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/diffuseaov.h
+++ b/src/appleseed/renderer/modeling/aov/diffuseaov.h
@@ -66,12 +66,10 @@ class APPLESEED_DLLSYMBOL DiffuseAOVFactory
 
     // Create a new AOV instance.
     virtual foundation::auto_release_ptr<AOV> create(
-        const char*         name,
         const ParamArray&   params) const override;
 
     // Static variant of the create() method above.
     static foundation::auto_release_ptr<AOV> static_create(
-        const char*         name,
         const ParamArray&   params);
 };
 
@@ -95,12 +93,10 @@ class APPLESEED_DLLSYMBOL DirectDiffuseAOVFactory
 
     // Create a new AOV instance.
     virtual foundation::auto_release_ptr<AOV> create(
-        const char*         name,
         const ParamArray&   params) const override;
 
     // Static variant of the create() method above.
     static foundation::auto_release_ptr<AOV> static_create(
-        const char*         name,
         const ParamArray&   params);
 };
 
@@ -124,12 +120,10 @@ class APPLESEED_DLLSYMBOL IndirectDiffuseAOVFactory
 
     // Create a new AOV instance.
     virtual foundation::auto_release_ptr<AOV> create(
-        const char*         name,
         const ParamArray&   params) const override;
 
     // Static variant of the create() method above.
     static foundation::auto_release_ptr<AOV> static_create(
-        const char*         name,
         const ParamArray&   params);
 };
 

--- a/src/appleseed/renderer/modeling/aov/emissionaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/emissionaov.cpp
@@ -86,8 +86,8 @@ namespace
       : public ColorAOV
     {
       public:
-        EmissionAOV(const char* name, const ParamArray& params)
-          : ColorAOV(name, params)
+        explicit EmissionAOV(const ParamArray& params)
+          : ColorAOV("emission", params)
         {
         }
 
@@ -135,21 +135,16 @@ DictionaryArray EmissionAOVFactory::get_input_metadata() const
 }
 
 auto_release_ptr<AOV> EmissionAOVFactory::create(
-    const char*         name,
     const ParamArray&   params) const
 {
     return
-        auto_release_ptr<AOV>(
-            new EmissionAOV(name, params));
+        auto_release_ptr<AOV>(new EmissionAOV(params));
 }
 
 auto_release_ptr<AOV> EmissionAOVFactory::static_create(
-    const char*         name,
     const ParamArray&   params)
 {
-    return
-        auto_release_ptr<AOV>(
-            new EmissionAOV(name, params));
+    return auto_release_ptr<AOV>(new EmissionAOV(params));
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/emissionaov.h
+++ b/src/appleseed/renderer/modeling/aov/emissionaov.h
@@ -66,12 +66,10 @@ class APPLESEED_DLLSYMBOL EmissionAOVFactory
 
     // Create a new AOV instance.
     virtual foundation::auto_release_ptr<AOV> create(
-        const char*         name,
         const ParamArray&   params) const override;
 
     // Static variant of the create() method above.
     static foundation::auto_release_ptr<AOV> static_create(
-        const char*         name,
         const ParamArray&   params);
 };
 

--- a/src/appleseed/renderer/modeling/aov/glossyaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/glossyaov.cpp
@@ -133,8 +133,8 @@ namespace
       : public ColorAOV
     {
       public:
-        GlossyAOV(const char* name, const ParamArray& params)
-          : ColorAOV(name, params)
+        explicit GlossyAOV(const ParamArray& params)
+          : ColorAOV("glossy", params)
         {
         }
 
@@ -166,8 +166,8 @@ namespace
       : public ColorAOV
     {
       public:
-        DirectGlossyAOV(const char* name, const ParamArray& params)
-          : ColorAOV(name, params)
+        explicit DirectGlossyAOV(const ParamArray& params)
+          : ColorAOV("direct_glossy", params)
         {
         }
 
@@ -199,8 +199,8 @@ namespace
       : public ColorAOV
     {
       public:
-        IndirectGlossyAOV(const char* name, const ParamArray& params)
-          : ColorAOV(name, params)
+        explicit IndirectGlossyAOV(const ParamArray& params)
+          : ColorAOV("indirect_glossy", params)
         {
         }
 
@@ -248,17 +248,15 @@ DictionaryArray GlossyAOVFactory::get_input_metadata() const
 }
 
 auto_release_ptr<AOV> GlossyAOVFactory::create(
-    const char*         name,
     const ParamArray&   params) const
 {
-    return auto_release_ptr<AOV>(new GlossyAOV(name, params));
+    return auto_release_ptr<AOV>(new GlossyAOV(params));
 }
 
 auto_release_ptr<AOV> GlossyAOVFactory::static_create(
-    const char*         name,
     const ParamArray&   params)
 {
-    return auto_release_ptr<AOV>(new GlossyAOV(name, params));
+    return auto_release_ptr<AOV>(new GlossyAOV(params));
 }
 
 
@@ -287,17 +285,15 @@ DictionaryArray DirectGlossyAOVFactory::get_input_metadata() const
 }
 
 auto_release_ptr<AOV> DirectGlossyAOVFactory::create(
-    const char*         name,
     const ParamArray&   params) const
 {
-    return auto_release_ptr<AOV>(new DirectGlossyAOV(name, params));
+    return auto_release_ptr<AOV>(new DirectGlossyAOV(params));
 }
 
 auto_release_ptr<AOV> DirectGlossyAOVFactory::static_create(
-    const char*         name,
     const ParamArray&   params)
 {
-    return auto_release_ptr<AOV>(new DirectGlossyAOV(name, params));
+    return auto_release_ptr<AOV>(new DirectGlossyAOV(params));
 }
 
 
@@ -326,17 +322,15 @@ DictionaryArray IndirectGlossyAOVFactory::get_input_metadata() const
 }
 
 auto_release_ptr<AOV> IndirectGlossyAOVFactory::create(
-    const char*         name,
     const ParamArray&   params) const
 {
-    return auto_release_ptr<AOV>(new IndirectGlossyAOV(name, params));
+    return auto_release_ptr<AOV>(new IndirectGlossyAOV(params));
 }
 
 auto_release_ptr<AOV> IndirectGlossyAOVFactory::static_create(
-    const char*         name,
     const ParamArray&   params)
 {
-    return auto_release_ptr<AOV>(new IndirectGlossyAOV(name, params));
+    return auto_release_ptr<AOV>(new IndirectGlossyAOV(params));
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/glossyaov.h
+++ b/src/appleseed/renderer/modeling/aov/glossyaov.h
@@ -66,12 +66,10 @@ class APPLESEED_DLLSYMBOL GlossyAOVFactory
 
     // Create a new AOV instance.
     virtual foundation::auto_release_ptr<AOV> create(
-        const char*         name,
         const ParamArray&   params) const override;
 
     // Static variant of the create() method above.
     static foundation::auto_release_ptr<AOV> static_create(
-        const char*         name,
         const ParamArray&   params);
 };
 
@@ -95,12 +93,10 @@ class APPLESEED_DLLSYMBOL DirectGlossyAOVFactory
 
     // Create a new AOV instance.
     virtual foundation::auto_release_ptr<AOV> create(
-        const char*         name,
         const ParamArray&   params) const override;
 
     // Static variant of the create() method above.
     static foundation::auto_release_ptr<AOV> static_create(
-        const char*         name,
         const ParamArray&   params);
 };
 
@@ -124,12 +120,10 @@ class APPLESEED_DLLSYMBOL IndirectGlossyAOVFactory
 
     // Create a new AOV instance.
     virtual foundation::auto_release_ptr<AOV> create(
-        const char*         name,
         const ParamArray&   params) const override;
 
     // Static variant of the create() method above.
     static foundation::auto_release_ptr<AOV> static_create(
-        const char*         name,
         const ParamArray&   params);
 };
 

--- a/src/appleseed/renderer/modeling/aov/iaovfactory.h
+++ b/src/appleseed/renderer/modeling/aov/iaovfactory.h
@@ -67,7 +67,6 @@ class APPLESEED_DLLSYMBOL IAOVFactory
 
     // Create a new AOV instance.
     virtual foundation::auto_release_ptr<AOV> create(
-        const char*         name,
         const ParamArray&   params) const = 0;
 };
 

--- a/src/appleseed/renderer/modeling/aov/normalaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/normalaov.cpp
@@ -103,8 +103,8 @@ namespace
       : public AOV
     {
       public:
-        NormalAOV(const char* name, const ParamArray& params)
-          : AOV(name, params)
+        explicit NormalAOV(const ParamArray& params)
+          : AOV("normal", params)
         {
         }
 
@@ -168,21 +168,15 @@ DictionaryArray NormalAOVFactory::get_input_metadata() const
 }
 
 auto_release_ptr<AOV> NormalAOVFactory::create(
-    const char*         name,
     const ParamArray&   params) const
 {
-    return
-        auto_release_ptr<AOV>(
-            new NormalAOV(name, params));
+    return auto_release_ptr<AOV>(new NormalAOV(params));
 }
 
 auto_release_ptr<AOV> NormalAOVFactory::static_create(
-    const char*         name,
     const ParamArray&   params)
 {
-    return
-        auto_release_ptr<AOV>(
-            new NormalAOV(name, params));
+    return auto_release_ptr<AOV>(new NormalAOV(params));
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/normalaov.h
+++ b/src/appleseed/renderer/modeling/aov/normalaov.h
@@ -66,12 +66,10 @@ class APPLESEED_DLLSYMBOL NormalAOVFactory
 
     // Create a new AOV instance.
     virtual foundation::auto_release_ptr<AOV> create(
-        const char*         name,
         const ParamArray&   params) const override;
 
     // Static variant of the create() method above.
     static foundation::auto_release_ptr<AOV> static_create(
-        const char*         name,
         const ParamArray&   params);
 };
 

--- a/src/appleseed/renderer/modeling/aov/uvaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/uvaov.cpp
@@ -98,8 +98,8 @@ namespace
       : public AOV
     {
       public:
-        UVAOV(const char* name, const ParamArray& params)
-          : AOV(name, params)
+        explicit UVAOV(const ParamArray& params)
+          : AOV("uv", params)
         {
         }
 
@@ -163,21 +163,15 @@ DictionaryArray UVAOVFactory::get_input_metadata() const
 }
 
 auto_release_ptr<AOV> UVAOVFactory::create(
-    const char*         name,
     const ParamArray&   params) const
 {
-    return
-        auto_release_ptr<AOV>(
-            new UVAOV(name, params));
+    return auto_release_ptr<AOV>(new UVAOV(params));
 }
 
 auto_release_ptr<AOV> UVAOVFactory::static_create(
-    const char*         name,
     const ParamArray&   params)
 {
-    return
-        auto_release_ptr<AOV>(
-            new UVAOV(name, params));
+    return auto_release_ptr<AOV>(new UVAOV(params));
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/uvaov.h
+++ b/src/appleseed/renderer/modeling/aov/uvaov.h
@@ -66,12 +66,10 @@ class APPLESEED_DLLSYMBOL UVAOVFactory
 
     // Create a new AOV instance.
     virtual foundation::auto_release_ptr<AOV> create(
-        const char*         name,
         const ParamArray&   params) const override;
 
     // Static variant of the create() method above.
     static foundation::auto_release_ptr<AOV> static_create(
-        const char*         name,
         const ParamArray&   params);
 };
 

--- a/src/appleseed/renderer/modeling/frame/frame.h
+++ b/src/appleseed/renderer/modeling/frame/frame.h
@@ -95,14 +95,8 @@ class APPLESEED_DLLSYMBOL Frame
     // Access the AOV images.
     ImageStack& aov_images() const;
 
-    // Add an AOV if it does not exist.
-    void add_aov(foundation::auto_release_ptr<AOV> aov);
-
-    // Transfer AOVs.
-    void transfer_aovs(AOVContainer& aovs);
-
     // Access the AOVs.
-    AOVContainer& aovs() const;
+    const AOVContainer& aovs() const;
 
     // Create an extra AOV image if it does not exist.
     size_t create_extra_aov_image(const char* name) const;
@@ -164,7 +158,8 @@ class APPLESEED_DLLSYMBOL Frame
     // Constructor.
     Frame(
         const char*         name,
-        const ParamArray&   params);
+        const ParamArray&   params,
+        const AOVContainer& aovs);
 
     // Destructor.
     ~Frame();
@@ -205,6 +200,12 @@ class APPLESEED_DLLSYMBOL FrameFactory
     static foundation::auto_release_ptr<Frame> create(
         const char*         name,
         const ParamArray&   params);
+
+    // Create a new frame.
+    static foundation::auto_release_ptr<Frame> create(
+        const char*         name,
+        const ParamArray&   params,
+        const AOVContainer& aovs);
 };
 
 

--- a/src/appleseed/renderer/modeling/project/project.xsd
+++ b/src/appleseed/renderer/modeling/project/project.xsd
@@ -325,7 +325,6 @@
                                                             <xsd:complexType>
                                                                 <xsd:complexContent>
                                                                     <xsd:extension base="parameterSet">
-                                                                        <xsd:attribute name="name" type="xsd:string" use="required"/>
                                                                         <xsd:attribute name="model" type="xsd:string" use="required"/>
                                                                     </xsd:extension>
                                                                 </xsd:complexContent>

--- a/src/appleseed/renderer/modeling/project/projectfilereader.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilereader.cpp
@@ -2405,18 +2405,78 @@ namespace
     //
 
     class AOVElementHandler
-      : public EntityElementHandler<
-                   AOV,
-                   AOVFactoryRegistrar,
-                   ParametrizedElementHandler>
+      : public ParametrizedElementHandler
     {
       public:
         explicit AOVElementHandler(ParseContext& context)
-          : EntityElementHandler<
-                AOV,
-                AOVFactoryRegistrar,
-                ParametrizedElementHandler>("AOV", context)
+          : m_context(context)
         {
+        }
+
+        virtual void start_element(const Attributes& attrs) override
+        {
+            ParametrizedElementHandler::start_element(attrs);
+
+            m_aov.reset();
+
+            m_model = ParametrizedElementHandler::get_value(attrs, "model");
+        }
+
+        virtual void end_element() override
+        {
+            ParametrizedElementHandler::end_element();
+
+            m_aov = create_aov();
+        }
+
+        auto_release_ptr<AOV> get_aov()
+        {
+            return m_aov;
+        }
+
+      protected:
+        ParseContext&                   m_context;
+        const AOVFactoryRegistrar       m_registrar;
+        auto_release_ptr<AOV>           m_aov;
+        string                          m_model;
+
+        auto_release_ptr<AOV> create_aov() const
+        {
+            try
+            {
+                const typename AOVFactoryRegistrar::FactoryType* factory =
+                    m_registrar.lookup(m_model.c_str());
+
+                if (factory)
+                {
+                    return factory->create(m_params);
+                }
+                else
+                {
+                    RENDERER_LOG_ERROR(
+                        "while defining AOV: invalid model \"%s\".",
+                        m_model.c_str());
+                    m_context.get_event_counters().signal_error();
+                }
+            }
+            catch (const ExceptionDictionaryKeyNotFound& e)
+            {
+                RENDERER_LOG_ERROR(
+                    "while defining AOV \"%s\": required parameter \"%s\" missing.",
+                    m_model.c_str(),
+                    e.string());
+                m_context.get_event_counters().signal_error();
+            }
+            catch (const ExceptionUnknownEntity& e)
+            {
+                RENDERER_LOG_ERROR(
+                    "while defining AOV \"%s\": unknown entity \"%s\".",
+                    m_model.c_str(),
+                    e.string());
+                m_context.get_event_counters().signal_error();
+            }
+
+            return auto_release_ptr<AOV>(0);
         }
     };
 
@@ -2446,7 +2506,7 @@ namespace
               case ElementAOV:
                 {
                     auto_release_ptr<AOV> aov(
-                        static_cast<AOVElementHandler*>(handler)->get_entity());
+                        static_cast<AOVElementHandler*>(handler)->get_aov());
 
                     if (aov.get() == 0)
                         return;

--- a/src/appleseed/renderer/modeling/project/projectfilereader.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilereader.cpp
@@ -2565,8 +2565,7 @@ namespace
         {
             ParametrizedElementHandler::end_element();
 
-            m_frame = FrameFactory::create(m_name.c_str(), m_params);
-            m_frame->transfer_aovs(m_aovs);
+            m_frame = FrameFactory::create(m_name.c_str(), m_params, m_aovs);
         }
 
         virtual void start_child_element(

--- a/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
@@ -313,7 +313,14 @@ namespace
         // Write an <aov> element.
         void write(const AOV& aov)
         {
-            write_entity("aov", aov);
+            XMLElement element("aov", m_file, m_indenter);
+            element.add_attribute("model", aov.get_model());
+            element.write(
+                !aov.get_parameters().empty()
+                    ? XMLElement::HasChildElements
+                    : XMLElement::HasNoContent);
+
+            write_params(aov.get_parameters());
         }
 
         // Write an <assembly> element.

--- a/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
@@ -401,12 +401,14 @@ namespace
         // Write an <aovs> element.
         void write_aovs(const Frame& frame)
         {
-            if (!frame.aovs().empty())
+            const AOVContainer& aovs = frame.aovs();
+            if (!aovs.empty())
             {
                 XMLElement element("aovs", m_file, m_indenter);
                 element.write(XMLElement::HasChildElements);
 
-                write_collection(frame.aovs());
+                for (size_t i = 0, e = aovs.size(); i != e; ++i)
+                    write(*aovs.get_by_index(i));
             }
         }
 


### PR DESCRIPTION
- Fix AOV entity names.
- Removed Frame add / transfer AOVs. Frame is now inmutable again.
- Do not reorder AOVs when saving projects. This fixes parts order in multi-part EXR images. 

 