### PR TITLE
clang-tidy modernize-use-emplace

### DIFF
--- a/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
+++ b/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
@@ -1295,7 +1295,7 @@ void RenderingSettingsWindow::reload()
     for (const_each<ConfigurationContainer> i = m_project_manager.get_project()->configurations(); i; ++i)
     {
         if (!BaseConfigurationFactory::is_base_configuration(i->get_name()))
-            configs.push_back(i->get_name());
+            configs.emplace_back(i->get_name());
     }
 
     // Sort configuration names alphabetically.

--- a/src/appleseed.studio/utility/chartwidget.cpp
+++ b/src/appleseed.studio/utility/chartwidget.cpp
@@ -88,7 +88,7 @@ void ChartBase::add_point(const Vector2d& p)
 
 void ChartBase::add_point(const double x, const double y)
 {
-    m_original_points.push_back(Vector2d(x, y));
+    m_original_points.emplace_back(x, y);
 }
 
 void ChartBase::prepare_drawing(QPainter& painter)

--- a/src/appleseed/foundation/meta/tests/test_beziercurve.cpp
+++ b/src/appleseed/foundation/meta/tests/test_beziercurve.cpp
@@ -401,7 +401,7 @@ TEST_SUITE(Foundation_Math_BezierCurveIntersector)
         vector<BezierCurve3f> curves;
 
         for (size_t i = 0, e = new_points.size(); i + 3 < e; i += 3)
-            curves.push_back(BezierCurve3f(&new_points[i], 0.05f));
+            curves.emplace_back(&new_points[i], 0.05f);
 
         render_curves_to_image(&curves[0], curves.size(), "unit tests/outputs/test_beziercurveintersector_multiplebezier3curves.png", false);
     }

--- a/src/appleseed/foundation/meta/tests/test_bvh.cpp
+++ b/src/appleseed/foundation/meta/tests/test_bvh.cpp
@@ -109,7 +109,7 @@ TEST_SUITE(Foundation_Math_BVH_SpatialBuilder)
         typedef bvh::SBVHPartitioner<ItemHandler, AABBVector> Partitioner;
 
         AABBVector bboxes;
-        bboxes.push_back(AABB3d(Vector3d(0.0), Vector3d(1.0)));
+        bboxes.emplace_back(Vector3d(0.0), Vector3d(1.0));
 
         ItemHandler item_handler;
         Partitioner partitioner(item_handler, bboxes);

--- a/src/appleseed/foundation/meta/tests/test_bvh_partitioner.cpp
+++ b/src/appleseed/foundation/meta/tests/test_bvh_partitioner.cpp
@@ -53,9 +53,9 @@ TEST_SUITE(Foundation_Math_BVH_MiddlePartitioner)
     TEST_CASE(Partition_BBoxesOrderedAlongLongestDimension_ReturnsFirstElementAfterCenter)
     {
         AABB2dVector bboxes;
-        bboxes.push_back(AABB2d(Vector2d(-10.0, -1.0 ), Vector2d( -9.0,  0.0 )));
-        bboxes.push_back(AABB2d(Vector2d( -2.0,  0.0 ), Vector2d( -1.0,  1.0 )));
-        bboxes.push_back(AABB2d(Vector2d(  1.0, -1.0 ), Vector2d(  2.0,  0.0 )));
+        bboxes.emplace_back(Vector2d(-10.0, -1.0 ), Vector2d( -9.0,  0.0 ));
+        bboxes.emplace_back(Vector2d( -2.0,  0.0 ), Vector2d( -1.0,  1.0 ));
+        bboxes.emplace_back(Vector2d(  1.0, -1.0 ), Vector2d(  2.0,  0.0 ));
 
         MiddlePartitioner<AABB2dVector> partitioner(bboxes, 1);
         const AABB2d root_bbox(partitioner.compute_bbox(0, bboxes.size()));
@@ -77,9 +77,9 @@ TEST_SUITE(Foundation_Math_BVH_MiddlePartitioner)
     TEST_CASE(Partition_BBoxesUnorderedAlongAllDimensions_ReturnsFirstElementAfterCenter)
     {
         AABB2dVector bboxes;
-        bboxes.push_back(AABB2d(Vector2d( -2.0,  0.0 ), Vector2d( -1.0,  1.0 )));
-        bboxes.push_back(AABB2d(Vector2d(-10.0, -1.0 ), Vector2d( -9.0,  0.0 )));
-        bboxes.push_back(AABB2d(Vector2d(  1.0,  1.0 ), Vector2d(  2.0,  2.0 )));
+        bboxes.emplace_back(Vector2d( -2.0,  0.0 ), Vector2d( -1.0,  1.0 ));
+        bboxes.emplace_back(Vector2d(-10.0, -1.0 ), Vector2d( -9.0,  0.0 ));
+        bboxes.emplace_back(Vector2d(  1.0,  1.0 ), Vector2d(  2.0,  2.0 ));
 
         MiddlePartitioner<AABB2dVector> partitioner(bboxes, 1);
         const AABB2d root_bbox(partitioner.compute_bbox(0, bboxes.size()));
@@ -102,10 +102,10 @@ TEST_SUITE(Foundation_Math_BVH_MiddlePartitioner)
     TEST_CASE(Partition_BBoxesFormingRectangle_ReturnsFirstElementAfterCenter)
     {
         AABB2dVector bboxes;
-        bboxes.push_back(AABB2d(Vector2d(-2.0, 1.0 ), Vector2d(-1.0, 2.0 )));
-        bboxes.push_back(AABB2d(Vector2d(-2.0,-2.0 ), Vector2d(-1.0,-1.0 )));
-        bboxes.push_back(AABB2d(Vector2d( 1.0, 1.0 ), Vector2d( 2.0, 2.0 )));
-        bboxes.push_back(AABB2d(Vector2d( 1.0,-2.0 ), Vector2d( 2.0,-1.0 )));
+        bboxes.emplace_back(Vector2d(-2.0, 1.0 ), Vector2d(-1.0, 2.0 ));
+        bboxes.emplace_back(Vector2d(-2.0,-2.0 ), Vector2d(-1.0,-1.0 ));
+        bboxes.emplace_back(Vector2d( 1.0, 1.0 ), Vector2d( 2.0, 2.0 ));
+        bboxes.emplace_back(Vector2d( 1.0,-2.0 ), Vector2d( 2.0,-1.0 ));
 
         MiddlePartitioner<AABB2dVector> partitioner(bboxes, 1);
         const AABB2d root_bbox(partitioner.compute_bbox(0, bboxes.size()));
@@ -128,9 +128,9 @@ TEST_SUITE(Foundation_Math_BVH_MiddlePartitioner)
     TEST_CASE(Partition_BBoxesFormingEvenTriangle_ReturnsMiddleElement)
     {
         AABB2dVector bboxes;
-        bboxes.push_back(AABB2d(Vector2d(-2.0, 1.0 ), Vector2d(-1.0, 2.0 )));
-        bboxes.push_back(AABB2d(Vector2d(-1.0,-2.0 ), Vector2d( 1.0,-1.0 )));
-        bboxes.push_back(AABB2d(Vector2d( 1.0, 1.0 ), Vector2d( 2.0, 2.0 )));
+        bboxes.emplace_back(Vector2d(-2.0, 1.0 ), Vector2d(-1.0, 2.0 ));
+        bboxes.emplace_back(Vector2d(-1.0,-2.0 ), Vector2d( 1.0,-1.0 ));
+        bboxes.emplace_back(Vector2d( 1.0, 1.0 ), Vector2d( 2.0, 2.0 ));
 
         MiddlePartitioner<AABB2dVector> partitioner(bboxes, 1);
         const AABB2d root_bbox(partitioner.compute_bbox(0, bboxes.size()));
@@ -143,10 +143,10 @@ TEST_SUITE(Foundation_Math_BVH_MiddlePartitioner)
     TEST_CASE(Partition_BBoxesOverlapping_ReturnMiddleElement)
     {
         AABB2dVector bboxes;
-        bboxes.push_back(AABB2d(Vector2d(-1.0,-1.0 ), Vector2d( 1.0, 1.0 )));
-        bboxes.push_back(AABB2d(Vector2d(-1.0,-1.0 ), Vector2d( 1.0, 1.0 )));
-        bboxes.push_back(AABB2d(Vector2d(-1.0,-1.0 ), Vector2d( 1.0, 1.0 )));
-        bboxes.push_back(AABB2d(Vector2d(-1.0,-1.0 ), Vector2d( 1.0, 1.0 )));
+        bboxes.emplace_back(Vector2d(-1.0,-1.0 ), Vector2d( 1.0, 1.0 ));
+        bboxes.emplace_back(Vector2d(-1.0,-1.0 ), Vector2d( 1.0, 1.0 ));
+        bboxes.emplace_back(Vector2d(-1.0,-1.0 ), Vector2d( 1.0, 1.0 ));
+        bboxes.emplace_back(Vector2d(-1.0,-1.0 ), Vector2d( 1.0, 1.0 ));
 
         MiddlePartitioner<AABB2dVector> partitioner(bboxes, 1);
         const AABB2d root_bbox(partitioner.compute_bbox(0, bboxes.size()));

--- a/src/appleseed/foundation/meta/tests/test_fresnel.cpp
+++ b/src/appleseed/foundation/meta/tests/test_fresnel.cpp
@@ -149,8 +149,8 @@ TEST_SUITE(Foundation_Math_Fresnel)
             double transmittance;
             fresnel_transmittance_dielectric(transmittance, Eta, cos_theta_i);
 
-            reflectance_points.push_back(Vector2d(theta_i, reflectance));
-            transmittance_points.push_back(Vector2d(theta_i, transmittance));
+            reflectance_points.emplace_back(theta_i, reflectance);
+            transmittance_points.emplace_back(theta_i, transmittance);
         }
 
         plotfile
@@ -197,8 +197,8 @@ TEST_SUITE(Foundation_Math_Fresnel)
             double schlick_refl;
             fresnel_reflectance_dielectric_schlick(schlick_refl, r0, cos_theta_i);
 
-            ref_refl_points.push_back(Vector2d(theta_i, ref_refl));
-            schlick_refl_points.push_back(Vector2d(theta_i, schlick_refl));
+            ref_refl_points.emplace_back(theta_i, ref_refl);
+            schlick_refl_points.emplace_back(theta_i, schlick_refl);
         }
 
         plotfile
@@ -271,15 +271,13 @@ TEST_SUITE(Foundation_Math_Fresnel)
         {
             const double eta = fit<size_t, double>(i, 0, PointCount - 1, 0.5, 2.0);
 
-            integral_points.push_back(
-                Vector2d(
-                    eta,
-                    integrate_diffuse_fresnel_reflectance(eta)));
+            integral_points.emplace_back(
+                eta,
+                integrate_diffuse_fresnel_reflectance(eta));
 
-            approx_points.push_back(
-                Vector2d(
-                    eta,
-                    fresnel_internal_diffuse_reflectance(eta)));
+            approx_points.emplace_back(
+                eta,
+                fresnel_internal_diffuse_reflectance(eta));
         }
 
         plotfile
@@ -378,21 +376,21 @@ TEST_SUITE(Foundation_Math_Fresnel)
                 CopperN[0],
                 CopperK[0],
                 cos_theta_i);
-            red_points.push_back(Vector2d(theta_i, result));
+            red_points.emplace_back(theta_i, result);
 
             fresnel_reflectance_conductor(
                 result,
                 CopperN[1],
                 CopperK[1],
                 cos_theta_i);
-            green_points.push_back(Vector2d(theta_i, result));
+            green_points.emplace_back(theta_i, result);
 
             fresnel_reflectance_conductor(
                 result,
                 CopperN[2],
                 CopperK[2],
                 cos_theta_i);
-            blue_points.push_back(Vector2d(theta_i, result));
+            blue_points.emplace_back(theta_i, result);
         }
 
         plotfile
@@ -491,21 +489,21 @@ TEST_SUITE(Foundation_Math_Fresnel)
                 normal_reflectance,
                 edge_tint[0],
                 cos_theta_i);
-            red_points.push_back(Vector2d(theta_i, result));
+            red_points.emplace_back(theta_i, result);
 
             artist_friendly_fresnel_reflectance_conductor(
                 result,
                 normal_reflectance,
                 edge_tint[1],
                 cos_theta_i);
-            green_points.push_back(Vector2d(theta_i, result));
+            green_points.emplace_back(theta_i, result);
 
             artist_friendly_fresnel_reflectance_conductor(
                 result,
                 normal_reflectance,
                 edge_tint[2],
                 cos_theta_i);
-            blue_points.push_back(Vector2d(theta_i, result));
+            blue_points.emplace_back(theta_i, result);
         }
 
         plotfile

--- a/src/appleseed/foundation/meta/tests/test_makevector.cpp
+++ b/src/appleseed/foundation/meta/tests/test_makevector.cpp
@@ -62,9 +62,9 @@ TEST_SUITE(Foundation_Utility_MakeVector)
     TEST_CASE(TestMakeVectorWithMultipleStringValues)
     {
         vector<string> expected_vector;
-        expected_vector.push_back("hello");
-        expected_vector.push_back("world");
-        expected_vector.push_back("bunny");
+        expected_vector.emplace_back("hello");
+        expected_vector.emplace_back("world");
+        expected_vector.emplace_back("bunny");
 
         EXPECT_EQ(expected_vector, make_vector("hello", "world", "bunny"));
     }

--- a/src/appleseed/foundation/meta/tests/test_objmeshfilereader.cpp
+++ b/src/appleseed/foundation/meta/tests/test_objmeshfilereader.cpp
@@ -62,7 +62,7 @@ TEST_SUITE(Foundation_Mesh_OBJMeshFileReader)
 
         virtual void begin_mesh(const char* name) override
         {
-            m_meshes.push_back(Mesh());
+            m_meshes.emplace_back();
             m_meshes.back().m_name = name;
         }
 
@@ -86,7 +86,7 @@ TEST_SUITE(Foundation_Mesh_OBJMeshFileReader)
 
         virtual void begin_face(const size_t vertex_count) override
         {
-            m_meshes.back().m_faces.push_back(Face());
+            m_meshes.back().m_faces.emplace_back();
         }
     };
 

--- a/src/appleseed/foundation/meta/tests/test_objmeshfilewriter.cpp
+++ b/src/appleseed/foundation/meta/tests/test_objmeshfilewriter.cpp
@@ -66,7 +66,7 @@ TEST_SUITE(Foundation_Mesh_OBJMeshFileWriter)
 
         virtual void begin_mesh(const char* name) override
         {
-            m_meshes.push_back(Mesh());
+            m_meshes.emplace_back();
             m_meshes.back().m_name = name;
         }
 
@@ -79,7 +79,7 @@ TEST_SUITE(Foundation_Mesh_OBJMeshFileWriter)
         virtual void begin_face(const size_t vertex_count) override
         {
             assert(vertex_count == 3);
-            m_meshes.back().m_faces.push_back(Face());
+            m_meshes.back().m_faces.emplace_back();
         }
 
         virtual void set_face_vertices(const size_t vertices[]) override
@@ -183,9 +183,9 @@ TEST_SUITE(Foundation_Mesh_OBJMeshFileWriter)
         Mesh mesh;
         mesh.m_name = name;
 
-        mesh.m_vertices.push_back(Vector3d(0.0, 0.0, 0.0));
-        mesh.m_vertices.push_back(Vector3d(1.0, 0.0, 0.0));
-        mesh.m_vertices.push_back(Vector3d(1.0, 1.0, 0.0));
+        mesh.m_vertices.emplace_back(0.0, 0.0, 0.0);
+        mesh.m_vertices.emplace_back(1.0, 0.0, 0.0);
+        mesh.m_vertices.emplace_back(1.0, 1.0, 0.0);
 
         Face face;
         face.m_v0 = 0;

--- a/src/appleseed/foundation/meta/tests/test_quaternion.cpp
+++ b/src/appleseed/foundation/meta/tests/test_quaternion.cpp
@@ -164,7 +164,7 @@ TEST_SUITE(Foundation_Math_Quaternion)
             const Quaterniond q_slerp = slerp(q1, q2, t);
             const Quaterniond q_fast_slerp = fast_slerp(q1, q2, t);
             const double e = 2.0 * abs(acos(q_slerp.s) - acos(q_fast_slerp.s));
-            points.push_back(Vector2d(t, e));
+            points.emplace_back(t, e);
         }
 
         plotfile

--- a/src/appleseed/foundation/meta/tests/test_triangulator.cpp
+++ b/src/appleseed/foundation/meta/tests/test_triangulator.cpp
@@ -49,10 +49,10 @@ TEST_SUITE(Foundation_Math_Triangulator)
     TEST_CASE_F(ComputePolygonOrientation_GivenLowestLeftmostTriangleIsValid_ReturnsCorrectOrientation, Fixture)
     {
         Polygon2 polygon;
-        polygon.push_back(Vector2Type(0.0, 0.0));
-        polygon.push_back(Vector2Type(0.0, 1.0));
-        polygon.push_back(Vector2Type(1.0, 1.0));
-        polygon.push_back(Vector2Type(1.0, 0.0));
+        polygon.emplace_back(0.0, 0.0);
+        polygon.emplace_back(0.0, 1.0);
+        polygon.emplace_back(1.0, 1.0);
+        polygon.emplace_back(1.0, 0.0);
 
         TriangulatorType triangulator;
         const TriangulatorType::Orientation orientation =
@@ -64,10 +64,10 @@ TEST_SUITE(Foundation_Math_Triangulator)
     TEST_CASE_F(ComputePolygonOrientation_GivenLowestLeftmostTriangleIsDegenerate_ReturnsCorrectOrientation, Fixture)
     {
         Polygon2 polygon;
-        polygon.push_back(Vector2Type(0.0, 1.0));
-        polygon.push_back(Vector2Type(1.0, 1.0));
-        polygon.push_back(Vector2Type(0.0, 0.0));
-        polygon.push_back(Vector2Type(0.0, 0.0));
+        polygon.emplace_back(0.0, 1.0);
+        polygon.emplace_back(1.0, 1.0);
+        polygon.emplace_back(0.0, 0.0);
+        polygon.emplace_back(0.0, 0.0);
 
         TriangulatorType triangulator;
         const TriangulatorType::Orientation orientation =
@@ -79,10 +79,10 @@ TEST_SUITE(Foundation_Math_Triangulator)
     TEST_CASE_F(Triangulate_GivenQuadWithCoincidentVertices_KeepDegenerateTrianglesIsFalse_ReturnsOneTriangle, Fixture)
     {
         Polygon3 polygon;
-        polygon.push_back(Vector3Type(0.0, 0.0, 0.0));
-        polygon.push_back(Vector3Type(0.0, 1.0, 0.0));
-        polygon.push_back(Vector3Type(1.0, 1.0, 0.0));
-        polygon.push_back(Vector3Type(0.0, 0.0, 0.0));
+        polygon.emplace_back(0.0, 0.0, 0.0);
+        polygon.emplace_back(0.0, 1.0, 0.0);
+        polygon.emplace_back(1.0, 1.0, 0.0);
+        polygon.emplace_back(0.0, 0.0, 0.0);
 
         TriangulatorType triangulator;
         TriangulatorType::IndexArray triangles;
@@ -96,10 +96,10 @@ TEST_SUITE(Foundation_Math_Triangulator)
     TEST_CASE_F(Triangulate_GivenQuadWithCoincidentVertices_KeepDegenerateTrianglesIsTrue_ReturnsTwoTriangles, Fixture)
     {
         Polygon3 polygon;
-        polygon.push_back(Vector3Type(0.0, 0.0, 0.0));
-        polygon.push_back(Vector3Type(0.0, 1.0, 0.0));
-        polygon.push_back(Vector3Type(1.0, 1.0, 0.0));
-        polygon.push_back(Vector3Type(0.0, 0.0, 0.0));
+        polygon.emplace_back(0.0, 0.0, 0.0);
+        polygon.emplace_back(0.0, 1.0, 0.0);
+        polygon.emplace_back(1.0, 1.0, 0.0);
+        polygon.emplace_back(0.0, 0.0, 0.0);
 
         TriangulatorType triangulator(TriangulatorType::KeepDegenerateTriangles);
         TriangulatorType::IndexArray triangles;
@@ -113,10 +113,10 @@ TEST_SUITE(Foundation_Math_Triangulator)
     TEST_CASE_F(Triangulate_GivenSelfCrossingTriangle_ReturnsFalse, Fixture)
     {
         Polygon3 polygon;
-        polygon.push_back(Vector3Type(0.0, 0.0, 1.0));
-        polygon.push_back(Vector3Type(3.0, 2.0, 2.0));
-        polygon.push_back(Vector3Type(3.0, 3.0, 3.0));
-        polygon.push_back(Vector3Type(1.0, 0.0, 0.0));
+        polygon.emplace_back(0.0, 0.0, 1.0);
+        polygon.emplace_back(3.0, 2.0, 2.0);
+        polygon.emplace_back(3.0, 3.0, 3.0);
+        polygon.emplace_back(1.0, 0.0, 0.0);
 
         TriangulatorType triangulator;
         TriangulatorType::IndexArray triangles;
@@ -129,18 +129,18 @@ TEST_SUITE(Foundation_Math_Triangulator)
     TEST_CASE_F(Triangulate_GivenComplexConcavePolygon_ReturnsTrue, Fixture)
     {
         Polygon3 polygon;
-        polygon.push_back(Vector3Type(0.137498, -1.09128, 0.0));
-        polygon.push_back(Vector3Type(0.124257, -1.10419, 0.0));
-        polygon.push_back(Vector3Type(0.124257, -1.31878, 0.0));
-        polygon.push_back(Vector3Type(0.240957, -1.30956, 0.0));
-        polygon.push_back(Vector3Type(0.240957, 1.3116, 0.0));
-        polygon.push_back(Vector3Type(0.124256, 1.30447, 0.0));
-        polygon.push_back(Vector3Type(0.124256, 1.08131, 0.0));
-        polygon.push_back(Vector3Type(0.137498, 1.0684, 0.0));
-        polygon.push_back(Vector3Type(0.160558, 1.02428, 0.0));
-        polygon.push_back(Vector3Type(0.168503, 0.975371, 0.0));
-        polygon.push_back(Vector3Type(0.168503, -0.998254, 0.0));
-        polygon.push_back(Vector3Type(0.160558, -1.04716, 0.0));
+        polygon.emplace_back(0.137498, -1.09128, 0.0);
+        polygon.emplace_back(0.124257, -1.10419, 0.0);
+        polygon.emplace_back(0.124257, -1.31878, 0.0);
+        polygon.emplace_back(0.240957, -1.30956, 0.0);
+        polygon.emplace_back(0.240957, 1.3116, 0.0);
+        polygon.emplace_back(0.124256, 1.30447, 0.0);
+        polygon.emplace_back(0.124256, 1.08131, 0.0);
+        polygon.emplace_back(0.137498, 1.0684, 0.0);
+        polygon.emplace_back(0.160558, 1.02428, 0.0);
+        polygon.emplace_back(0.168503, 0.975371, 0.0);
+        polygon.emplace_back(0.168503, -0.998254, 0.0);
+        polygon.emplace_back(0.160558, -1.04716, 0.0);
 
         TriangulatorType triangulator;
         TriangulatorType::IndexArray triangles;

--- a/src/appleseed/foundation/utility/benchmark/benchmarksuite.cpp
+++ b/src/appleseed/foundation/utility/benchmark/benchmarksuite.cpp
@@ -268,10 +268,9 @@ void BenchmarkSuite::run(
                         stopwatch,
                         BenchmarkSuite::Impl::measure_runtime_ticks,
                         max<size_t>(1, measurement_count / 100));
-                points.push_back(
-                    Vector2d(
-                        static_cast<double>(j),
-                        ticks > overhead_ticks ? ticks - overhead_ticks : 0.0));
+                points.emplace_back(
+                    static_cast<double>(j),
+                    ticks > overhead_ticks ? ticks - overhead_ticks : 0.0);
             }
 
             stringstream sstr;

--- a/src/appleseed/foundation/utility/gnuplotfile.cpp
+++ b/src/appleseed/foundation/utility/gnuplotfile.cpp
@@ -101,7 +101,7 @@ GnuplotFile& GnuplotFile::set_logscale_y()
 
 GnuplotFile::Plot& GnuplotFile::new_plot()
 {
-    m_plots.push_back(Plot());
+    m_plots.emplace_back();
     return m_plots.back();
 }
 

--- a/src/appleseed/foundation/utility/makevector.h
+++ b/src/appleseed/foundation/utility/makevector.h
@@ -69,45 +69,45 @@ std::vector<T> make_vector_n(const size_t n, const T& val, ...);
 inline std::vector<std::string> make_vector(const char* v1)
 {
     std::vector<std::string> vec;
-    vec.push_back(v1);
+    vec.emplace_back(v1);
     return vec;
 }
 
 inline std::vector<std::string> make_vector(const char* v1, const char* v2)
 {
     std::vector<std::string> vec;
-    vec.push_back(v1);
-    vec.push_back(v2);
+    vec.emplace_back(v1);
+    vec.emplace_back(v2);
     return vec;
 }
 
 inline std::vector<std::string> make_vector(const char* v1, const char* v2, const char* v3)
 {
     std::vector<std::string> vec;
-    vec.push_back(v1);
-    vec.push_back(v2);
-    vec.push_back(v3);
+    vec.emplace_back(v1);
+    vec.emplace_back(v2);
+    vec.emplace_back(v3);
     return vec;
 }
 
 inline std::vector<std::string> make_vector(const char* v1, const char* v2, const char* v3, const char* v4)
 {
     std::vector<std::string> vec;
-    vec.push_back(v1);
-    vec.push_back(v2);
-    vec.push_back(v3);
-    vec.push_back(v4);
+    vec.emplace_back(v1);
+    vec.emplace_back(v2);
+    vec.emplace_back(v3);
+    vec.emplace_back(v4);
     return vec;
 }
 
 inline std::vector<std::string> make_vector(const char* v1, const char* v2, const char* v3, const char* v4, const char* v5)
 {
     std::vector<std::string> vec;
-    vec.push_back(v1);
-    vec.push_back(v2);
-    vec.push_back(v3);
-    vec.push_back(v4);
-    vec.push_back(v5);
+    vec.emplace_back(v1);
+    vec.emplace_back(v2);
+    vec.emplace_back(v3);
+    vec.emplace_back(v4);
+    vec.emplace_back(v5);
     return vec;
 }
 
@@ -166,13 +166,13 @@ inline std::vector<std::string> make_vector_n(const size_t n, const char* val, .
     assert(n > 0);
 
     std::vector<std::string> vec;
-    vec.push_back(val);
+    vec.emplace_back(val);
 
     va_list argptr;
     va_start(argptr, val);
 
     for (size_t i = 1; i < n; ++i)
-        vec.push_back(va_arg(argptr, char*));
+        vec.emplace_back(va_arg(argptr, char*));
 
     va_end(argptr);
 

--- a/src/appleseed/foundation/utility/searchpaths.cpp
+++ b/src/appleseed/foundation/utility/searchpaths.cpp
@@ -102,8 +102,8 @@ SearchPaths::SearchPaths(const char* envvar, const char separator)
 
             if (!i->empty())
             {
-                impl->m_environment_paths.push_back(i->c_str());
-                impl->m_all_paths.push_back(i->c_str());
+                impl->m_environment_paths.emplace_back(i->c_str());
+                impl->m_all_paths.emplace_back(i->c_str());
             }
         }
     }
@@ -179,8 +179,8 @@ const char* SearchPaths::operator[](const size_t i) const
 void SearchPaths::push_back(const char* path)
 {
     assert(path);
-    impl->m_explicit_paths.push_back(path);
-    impl->m_all_paths.push_back(path);
+    impl->m_explicit_paths.emplace_back(path);
+    impl->m_all_paths.emplace_back(path);
 }
 
 void SearchPaths::split_and_push_back(const char* paths, const char separator)
@@ -298,7 +298,7 @@ APIString SearchPaths::do_to_string(const char separator, const bool reversed) c
     const bool root_path = has_root_path();
 
     if (root_path)
-        paths.push_back(impl->m_root_path.string().c_str());
+        paths.emplace_back(impl->m_root_path.string().c_str());
 
     copy(impl->m_all_paths.begin(), impl->m_all_paths.end(), back_inserter(paths));
 

--- a/src/appleseed/renderer/kernel/intersection/assemblytree.cpp
+++ b/src/appleseed/renderer/kernel/intersection/assemblytree.cpp
@@ -137,11 +137,10 @@ void AssemblyTree::collect_assembly_instances(
             continue;
 
         // Create and store an item for this assembly instance.
-        m_items.push_back(
-            Item(
-                &assembly,
-                &assembly_instance,
-                cumulated_transform_seq));
+        m_items.emplace_back(
+            &assembly,
+            &assembly_instance,
+            cumulated_transform_seq);
 
         // Compute and store the assembly instance bounding box.
         AABB3d assembly_instance_bbox(
@@ -393,11 +392,10 @@ namespace
                 const GAABB3 region_bbox =
                     transform.to_parent(region->compute_local_bbox());
 
-                regions.push_back(
-                    RegionInfo(
-                        obj_inst_index,
-                        region_index,
-                        region_bbox));
+                regions.emplace_back(
+                    obj_inst_index,
+                    region_index,
+                    region_bbox);
             }
         }
     }

--- a/src/appleseed/renderer/kernel/intersection/intersectionfilter.cpp
+++ b/src/appleseed/renderer/kernel/intersection/intersectionfilter.cpp
@@ -86,15 +86,15 @@ namespace
                 const Vector2f uv1(tess.get_tex_coords(i->m_a1));
                 const Vector2f uv2(tess.get_tex_coords(i->m_a2));
 
-                uv.push_back(Vector2f(uv0[0], 1.0f - uv0[1]));
-                uv.push_back(Vector2f(uv1[0], 1.0f - uv1[1]));
-                uv.push_back(Vector2f(uv2[0], 1.0f - uv2[1]));
+                uv.emplace_back(uv0[0], 1.0f - uv0[1]);
+                uv.emplace_back(uv1[0], 1.0f - uv1[1]);
+                uv.emplace_back(uv2[0], 1.0f - uv2[1]);
             }
             else
             {
-                uv.push_back(Vector2f(0.0f));
-                uv.push_back(Vector2f(0.0f));
-                uv.push_back(Vector2f(0.0f));
+                uv.emplace_back(0.0f);
+                uv.emplace_back(0.0f);
+                uv.emplace_back(0.0f);
             }
         }
     }

--- a/src/appleseed/renderer/kernel/lighting/lighttree.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttree.cpp
@@ -96,7 +96,7 @@ vector<size_t> LightTree::build()
                                             position[2] + BboxSize));
         light_bboxes.push_back(bbox);
 
-        m_items.push_back(Item(bbox, i, NonPhysicalLightType));
+        m_items.emplace_back(bbox, i, NonPhysicalLightType);
     }
 
     // Collect emitting triangles.
@@ -111,7 +111,7 @@ vector<size_t> LightTree::build()
 
         light_bboxes.push_back(bbox);
 
-        m_items.push_back(Item(bbox, i, EmittingTriangleType));
+        m_items.emplace_back(bbox, i, EmittingTriangleType);
     }
 
     // Create the partitioner.

--- a/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
@@ -640,7 +640,7 @@ namespace
                     pretty_uint(samples_per_second).c_str());
 
                 if (m_perf_stats)
-                    m_sample_count_records.push_back(Vector2d(time, static_cast<double>(samples)));
+                    m_sample_count_records.emplace_back(time, static_cast<double>(samples));
             }
 
             void record_and_print_convergence_stats()
@@ -667,7 +667,7 @@ namespace
                 {
                     const double samples_per_pixel = m_buffer.get_sample_count() * m_rcp_pixel_count;
                     const double rmsd = compute_rms_deviation(m_project.get_frame()->image(), *m_ref_image);
-                    m_rmsd_records.push_back(Vector2d(samples_per_pixel, rmsd));
+                    m_rmsd_records.emplace_back(samples_per_pixel, rmsd);
 
                     if (m_luminance_stats)
                         output += ", ";

--- a/src/appleseed/renderer/meta/tests/test_samplegeneratorjob.cpp
+++ b/src/appleseed/renderer/meta/tests/test_samplegeneratorjob.cpp
@@ -55,10 +55,9 @@ TEST_SUITE(Renderer_Kernel_Rendering_Progressive_SampleGeneratorJob)
         for (uint64 x = 0; x < N; x += 100)
         {
             const uint64 y = SampleGeneratorJob::samples_to_samples_per_job(x);
-            points.push_back(
-                Vector2d(
-                    static_cast<double>(x),
-                    static_cast<double>(y)));
+            points.emplace_back(
+                static_cast<double>(x),
+                static_cast<double>(y));
         }
 
         GnuplotFile plotfile;

--- a/src/appleseed/renderer/meta/tests/test_sss.cpp
+++ b/src/appleseed/renderer/meta/tests/test_sss.cpp
@@ -389,15 +389,13 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         {
             const float rd = fit<size_t, float>(i, 0, PointCount - 1, 0.0f, 1.0f);
 
-            std_points.push_back(
-                Vector2d(
-                    rd,
-                    compute_alpha_prime(std_rd_fun, rd)));
+            std_points.emplace_back(
+                rd,
+                compute_alpha_prime(std_rd_fun, rd));
 
-            better_points.push_back(
-                Vector2d(
-                    rd,
-                    compute_alpha_prime(better_rd_fun, rd)));
+            better_points.emplace_back(
+                rd,
+                compute_alpha_prime(better_rd_fun, rd));
         }
 
         plotfile
@@ -435,7 +433,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
 
             // Analytical integration.
             const float rd_a = rd_fun(alpha_prime);
-            ai_points.push_back(Vector2d(alpha_prime, rd_a));
+            ai_points.emplace_back(alpha_prime, rd_a);
 
             // Numerical integration.
             const float sigma_s_prime = alpha_prime;
@@ -443,7 +441,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
             BSSRDFEvaluator<StandardDipoleBSSRDFFactory, DipoleBSSRDFInputValues> bssrdf_eval;
             bssrdf_eval.set_values_from_sigmas(sigma_a, sigma_s_prime);
             const float rd_n = integrate_bssrdf(bssrdf_eval, SampleCount);
-            ni_points.push_back(Vector2d(alpha_prime, rd_n));
+            ni_points.emplace_back(alpha_prime, rd_n);
         }
 
         plotfile
@@ -481,7 +479,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
 
             // Analytical integration.
             const float rd_a = rd_fun(alpha_prime);
-            ai_points.push_back(Vector2d(alpha_prime, rd_a));
+            ai_points.emplace_back(alpha_prime, rd_a);
 
             // Numerical integration.
             const float sigma_s_prime = alpha_prime;
@@ -489,7 +487,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
             BSSRDFEvaluator<BetterDipoleBSSRDFFactory, DipoleBSSRDFInputValues> bssrdf_eval;
             bssrdf_eval.set_values_from_sigmas(sigma_a, sigma_s_prime);
             const float rd_n = integrate_bssrdf(bssrdf_eval, SampleCount);
-            ni_points.push_back(Vector2d(alpha_prime, rd_n));
+            ni_points.emplace_back(alpha_prime, rd_n);
         }
 
         plotfile
@@ -545,7 +543,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         {
             const float a = fit<size_t, float>(i, 0, N - 1, 0.0f, 1.0f);
             const float s = normalized_diffusion_s_mfp(a);
-            points.push_back(Vector2d(a, s));
+            points.emplace_back(a, s);
         }
 
         plotfile.new_plot().set_points(points);
@@ -568,7 +566,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         {
             const float a = fit<size_t, float>(i, 0, N - 1, 0.0f, 1.0f);
             const float s = normalized_diffusion_s_dmfp(a);
-            points.push_back(Vector2d(a, s));
+            points.emplace_back(a, s);
         }
 
         plotfile.new_plot().set_points(points);
@@ -597,7 +595,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
             {
                 const float r = max(fit<size_t, float>(j, 0, N - 1, 0.0f, 8.0f), 0.0001f);
                 const float y = r * normalized_diffusion_profile(r, 1.0f, s, a);
-                points.push_back(Vector2d(r, y));
+                points.emplace_back(r, y);
             }
 
             static const char* Colors[9] =
@@ -645,7 +643,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
             {
                 const float r = max(fit<size_t, float>(j, 0, N - 1, 0.0f, 8.0f), 0.0001f);
                 const float y = r * normalized_diffusion_profile(r, 1.0f, s, a);
-                points.push_back(Vector2d(r, y));
+                points.emplace_back(r, y);
             }
 
             static const char* Colors[9] =
@@ -687,7 +685,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         {
             const float r = fit<size_t, float>(i, 0, N - 1, 0.0f, 40.0f);
             const float u = normalized_diffusion_cdf(r, 1.0f);
-            points.push_back(Vector2d(r, u));
+            points.emplace_back(r, u);
         }
 
         plotfile.new_plot().set_points(points);
@@ -783,7 +781,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
             bssrdf_eval.set_values_from_rd_mfp(rd, 1.0f);
 
             const float integral = integrate_bssrdf(bssrdf_eval, 1000);
-            points.push_back(Vector2d(rd, integral));
+            points.emplace_back(rd, integral);
         }
 
         plotfile.new_plot().set_points(points);
@@ -848,7 +846,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
             bssrdf_eval.set_values_from_rd_mfp(rd, 1.0f);
 
             const float integral = integrate_bssrdf(bssrdf_eval, 1000);
-            points.push_back(Vector2d(rd, integral));
+            points.emplace_back(rd, integral);
         }
 
         plotfile.new_plot().set_points(points);
@@ -917,7 +915,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         {
             const float r = fit<size_t, float>(i, 0, N - 1, -16.0f, 16.0f);
             const float rd = bssrdf_eval.evaluate(r);   // integral of Lambertian BRDF equals 1
-            points.push_back(Vector2d(r, rd));
+            points.emplace_back(r, rd);
         }
 
         plotfile

--- a/src/appleseed/renderer/meta/tests/test_variationtracker.cpp
+++ b/src/appleseed/renderer/meta/tests/test_variationtracker.cpp
@@ -125,8 +125,8 @@ TEST_SUITE(Renderer_Kernel_Rendering_Final_VariationTracker)
 
             const float s = static_cast<float>(i);
 
-            mean.push_back(Vector2f(s, tracker.get_mean()));
-            variation.push_back(Vector2f(s, tracker.get_variation()));
+            mean.emplace_back(s, tracker.get_mean());
+            variation.emplace_back(s, tracker.get_variation());
         }
 
         GnuplotFile plotfile;

--- a/src/appleseed/renderer/modeling/object/curveobjectreader.cpp
+++ b/src/appleseed/renderer/modeling/object/curveobjectreader.cpp
@@ -420,7 +420,7 @@ auto_release_ptr<CurveObject> CurveObjectReader::load_mitsuba_curve_file(
             return object;
         }
 
-        vertices.push_back(GVector3(x, yz[0], yz[1]));
+        vertices.emplace_back(x, yz[0], yz[1]);
         ++vertex_index;
     }
 

--- a/src/appleseed/renderer/modeling/object/meshobject.cpp
+++ b/src/appleseed/renderer/modeling/object/meshobject.cpp
@@ -372,7 +372,7 @@ void MeshObject::reserve_material_slots(const size_t count)
 size_t MeshObject::push_material_slot(const char* name)
 {
     const size_t index = impl->m_material_slots.size();
-    impl->m_material_slots.push_back(name);
+    impl->m_material_slots.emplace_back(name);
     return index;
 }
 

--- a/src/appleseed/renderer/modeling/object/meshobjectreader.cpp
+++ b/src/appleseed/renderer/modeling/object/meshobjectreader.cpp
@@ -229,10 +229,7 @@ namespace
 
                 // Create the polygon to triangulate.
                 for (size_t i = 0; i < m_vertex_count; ++i)
-                {
-                    m_polygon.push_back(
-                        Vector3d(m_objects.back()->get_vertex(m_face_vertices[i])));
-                }
+                    m_polygon.emplace_back(m_objects.back()->get_vertex(m_face_vertices[i]));
 
                 // Triangulate the polygon.
                 if (m_triangulator.triangulate(m_polygon, m_triangles))
@@ -725,7 +722,7 @@ namespace
         {
             const double key = from_string<double>(i->key());
             const string filename = i->value<string>();
-            key_frames.push_back(MeshObjectKeyFrame(key, filename));
+            key_frames.emplace_back(key, filename);
         }
 
         sort(key_frames.begin(), key_frames.end());

--- a/src/tools/convertmeshfile/main.cpp
+++ b/src/tools/convertmeshfile/main.cpp
@@ -114,7 +114,7 @@ namespace
 
         virtual size_t push_material_slot(const char* name) override
         {
-            m_current_mesh.m_material_slots.push_back(name);
+            m_current_mesh.m_material_slots.emplace_back(name);
             return m_current_mesh.m_material_slots.size() - 1;
         }
 


### PR DESCRIPTION
Avoid a copy when adding objects to STL containers.