### PR TITLE
Frame image and AOVs saving refactors and improvements

### DIFF
--- a/src/appleseed.cli/main.cpp
+++ b/src/appleseed.cli/main.cpp
@@ -608,39 +608,16 @@ namespace
         }
 
         // Write the frame to disk.
+
         if (g_cl.m_output.is_set())
         {
-            LOG_INFO(g_logger, "writing frame to disk...");
             project->get_frame()->write_main_image(g_cl.m_output.value().c_str());
             project->get_frame()->write_aov_images(g_cl.m_output.value().c_str());
         }
         else
         {
             const Frame* frame = project->get_frame();
-
-            // Write the main image.
-            const string output_filename =
-                frame->get_parameters().get_optional<string>("output_filename");
-
-            if (!output_filename.empty())
-            {
-                LOG_INFO(g_logger, "writing frame to disk...");
-                frame->write_main_image(output_filename.c_str());
-            }
-
-            // Write AOVs.
-            for (size_t i = 0, e = frame->aovs().size(); i < e; ++i)
-            {
-                const AOV* aov = frame->aovs().get_by_index(i);
-                const string output_filename =
-                    aov->get_parameters().get_optional<string>("output_filename");
-
-                if (!output_filename.empty())
-                {
-                    LOG_INFO(g_logger, "writing %s aov to disk...", aov->get_model());
-                    frame->write_aov_image(output_filename.c_str(), i);
-                }
-            }
+            frame->write_main_and_aov_images();
         }
 
 #if defined __APPLE__ || defined _WIN32

--- a/src/appleseed.python/bindframe.cpp
+++ b/src/appleseed.python/bindframe.cpp
@@ -146,7 +146,7 @@ void bind_frame()
         .def("write_main_image", &Frame::write_main_image)
         .def("write_aov_images", &Frame::write_aov_images)
         .def("write_aov_image", &Frame::write_aov_image)
-        .def("write_image_and_aovs_to_multipart_exr", &Frame::write_image_and_aovs_to_multipart_exr)
+        .def("write_main_and_aov_images_to_multipart_exr", &Frame::write_main_and_aov_images_to_multipart_exr)
         .def("archive", archive_frame)
 
         .def("aovs", &Frame::aovs, bpy::return_value_policy<bpy::reference_existing_object>())

--- a/src/appleseed/renderer/modeling/frame/frame.h
+++ b/src/appleseed/renderer/modeling/frame/frame.h
@@ -136,8 +136,13 @@ class APPLESEED_DLLSYMBOL Frame
     bool write_aov_images(const char* file_path) const;
     bool write_aov_image(const char* file_path, const size_t aov_index) const;
 
-    // Write the main image and the AOVs as a multipart OpenEXR file.
-    void write_image_and_aovs_to_multipart_exr(const char* file_path) const;
+    // Write the main image and the AOV images to disk.
+    // The images file paths are taken from the frame and AOV "output_filename" parameters.
+    // Return true if successful, false otherwise.
+    bool write_main_and_aov_images() const;
+
+    // Write the main image and the AOVs to a multipart OpenEXR file.
+    void write_main_and_aov_images_to_multipart_exr(const char* file_path) const;
 
     // Archive the frame to a given directory on disk. If output_path is provided,
     // the full path to the output file will be returned. The returned string must


### PR DESCRIPTION
- Moved cli code to save main and AOV images to Frame so that it can be reused.
- Create directories if needed before saving images and AOVs.
- Renamed Frame's write_image_and_aovs_to_multipart_exr for consistency with similar methods.
