### PR TITLE
AOVs refactor

### DIFF
--- a/sandbox/tests/unit tests/inputs/test_projectfilereader_configurationblocks.appleseed
+++ b/sandbox/tests/unit tests/inputs/test_projectfilereader_configurationblocks.appleseed
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project format_revision="20">
+<project format_revision="21">
     <scene>
         <camera name="camera" model="pinhole_camera">
             <parameter name="film_dimensions" value="0.025 0.025" />

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
@@ -65,15 +65,41 @@ void AOVAccumulator::release()
     delete this;
 }
 
-void AOVAccumulator::write(
-    const ShadingComponents&    shading_components,
-    const float                 multiplier)
+void AOVAccumulator::on_tile_begin(
+    const Frame& frame,
+    const size_t tile_x,
+    const size_t tile_y)
+{
+}
+
+void AOVAccumulator::on_tile_end(
+    const Frame& frame,
+    const size_t tile_x,
+    const size_t tile_y)
+{
+}
+
+void AOVAccumulator::on_pixel_begin()
+{
+}
+
+void AOVAccumulator::on_pixel_end()
+{
+}
+
+void AOVAccumulator::on_sample_begin()
+{
+}
+
+void AOVAccumulator::on_sample_end()
 {
 }
 
 void AOVAccumulator::write(
+    const PixelContext&         pixel_context,
     const ShadingPoint&         shading_point,
-    const Camera&               camera)
+    const ShadingComponents&    shading_components,
+    const float                 multiplier)
 {
 }
 
@@ -89,11 +115,6 @@ ColorAOVAccumulator::ColorAOVAccumulator(const size_t index)
 
 ColorAOVAccumulator::~ColorAOVAccumulator()
 {
-}
-
-void ColorAOVAccumulator::reset()
-{
-    m_color.set(0.0f);
 }
 
 void ColorAOVAccumulator::flush(ShadingResult& result)
@@ -132,12 +153,9 @@ void BeautyAOVAccumulator::apply_multiplier(const float multiplier)
     m_color *= multiplier;
 }
 
-void BeautyAOVAccumulator::reset()
-{
-    m_color.set(0.0f);
-}
-
 void BeautyAOVAccumulator::write(
+    const PixelContext&         pixel_context,
+    const ShadingPoint&         shading_point,
     const ShadingComponents&    shading_components,
     const float                 multiplier)
 {
@@ -168,11 +186,6 @@ void AlphaAOVAccumulator::set(const Alpha& alpha)
 void AlphaAOVAccumulator::apply_multiplier(const Alpha& multiplier)
 {
     m_alpha *= multiplier;
-}
-
-void AlphaAOVAccumulator::reset()
-{
-    m_alpha.set(0.0f);
 }
 
 void AlphaAOVAccumulator::flush(ShadingResult& result)
@@ -218,26 +231,62 @@ AOVAccumulatorContainer::~AOVAccumulatorContainer()
         m_accumulators[i]->release();
 }
 
-void AOVAccumulatorContainer::reset()
+void AOVAccumulatorContainer::on_tile_begin(
+    const Frame&                frame,
+    const size_t                tile_x,
+    const size_t                tile_y)
 {
     for (size_t i = 0, e = m_size; i < e; ++i)
-        m_accumulators[i]->reset();
+        m_accumulators[i]->on_tile_begin(frame, tile_x, tile_y);
+}
+
+void AOVAccumulatorContainer::on_tile_end(
+    const Frame&                frame,
+    const size_t                tile_x,
+    const size_t                tile_y)
+{
+    for (size_t i = 0, e = m_size; i < e; ++i)
+        m_accumulators[i]->on_tile_end(frame, tile_x, tile_y);
+}
+
+void AOVAccumulatorContainer::on_pixel_begin()
+{
+    for (size_t i = 0, e = m_size; i < e; ++i)
+        m_accumulators[i]->on_pixel_begin();
+}
+
+void AOVAccumulatorContainer::on_pixel_end()
+{
+    for (size_t i = 0, e = m_size; i < e; ++i)
+        m_accumulators[i]->on_pixel_end();
+}
+
+void AOVAccumulatorContainer::on_sample_begin()
+{
+    for (size_t i = 0, e = m_size; i < e; ++i)
+        m_accumulators[i]->on_sample_begin();
+}
+
+void AOVAccumulatorContainer::on_sample_end()
+{
+    for (size_t i = 0, e = m_size; i < e; ++i)
+        m_accumulators[i]->on_sample_end();
 }
 
 void AOVAccumulatorContainer::write(
+    const PixelContext&         pixel_context,
+    const ShadingPoint&         shading_point,
     const ShadingComponents&    shading_components,
     const float                 multiplier)
 {
     for (size_t i = 0, e = m_size; i < e; ++i)
-        m_accumulators[i]->write(shading_components, multiplier);
-}
-
-void AOVAccumulatorContainer::write(
-    const ShadingPoint&         shading_point,
-    const Camera&               camera)
-{
-    for (size_t i = 0, e = m_size; i < e; ++i)
-        m_accumulators[i]->write(shading_point, camera);
+    {
+        m_accumulators[i]->write(
+            pixel_context,
+            shading_point,
+            shading_components,
+            multiplier);
+    }
 }
 
 void AOVAccumulatorContainer::flush(ShadingResult& result)

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
@@ -120,7 +120,7 @@ UnfilteredAOVAccumulator::UnfilteredAOVAccumulator(Image& image)
 {
 }
 
-void UnfilteredAOVAccumulator::fetch_tile(
+void UnfilteredAOVAccumulator::on_tile_begin(
     const Frame& frame,
     const size_t tile_x,
     const size_t tile_y)

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
@@ -35,6 +35,12 @@
 #include "renderer/kernel/shading/shadingresult.h"
 #include "renderer/modeling/aov/aov.h"
 #include "renderer/modeling/color/colorspace.h"
+#include "renderer/modeling/frame/frame.h"
+
+// appleseed.foundation headers.
+#include "foundation/image/canvasproperties.h"
+#include "foundation/image/image.h"
+#include "foundation/image/tile.h"
 
 // Standard headers.
 #include <cassert>
@@ -103,6 +109,33 @@ namespace
         }
     };
 }
+
+
+//
+// UnfilteredAOVAccumulator class implementation.
+//
+
+UnfilteredAOVAccumulator::UnfilteredAOVAccumulator(Image& image)
+  : m_image(image)
+{
+}
+
+void UnfilteredAOVAccumulator::fetch_tile(
+    const Frame& frame,
+    const size_t tile_x,
+    const size_t tile_y)
+{
+    // Fetch the destination tile.
+    const CanvasProperties& props = frame.image().properties();
+    m_tile = &m_image.tile(tile_x, tile_y);
+
+    // Fetch the tile bounds (inclusive).
+    m_tile_origin_x = static_cast<int>(tile_x * props.m_tile_width);
+    m_tile_origin_y = static_cast<int>(tile_y * props.m_tile_height);
+    m_tile_end_x = static_cast<int>(m_tile_origin_x + m_tile->get_width() - 1);
+    m_tile_end_y = static_cast<int>(m_tile_origin_y + m_tile->get_height() - 1);
+}
+
 
 //
 // AOVAccumulatorContainer class implementation.

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
@@ -51,11 +51,6 @@ namespace renderer
 // AOVAccumulator class implementation.
 //
 
-AOVAccumulator::AOVAccumulator(const size_t index)
-  : m_index(index)
-{
-}
-
 AOVAccumulator::~AOVAccumulator()
 {
 }
@@ -97,11 +92,6 @@ namespace
       : public AOVAccumulator
     {
       public:
-        BeautyAOVAccumulator()
-          : AOVAccumulator(~0)
-        {
-        }
-
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
@@ -147,7 +137,7 @@ void AOVAccumulatorContainer::init()
 AOVAccumulatorContainer::~AOVAccumulatorContainer()
 {
     for (size_t i = 0, e = m_size; i < e; ++i)
-        m_accumulators[i]->release();
+        delete m_accumulators[i];
 }
 
 void AOVAccumulatorContainer::on_tile_begin(
@@ -166,14 +156,6 @@ void AOVAccumulatorContainer::on_tile_end(
 {
     for (size_t i = 0, e = m_size; i < e; ++i)
         m_accumulators[i]->on_tile_end(frame, tile_x, tile_y);
-}
-
-void AOVAccumulatorContainer::on_pixel_begin()
-{
-}
-
-void AOVAccumulatorContainer::on_pixel_end()
-{
 }
 
 void AOVAccumulatorContainer::write(

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
@@ -148,19 +148,12 @@ void BeautyAOVAccumulator::set_to_pink_linear_rgb()
     set(Color3f(1.0f, 0.0f, 1.0f));
 }
 
-void BeautyAOVAccumulator::apply_multiplier(const float multiplier)
-{
-    m_color *= multiplier;
-}
-
 void BeautyAOVAccumulator::write(
     const PixelContext&         pixel_context,
     const ShadingPoint&         shading_point,
-    const ShadingComponents&    shading_components,
-    const float                 multiplier)
+    const ShadingComponents&    shading_components)
 {
     m_color = shading_components.m_beauty.to_rgb(g_std_lighting_conditions);
-    m_color *= multiplier;
 }
 
 void BeautyAOVAccumulator::flush(ShadingResult& result)
@@ -276,16 +269,14 @@ void AOVAccumulatorContainer::on_sample_end()
 void AOVAccumulatorContainer::write(
     const PixelContext&         pixel_context,
     const ShadingPoint&         shading_point,
-    const ShadingComponents&    shading_components,
-    const float                 multiplier)
+    const ShadingComponents&    shading_components)
 {
     for (size_t i = 0, e = m_size; i < e; ++i)
     {
         m_accumulators[i]->write(
             pixel_context,
             shading_point,
-            shading_components,
-            multiplier);
+            shading_components);
     }
 }
 

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.h
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.h
@@ -114,6 +114,8 @@ class UnfilteredAOVAccumulator
         const size_t tile_x,
         const size_t tile_y);
 
+    foundation::Tile& get_tile() const;
+
     bool outside_tile(const foundation::Vector2i& pi) const;
 
     static float squared_distace_to_pixel_center(const foundation::Vector2d& ps);
@@ -123,6 +125,11 @@ class UnfilteredAOVAccumulator
 //
 // Unfiltered AOV class implementation.
 //
+
+inline foundation::Tile& UnfilteredAOVAccumulator::get_tile() const
+{
+    return *m_tile;
+}
 
 inline bool UnfilteredAOVAccumulator::outside_tile(
     const foundation::Vector2i& pi) const

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.h
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.h
@@ -46,7 +46,6 @@
 // Forward declarations.
 namespace foundation    { class Image; }
 namespace foundation    { class Tile; }
-namespace renderer      { class Camera; }
 namespace renderer      { class Frame; }
 namespace renderer      { class PixelContext; }
 namespace renderer      { class ShadingComponents; }
@@ -101,6 +100,11 @@ class UnfilteredAOVAccumulator
   public:
     explicit UnfilteredAOVAccumulator(foundation::Image& image);
 
+    virtual void on_tile_begin(
+        const Frame& frame,
+        const size_t tile_x,
+        const size_t tile_y) override;
+
   protected:
     foundation::Image&  m_image;
     foundation::Tile*   m_tile;
@@ -109,12 +113,8 @@ class UnfilteredAOVAccumulator
     int                 m_tile_end_x;
     int                 m_tile_end_y;
 
-    void fetch_tile(
-        const Frame& frame,
-        const size_t tile_x,
-        const size_t tile_y);
-
     foundation::Tile& get_tile() const;
+
 
     bool outside_tile(const foundation::Vector2i& pi) const;
 

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.h
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.h
@@ -77,98 +77,18 @@ class AOVAccumulator
         const size_t                tile_x,
         const size_t                tile_y);
 
-    virtual void on_pixel_begin();
-    virtual void on_pixel_end();
-
-    virtual void on_sample_begin();
-    virtual void on_sample_end();
-
     // Write a value to the accumulator.
     virtual void write(
         const PixelContext&         pixel_context,
         const ShadingPoint&         shading_point,
-        const ShadingComponents&    shading_components);
-
-    // Flush the result.
-    virtual void flush(ShadingResult& result) = 0;
+        const ShadingComponents&    shading_components,
+        ShadingResult&              shading_result);
 
   protected:
     // Constructor.
     explicit AOVAccumulator(const size_t index);
 
     const size_t m_index;
-};
-
-
-//
-// Color AOV accumulator base class.
-//
-
-class ColorAOVAccumulator
-  : public AOVAccumulator
-{
-  public:
-    // Destructor.
-    ~ColorAOVAccumulator() override;
-
-    // Flush the result.
-    void flush(ShadingResult& result) override;
-
-  protected:
-    // Constructor.
-    explicit ColorAOVAccumulator(const size_t index);
-
-    foundation::Color3f m_color;
-};
-
-
-//
-// BeautyAOVAccumulator class.
-//
-
-class BeautyAOVAccumulator
-  : public AOVAccumulator
-{
-  public:
-    BeautyAOVAccumulator();
-
-    void set(const Spectrum& value);
-    void set(const foundation::Color3f& color);
-
-    void set_to_pink_linear_rgb();
-
-    virtual void write(
-        const PixelContext&         pixel_context,
-        const ShadingPoint&         shading_point,
-        const ShadingComponents&    shading_components) override;
-
-    virtual void flush(ShadingResult& result) override;
-
-  private:
-    foundation::Color3f m_color;
-};
-
-
-//
-// AlphaAOVAccumulator class.
-//
-
-class AlphaAOVAccumulator
-  : public AOVAccumulator
-{
-  public:
-    AlphaAOVAccumulator();
-
-    const Alpha& get() const;
-
-    void set(const Alpha& alpha);
-
-    void apply_multiplier(const Alpha& multiplier);
-
-    virtual void flush(ShadingResult& result) override;
-
-  private:
-    Alpha m_alpha;
 };
 
 
@@ -202,58 +122,22 @@ class AOVAccumulatorContainer
     void on_pixel_begin();
     void on_pixel_end();
 
-    void on_sample_begin();
-    void on_sample_end();
-
     // Write a sample to all accumulators.
     void write(
         const PixelContext&         pixel_context,
         const ShadingPoint&         shading_point,
-        const ShadingComponents&    shading_components);
-
-    // Flush all the accumulators.
-    void flush(ShadingResult& result);
-
-    // Access the beauty AOV.
-    BeautyAOVAccumulator& beauty();
-
-    // Access the alpha AOV.
-    AlphaAOVAccumulator& alpha();
+        const ShadingComponents&    shading_components,
+        ShadingResult&              shading_result);
 
   private:
     void init();
     bool insert(foundation::auto_release_ptr<AOVAccumulator> aov_accum);
 
-    enum { MaxAovAccumulators = MaxAOVCount + 2 };  // MaxAOVCount + Beauty + Alpha
+    enum { MaxAovAccumulators = MaxAOVCount + 1 };  // MaxAOVCount + Beauty
 
     size_t          m_size;
     AOVAccumulator* m_accumulators[MaxAovAccumulators];
 };
-
-
-//
-// AlphaAOVAccumulator class implementation.
-//
-
-inline const Alpha& AlphaAOVAccumulator::get() const
-{
-    return m_alpha;
-}
-
-
-//
-// AOVAccumulatorContainer class implementation.
-//
-
-inline BeautyAOVAccumulator& AOVAccumulatorContainer::beauty()
-{
-    return static_cast<BeautyAOVAccumulator&>(*m_accumulators[0]);
-}
-
-inline AlphaAOVAccumulator& AOVAccumulatorContainer::alpha()
-{
-    return static_cast<AlphaAOVAccumulator&>(*m_accumulators[1]);
-}
 
 }       // namespace renderer
 

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.h
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.h
@@ -118,7 +118,7 @@ class UnfilteredAOVAccumulator
 
     bool outside_tile(const foundation::Vector2i& pi) const;
 
-    static float squared_distace_to_pixel_center(const foundation::Vector2d& ps);
+    static float square_distance_to_pixel_center(const foundation::Vector2d& ps);
 };
 
 
@@ -135,11 +135,11 @@ inline bool UnfilteredAOVAccumulator::outside_tile(
     const foundation::Vector2i& pi) const
 {
    return
-    pi.x < m_tile_origin_x || pi.y < m_tile_origin_y ||
-    pi.x > m_tile_end_x || pi.y > m_tile_end_y;
+      pi.x < m_tile_origin_x || pi.y < m_tile_origin_y ||
+      pi.x > m_tile_end_x || pi.y > m_tile_end_y;
 }
 
-inline float UnfilteredAOVAccumulator::squared_distace_to_pixel_center(
+inline float UnfilteredAOVAccumulator::square_distance_to_pixel_center(
     const foundation::Vector2d& ps)
 {
     return static_cast<float>(

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.h
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.h
@@ -44,6 +44,8 @@
 
 // Forward declarations.
 namespace renderer  { class Camera; }
+namespace renderer  { class Frame; }
+namespace renderer  { class PixelContext; }
 namespace renderer  { class ShadingComponents; }
 namespace renderer  { class ShadingPoint; }
 namespace renderer  { class ShadingResult; }
@@ -65,20 +67,28 @@ class AOVAccumulator
     // Delete this instance.
     void release();
 
-    // Reset the accumulator.
-    virtual void reset() = 0;
+    virtual void on_tile_begin(
+        const Frame&                frame,
+        const size_t                tile_x,
+        const size_t                tile_y);
+
+    virtual void on_tile_end(
+        const Frame&                frame,
+        const size_t                tile_x,
+        const size_t                tile_y);
+
+    virtual void on_pixel_begin();
+    virtual void on_pixel_end();
+
+    virtual void on_sample_begin();
+    virtual void on_sample_end();
 
     // Write a value to the accumulator.
-    // Normally, this is used for shading AOVs like diffuse, glossy...
     virtual void write(
+        const PixelContext&         pixel_context,
+        const ShadingPoint&         shading_point,
         const ShadingComponents&    shading_components,
         const float                 multiplier);
-
-    // Write a value to the accumulator.
-    // Normally, this is used for geometry AOVs like normals, velocity...
-    virtual void write(
-        const ShadingPoint&         shading_point,
-        const Camera&               camera);
 
     // Flush the result.
     virtual void flush(ShadingResult& result) = 0;
@@ -101,9 +111,6 @@ class ColorAOVAccumulator
   public:
     // Destructor.
     ~ColorAOVAccumulator() override;
-
-    // Reset the accumulator.
-    void reset() override;
 
     // Flush the result.
     void flush(ShadingResult& result) override;
@@ -133,9 +140,9 @@ class BeautyAOVAccumulator
 
     void apply_multiplier(const float multiplier);
 
-    virtual void reset() override;
-
     virtual void write(
+        const PixelContext&         pixel_context,
+        const ShadingPoint&         shading_point,
         const ShadingComponents&    shading_components,
         const float                 multiplier) override;
 
@@ -162,8 +169,6 @@ class AlphaAOVAccumulator
 
     void apply_multiplier(const Alpha& multiplier);
 
-    virtual void reset() override;
-
     virtual void flush(ShadingResult& result) override;
 
   private:
@@ -188,18 +193,28 @@ class AOVAccumulatorContainer
     // Destructor.
     ~AOVAccumulatorContainer();
 
-    // Reset all accumulators.
-    void reset();
+    void on_tile_begin(
+        const Frame&                frame,
+        const size_t                tile_x,
+        const size_t                tile_y);
+
+    void on_tile_end(
+        const Frame&                frame,
+        const size_t                tile_x,
+        const size_t                tile_y);
+
+    void on_pixel_begin();
+    void on_pixel_end();
+
+    void on_sample_begin();
+    void on_sample_end();
 
     // Write a sample to all accumulators.
     void write(
+        const PixelContext&         pixel_context,
+        const ShadingPoint&         shading_point,
         const ShadingComponents&    shading_components,
         const float                 multiplier);
-
-    // Write a sample to all accumulators.
-    void write(
-        const ShadingPoint&         shading_point,
-        const Camera&               camera);
 
     // Flush all the accumulators.
     void flush(ShadingResult& result);

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.h
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.h
@@ -87,8 +87,7 @@ class AOVAccumulator
     virtual void write(
         const PixelContext&         pixel_context,
         const ShadingPoint&         shading_point,
-        const ShadingComponents&    shading_components,
-        const float                 multiplier);
+        const ShadingComponents&    shading_components);
 
     // Flush the result.
     virtual void flush(ShadingResult& result) = 0;
@@ -138,13 +137,10 @@ class BeautyAOVAccumulator
 
     void set_to_pink_linear_rgb();
 
-    void apply_multiplier(const float multiplier);
-
     virtual void write(
         const PixelContext&         pixel_context,
         const ShadingPoint&         shading_point,
-        const ShadingComponents&    shading_components,
-        const float                 multiplier) override;
+        const ShadingComponents&    shading_components) override;
 
     virtual void flush(ShadingResult& result) override;
 
@@ -213,8 +209,7 @@ class AOVAccumulatorContainer
     void write(
         const PixelContext&         pixel_context,
         const ShadingPoint&         shading_point,
-        const ShadingComponents&    shading_components,
-        const float                 multiplier);
+        const ShadingComponents&    shading_components);
 
     // Flush all the accumulators.
     void flush(ShadingResult& result);

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.h
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.h
@@ -67,11 +67,13 @@ class AOVAccumulator
     // Delete this instance.
     void release();
 
+    // This method is called before a tile gets rendered.
     virtual void on_tile_begin(
         const Frame&                frame,
         const size_t                tile_x,
         const size_t                tile_y);
 
+    // This method is called after a tile gets rendered.
     virtual void on_tile_end(
         const Frame&                frame,
         const size_t                tile_x,
@@ -83,12 +85,6 @@ class AOVAccumulator
         const ShadingPoint&         shading_point,
         const ShadingComponents&    shading_components,
         ShadingResult&              shading_result);
-
-  protected:
-    // Constructor.
-    explicit AOVAccumulator(const size_t index);
-
-    const size_t m_index;
 };
 
 
@@ -109,18 +105,17 @@ class AOVAccumulatorContainer
     // Destructor.
     ~AOVAccumulatorContainer();
 
+    // This method is called before a tile gets rendered.
     void on_tile_begin(
         const Frame&                frame,
         const size_t                tile_x,
         const size_t                tile_y);
 
+    // This method is called after a tile gets rendered.
     void on_tile_end(
         const Frame&                frame,
         const size_t                tile_x,
         const size_t                tile_y);
-
-    void on_pixel_begin();
-    void on_pixel_end();
 
     // Write a sample to all accumulators.
     void write(

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.h
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.h
@@ -37,18 +37,21 @@
 // appleseed.foundation headers.
 #include "foundation/core/concepts/noncopyable.h"
 #include "foundation/image/color.h"
+#include "foundation/math/vector.h"
 #include "foundation/utility/autoreleaseptr.h"
 
 // Standard headers.
 #include <cstddef>
 
 // Forward declarations.
-namespace renderer  { class Camera; }
-namespace renderer  { class Frame; }
-namespace renderer  { class PixelContext; }
-namespace renderer  { class ShadingComponents; }
-namespace renderer  { class ShadingPoint; }
-namespace renderer  { class ShadingResult; }
+namespace foundation    { class Image; }
+namespace foundation    { class Tile; }
+namespace renderer      { class Camera; }
+namespace renderer      { class Frame; }
+namespace renderer      { class PixelContext; }
+namespace renderer      { class ShadingComponents; }
+namespace renderer      { class ShadingPoint; }
+namespace renderer      { class ShadingResult; }
 
 namespace renderer
 {
@@ -86,6 +89,55 @@ class AOVAccumulator
         const ShadingComponents&    shading_components,
         ShadingResult&              shading_result);
 };
+
+
+//
+// Unfiltered AOV accumulator base class.
+//
+
+class UnfilteredAOVAccumulator
+  : public AOVAccumulator
+{
+  public:
+    explicit UnfilteredAOVAccumulator(foundation::Image& image);
+
+  protected:
+    foundation::Image&  m_image;
+    foundation::Tile*   m_tile;
+    int                 m_tile_origin_x;
+    int                 m_tile_origin_y;
+    int                 m_tile_end_x;
+    int                 m_tile_end_y;
+
+    void fetch_tile(
+        const Frame& frame,
+        const size_t tile_x,
+        const size_t tile_y);
+
+    bool outside_tile(const foundation::Vector2i& pi) const;
+
+    static float squared_distace_to_pixel_center(const foundation::Vector2d& ps);
+};
+
+
+//
+// Unfiltered AOV class implementation.
+//
+
+inline bool UnfilteredAOVAccumulator::outside_tile(
+    const foundation::Vector2i& pi) const
+{
+   return
+    pi.x < m_tile_origin_x || pi.y < m_tile_origin_y ||
+    pi.x > m_tile_end_x || pi.y > m_tile_end_y;
+}
+
+inline float UnfilteredAOVAccumulator::squared_distace_to_pixel_center(
+    const foundation::Vector2d& ps)
+{
+    return static_cast<float>(
+        foundation::square(ps.y - 0.5) + foundation::square(ps.y - 0.5));
+}
 
 
 //

--- a/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
@@ -33,6 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
 #include "renderer/global/globaltypes.h"
+#include "renderer/kernel/aov/aovaccumulator.h"
 #include "renderer/kernel/aov/aovsettings.h"
 #include "renderer/kernel/aov/imagestack.h"
 #include "renderer/kernel/aov/tilestack.h"
@@ -168,6 +169,7 @@ namespace
             const size_t aov_count = frame.aov_images().size();
 
             on_pixel_begin();
+            aov_accumulators.on_pixel_begin();
 
             m_scratch_fb->clear();
 
@@ -293,6 +295,7 @@ namespace
                 m_diagnostics->set_pixel(pt.x, pt.y, values);
             }
 
+            aov_accumulators.on_pixel_end();
             on_pixel_end(pi);
         }
 

--- a/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
@@ -33,7 +33,6 @@
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
 #include "renderer/global/globaltypes.h"
-#include "renderer/kernel/aov/aovaccumulator.h"
 #include "renderer/kernel/aov/aovsettings.h"
 #include "renderer/kernel/aov/imagestack.h"
 #include "renderer/kernel/aov/tilestack.h"
@@ -169,7 +168,6 @@ namespace
             const size_t aov_count = frame.aov_images().size();
 
             on_pixel_begin();
-            aov_accumulators.on_pixel_begin();
 
             m_scratch_fb->clear();
 
@@ -295,7 +293,6 @@ namespace
                 m_diagnostics->set_pixel(pt.x, pt.y, values);
             }
 
-            aov_accumulators.on_pixel_end();
             on_pixel_end(pi);
         }
 

--- a/src/appleseed/renderer/kernel/rendering/final/uniformpixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/uniformpixelrenderer.cpp
@@ -33,6 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
 #include "renderer/global/globaltypes.h"
+#include "renderer/kernel/aov/aovaccumulator.h"
 #include "renderer/kernel/aov/imagestack.h"
 #include "renderer/kernel/rendering/final/pixelsampler.h"
 #include "renderer/kernel/rendering/isamplerenderer.h"
@@ -124,6 +125,7 @@ namespace
             const size_t aov_count = frame.aov_images().size();
 
             on_pixel_begin();
+            aov_accumulators.on_pixel_begin();
 
             if (m_params.m_decorrelate)
             {
@@ -237,6 +239,7 @@ namespace
                 }
             }
 
+            aov_accumulators.on_pixel_end();
             on_pixel_end(pi);
         }
 

--- a/src/appleseed/renderer/kernel/rendering/final/uniformpixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/uniformpixelrenderer.cpp
@@ -33,7 +33,6 @@
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
 #include "renderer/global/globaltypes.h"
-#include "renderer/kernel/aov/aovaccumulator.h"
 #include "renderer/kernel/aov/imagestack.h"
 #include "renderer/kernel/rendering/final/pixelsampler.h"
 #include "renderer/kernel/rendering/isamplerenderer.h"
@@ -125,7 +124,6 @@ namespace
             const size_t aov_count = frame.aov_images().size();
 
             on_pixel_begin();
-            aov_accumulators.on_pixel_begin();
 
             if (m_params.m_decorrelate)
             {
@@ -239,7 +237,6 @@ namespace
                 }
             }
 
-            aov_accumulators.on_pixel_end();
             on_pixel_end(pi);
         }
 

--- a/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
@@ -175,6 +175,8 @@ namespace
             const ShadingPoint* shading_point_ptr = 0;
             size_t iterations = 0;
 
+            aov_accumulators.on_sample_begin();
+
             while (true)
             {
                 // Put a hard limit on the number of iterations.
@@ -199,8 +201,6 @@ namespace
                 shading_point_ptr = &shading_points[shading_point_index];
                 shading_point_index = 1 - shading_point_index;
 
-                aov_accumulators.reset();
-
                 if (iterations == 1)
                 {
                     // Shade the intersection point.
@@ -210,10 +210,6 @@ namespace
                         m_shading_context,
                         *shading_point_ptr,
                         aov_accumulators);
-
-                    aov_accumulators.write(
-                        *shading_point_ptr,
-                        *m_scene.get_active_camera());
 
                     aov_accumulators.flush(shading_result);
 
@@ -231,10 +227,6 @@ namespace
                         m_shading_context,
                         *shading_point_ptr,
                         aov_accumulators);
-
-                    aov_accumulators.write(
-                        *shading_point_ptr,
-                        *m_scene.get_active_camera());
 
                     aov_accumulators.flush(local_result);
 
@@ -263,6 +255,8 @@ namespace
                     primary_ray.m_ry.m_org = primary_ray.m_ry.point_at(t);
                 }
             }
+
+            aov_accumulators.on_sample_end();
 
 #ifdef DEBUG_DISPLAY_TEXTURE_CACHE_PERFORMANCES
 

--- a/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
@@ -33,7 +33,6 @@
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
 #include "renderer/global/globaltypes.h"
-#include "renderer/kernel/aov/aovaccumulator.h"
 #include "renderer/kernel/intersection/intersector.h"
 #include "renderer/kernel/intersection/tracecontext.h"
 #include "renderer/kernel/lighting/ilightingengine.h"
@@ -175,8 +174,6 @@ namespace
             const ShadingPoint* shading_point_ptr = 0;
             size_t iterations = 0;
 
-            aov_accumulators.on_sample_begin();
-
             while (true)
             {
                 // Put a hard limit on the number of iterations.
@@ -209,9 +206,8 @@ namespace
                         pixel_context,
                         m_shading_context,
                         *shading_point_ptr,
-                        aov_accumulators);
-
-                    aov_accumulators.flush(shading_result);
+                        aov_accumulators,
+                        shading_result);
 
                     // Apply alpha premultiplication.
                     if (shading_point_ptr->hit())
@@ -226,9 +222,8 @@ namespace
                         pixel_context,
                         m_shading_context,
                         *shading_point_ptr,
-                        aov_accumulators);
-
-                    aov_accumulators.flush(local_result);
+                        aov_accumulators,
+                        local_result);
 
                     // Apply alpha premultiplication.
                     if (shading_point_ptr->hit())
@@ -255,8 +250,6 @@ namespace
                     primary_ray.m_ry.m_org = primary_ray.m_ry.point_at(t);
                 }
             }
-
-            aov_accumulators.on_sample_end();
 
 #ifdef DEBUG_DISPLAY_TEXTURE_CACHE_PERFORMANCES
 

--- a/src/appleseed/renderer/kernel/rendering/generic/generictilerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/generictilerenderer.cpp
@@ -155,7 +155,7 @@ namespace
             // Inform the pixel renderer that we are about to render a tile.
             m_pixel_renderer->on_tile_begin(frame, tile, aov_tiles);
 
-            // Inform the aov accumulators that we are about to render a tile.
+            // Inform the AOV accumulators that we are about to render a tile.
             m_aov_accumulators.on_tile_begin(frame, tile_x, tile_y);
 
             // Create the framebuffer into which we will accumulate the samples.

--- a/src/appleseed/renderer/kernel/rendering/generic/generictilerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/generictilerenderer.cpp
@@ -155,6 +155,9 @@ namespace
             // Inform the pixel renderer that we are about to render a tile.
             m_pixel_renderer->on_tile_begin(frame, tile, aov_tiles);
 
+            // Inform the aov accumulators that we are about to render a tile.
+            m_aov_accumulators.on_tile_begin(frame, tile_x, tile_y);
+
             // Create the framebuffer into which we will accumulate the samples.
             ShadingResultFrameBuffer* framebuffer =
                 m_framebuffer_factory->create(

--- a/src/appleseed/renderer/kernel/shading/shadingengine.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingengine.cpp
@@ -179,7 +179,11 @@ void ShadingEngine::shade_environment(
             alpha);
 
         value.m_beauty = value.m_emission;
-        aov_accumulators.write(value, 1.0f);
+        aov_accumulators.write(
+            pixel_context,
+            shading_point,
+            value,
+            1.0f);
         aov_accumulators.alpha().set(alpha);
     }
 }

--- a/src/appleseed/renderer/kernel/shading/shadingengine.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingengine.cpp
@@ -35,6 +35,7 @@
 #include "renderer/kernel/shading/shadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingray.h"
+#include "renderer/kernel/shading/shadingresult.h"
 #include "renderer/modeling/environment/environment.h"
 #include "renderer/modeling/environmentshader/environmentshader.h"
 #include "renderer/modeling/input/source.h"
@@ -94,10 +95,11 @@ void ShadingEngine::shade_hit_point(
     const PixelContext&         pixel_context,
     const ShadingContext&       shading_context,
     const ShadingPoint&         shading_point,
-    AOVAccumulatorContainer&    aov_accumulators) const
+    AOVAccumulatorContainer&    aov_accumulators,
+    ShadingResult&              shading_result) const
 {
     // Compute the alpha channel of the main output.
-    aov_accumulators.alpha().set(shading_point.get_alpha());
+    shading_result.m_main.a = shading_point.get_alpha()[0];
 
     // Retrieve the material of the intersected surface.
     const Material* material = shading_point.get_material();
@@ -112,11 +114,11 @@ void ShadingEngine::shade_hit_point(
             *material->get_render_data().m_shader_group,
             shading_point,
             alpha);
-        aov_accumulators.alpha().apply_multiplier(alpha);
+        shading_result.m_main.a *= alpha[0];
     }
 
     // Shade the sample if it isn't fully transparent.
-    if (aov_accumulators.alpha().get()[0] > 0.0f)
+    if (shading_result.m_main.a > 0.0f)
     {
         // Use the diagnostic surface shader if there is one.
         const SurfaceShader* surface_shader = m_diagnostic_surface_shader.get();
@@ -126,8 +128,7 @@ void ShadingEngine::shade_hit_point(
             if (material == 0)
             {
                 // The intersected surface has no material: return solid pink.
-                aov_accumulators.beauty().set_to_pink_linear_rgb();
-                aov_accumulators.alpha().set(Alpha(1.0f));
+                shading_result.set_to_opaque_pink();
                 return;
             }
 
@@ -137,8 +138,7 @@ void ShadingEngine::shade_hit_point(
             if (surface_shader == 0)
             {
                 // The intersected surface has no surface shader: return solid pink.
-                aov_accumulators.beauty().set_to_pink_linear_rgb();
-                aov_accumulators.alpha().set(Alpha(1.0f));
+                shading_result.set_to_opaque_pink();
                 return;
             }
         }
@@ -149,7 +149,8 @@ void ShadingEngine::shade_hit_point(
             pixel_context,
             shading_context,
             shading_point,
-            aov_accumulators);
+            aov_accumulators,
+            shading_result);
     }
 }
 
@@ -158,7 +159,8 @@ void ShadingEngine::shade_environment(
     const PixelContext&         pixel_context,
     const ShadingContext&       shading_context,
     const ShadingPoint&         shading_point,
-    AOVAccumulatorContainer&    aov_accumulators) const
+    AOVAccumulatorContainer&    aov_accumulators,
+    ShadingResult&              shading_result) const
 {
     // Retrieve the environment shader of the scene.
     const EnvironmentShader* environment_shader =
@@ -178,12 +180,13 @@ void ShadingEngine::shade_environment(
             value.m_emission,
             alpha);
 
+        shading_result.m_main.a = alpha[0];
         value.m_beauty = value.m_emission;
         aov_accumulators.write(
             pixel_context,
             shading_point,
-            value);
-        aov_accumulators.alpha().set(alpha);
+            value,
+            shading_result);
     }
 }
 

--- a/src/appleseed/renderer/kernel/shading/shadingengine.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingengine.cpp
@@ -182,8 +182,7 @@ void ShadingEngine::shade_environment(
         aov_accumulators.write(
             pixel_context,
             shading_point,
-            value,
-            1.0f);
+            value);
         aov_accumulators.alpha().set(alpha);
     }
 }

--- a/src/appleseed/renderer/kernel/shading/shadingengine.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingengine.cpp
@@ -128,7 +128,7 @@ void ShadingEngine::shade_hit_point(
             if (material == 0)
             {
                 // The intersected surface has no material: return solid pink.
-                shading_result.set_to_opaque_pink();
+                shading_result.set_main_to_opaque_pink();
                 return;
             }
 
@@ -138,7 +138,7 @@ void ShadingEngine::shade_hit_point(
             if (surface_shader == 0)
             {
                 // The intersected surface has no surface shader: return solid pink.
-                shading_result.set_to_opaque_pink();
+                shading_result.set_main_to_opaque_pink();
                 return;
             }
         }
@@ -188,6 +188,8 @@ void ShadingEngine::shade_environment(
             value,
             shading_result);
     }
+    else
+        shading_result.m_main.set(0.0f);
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/kernel/shading/shadingengine.h
+++ b/src/appleseed/renderer/kernel/shading/shadingengine.h
@@ -47,6 +47,7 @@ namespace renderer      { class ParamArray; }
 namespace renderer      { class PixelContext; }
 namespace renderer      { class Project; }
 namespace renderer      { class ShadingContext; }
+namespace renderer      { class ShadingResult; }
 
 namespace renderer
 {
@@ -75,7 +76,8 @@ class ShadingEngine
         const PixelContext&         pixel_context,
         const ShadingContext&       shading_context,
         const ShadingPoint&         shading_point,
-        AOVAccumulatorContainer&    aov_accumulators) const;
+        AOVAccumulatorContainer&    aov_accumulators,
+        ShadingResult&              shading_result) const;
 
   private:
     foundation::auto_release_ptr<SurfaceShader> m_diagnostic_surface_shader;
@@ -87,14 +89,16 @@ class ShadingEngine
         const PixelContext&         pixel_context,
         const ShadingContext&       shading_context,
         const ShadingPoint&         shading_point,
-        AOVAccumulatorContainer&    aov_accumulators) const;
+        AOVAccumulatorContainer&    aov_accumulators,
+        ShadingResult&              shading_result) const;
 
     void shade_environment(
         SamplingContext&            sampling_context,
         const PixelContext&         pixel_context,
         const ShadingContext&       shading_context,
         const ShadingPoint&         shading_point,
-        AOVAccumulatorContainer&    aov_accumulators) const;
+        AOVAccumulatorContainer&    aov_accumulators,
+        ShadingResult&              shading_result) const;
 };
 
 
@@ -107,7 +111,8 @@ inline void ShadingEngine::shade(
     const PixelContext&         pixel_context,
     const ShadingContext&       shading_context,
     const ShadingPoint&         shading_point,
-    AOVAccumulatorContainer&    aov_accumulators) const
+    AOVAccumulatorContainer&    aov_accumulators,
+    ShadingResult&              shading_result) const
 {
     if (shading_point.hit())
     {
@@ -117,7 +122,8 @@ inline void ShadingEngine::shade(
                 pixel_context,
                 shading_context,
                 shading_point,
-                aov_accumulators);
+                aov_accumulators,
+                shading_result);
     }
     else
     {
@@ -127,7 +133,8 @@ inline void ShadingEngine::shade(
                 pixel_context,
                 shading_context,
                 shading_point,
-                aov_accumulators);
+                aov_accumulators,
+                shading_result);
     }
 }
 

--- a/src/appleseed/renderer/kernel/shading/shadingresult.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingresult.cpp
@@ -114,7 +114,7 @@ void ShadingResult::apply_alpha_premult()
     }
 }
 
-void ShadingResult::set_to_opaque_pink()
+void ShadingResult::set_main_to_opaque_pink()
 {
     m_main = Color4f(1.0f, 0.0f, 1.0f, 1.0f);
 }

--- a/src/appleseed/renderer/kernel/shading/shadingresult.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingresult.cpp
@@ -114,4 +114,9 @@ void ShadingResult::apply_alpha_premult()
     }
 }
 
+void ShadingResult::set_to_opaque_pink()
+{
+    m_main = Color4f(1.0f, 0.0f, 1.0f, 1.0f);
+}
+
 }   // namespace renderer

--- a/src/appleseed/renderer/kernel/shading/shadingresult.h
+++ b/src/appleseed/renderer/kernel/shading/shadingresult.h
@@ -72,6 +72,8 @@ class ShadingResult
 
     // Apply alpha premultiplication to the main output and the AOVs.
     void apply_alpha_premult();
+
+    void set_to_opaque_pink();
 };
 
 

--- a/src/appleseed/renderer/kernel/shading/shadingresult.h
+++ b/src/appleseed/renderer/kernel/shading/shadingresult.h
@@ -73,7 +73,8 @@ class ShadingResult
     // Apply alpha premultiplication to the main output and the AOVs.
     void apply_alpha_premult();
 
-    void set_to_opaque_pink();
+    // Set the main output to opaque pink.
+    void set_main_to_opaque_pink();
 };
 
 

--- a/src/appleseed/renderer/modeling/aov/aov.cpp
+++ b/src/appleseed/renderer/modeling/aov/aov.cpp
@@ -65,7 +65,12 @@ void AOV::release()
     delete this;
 }
 
-void AOV::create_image(ImageStack& aov_images)
+void AOV::create_image(
+    const size_t    canvas_width,
+    const size_t    canvas_height,
+    const size_t    tile_width,
+    const size_t    tile_height,
+    ImageStack&     aov_images)
 {
     const size_t index = aov_images.append(
         get_name(),

--- a/src/appleseed/renderer/modeling/aov/aov.cpp
+++ b/src/appleseed/renderer/modeling/aov/aov.cpp
@@ -32,6 +32,9 @@
 // appleseed.renderer headers.
 #include "renderer/kernel/aov/imagestack.h"
 
+// appleseed.foundation headers.
+#include "foundation/image/image.h"
+
 using namespace foundation;
 
 namespace renderer
@@ -108,6 +111,42 @@ const char** ColorAOV::get_channel_names() const
 bool ColorAOV::has_color_data() const
 {
     return true;
+}
+
+
+//
+// UnfilteredAOV class implementation.
+//
+
+UnfilteredAOV::UnfilteredAOV(const char* name, const ParamArray& params)
+  : AOV(name, params)
+{
+}
+
+UnfilteredAOV::~UnfilteredAOV()
+{
+    delete m_image;
+}
+
+void UnfilteredAOV::create_image(
+    const size_t canvas_width,
+    const size_t canvas_height,
+    const size_t tile_width,
+    const size_t tile_height,
+    ImageStack& aov_images)
+{
+    // One extra channel to keep track of the distance
+    // to the nearest sample for each pixel.
+    const size_t num_channels = get_channel_count() + 1;
+
+    m_image =
+        new Image(
+            canvas_width,
+            canvas_height,
+            tile_width,
+            tile_height,
+            num_channels,
+            PixelFormatFloat);
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/aov.cpp
+++ b/src/appleseed/renderer/modeling/aov/aov.cpp
@@ -29,6 +29,9 @@
 // Interface header.
 #include "aov.h"
 
+// appleseed.renderer headers.
+#include "renderer/kernel/aov/imagestack.h"
+
 using namespace foundation;
 
 namespace renderer
@@ -52,6 +55,7 @@ AOV::AOV(
     const char*         name,
     const ParamArray&   params)
   : Entity(g_class_uid, params)
+  , m_image(nullptr)
 {
     set_name(name);
 }
@@ -59,6 +63,20 @@ AOV::AOV(
 void AOV::release()
 {
     delete this;
+}
+
+void AOV::create_image(ImageStack& aov_images)
+{
+    const size_t index = aov_images.append(
+        get_name(),
+        4, // TODO: check if we can pass aov->get_channel_count() here.
+        PixelFormatFloat);
+    m_image = &aov_images.get_image(index);
+}
+
+Image& AOV::get_image() const
+{
+    return *m_image;
 }
 
 

--- a/src/appleseed/renderer/modeling/aov/aov.h
+++ b/src/appleseed/renderer/modeling/aov/aov.h
@@ -87,7 +87,7 @@ class APPLESEED_DLLSYMBOL AOV
 
     // Create an accumulator for this AOV.
     virtual foundation::auto_release_ptr<AOVAccumulator> create_accumulator(
-        const size_t index) const = 0;
+        const size_t        index) const = 0;
 
   protected:
     friend class Frame;
@@ -95,7 +95,12 @@ class APPLESEED_DLLSYMBOL AOV
     foundation::Image* m_image;
 
     // Create an image to store the AOV result.
-    virtual void create_image(ImageStack& aov_images);
+    virtual void create_image(
+            const size_t    canvas_width,
+            const size_t    canvas_height,
+            const size_t    tile_width,
+            const size_t    tile_height,
+            ImageStack&     aov_images);
 };
 
 

--- a/src/appleseed/renderer/modeling/aov/aov.h
+++ b/src/appleseed/renderer/modeling/aov/aov.h
@@ -46,6 +46,7 @@
 // Forward declarations.
 namespace foundation    { class Image; }
 namespace renderer      { class AOVAccumulator; }
+namespace renderer      { class AOVAccumulatorContainer; }
 namespace renderer      { class Frame; }
 namespace renderer      { class ImageStack; }
 namespace renderer      { class ParamArray; }
@@ -85,11 +86,8 @@ class APPLESEED_DLLSYMBOL AOV
     // Return a reference to the AOV image.
     foundation::Image& get_image() const;
 
-    // Create an accumulator for this AOV.
-    virtual foundation::auto_release_ptr<AOVAccumulator> create_accumulator(
-        const size_t        index) const = 0;
-
   protected:
+    friend class AOVAccumulatorContainer;
     friend class Frame;
 
     foundation::Image* m_image;
@@ -101,11 +99,15 @@ class APPLESEED_DLLSYMBOL AOV
             const size_t    tile_width,
             const size_t    tile_height,
             ImageStack&     aov_images);
+
+    // Create an accumulator for this AOV.
+    virtual foundation::auto_release_ptr<AOVAccumulator> create_accumulator(
+        const size_t        index) const = 0;
 };
 
 
 //
-// ColorAOV base class.
+// Color AOV base class.
 //
 
 class ColorAOV
@@ -123,6 +125,30 @@ class ColorAOV
 
     // Return true if this AOV contains color data.
     bool has_color_data() const override;
+};
+
+
+//
+// Unfiltered AOV base class.
+//
+
+class UnfilteredAOV
+  : public AOV
+{
+  public:
+    // Constructor.
+    UnfilteredAOV(const char* name, const ParamArray& params);
+
+    // Destructor.
+    virtual ~UnfilteredAOV() override;
+
+  protected:
+    virtual void create_image(
+            const size_t    canvas_width,
+            const size_t    canvas_height,
+            const size_t    tile_width,
+            const size_t    tile_height,
+            ImageStack&     aov_images) override;
 };
 
 }       // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/aov.h
+++ b/src/appleseed/renderer/modeling/aov/aov.h
@@ -94,11 +94,11 @@ class APPLESEED_DLLSYMBOL AOV
 
     // Create an image to store the AOV result.
     virtual void create_image(
-            const size_t    canvas_width,
-            const size_t    canvas_height,
-            const size_t    tile_width,
-            const size_t    tile_height,
-            ImageStack&     aov_images);
+        const size_t    canvas_width,
+        const size_t    canvas_height,
+        const size_t    tile_width,
+        const size_t    tile_height,
+        ImageStack&     aov_images);
 
     // Create an accumulator for this AOV.
     virtual foundation::auto_release_ptr<AOVAccumulator> create_accumulator(
@@ -144,11 +144,11 @@ class UnfilteredAOV
 
   protected:
     virtual void create_image(
-            const size_t    canvas_width,
-            const size_t    canvas_height,
-            const size_t    tile_width,
-            const size_t    tile_height,
-            ImageStack&     aov_images) override;
+        const size_t    canvas_width,
+        const size_t    canvas_height,
+        const size_t    tile_width,
+        const size_t    tile_height,
+        ImageStack&     aov_images) override;
 };
 
 }       // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/aov.h
+++ b/src/appleseed/renderer/modeling/aov/aov.h
@@ -44,7 +44,10 @@
 #include <cstddef>
 
 // Forward declarations.
+namespace foundation    { class Image; }
 namespace renderer      { class AOVAccumulator; }
+namespace renderer      { class Frame; }
+namespace renderer      { class ImageStack; }
 namespace renderer      { class ParamArray; }
 
 namespace renderer
@@ -79,9 +82,20 @@ class APPLESEED_DLLSYMBOL AOV
     // Return true if this AOV contains color data.
     virtual bool has_color_data() const = 0;
 
+    // Return a reference to the AOV image.
+    foundation::Image& get_image() const;
+
     // Create an accumulator for this AOV.
     virtual foundation::auto_release_ptr<AOVAccumulator> create_accumulator(
         const size_t index) const = 0;
+
+  protected:
+    friend class Frame;
+
+    foundation::Image* m_image;
+
+    // Create an image to store the AOV result.
+    virtual void create_image(ImageStack& aov_images);
 };
 
 

--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -64,11 +64,11 @@ namespace
     //
 
     class DepthAOVAccumulator
-      : public AOVAccumulator
+      : public UnfilteredAOVAccumulator
     {
       public:
         explicit DepthAOVAccumulator(Image& image)
-          : m_image(image)
+          : UnfilteredAOVAccumulator(image)
         {
         }
 
@@ -77,17 +77,11 @@ namespace
             const size_t                tile_x,
             const size_t                tile_y) override
         {
-            // Fetch the destination tile.
-            const CanvasProperties& props = frame.image().properties();
-            m_tile = &m_image.tile(tile_x, tile_y);
-            m_tile_origin_x = static_cast<int>(tile_x * props.m_tile_width);
-            m_tile_origin_y = static_cast<int>(tile_y * props.m_tile_height);
-            m_tile_end_x = static_cast<int>(m_tile_origin_x + props.m_tile_width - 1);
-            m_tile_end_y = static_cast<int>(m_tile_origin_y + props.m_tile_height - 1);
+            fetch_tile(frame, tile_x, tile_y);
 
             // Clear the tile.
-            float* p = reinterpret_cast<float*>(m_tile->get_storage());
-            for (size_t i = 0, e = m_tile->get_pixel_count() * props.m_channel_count; i < e; ++i)
+            float* p = reinterpret_cast<float*>(m_tile->pixel(0));
+            for (size_t i = 0, e = m_tile->get_size() / sizeof(float); i < e; ++i)
                 *p++ = std::numeric_limits<float>::max();
         }
 
@@ -106,43 +100,19 @@ namespace
             float* p = reinterpret_cast<float*>(
                 m_tile->pixel(pi.x - m_tile_origin_x, pi.y - m_tile_origin_y));
 
-            const float min_distance = p[1];
-            const float sample_distance = squared_distace_to_pixel_center(pixel_context.get_sample_position());
+            const float min_sample_squared_distance = p[1];
+            const float sample_squared_distance =
+                squared_distace_to_pixel_center(pixel_context.get_sample_position());
 
-            if (sample_distance > min_distance)
-                return;
-
-            const float depth = shading_point.hit()
-                ? static_cast<float>(shading_point.get_distance())
-                : numeric_limits<float>::max();
-
-            if (sample_distance < min_distance)
+            if (sample_squared_distance < min_sample_squared_distance)
             {
+                const float depth = shading_point.hit()
+                    ? static_cast<float>(shading_point.get_distance())
+                    : numeric_limits<float>::max();
+
                 p[0] = depth;
-                p[1] = sample_distance;
+                p[1] = sample_squared_distance;
             }
-            else
-                p[0] = std::min(p[0], depth);
-        }
-
-      private:
-        Image& m_image;
-        Tile* m_tile;
-        int m_tile_origin_x;
-        int m_tile_origin_y;
-        int m_tile_end_x;
-        int m_tile_end_y;
-
-        bool outside_tile(const Vector2i& pi) const
-        {
-           return
-            pi.x < m_tile_origin_x || pi.y < m_tile_origin_y ||
-            pi.x > m_tile_end_x || pi.y > m_tile_end_y;
-        }
-
-        static float squared_distace_to_pixel_center(const Vector2d& ps)
-        {
-            return static_cast<float>(square(ps.y - 0.5) + square(ps.y - 0.5));
         }
     };
 
@@ -154,11 +124,11 @@ namespace
     const char* Model = "depth_aov";
 
     class DepthAOV
-      : public AOV
+      : public UnfilteredAOV
     {
       public:
         explicit DepthAOV(const ParamArray& params)
-          : AOV("depth", params)
+          : UnfilteredAOV("depth", params)
         {
         }
 
@@ -188,30 +158,11 @@ namespace
             return false;
         }
 
-        virtual void create_image(
-            const size_t    canvas_width,
-            const size_t    canvas_height,
-            const size_t    tile_width,
-            const size_t    tile_height,
-            ImageStack&     aov_images) override
-        {
-            // One channel for depth, another to keep track of the minimum
-            // distance to the pixel center.
-            const size_t num_channels = 2;
-
-            m_image_storage.reset(
-                new Image(canvas_width, canvas_height, tile_width, tile_height, num_channels, PixelFormatFloat));
-            m_image = m_image_storage.get();
-        }
-
         virtual auto_release_ptr<AOVAccumulator> create_accumulator(
             const size_t index) const override
         {
             return auto_release_ptr<AOVAccumulator>(new DepthAOVAccumulator(*m_image));
         }
-
-      private:
-        unique_ptr<Image> m_image_storage;
     };
 }
 

--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -81,8 +81,11 @@ namespace
 
             // Clear the tile.
             float* p = reinterpret_cast<float*>(m_tile->pixel(0));
-            for (size_t i = 0, e = m_tile->get_size() / sizeof(float); i < e; ++i)
+            for (size_t i = 0, e = m_tile->get_pixel_count(); i < e; ++i)
+            {
                 *p++ = std::numeric_limits<float>::max();
+                *p++ = std::numeric_limits<float>::max();
+            }
         }
 
         virtual void write(
@@ -161,7 +164,7 @@ namespace
         virtual auto_release_ptr<AOVAccumulator> create_accumulator(
             const size_t index) const override
         {
-            return auto_release_ptr<AOVAccumulator>(new DepthAOVAccumulator(*m_image));
+            return auto_release_ptr<AOVAccumulator>(new DepthAOVAccumulator(get_image()));
         }
     };
 }

--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -66,17 +66,16 @@ namespace
         {
         }
 
-        virtual void reset() override
-        {
-            m_depth = numeric_limits<float>::max();
-        }
-
         virtual void write(
-            const ShadingPoint&     shading_point,
-            const Camera&           camera) override
+            const PixelContext&         pixel_context,
+            const ShadingPoint&         shading_point,
+            const ShadingComponents&    shading_components,
+            const float                 multiplier)
         {
             if (shading_point.hit())
                 m_depth = static_cast<float>(shading_point.get_distance());
+            else
+                m_depth = numeric_limits<float>::max();
         }
 
         virtual void flush(ShadingResult& result) override

--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -69,21 +69,15 @@ namespace
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components)
+            const ShadingComponents&    shading_components,
+            ShadingResult&              shading_result)
         {
-            if (shading_point.hit())
-                m_depth = static_cast<float>(shading_point.get_distance());
-            else
-                m_depth = numeric_limits<float>::max();
-        }
+            const float depth = shading_point.hit()
+                ? static_cast<float>(shading_point.get_distance())
+                : numeric_limits<float>::max();
 
-        virtual void flush(ShadingResult& result) override
-        {
-            result.m_aovs[m_index] = Color4f(m_depth, m_depth, m_depth, 1.0f);
+            shading_result.m_aovs[m_index] = Color4f(depth, depth, depth, 1.0f);
         }
-
-      private:
-        float m_depth;
     };
 
 

--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -77,7 +77,8 @@ namespace
             const size_t                tile_x,
             const size_t                tile_y) override
         {
-            fetch_tile(frame, tile_x, tile_y);
+            UnfilteredAOVAccumulator::on_tile_begin(frame, tile_x, tile_y);
+
             get_tile().clear(Vector2f(std::numeric_limits<float>::max()));
         }
 

--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -69,8 +69,7 @@ namespace
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components,
-            const float                 multiplier)
+            const ShadingComponents&    shading_components)
         {
             if (shading_point.hit())
                 m_depth = static_cast<float>(shading_point.get_distance());

--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -62,7 +62,7 @@ namespace
     {
       public:
         explicit DepthAOVAccumulator(const size_t index)
-          : AOVAccumulator(index)
+          : m_index(index)
         {
         }
 
@@ -78,6 +78,9 @@ namespace
 
             shading_result.m_aovs[m_index] = Color4f(depth, depth, depth, 1.0f);
         }
+
+      private:
+        const size_t m_index;
     };
 
 

--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -49,7 +49,6 @@
 // Standard headers.
 #include <cstddef>
 #include <limits>
-#include <memory>
 
 using namespace foundation;
 using namespace std;
@@ -78,8 +77,7 @@ namespace
             const size_t                tile_y) override
         {
             UnfilteredAOVAccumulator::on_tile_begin(frame, tile_x, tile_y);
-
-            get_tile().clear(Vector2f(std::numeric_limits<float>::max()));
+            get_tile().clear(Vector2f(numeric_limits<float>::max()));
         }
 
         virtual void write(
@@ -97,18 +95,18 @@ namespace
             float* p = reinterpret_cast<float*>(
                 get_tile().pixel(pi.x - m_tile_origin_x, pi.y - m_tile_origin_y));
 
-            const float min_sample_squared_distance = p[1];
-            const float sample_squared_distance =
-                squared_distace_to_pixel_center(pixel_context.get_sample_position());
+            const float min_sample_square_distance = p[1];
+            const float sample_square_distance =
+                square_distance_to_pixel_center(pixel_context.get_sample_position());
 
-            if (sample_squared_distance < min_sample_squared_distance)
+            if (sample_square_distance < min_sample_square_distance)
             {
                 const float depth = shading_point.hit()
                     ? static_cast<float>(shading_point.get_distance())
                     : numeric_limits<float>::max();
 
                 p[0] = depth;
-                p[1] = sample_squared_distance;
+                p[1] = sample_square_distance;
             }
         }
     };

--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -78,14 +78,7 @@ namespace
             const size_t                tile_y) override
         {
             fetch_tile(frame, tile_x, tile_y);
-
-            // Clear the tile.
-            float* p = reinterpret_cast<float*>(m_tile->pixel(0));
-            for (size_t i = 0, e = m_tile->get_pixel_count(); i < e; ++i)
-            {
-                *p++ = std::numeric_limits<float>::max();
-                *p++ = std::numeric_limits<float>::max();
-            }
+            get_tile().clear(Vector2f(std::numeric_limits<float>::max()));
         }
 
         virtual void write(
@@ -101,7 +94,7 @@ namespace
                 return;
 
             float* p = reinterpret_cast<float*>(
-                m_tile->pixel(pi.x - m_tile_origin_x, pi.y - m_tile_origin_y));
+                get_tile().pixel(pi.x - m_tile_origin_x, pi.y - m_tile_origin_y));
 
             const float min_sample_squared_distance = p[1];
             const float sample_squared_distance =

--- a/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
@@ -69,8 +69,7 @@ namespace
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components,
-            const float                 multiplier) override
+            const ShadingComponents&    shading_components) override
         {
             m_color = shading_components.m_diffuse.to_rgb(g_std_lighting_conditions);
             m_color += shading_components.m_indirect_diffuse.to_rgb(g_std_lighting_conditions);
@@ -95,8 +94,7 @@ namespace
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components,
-            const float                 multiplier) override
+            const ShadingComponents&    shading_components) override
         {
             m_color = shading_components.m_diffuse.to_rgb(g_std_lighting_conditions);
             m_color *= multiplier;
@@ -120,8 +118,7 @@ namespace
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components,
-            const float                 multiplier) override
+            const ShadingComponents&    shading_components) override
         {
             m_color = shading_components.m_indirect_diffuse.to_rgb(g_std_lighting_conditions);
             m_color *= multiplier;

--- a/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
@@ -73,9 +73,7 @@ namespace
             ShadingResult&              shading_result) override
         {
             shading_result.m_aovs[m_index].rgb() =
-                shading_components.m_diffuse.to_rgb(g_std_lighting_conditions);
-
-            shading_result.m_aovs[m_index].rgb() +=
+                shading_components.m_diffuse.to_rgb(g_std_lighting_conditions) +
                 shading_components.m_indirect_diffuse.to_rgb(g_std_lighting_conditions);
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;

--- a/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
@@ -58,22 +58,27 @@ namespace
     //
 
     class DiffuseAOVAccumulator
-      : public ColorAOVAccumulator
+      : public AOVAccumulator
     {
       public:
         explicit DiffuseAOVAccumulator(const size_t index)
-          : ColorAOVAccumulator(index)
+          : AOVAccumulator(index)
         {
         }
 
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components) override
+            const ShadingComponents&    shading_components,
+            ShadingResult&              shading_result) override
         {
-            m_color = shading_components.m_diffuse.to_rgb(g_std_lighting_conditions);
-            m_color += shading_components.m_indirect_diffuse.to_rgb(g_std_lighting_conditions);
-            m_color *= multiplier;
+            shading_result.m_aovs[m_index].rgb() =
+                shading_components.m_diffuse.to_rgb(g_std_lighting_conditions);
+
+            shading_result.m_aovs[m_index].rgb() +=
+                shading_components.m_indirect_diffuse.to_rgb(g_std_lighting_conditions);
+
+            shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
     };
 
@@ -83,21 +88,24 @@ namespace
     //
 
     class DirectDiffuseAOVAccumulator
-      : public ColorAOVAccumulator
+      : public AOVAccumulator
     {
       public:
         explicit DirectDiffuseAOVAccumulator(const size_t index)
-          : ColorAOVAccumulator(index)
+          : AOVAccumulator(index)
         {
         }
 
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components) override
+            const ShadingComponents&    shading_components,
+            ShadingResult&              shading_result) override
         {
-            m_color = shading_components.m_diffuse.to_rgb(g_std_lighting_conditions);
-            m_color *= multiplier;
+            shading_result.m_aovs[m_index].rgb() =
+                shading_components.m_diffuse.to_rgb(g_std_lighting_conditions);
+
+            shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
     };
 
@@ -107,21 +115,24 @@ namespace
     //
 
     class IndirectDiffuseAOVAccumulator
-      : public ColorAOVAccumulator
+      : public AOVAccumulator
     {
       public:
         explicit IndirectDiffuseAOVAccumulator(const size_t index)
-          : ColorAOVAccumulator(index)
+          : AOVAccumulator(index)
         {
         }
 
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components) override
+            const ShadingComponents&    shading_components,
+            ShadingResult&              shading_result) override
         {
-            m_color = shading_components.m_indirect_diffuse.to_rgb(g_std_lighting_conditions);
-            m_color *= multiplier;
+            shading_result.m_aovs[m_index].rgb() =
+                shading_components.m_indirect_diffuse.to_rgb(g_std_lighting_conditions);
+
+            shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
     };
 

--- a/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
@@ -62,7 +62,7 @@ namespace
     {
       public:
         explicit DiffuseAOVAccumulator(const size_t index)
-          : AOVAccumulator(index)
+          : m_index(index)
         {
         }
 
@@ -80,6 +80,9 @@ namespace
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
+
+      private:
+        const size_t m_index;
     };
 
 
@@ -92,7 +95,7 @@ namespace
     {
       public:
         explicit DirectDiffuseAOVAccumulator(const size_t index)
-          : AOVAccumulator(index)
+          : m_index(index)
         {
         }
 
@@ -107,6 +110,9 @@ namespace
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
+
+      private:
+        const size_t m_index;
     };
 
 
@@ -119,7 +125,7 @@ namespace
     {
       public:
         explicit IndirectDiffuseAOVAccumulator(const size_t index)
-          : AOVAccumulator(index)
+          : m_index(index)
         {
         }
 
@@ -134,6 +140,9 @@ namespace
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
+
+      private:
+        const size_t m_index;
     };
 
 

--- a/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
@@ -67,6 +67,8 @@ namespace
         }
 
         virtual void write(
+            const PixelContext&         pixel_context,
+            const ShadingPoint&         shading_point,
             const ShadingComponents&    shading_components,
             const float                 multiplier) override
         {
@@ -91,6 +93,8 @@ namespace
         }
 
         virtual void write(
+            const PixelContext&         pixel_context,
+            const ShadingPoint&         shading_point,
             const ShadingComponents&    shading_components,
             const float                 multiplier) override
         {
@@ -114,6 +118,8 @@ namespace
         }
 
         virtual void write(
+            const PixelContext&         pixel_context,
+            const ShadingPoint&         shading_point,
             const ShadingComponents&    shading_components,
             const float                 multiplier) override
         {

--- a/src/appleseed/renderer/modeling/aov/emissionaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/emissionaov.cpp
@@ -67,6 +67,8 @@ namespace
         }
 
         virtual void write(
+            const PixelContext&         pixel_context,
+            const ShadingPoint&         shading_point,
             const ShadingComponents&    shading_components,
             const float                 multiplier) override
         {

--- a/src/appleseed/renderer/modeling/aov/emissionaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/emissionaov.cpp
@@ -62,7 +62,7 @@ namespace
     {
       public:
         explicit EmissionAOVAccumulator(const size_t index)
-          : AOVAccumulator(index)
+          : m_index(index)
         {
         }
 
@@ -77,6 +77,9 @@ namespace
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
+
+      private:
+        const size_t m_index;
     };
 
 

--- a/src/appleseed/renderer/modeling/aov/emissionaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/emissionaov.cpp
@@ -69,8 +69,7 @@ namespace
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components,
-            const float                 multiplier) override
+            const ShadingComponents&    shading_components) override
         {
             m_color = shading_components.m_emission.to_rgb(g_std_lighting_conditions);
             m_color *= multiplier;

--- a/src/appleseed/renderer/modeling/aov/emissionaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/emissionaov.cpp
@@ -58,21 +58,24 @@ namespace
     //
 
     class EmissionAOVAccumulator
-      : public ColorAOVAccumulator
+      : public AOVAccumulator
     {
       public:
         explicit EmissionAOVAccumulator(const size_t index)
-          : ColorAOVAccumulator(index)
+          : AOVAccumulator(index)
         {
         }
 
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components) override
+            const ShadingComponents&    shading_components,
+            ShadingResult&              shading_result) override
         {
-            m_color = shading_components.m_emission.to_rgb(g_std_lighting_conditions);
-            m_color *= multiplier;
+            shading_result.m_aovs[m_index].rgb() =
+                shading_components.m_emission.to_rgb(g_std_lighting_conditions);
+
+            shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
     };
 

--- a/src/appleseed/renderer/modeling/aov/glossyaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/glossyaov.cpp
@@ -69,12 +69,10 @@ namespace
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components,
-            const float                 multiplier) override
+            const ShadingComponents&    shading_components) override
         {
             m_color = shading_components.m_glossy.to_rgb(g_std_lighting_conditions);
             m_color += shading_components.m_indirect_glossy.to_rgb(g_std_lighting_conditions);
-            m_color *= multiplier;
         }
     };
 
@@ -95,11 +93,9 @@ namespace
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components,
-            const float                 multiplier) override
+            const ShadingComponents&    shading_components) override
         {
             m_color = shading_components.m_glossy.to_rgb(g_std_lighting_conditions);
-            m_color *= multiplier;
         }
     };
 
@@ -120,11 +116,9 @@ namespace
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components,
-            const float                 multiplier) override
+            const ShadingComponents&    shading_components) override
         {
             m_color = shading_components.m_indirect_glossy.to_rgb(g_std_lighting_conditions);
-            m_color *= multiplier;
         }
     };
 

--- a/src/appleseed/renderer/modeling/aov/glossyaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/glossyaov.cpp
@@ -73,9 +73,7 @@ namespace
             ShadingResult&              shading_result) override
         {
             shading_result.m_aovs[m_index].rgb() =
-                shading_components.m_glossy.to_rgb(g_std_lighting_conditions);
-
-            shading_result.m_aovs[m_index].rgb() +=
+                shading_components.m_glossy.to_rgb(g_std_lighting_conditions) +
                 shading_components.m_indirect_glossy.to_rgb(g_std_lighting_conditions);
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;

--- a/src/appleseed/renderer/modeling/aov/glossyaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/glossyaov.cpp
@@ -62,7 +62,7 @@ namespace
     {
       public:
         explicit GlossyAOVAccumulator(const size_t index)
-          : AOVAccumulator(index)
+          : m_index(index)
         {
         }
 
@@ -80,6 +80,9 @@ namespace
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
+
+      private:
+        const size_t m_index;
     };
 
 
@@ -92,7 +95,7 @@ namespace
     {
       public:
         explicit DirectGlossyAOVAccumulator(const size_t index)
-          : AOVAccumulator(index)
+          : m_index(index)
         {
         }
 
@@ -107,6 +110,9 @@ namespace
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
+
+      private:
+        const size_t m_index;
     };
 
 
@@ -119,7 +125,7 @@ namespace
     {
       public:
         explicit IndirectGlossyAOVAccumulator(const size_t index)
-          : AOVAccumulator(index)
+          : m_index(index)
         {
         }
 
@@ -134,6 +140,9 @@ namespace
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
+
+      private:
+        const size_t m_index;
     };
 
 

--- a/src/appleseed/renderer/modeling/aov/glossyaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/glossyaov.cpp
@@ -58,21 +58,27 @@ namespace
     //
 
     class GlossyAOVAccumulator
-      : public ColorAOVAccumulator
+      : public AOVAccumulator
     {
       public:
         explicit GlossyAOVAccumulator(const size_t index)
-          : ColorAOVAccumulator(index)
+          : AOVAccumulator(index)
         {
         }
 
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components) override
+            const ShadingComponents&    shading_components,
+            ShadingResult&              shading_result) override
         {
-            m_color = shading_components.m_glossy.to_rgb(g_std_lighting_conditions);
-            m_color += shading_components.m_indirect_glossy.to_rgb(g_std_lighting_conditions);
+            shading_result.m_aovs[m_index].rgb() =
+                shading_components.m_glossy.to_rgb(g_std_lighting_conditions);
+
+            shading_result.m_aovs[m_index].rgb() +=
+                shading_components.m_indirect_glossy.to_rgb(g_std_lighting_conditions);
+
+            shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
     };
 
@@ -82,20 +88,24 @@ namespace
     //
 
     class DirectGlossyAOVAccumulator
-      : public ColorAOVAccumulator
+      : public AOVAccumulator
     {
       public:
         explicit DirectGlossyAOVAccumulator(const size_t index)
-          : ColorAOVAccumulator(index)
+          : AOVAccumulator(index)
         {
         }
 
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components) override
+            const ShadingComponents&    shading_components,
+            ShadingResult&              shading_result) override
         {
-            m_color = shading_components.m_glossy.to_rgb(g_std_lighting_conditions);
+            shading_result.m_aovs[m_index].rgb() =
+                shading_components.m_glossy.to_rgb(g_std_lighting_conditions);
+
+            shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
     };
 
@@ -105,20 +115,24 @@ namespace
     //
 
     class IndirectGlossyAOVAccumulator
-      : public ColorAOVAccumulator
+      : public AOVAccumulator
     {
       public:
         explicit IndirectGlossyAOVAccumulator(const size_t index)
-          : ColorAOVAccumulator(index)
+          : AOVAccumulator(index)
         {
         }
 
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components) override
+            const ShadingComponents&    shading_components,
+            ShadingResult&              shading_result) override
         {
-            m_color = shading_components.m_indirect_glossy.to_rgb(g_std_lighting_conditions);
+            shading_result.m_aovs[m_index].rgb() =
+                shading_components.m_indirect_glossy.to_rgb(g_std_lighting_conditions);
+
+            shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
     };
 

--- a/src/appleseed/renderer/modeling/aov/glossyaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/glossyaov.cpp
@@ -67,6 +67,8 @@ namespace
         }
 
         virtual void write(
+            const PixelContext&         pixel_context,
+            const ShadingPoint&         shading_point,
             const ShadingComponents&    shading_components,
             const float                 multiplier) override
         {
@@ -91,6 +93,8 @@ namespace
         }
 
         virtual void write(
+            const PixelContext&         pixel_context,
+            const ShadingPoint&         shading_point,
             const ShadingComponents&    shading_components,
             const float                 multiplier) override
         {
@@ -114,6 +118,8 @@ namespace
         }
 
         virtual void write(
+            const PixelContext&         pixel_context,
+            const ShadingPoint&         shading_point,
             const ShadingComponents&    shading_components,
             const float                 multiplier) override
         {

--- a/src/appleseed/renderer/modeling/aov/normalaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/normalaov.cpp
@@ -61,7 +61,7 @@ namespace
     {
       public:
         explicit NormalAOVAccumulator(const size_t index)
-          : AOVAccumulator(index)
+          : m_index(index)
         {
         }
 
@@ -82,6 +82,9 @@ namespace
                         1.0f);
             }
         }
+
+      private:
+        const size_t m_index;
     };
 
 

--- a/src/appleseed/renderer/modeling/aov/normalaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/normalaov.cpp
@@ -68,8 +68,7 @@ namespace
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components,
-            const float                 multiplier) override
+            const ShadingComponents&    shading_components) override
         {
             if (shading_point.hit())
                 m_normal = Vector3f(shading_point.get_shading_normal());

--- a/src/appleseed/renderer/modeling/aov/normalaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/normalaov.cpp
@@ -65,17 +65,16 @@ namespace
         {
         }
 
-        virtual void reset() override
-        {
-            m_normal = Vector3f(0.0f);
-        }
-
         virtual void write(
-            const ShadingPoint&     shading_point,
-            const Camera&           camera) override
+            const PixelContext&         pixel_context,
+            const ShadingPoint&         shading_point,
+            const ShadingComponents&    shading_components,
+            const float                 multiplier) override
         {
             if (shading_point.hit())
                 m_normal = Vector3f(shading_point.get_shading_normal());
+            else
+                m_normal = Vector3f(0.0f);
         }
 
         virtual void flush(ShadingResult& result) override

--- a/src/appleseed/renderer/modeling/aov/normalaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/normalaov.cpp
@@ -59,8 +59,6 @@ namespace
     // Normal AOV accumulator.
     //
 
-    const Vector3d zero_normal(0.0, 0.0, 0.0);
-
     class NormalAOVAccumulator
       : public UnfilteredAOVAccumulator
     {
@@ -76,8 +74,7 @@ namespace
             const size_t                tile_y) override
         {
             UnfilteredAOVAccumulator::on_tile_begin(frame, tile_x, tile_y);
-
-            get_tile().clear(Color4f(0.5f, 0.5f, 0.5f, std::numeric_limits<float>::max()));
+            get_tile().clear(Color4f(0.5f, 0.5f, 0.5f, numeric_limits<float>::max()));
         }
 
         virtual void write(
@@ -95,21 +92,27 @@ namespace
             float* p = reinterpret_cast<float*>(
                 get_tile().pixel(pi.x - m_tile_origin_x, pi.y - m_tile_origin_y));
 
-            const float min_sample_squared_distance = p[3];
-            const float sample_squared_distance =
-                squared_distace_to_pixel_center(pixel_context.get_sample_position());
+            const float min_sample_square_distance = p[3];
+            const float sample_square_distance =
+                square_distance_to_pixel_center(pixel_context.get_sample_position());
 
-            if (sample_squared_distance < min_sample_squared_distance)
+            if (sample_square_distance < min_sample_square_distance)
             {
-                const Vector3d& normal =
-                    shading_point.hit()
-                        ? shading_point.get_shading_normal()
-                        : zero_normal;
-
-                p[0] = static_cast<float>(normal[0]) * 0.5f + 0.5f;
-                p[1] = static_cast<float>(normal[1]) * 0.5f + 0.5f;
-                p[2] = static_cast<float>(normal[2]) * 0.5f + 0.5f;
-                p[3] = sample_squared_distance;
+                if (shading_point.hit())
+                {
+                    const Vector3d& n = shading_point.get_shading_normal();
+                    p[0] = static_cast<float>(n[0]) * 0.5f + 0.5f;
+                    p[1] = static_cast<float>(n[1]) * 0.5f + 0.5f;
+                    p[2] = static_cast<float>(n[2]) * 0.5f + 0.5f;
+                    p[3] = sample_square_distance;
+                }
+                else
+                {
+                    p[0] = 0.5f;
+                    p[1] = 0.5f;
+                    p[2] = 0.5f;
+                    p[3] = sample_square_distance;
+                }
             }
         }
     };

--- a/src/appleseed/renderer/modeling/aov/normalaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/normalaov.cpp
@@ -76,16 +76,8 @@ namespace
             const size_t                tile_y) override
         {
             fetch_tile(frame, tile_x, tile_y);
-
-            // Clear the tile.
-            float* p = reinterpret_cast<float*>(m_tile->pixel(0));
-            for (size_t i = 0, e = m_tile->get_pixel_count(); i < e; ++i)
-            {
-                *p++ = 0.0f;
-                *p++ = 0.0f;
-                *p++ = 0.0f;
-                *p++ = std::numeric_limits<float>::max();
-            }
+            get_tile().clear(
+                Color4f(0.5f, 0.5f, 0.5f, std::numeric_limits<float>::max()));
         }
 
         virtual void write(
@@ -101,7 +93,7 @@ namespace
                 return;
 
             float* p = reinterpret_cast<float*>(
-                m_tile->pixel(pi.x - m_tile_origin_x, pi.y - m_tile_origin_y));
+                get_tile().pixel(pi.x - m_tile_origin_x, pi.y - m_tile_origin_y));
 
             const float min_sample_squared_distance = p[3];
             const float sample_squared_distance =
@@ -155,7 +147,7 @@ namespace
 
         virtual const char** get_channel_names() const override
         {
-            static const char* ChannelNames[] = {"X", "Y", "Z"};
+            static const char* ChannelNames[] = {"R", "G", "B"};
             return ChannelNames;
         }
 

--- a/src/appleseed/renderer/modeling/aov/normalaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/normalaov.cpp
@@ -68,26 +68,20 @@ namespace
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components) override
+            const ShadingComponents&    shading_components,
+            ShadingResult&              shading_result) override
         {
             if (shading_point.hit())
-                m_normal = Vector3f(shading_point.get_shading_normal());
-            else
-                m_normal = Vector3f(0.0f);
+            {
+                const Vector3f normal(shading_point.get_shading_normal());
+                shading_result.m_aovs[m_index] =
+                    Color4f(
+                        normal[0] * 0.5f + 0.5f,
+                        normal[1] * 0.5f + 0.5f,
+                        normal[2] * 0.5f + 0.5f,
+                        1.0f);
+            }
         }
-
-        virtual void flush(ShadingResult& result) override
-        {
-            result.m_aovs[m_index] =
-                Color4f(
-                    m_normal[0] * 0.5f + 0.5f,
-                    m_normal[1] * 0.5f + 0.5f,
-                    m_normal[2] * 0.5f + 0.5f,
-                    1.0f);
-        }
-
-      private:
-        Vector3f m_normal;
     };
 
 

--- a/src/appleseed/renderer/modeling/aov/normalaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/normalaov.cpp
@@ -75,9 +75,9 @@ namespace
             const size_t                tile_x,
             const size_t                tile_y) override
         {
-            fetch_tile(frame, tile_x, tile_y);
-            get_tile().clear(
-                Color4f(0.5f, 0.5f, 0.5f, std::numeric_limits<float>::max()));
+            UnfilteredAOVAccumulator::on_tile_begin(frame, tile_x, tile_y);
+
+            get_tile().clear(Color4f(0.5f, 0.5f, 0.5f, std::numeric_limits<float>::max()));
         }
 
         virtual void write(

--- a/src/appleseed/renderer/modeling/aov/uvaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/uvaov.cpp
@@ -75,11 +75,9 @@ namespace
             const size_t                tile_x,
             const size_t                tile_y) override
         {
-            fetch_tile(frame, tile_x, tile_y);
+            UnfilteredAOVAccumulator::on_tile_begin(frame, tile_x, tile_y);
 
-            // Clear the tile.
-            get_tile().clear(
-                Color3f(0.0f, 0.0f, std::numeric_limits<float>::max()));
+            get_tile().clear(Color3f(0.0f, 0.0f, std::numeric_limits<float>::max()));
         }
 
         virtual void write(

--- a/src/appleseed/renderer/modeling/aov/uvaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/uvaov.cpp
@@ -59,8 +59,6 @@ namespace
     // UV AOV accumulator.
     //
 
-    const Vector2f zero_uvs(0.0f, 0.0f);
-
     class UVAOVAccumulator
       : public UnfilteredAOVAccumulator
     {
@@ -76,8 +74,7 @@ namespace
             const size_t                tile_y) override
         {
             UnfilteredAOVAccumulator::on_tile_begin(frame, tile_x, tile_y);
-
-            get_tile().clear(Color3f(0.0f, 0.0f, std::numeric_limits<float>::max()));
+            get_tile().clear(Color3f(0.0f, 0.0f, numeric_limits<float>::max()));
         }
 
         virtual void write(
@@ -95,21 +92,27 @@ namespace
             float* p = reinterpret_cast<float*>(
                 get_tile().pixel(pi.x - m_tile_origin_x, pi.y - m_tile_origin_y));
 
-            const float min_sample_squared_distance = p[3];
-            const float sample_squared_distance =
-                squared_distace_to_pixel_center(pixel_context.get_sample_position());
+            const float min_sample_square_distance = p[3];
+            const float sample_square_distance =
+                square_distance_to_pixel_center(pixel_context.get_sample_position());
 
-            if (sample_squared_distance < min_sample_squared_distance)
+            if (sample_square_distance < min_sample_square_distance)
             {
-                const Vector2f& uv =
-                    shading_point.hit()
-                        ? shading_point.get_uv(0)
-                        : zero_uvs;
-
-                p[0] = uv[0];
-                p[1] = uv[1];
-                p[2] = 0.0f;
-                p[3] = sample_squared_distance;
+                if (shading_point.hit())
+                {
+                    const Vector2f& uv = shading_point.get_uv(0);
+                    p[0] = uv[0];
+                    p[1] = uv[1];
+                    p[2] = 0.0f;
+                    p[3] = sample_square_distance;
+                }
+                else
+                {
+                    p[0] = 0.0f;
+                    p[1] = 0.0f;
+                    p[2] = 0.0f;
+                    p[3] = sample_square_distance;
+                }
             }
         }
     };

--- a/src/appleseed/renderer/modeling/aov/uvaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/uvaov.cpp
@@ -78,13 +78,8 @@ namespace
             fetch_tile(frame, tile_x, tile_y);
 
             // Clear the tile.
-            float* p = reinterpret_cast<float*>(m_tile->pixel(0));
-            for (size_t i = 0, e = m_tile->get_pixel_count(); i < e; ++i)
-            {
-                *p++ = 0.0f;
-                *p++ = 0.0f;
-                *p++ = std::numeric_limits<float>::max();
-            }
+            get_tile().clear(
+                Color3f(0.0f, 0.0f, std::numeric_limits<float>::max()));
         }
 
         virtual void write(
@@ -100,9 +95,9 @@ namespace
                 return;
 
             float* p = reinterpret_cast<float*>(
-                m_tile->pixel(pi.x - m_tile_origin_x, pi.y - m_tile_origin_y));
+                get_tile().pixel(pi.x - m_tile_origin_x, pi.y - m_tile_origin_y));
 
-            const float min_sample_squared_distance = p[2];
+            const float min_sample_squared_distance = p[3];
             const float sample_squared_distance =
                 squared_distace_to_pixel_center(pixel_context.get_sample_position());
 
@@ -115,7 +110,8 @@ namespace
 
                 p[0] = uv[0];
                 p[1] = uv[1];
-                p[2] = sample_squared_distance;
+                p[2] = 0.0f;
+                p[3] = sample_squared_distance;
             }
         }
     };
@@ -148,12 +144,12 @@ namespace
 
         virtual size_t get_channel_count() const override
         {
-            return 2;
+            return 3;
         }
 
         virtual const char** get_channel_names() const override
         {
-            static const char* ChannelNames[] = {"U", "V"};
+            static const char* ChannelNames[] = {"R", "G", "B"};
             return ChannelNames;
         }
 

--- a/src/appleseed/renderer/modeling/aov/uvaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/uvaov.cpp
@@ -65,17 +65,16 @@ namespace
         {
         }
 
-        virtual void reset() override
-        {
-            m_uvs = Vector2f(0.0f);
-        }
-
         virtual void write(
-            const ShadingPoint&     shading_point,
-            const Camera&           camera) override
+            const PixelContext&         pixel_context,
+            const ShadingPoint&         shading_point,
+            const ShadingComponents&    shading_components,
+            const float                 multiplier) override
         {
             if (shading_point.hit())
                 m_uvs = shading_point.get_uv(0);
+            else
+                m_uvs = Vector2f(0.0f);
         }
 
         virtual void flush(ShadingResult& result) override

--- a/src/appleseed/renderer/modeling/aov/uvaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/uvaov.cpp
@@ -61,7 +61,7 @@ namespace
     {
       public:
         explicit UVAOVAccumulator(const size_t index)
-          : AOVAccumulator(index)
+          : m_index(index)
         {
         }
 
@@ -77,6 +77,9 @@ namespace
                 shading_result.m_aovs[m_index] = Color4f(uvs[0], uvs[1], 0.0f, 1.0f);
             }
         }
+
+      private:
+        const size_t m_index;
     };
 
 

--- a/src/appleseed/renderer/modeling/aov/uvaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/uvaov.cpp
@@ -68,21 +68,15 @@ namespace
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components) override
+            const ShadingComponents&    shading_components,
+            ShadingResult&              shading_result) override
         {
             if (shading_point.hit())
-                m_uvs = shading_point.get_uv(0);
-            else
-                m_uvs = Vector2f(0.0f);
+            {
+                const Vector2f uvs(shading_point.get_uv(0));
+                shading_result.m_aovs[m_index] = Color4f(uvs[0], uvs[1], 0.0f, 1.0f);
+            }
         }
-
-        virtual void flush(ShadingResult& result) override
-        {
-            result.m_aovs[m_index] = Color4f(m_uvs[0], m_uvs[1], 0.0f, 1.0f);
-        }
-
-      private:
-        Vector2f m_uvs;
     };
 
 

--- a/src/appleseed/renderer/modeling/aov/uvaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/uvaov.cpp
@@ -68,8 +68,7 @@ namespace
         virtual void write(
             const PixelContext&         pixel_context,
             const ShadingPoint&         shading_point,
-            const ShadingComponents&    shading_components,
-            const float                 multiplier) override
+            const ShadingComponents&    shading_components) override
         {
             if (shading_point.hit())
                 m_uvs = shading_point.get_uv(0);

--- a/src/appleseed/renderer/modeling/frame/frame.h
+++ b/src/appleseed/renderer/modeling/frame/frame.h
@@ -181,8 +181,7 @@ class APPLESEED_DLLSYMBOL Frame
     void write_png_image(
         const char*                         file_path,
         const foundation::Image&            image,
-        const foundation::ImageAttributes&  image_attributes,
-        const AOV*                          aov) const;
+        const foundation::ImageAttributes&  image_attributes) const;
 };
 
 

--- a/src/appleseed/renderer/modeling/frame/frame.h
+++ b/src/appleseed/renderer/modeling/frame/frame.h
@@ -165,23 +165,6 @@ class APPLESEED_DLLSYMBOL Frame
     ~Frame();
 
     void extract_parameters();
-
-    // Write an image to disk. Return true if successful, false otherwise.
-    bool write_image(
-        const char*                         file_path,
-        const foundation::Image&            image,
-        const AOV*                          aov) const;
-
-    void write_exr_image(
-        const char*                         file_path,
-        const foundation::Image&            image,
-        const foundation::ImageAttributes&  image_attributes,
-        const AOV*                          aov) const;
-
-    void write_png_image(
-        const char*                         file_path,
-        const foundation::Image&            image,
-        const foundation::ImageAttributes&  image_attributes) const;
 };
 
 

--- a/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
@@ -1510,10 +1510,7 @@ namespace
         virtual void update() override
         {
             if (Scene* scene = m_project.get_scene())
-            {
                 update_material_and_object_inputs(scene->assemblies());
-                update_physical_surface_shader_inputs(scene->assemblies());
-            }
         }
 
       private:
@@ -1541,7 +1538,28 @@ namespace
             ParamArray& params = entity.get_parameters();
             params.remove_path("shade_alpha_cutouts");
         }
+    };
 
+    //
+    // Update from revision 20 to revision 21.
+    //
+
+    class UpdateFromRevision_20
+      : public Updater
+    {
+      public:
+        explicit UpdateFromRevision_20(Project& project)
+            : Updater(project, 20)
+        {
+        }
+
+        virtual void update() override
+        {
+            if (Scene* scene = m_project.get_scene())
+                update_physical_surface_shader_inputs(scene->assemblies());
+        }
+
+      private:
         static void update_physical_surface_shader_inputs(AssemblyContainer& assemblies)
         {
             for (each<AssemblyContainer> i = assemblies; i; ++i)
@@ -1567,7 +1585,6 @@ namespace
             }
         }
     };
-
 }
 
 bool ProjectFileUpdater::update(
@@ -1620,6 +1637,7 @@ void ProjectFileUpdater::update(
       CASE_UPDATE_FROM_REVISION(17);
       CASE_UPDATE_FROM_REVISION(18);
       CASE_UPDATE_FROM_REVISION(19);
+      CASE_UPDATE_FROM_REVISION(20);
 
       case ProjectFormatRevision:
         // Project is up-to-date.

--- a/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
@@ -1510,7 +1510,10 @@ namespace
         virtual void update() override
         {
             if (Scene* scene = m_project.get_scene())
+            {
                 update_material_and_object_inputs(scene->assemblies());
+                update_physical_surface_shader_inputs(scene->assemblies());
+            }
         }
 
       private:
@@ -1537,6 +1540,31 @@ namespace
         {
             ParamArray& params = entity.get_parameters();
             params.remove_path("shade_alpha_cutouts");
+        }
+
+        static void update_physical_surface_shader_inputs(AssemblyContainer& assemblies)
+        {
+            for (each<AssemblyContainer> i = assemblies; i; ++i)
+            {
+                update_physical_surface_shader_inputs(*i);
+                update_physical_surface_shader_inputs(i->assemblies());
+            }
+        }
+
+        static void update_physical_surface_shader_inputs(Assembly& assembly)
+        {
+            for (each<SurfaceShaderContainer> i = assembly.surface_shaders(); i; ++i)
+                update_physical_surface_shader_inputs(*i);
+        }
+
+        static void update_physical_surface_shader_inputs(SurfaceShader& surface_shader)
+        {
+            if (strcmp(surface_shader.get_model(), PhysicalSurfaceShaderFactory().get_model()) == 0)
+            {
+                ParamArray& params = surface_shader.get_parameters();
+                params.strings().remove("color_multiplier");
+                params.strings().remove("alpha_multiplier");
+            }
         }
     };
 

--- a/src/appleseed/renderer/modeling/project/projectformatrevision.h
+++ b/src/appleseed/renderer/modeling/project/projectformatrevision.h
@@ -39,7 +39,7 @@ namespace renderer
 // when you increment this value.
 //
 
-const size_t ProjectFormatRevision = 20;
+const size_t ProjectFormatRevision = 21;
 
 }       // namespace renderer
 

--- a/src/appleseed/renderer/modeling/surfaceshader/aosurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/aosurfaceshader.cpp
@@ -33,6 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/kernel/aov/aovaccumulator.h"
 #include "renderer/kernel/shading/ambientocclusion.h"
+#include "renderer/kernel/shading/shadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/modeling/input/inputarray.h"
@@ -133,7 +134,13 @@ namespace
 
             const float accessibility = static_cast<float>(1.0 - occlusion);
 
-            aov_accumulators.beauty().set(Color3f(accessibility));
+            ShadingComponents shading_components;
+            result.m_beauty.set(accessibility);
+            aov_accumulators.write(
+                pixel_context,
+                shading_point,
+                shading_components,
+                1.0f);
         }
 
       private:

--- a/src/appleseed/renderer/modeling/surfaceshader/aosurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/aosurfaceshader.cpp
@@ -31,11 +31,11 @@
 #include "aosurfaceshader.h"
 
 // appleseed.renderer headers.
-#include "renderer/kernel/aov/aovaccumulator.h"
 #include "renderer/kernel/shading/ambientocclusion.h"
 #include "renderer/kernel/shading/shadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
+#include "renderer/kernel/shading/shadingresult.h"
 #include "renderer/modeling/input/inputarray.h"
 #include "renderer/modeling/input/source.h"
 #include "renderer/modeling/surfaceshader/surfaceshader.h"
@@ -105,7 +105,8 @@ namespace
             const PixelContext&         pixel_context,
             const ShadingContext&       shading_context,
             const ShadingPoint&         shading_point,
-            AOVAccumulatorContainer&    aov_accumulators) const override
+            AOVAccumulatorContainer&    aov_accumulators,
+            ShadingResult&              shading_result) const override
         {
             double occlusion;
 
@@ -133,13 +134,7 @@ namespace
             }
 
             const float accessibility = static_cast<float>(1.0 - occlusion);
-
-            ShadingComponents shading_components;
-            result.m_beauty.set(accessibility);
-            aov_accumulators.write(
-                pixel_context,
-                shading_point,
-                shading_components);
+            shading_result.m_main = Color4f(accessibility, accessibility, accessibility, 1.0f);
         }
 
       private:

--- a/src/appleseed/renderer/modeling/surfaceshader/aosurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/aosurfaceshader.cpp
@@ -139,8 +139,7 @@ namespace
             aov_accumulators.write(
                 pixel_context,
                 shading_point,
-                shading_components,
-                1.0f);
+                shading_components);
         }
 
       private:

--- a/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
@@ -121,8 +121,7 @@ namespace
             aov_accumulators.write(
                 pixel_context,
                 shading_point,
-                shading_components,
-                1.0f);
+                shading_components);
 
             // This surface shader can override alpha.
             if (m_alpha_source == AlphaSourceColor)

--- a/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
@@ -33,6 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
 #include "renderer/kernel/aov/aovaccumulator.h"
+#include "renderer/kernel/shading/shadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/modeling/input/inputarray.h"
@@ -114,15 +115,18 @@ namespace
                 &values);
 
             // Initialize the shading result.
-            aov_accumulators.beauty().set(values.m_color);
+            ShadingComponents shading_components;
+            shading_components.m_beauty = values.m_color;
+            shading_components.m_beauty *= values.m_color_multiplier;
+            aov_accumulators.write(
+                pixel_context,
+                shading_point,
+                shading_components,
+                1.0f);
 
             // This surface shader can override alpha.
             if (m_alpha_source == AlphaSourceColor)
-                aov_accumulators.alpha().set(values.m_alpha);
-
-            // Apply multipliers.
-            aov_accumulators.beauty().apply_multiplier(values.m_color_multiplier);
-            aov_accumulators.alpha().apply_multiplier(Alpha(values.m_alpha_multiplier));
+                aov_accumulators.alpha().set(values.m_alpha * values.m_alpha_multiplier);
         }
 
       private:

--- a/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
@@ -32,10 +32,10 @@
 
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
-#include "renderer/kernel/aov/aovaccumulator.h"
-#include "renderer/kernel/shading/shadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
+#include "renderer/kernel/shading/shadingresult.h"
+#include "renderer/modeling/color/colorspace.h"
 #include "renderer/modeling/input/inputarray.h"
 #include "renderer/modeling/surfaceshader/surfaceshader.h"
 #include "renderer/utility/paramarray.h"
@@ -105,7 +105,8 @@ namespace
             const PixelContext&         pixel_context,
             const ShadingContext&       shading_context,
             const ShadingPoint&         shading_point,
-            AOVAccumulatorContainer&    aov_accumulators) const override
+            AOVAccumulatorContainer&    aov_accumulators,
+            ShadingResult&              shading_result) const override
         {
             // Evaluate the shader inputs.
             InputValues values;
@@ -115,17 +116,11 @@ namespace
                 &values);
 
             // Initialize the shading result.
-            ShadingComponents shading_components;
-            shading_components.m_beauty = values.m_color;
-            shading_components.m_beauty *= values.m_color_multiplier;
-            aov_accumulators.write(
-                pixel_context,
-                shading_point,
-                shading_components);
+            shading_result.m_main.rgb() = values.m_color.to_rgb(g_std_lighting_conditions);
 
             // This surface shader can override alpha.
             if (m_alpha_source == AlphaSourceColor)
-                aov_accumulators.alpha().set(values.m_alpha * values.m_alpha_multiplier);
+                shading_result.m_main.a = values.m_alpha[0] * values.m_alpha_multiplier;
         }
 
       private:

--- a/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
@@ -31,14 +31,15 @@
 #include "diagnosticsurfaceshader.h"
 
 // appleseed.renderer headers.
-#include "renderer/kernel/aov/aovaccumulator.h"
 #include "renderer/kernel/shading/ambientocclusion.h"
 #include "renderer/kernel/shading/directshadingcomponents.h"
 #include "renderer/kernel/shading/shadingcontext.h"
 #include "renderer/kernel/shading/shadingpoint.h"
+#include "renderer/kernel/shading/shadingresult.h"
 #include "renderer/modeling/bsdf/bsdf.h"
 #include "renderer/modeling/bsdf/bsdfsample.h"
 #include "renderer/modeling/camera/camera.h"
+#include "renderer/modeling/color/colorspace.h"
 #include "renderer/modeling/input/inputarray.h"
 #include "renderer/modeling/material/material.h"
 #include "renderer/modeling/scene/scene.h"
@@ -219,13 +220,14 @@ void DiagnosticSurfaceShader::evaluate(
     const PixelContext&         pixel_context,
     const ShadingContext&       shading_context,
     const ShadingPoint&         shading_point,
-    AOVAccumulatorContainer&    aov_accumulators) const
+    AOVAccumulatorContainer&    aov_accumulators,
+    ShadingResult&              shading_result) const
 {
     switch (m_shading_mode)
     {
       case Color:
         {
-            set_result_to_opaque_pink(aov_accumulators);
+            shading_result.set_to_opaque_pink();
 
             const Material* material = shading_point.get_material();
             if (material)
@@ -255,26 +257,26 @@ void DiagnosticSurfaceShader::evaluate(
                         direction,
                         ScatteringMode::All,
                         value);
-                    set_result(value.m_beauty, aov_accumulators);
+                    set_result(value.m_beauty, shading_result);
                 }
             }
         }
         break;
 
       case Coverage:
-        set_result(Color3f(1.0f), aov_accumulators);
+        set_result(Color3f(1.0f), shading_result);
         break;
 
       case Barycentric:
         set_result(
             vector2_to_color(shading_point.get_bary()),
-            aov_accumulators);
+            shading_result);
         break;
 
       case UV:
         set_result(
             uvs_to_color(shading_point.get_uv(0)),
-            aov_accumulators);
+            shading_result);
         break;
 
       case Tangent:
@@ -301,20 +303,20 @@ void DiagnosticSurfaceShader::evaluate(
                 m_shading_mode == ShadingNormal ? shading_point.get_shading_basis().get_normal() :
                 m_shading_mode == Tangent ? shading_point.get_shading_basis().get_tangent_u() :
                 shading_point.get_shading_basis().get_tangent_v();
-            set_result(vector3_to_color(v), aov_accumulators);
+            set_result(vector3_to_color(v), shading_result);
         }
         break;
 
       case GeometricNormal:
         set_result(
             vector3_to_color(shading_point.get_geometric_normal()),
-            aov_accumulators);
+            shading_result);
         break;
 
       case OriginalShadingNormal:
         set_result(
             vector3_to_color(shading_point.get_original_shading_normal()),
-            aov_accumulators);
+            shading_result);
         break;
 
       case WorldSpacePosition:
@@ -322,7 +324,7 @@ void DiagnosticSurfaceShader::evaluate(
             const Vector3d& p = shading_point.get_point();
             set_result(
                 Color3f(Color3d(p.x, p.y, p.z)),
-                aov_accumulators);
+                shading_result);
         }
         break;
 
@@ -331,19 +333,19 @@ void DiagnosticSurfaceShader::evaluate(
             shading_point.get_side() == ObjectInstance::FrontSide
                 ? Color3f(0.0f, 0.0f, 1.0f)
                 : Color3f(1.0f, 0.0f, 0.0f),
-            aov_accumulators);
+            shading_result);
         break;
 
       case Depth:
         set_result(
             Color3f(static_cast<float>(shading_point.get_distance())),
-            aov_accumulators);
+            shading_result);
         break;
 
       case ScreenSpaceWireframe:
         {
             // Initialize the shading result to the background color.
-            set_result(Color4f(0.0f, 0.0f, 0.8f, 0.5f), aov_accumulators);
+            set_result(Color4f(0.0f, 0.0f, 0.8f, 0.5f), shading_result);
 
             if (shading_point.is_triangle_primitive())
             {
@@ -378,7 +380,7 @@ void DiagnosticSurfaceShader::evaluate(
                     // Shade with the wire's color if the hit point is close enough to the edge.
                     if (d < SquareWireThickness)
                     {
-                        set_result(Color4f(1.0f), aov_accumulators);
+                        set_result(Color4f(1.0f), shading_result);
                         break;
                     }
                 }
@@ -395,7 +397,7 @@ void DiagnosticSurfaceShader::evaluate(
       case WorldSpaceWireframe:
         {
             // Initialize the shading result to the background color.
-            set_result(Color4f(0.0f, 0.0f, 0.8f, 0.5f), aov_accumulators);
+            set_result(Color4f(0.0f, 0.0f, 0.8f, 0.5f), shading_result);
 
             if (shading_point.is_triangle_primitive())
             {
@@ -419,7 +421,7 @@ void DiagnosticSurfaceShader::evaluate(
                     // Shade with the wire's color if the hit point is close enough to the edge.
                     if (d < SquareWireThickness)
                     {
-                        set_result(Color4f(1.0f), aov_accumulators);
+                        set_result(Color4f(1.0f), shading_result);
                         break;
                     }
                 }
@@ -447,20 +449,20 @@ void DiagnosticSurfaceShader::evaluate(
 
             // Return a gray scale value proportional to the accessibility.
             const float accessibility = static_cast<float>(1.0 - occlusion);
-            set_result(Color3f(accessibility), aov_accumulators);
+            set_result(Color3f(accessibility), shading_result);
         }
         break;
 
       case AssemblyInstances:
         set_result(
             integer_to_color(shading_point.get_assembly_instance().get_uid()),
-            aov_accumulators);
+            shading_result);
         break;
 
       case ObjectInstances:
         set_result(
             integer_to_color(shading_point.get_object_instance().get_uid()),
-            aov_accumulators);
+            shading_result);
         break;
 
       case Regions:
@@ -469,7 +471,7 @@ void DiagnosticSurfaceShader::evaluate(
                 mix_uint32(
                     static_cast<uint32>(shading_point.get_object_instance().get_uid()),
                     static_cast<uint32>(shading_point.get_region_index()));
-            set_result(integer_to_color(h), aov_accumulators);
+            set_result(integer_to_color(h), shading_result);
         }
         break;
 
@@ -480,7 +482,7 @@ void DiagnosticSurfaceShader::evaluate(
                     static_cast<uint32>(shading_point.get_object_instance().get_uid()),
                     static_cast<uint32>(shading_point.get_region_index()),
                     static_cast<uint32>(shading_point.get_primitive_index()));
-            set_result(integer_to_color(h), aov_accumulators);
+            set_result(integer_to_color(h), shading_result);
         }
         break;
 
@@ -488,8 +490,8 @@ void DiagnosticSurfaceShader::evaluate(
         {
             const Material* material = shading_point.get_material();
             if (material)
-                set_result(integer_to_color(material->get_uid()), aov_accumulators);
-            else set_result_to_opaque_pink(aov_accumulators);
+                set_result(integer_to_color(material->get_uid()), shading_result);
+            else shading_result.set_to_opaque_pink();
         }
         break;
 
@@ -538,7 +540,7 @@ void DiagnosticSurfaceShader::evaluate(
                             norm(sample.m_incoming.get_dy())) * 3.0;
                     set_result(
                         Color3f(static_cast<float>(spread)),
-                        aov_accumulators);
+                        shading_result);
 
                 }
             }
@@ -552,7 +554,7 @@ void DiagnosticSurfaceShader::evaluate(
             const double facing = abs(dot(normal, view));
             set_result(
                 Color3f(static_cast<float>(facing)),
-                aov_accumulators);
+                shading_result);
         }
         break;
 
@@ -589,31 +591,25 @@ void DiagnosticSurfaceShader::extract_parameters()
 
 void DiagnosticSurfaceShader::set_result(
     const Color3f&              color,
-    AOVAccumulatorContainer&    aov_accumulators)
+    ShadingResult&              shading_result)
 {
-    set_result(Color4f(color.r, color.g, color.b, 1.0f), aov_accumulators);
+    shading_result.m_main.rgb() = color;
+    shading_result.m_main.a = 1.0f;
 }
 
 void DiagnosticSurfaceShader::set_result(
     const Color4f&              color,
-    AOVAccumulatorContainer&    aov_accumulators)
+    ShadingResult&              shading_result)
 {
-    aov_accumulators.beauty().set(color.rgb());
-    aov_accumulators.alpha().set(Alpha(color[3]));
+    shading_result.m_main = color;
 }
 
 void DiagnosticSurfaceShader::set_result(
     const Spectrum&             value,
-    AOVAccumulatorContainer&    aov_accumulators)
+    ShadingResult&              shading_result)
 {
-    aov_accumulators.beauty().set(value);
-}
-
-void DiagnosticSurfaceShader::set_result_to_opaque_pink(
-    AOVAccumulatorContainer&    aov_accumulators)
-{
-    aov_accumulators.beauty().set_to_pink_linear_rgb();
-    aov_accumulators.alpha().set(Alpha(1.0f));
+    shading_result.m_main.rgb() = value.to_rgb(g_std_lighting_conditions);
+    shading_result.m_main.a = 1.0f;
 }
 
 

--- a/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
@@ -227,7 +227,7 @@ void DiagnosticSurfaceShader::evaluate(
     {
       case Color:
         {
-            shading_result.set_to_opaque_pink();
+            shading_result.set_main_to_opaque_pink();
 
             const Material* material = shading_point.get_material();
             if (material)
@@ -491,7 +491,7 @@ void DiagnosticSurfaceShader::evaluate(
             const Material* material = shading_point.get_material();
             if (material)
                 set_result(integer_to_color(material->get_uid()), shading_result);
-            else shading_result.set_to_opaque_pink();
+            else shading_result.set_main_to_opaque_pink();
         }
         break;
 

--- a/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
@@ -591,7 +591,7 @@ void DiagnosticSurfaceShader::set_result(
     const Color3f&              color,
     AOVAccumulatorContainer&    aov_accumulators)
 {
-    aov_accumulators.beauty().set(color);
+    set_result(Color4f(color.r, color.g, color.b, 1.0f), aov_accumulators);
 }
 
 void DiagnosticSurfaceShader::set_result(

--- a/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.h
+++ b/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.h
@@ -113,7 +113,8 @@ class APPLESEED_DLLSYMBOL DiagnosticSurfaceShader
         const PixelContext&         pixel_context,
         const ShadingContext&       shading_context,
         const ShadingPoint&         shading_point,
-        AOVAccumulatorContainer&    aov_accumulators) const override;
+        AOVAccumulatorContainer&    aov_accumulators,
+        ShadingResult&              shading_result) const override;
 
   private:
     ShadingMode m_shading_mode;
@@ -124,18 +125,15 @@ class APPLESEED_DLLSYMBOL DiagnosticSurfaceShader
 
     static void set_result(
         const foundation::Color3f&  color,
-        AOVAccumulatorContainer&    aov_accumulators);
+        ShadingResult&              shading_result);
 
     static void set_result(
         const foundation::Color4f&  color,
-        AOVAccumulatorContainer&    aov_accumulators);
+        ShadingResult&              shading_result);
 
     static void set_result(
         const Spectrum&             value,
-        AOVAccumulatorContainer&    aov_accumulators);
-
-    static void set_result_to_opaque_pink(
-        AOVAccumulatorContainer&    aov_accumulators);
+        ShadingResult&              shading_result);
 };
 
 

--- a/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
@@ -123,8 +123,7 @@ namespace
             aov_accumulators.write(
                 pixel_context,
                 shading_point,
-                radiance,
-                1.0f);
+                radiance);
         }
 
       private:

--- a/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
@@ -103,7 +103,8 @@ namespace
             const PixelContext&         pixel_context,
             const ShadingContext&       shading_context,
             const ShadingPoint&         shading_point,
-            AOVAccumulatorContainer&    aov_accumulators) const override
+            AOVAccumulatorContainer&    aov_accumulators,
+            ShadingResult&              shading_result) const override
         {
             // Compute lighting.
             ShadingComponents radiance;
@@ -123,7 +124,8 @@ namespace
             aov_accumulators.write(
                 pixel_context,
                 shading_point,
-                radiance);
+                radiance,
+                shading_result);
         }
 
       private:

--- a/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
@@ -120,7 +120,11 @@ namespace
                 radiance /= static_cast<float>(m_lighting_samples);
 
             // Accumulate into AOVs.
-            aov_accumulators.write(radiance, 1.0f);
+            aov_accumulators.write(
+                pixel_context,
+                shading_point,
+                radiance,
+                1.0f);
         }
 
       private:

--- a/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
@@ -105,13 +105,6 @@ namespace
             const ShadingPoint&         shading_point,
             AOVAccumulatorContainer&    aov_accumulators) const override
         {
-            // Evaluate the shader inputs.
-            InputValues values;
-            m_inputs.evaluate(
-                shading_context.get_texture_cache(),
-                shading_point.get_uv(0),
-                &values);
-
             // Compute lighting.
             ShadingComponents radiance;
             for (size_t i = 0, e = m_lighting_samples; i < e; ++i)
@@ -127,19 +120,10 @@ namespace
                 radiance /= static_cast<float>(m_lighting_samples);
 
             // Accumulate into AOVs.
-            aov_accumulators.write(radiance, values.m_color_multiplier);
-
-            // Apply alpha multiplier.
-            aov_accumulators.alpha().apply_multiplier(Alpha(values.m_alpha_multiplier));
+            aov_accumulators.write(radiance, 1.0f);
         }
 
       private:
-        APPLESEED_DECLARE_INPUT_VALUES(InputValues)
-        {
-            float   m_color_multiplier;
-            float   m_alpha_multiplier;
-        };
-
         size_t      m_lighting_samples;
     };
 }
@@ -166,26 +150,6 @@ Dictionary PhysicalSurfaceShaderFactory::get_model_metadata() const
 DictionaryArray PhysicalSurfaceShaderFactory::get_input_metadata() const
 {
     DictionaryArray metadata;
-
-    metadata.push_back(
-        Dictionary()
-            .insert("name", "color_multiplier")
-            .insert("label", "Color Multiplier")
-            .insert("type", "colormap")
-            .insert("entity_types",
-                Dictionary().insert("texture_instance", "Textures"))
-            .insert("default", "1.0")
-            .insert("use", "optional"));
-
-    metadata.push_back(
-        Dictionary()
-            .insert("name", "alpha_multiplier")
-            .insert("label", "Alpha Multiplier")
-            .insert("type", "colormap")
-            .insert("entity_types",
-                Dictionary().insert("texture_instance", "Textures"))
-            .insert("default", "1.0")
-            .insert("use", "optional"));
 
     metadata.push_back(
         Dictionary()

--- a/src/appleseed/renderer/modeling/surfaceshader/surfaceshader.h
+++ b/src/appleseed/renderer/modeling/surfaceshader/surfaceshader.h
@@ -46,6 +46,7 @@ namespace renderer      { class ParamArray; }
 namespace renderer      { class PixelContext; }
 namespace renderer      { class ShadingContext; }
 namespace renderer      { class ShadingPoint; }
+namespace renderer      { class ShadingResult; }
 
 namespace renderer
 {
@@ -75,7 +76,8 @@ class APPLESEED_DLLSYMBOL SurfaceShader
         const PixelContext&         pixel_context,
         const ShadingContext&       shading_context,
         const ShadingPoint&         shading_point,
-        AOVAccumulatorContainer&    aov_accumulators) const = 0;
+        AOVAccumulatorContainer&    aov_accumulators,
+        ShadingResult&              shading_result) const = 0;
 };
 
 }       // namespace renderer


### PR DESCRIPTION
- Simplified AOVs code.
- Geometric AOVs (normals, uvs, depth) are now unfiltered.
- Normal and UV AOVs are saved as RGB images to make them easier to use in comp apps.
- Removed color and alpha multipliers from physical surface shader.
