### PR TITLE
Fix multipart EXR image writting

### DIFF
--- a/src/appleseed/foundation/image/exrimagefilewriter.cpp
+++ b/src/appleseed/foundation/image/exrimagefilewriter.cpp
@@ -48,6 +48,7 @@
 #include "OpenEXR/ImfFrameBuffer.h"
 #include "OpenEXR/ImfHeader.h"
 #include "OpenEXR/ImfMultiPartOutputFile.h"
+#include "OpenEXR/ImfPartType.h"
 #include "OpenEXR/ImfPixelType.h"
 #include "OpenEXR/ImfTileDescription.h"
 #include "OpenEXR/ImfTiledOutputPart.h"
@@ -254,8 +255,9 @@ void EXRImageFileWriter::append_part(
     // Build the header.
     PixelType pixel_type;
     Header header = build_header(props, image_attributes, channel_count, channel_names, pixel_type);
-
     header.setName(part_name);
+    header.setType(TILEDIMAGE);
+
     impl->m_image_headers.push_back(header);
 }
 

--- a/src/appleseed/renderer/modeling/frame/frame.cpp
+++ b/src/appleseed/renderer/modeling/frame/frame.cpp
@@ -298,6 +298,15 @@ namespace
         }
     }
 
+    void add_chromaticities(ImageAttributes& image_attributes)
+    {
+        // Scene linear sRGB Rec 709 chromaticities.
+        image_attributes.insert("white_xy_chromaticity", Vector2f(0.3127f, 0.3290f));
+        image_attributes.insert("red_xy_chromaticity", Vector2f(0.64f, 0.33f));
+        image_attributes.insert("green_xy_chromaticity", Vector2f(0.30f, 0.60f));
+        image_attributes.insert("blue_xy_chromaticity",  Vector2f(0.15f, 0.06f));
+    }
+
     void write_exr_image(
         const char*             file_path,
         const Image&            image,
@@ -389,12 +398,7 @@ namespace
         const string extension = lower_case(filepath.extension().string());
 
         ImageAttributes image_attributes = ImageAttributes::create_default_attributes();
-
-        // Scene linear sRGB Rec 709 chromaticities.
-        image_attributes.insert("white_xy_chromaticity", Vector2f(0.3127f, 0.3290f));
-        image_attributes.insert("red_xy_chromaticity", Vector2f(0.64f, 0.33f));
-        image_attributes.insert("green_xy_chromaticity", Vector2f(0.30f, 0.60f));
-        image_attributes.insert("blue_xy_chromaticity",  Vector2f(0.15f, 0.06f));
+        add_chromaticities(image_attributes);
 
         try
         {
@@ -531,7 +535,7 @@ void Frame::write_main_and_aov_images_to_multipart_exr(const char* file_path) co
     EXRImageFileWriter writer;
 
     ImageAttributes image_attributes = ImageAttributes::create_default_attributes();
-    // todo: add chromaticity attributes here...
+    add_chromaticities(image_attributes);
 
     std::vector<Image> images;
 


### PR DESCRIPTION
We were not setting the type of each part for multi-part EXRs. Also fixes #1725.
