### PR TITLE
Restore method to construct MemoryTexture2d with texture data

### DIFF
--- a/src/appleseed/renderer/modeling/texture/memorytexture2d.cpp
+++ b/src/appleseed/renderer/modeling/texture/memorytexture2d.cpp
@@ -245,4 +245,12 @@ auto_release_ptr<Texture> MemoryTexture2dFactory::create(
     return auto_release_ptr<Texture>(new MemoryTexture2d(name, params));
 }
 
+auto_release_ptr<Texture> MemoryTexture2dFactory::create(
+    const char*             name,
+    const ParamArray&       params,
+    auto_release_ptr<Image> image) const
+{
+    return auto_release_ptr<Texture>(new MemoryTexture2d(name, params, image));
+}
+
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/texture/memorytexture2d.h
+++ b/src/appleseed/renderer/modeling/texture/memorytexture2d.h
@@ -76,6 +76,12 @@ class APPLESEED_DLLSYMBOL MemoryTexture2dFactory
         const char*                                     name,
         const ParamArray&                               params,
         const foundation::SearchPaths&                  search_paths) const override;
+
+    // Create a texture with texture data.
+    foundation::auto_release_ptr<Texture> create(
+        const char*                                     name,
+        const ParamArray&                               params,
+        foundation::auto_release_ptr<foundation::Image> image) const;
 };
 
 }       // namespace renderer


### PR DESCRIPTION
Got lost in f60f52c2982fd33e3606889be320ffbc73c3293e: "Get rid of static_create() methods in factories".