### PR TITLE
Clear AOV images when clearing the main image.

### DIFF
--- a/src/appleseed.python/bindframe.cpp
+++ b/src/appleseed.python/bindframe.cpp
@@ -142,7 +142,6 @@ void bind_frame()
         .def("image", &Frame::image, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("aov_images", &Frame::aov_images, bpy::return_value_policy<bpy::reference_existing_object>())
 
-        .def("clear_main_image", &Frame::clear_main_image)
         .def("write_main_image", &Frame::write_main_image)
         .def("write_aov_images", &Frame::write_aov_images)
         .def("write_aov_image", &Frame::write_aov_image)

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -1150,8 +1150,7 @@ void MainWindow::start_rendering(const RenderingMode rendering_mode)
     Project* project = m_project_manager.get_project();
     Frame* frame = project->get_frame();
 
-    // Clear the main image to transparent black.
-    frame->clear_main_image();
+    frame->clear_main_and_aov_images();
 
     // In the UI, darken all render widgets.
     for (const_each<RenderTabCollection> i = m_render_tabs; i; ++i)
@@ -1881,9 +1880,8 @@ void MainWindow::slot_quicksave_all_aovs()
 
 void MainWindow::slot_clear_frame()
 {
-    // Clear the main image to transparent black.
     Frame* frame = m_project_manager.get_project()->get_frame();
-    frame->clear_main_image();
+    frame->clear_main_and_aov_images();
 
     // In the UI, clear all render widgets to black.
     for (const_each<RenderTabCollection> i = m_render_tabs; i; ++i)

--- a/src/appleseed/renderer/modeling/aov/aov.cpp
+++ b/src/appleseed/renderer/modeling/aov/aov.cpp
@@ -33,6 +33,7 @@
 #include "renderer/kernel/aov/imagestack.h"
 
 // appleseed.foundation headers.
+#include "foundation/image/color.h"
 #include "foundation/image/image.h"
 
 using namespace foundation;
@@ -85,6 +86,11 @@ void AOV::create_image(
 Image& AOV::get_image() const
 {
     return *m_image;
+}
+
+void AOV::clear_image()
+{
+    m_image->clear(Color4f(0.0f));
 }
 
 

--- a/src/appleseed/renderer/modeling/aov/aov.h
+++ b/src/appleseed/renderer/modeling/aov/aov.h
@@ -86,6 +86,9 @@ class APPLESEED_DLLSYMBOL AOV
     // Return a reference to the AOV image.
     foundation::Image& get_image() const;
 
+    // Clear the AOV image to transparent black.
+    void clear_image();
+
   protected:
     friend class AOVAccumulatorContainer;
     friend class Frame;

--- a/src/appleseed/renderer/modeling/frame/frame.cpp
+++ b/src/appleseed/renderer/modeling/frame/frame.cpp
@@ -211,9 +211,12 @@ Image& Frame::image() const
     return *impl->m_image.get();
 }
 
-void Frame::clear_main_image()
+void Frame::clear_main_and_aov_images()
 {
     impl->m_image->clear(Color4f(0.0));
+
+    for (size_t i = 0, e = aovs().size(); i < e; ++i)
+        aovs().get_by_index(i)->clear_image();
 }
 
 ImageStack& Frame::aov_images() const

--- a/src/appleseed/renderer/modeling/frame/frame.h
+++ b/src/appleseed/renderer/modeling/frame/frame.h
@@ -89,8 +89,8 @@ class APPLESEED_DLLSYMBOL Frame
     // Access the main underlying image.
     foundation::Image& image() const;
 
-    // Clear the main image to transparent black.
-    void clear_main_image();
+    // Clear the main and AOV images to transparent black.
+    void clear_main_and_aov_images();
 
     // Access the AOV images.
     ImageStack& aov_images() const;


### PR DESCRIPTION
Fix the issue when doing final renders with AOVs + render regions in studio.
When you re-render with a smaller region, the previous pixels outside the region were not cleared.