### PR TITLE
Fix pow_int()

### DIFF
--- a/src/appleseed/foundation/math/scalar.h
+++ b/src/appleseed/foundation/math/scalar.h
@@ -358,7 +358,11 @@ struct PowIntHelper
 {
     static T eval(const T x)
     {
-        return x * PowIntHelper<T, P - 1>::eval(x);
+        if (P % 2 == 0)
+            return PowIntHelper<T, P / 2>::eval(x * x);
+        else
+            return x * PowIntHelper<T, (P - 1) / 2>::eval(x * x);
+
     }
 };
 
@@ -374,22 +378,31 @@ struct PowIntHelper<T, 0>
 template <size_t P, typename T>
 inline T pow_int(const T x)
 {
-    // todo: implement exponentiation by squaring.
     // Reference: http://en.wikipedia.org/wiki/Exponentiation_by_squaring.
     return PowIntHelper<T, P>::eval(x);
 }
 
 template <typename T>
-inline T pow_int(const T x, size_t p)
+inline T pow_int(T x, size_t p)
 {
-    // todo: implement exponentiation by squaring.
     // Reference: http://en.wikipedia.org/wiki/Exponentiation_by_squaring.
- 
+
     T y = T(1);
 
-    while (p--)
-        y *= x;
-
+    while (p)
+    {
+        if (p % 2 == 0)
+        {
+            x *= x;
+            p /= 2;
+        }
+        else
+        {
+            y *= x;
+            x *= x;
+            p = (p - 1) / 2;
+        }
+    }
     return y;
 }
 

--- a/src/appleseed/foundation/math/scalar.h
+++ b/src/appleseed/foundation/math/scalar.h
@@ -384,7 +384,7 @@ inline T pow_int(const T x, size_t p)
 {
     // todo: implement exponentiation by squaring.
     // Reference: http://en.wikipedia.org/wiki/Exponentiation_by_squaring.
-
+ 
     T y = T(1);
 
     while (p--)

--- a/src/appleseed/foundation/meta/tests/test_scalar.cpp
+++ b/src/appleseed/foundation/meta/tests/test_scalar.cpp
@@ -84,6 +84,26 @@ TEST_SUITE(Foundation_Math_Scalar)
         EXPECT_FEQ(1.0, (pow_int<0, double>(2.0)));
         EXPECT_FEQ(2.0, (pow_int<1, double>(2.0)));
         EXPECT_FEQ(4.0, (pow_int<2, double>(2.0)));
+
+        EXPECT_EQ(1, (pow_int<int>(0,0)));
+        EXPECT_EQ(0, (pow_int<int>(0,1)));
+        EXPECT_EQ(0, (pow_int<int>(0,2)));
+
+        EXPECT_EQ(1, (pow_int<int>(1,0)));
+        EXPECT_EQ(1, (pow_int<int>(1,1)));
+        EXPECT_EQ(1, (pow_int<int>(1,2)));
+
+        EXPECT_EQ(1, (pow_int<int>(2,0)));
+        EXPECT_EQ(2, (pow_int<int>(2,1)));
+        EXPECT_EQ(4, (pow_int<int>(2,2)));
+
+        EXPECT_EQ(1, (pow_int<unsigned int>(2,0)));
+        EXPECT_EQ(2, (pow_int<unsigned int>(2,1)));
+        EXPECT_EQ(4, (pow_int<unsigned int>(2,2)));
+
+        EXPECT_FEQ(1.0, (pow_int<double>(2.0,0)));
+        EXPECT_FEQ(2.0, (pow_int<double>(2.0,1)));
+        EXPECT_FEQ(4.0, (pow_int<double>(2.0,2)));
     }
 
     TEST_CASE(NextPow2)


### PR DESCRIPTION
I run tests and it passed. 

> Could you also add unit tests for the variant of pow_int() taking the exponent as a runtime argument?

How can I make pow_int() take runtime argument?