### PR TITLE
Add UV transform shader for 3ds max bitmap textures

### DIFF
--- a/src/appleseed.shaders/CMakeLists.txt
+++ b/src/appleseed.shaders/CMakeLists.txt
@@ -306,6 +306,7 @@ set (src_max_sources
      src/max/as_max_float_texture.osl
      src/max/as_max_normal_map.osl
      src/max/as_max_srgb_to_linear_rgb.osl
+     src/max/as_max_uv_transform.osl
 )
 list (APPEND osl_sources
     ${src_max_sources}

--- a/src/appleseed.shaders/src/max/as_max_uv_transform.osl
+++ b/src/appleseed.shaders/src/max/as_max_uv_transform.osl
@@ -1,0 +1,131 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Sergo Pogosyan, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+shader as_max_uv_transform
+(
+    float in_coordU = u,
+    float in_coordV = v,
+
+    float in_offsetU = 0.0,
+    float in_offsetV = 0.0,
+
+    float in_tilingU = 1.0,
+    float in_tilingV = 1.0,
+
+    float in_rotateW = 0.0,
+
+    int in_mirrorU = 0,
+    int in_mirrorV = 0,
+    
+    int in_wrapU = 0,
+    int in_wrapV = 0,
+
+    float in_cropW = 1.0,
+    float in_cropH = 1.0,
+    float in_cropU = 0.0,
+    float in_cropV = 0.0,
+
+    string in_crop_mode = "off",
+
+    output float out_U = 0.0,
+    output float out_V = 0.0,
+)
+{
+    float out_u = in_coordU;
+    float out_v = in_coordV;
+    float u_center = 0.5;
+    float v_center = 0.5;
+
+    // Apply rotation before tiling/offset which is different from 3ds max native bitmap transforms
+    if (in_rotateW != 0.0)
+    {
+        point rot = rotate(
+            point(out_u, out_v, 0.0),
+            in_rotateW,
+            point(u_center, v_center, 0.0),
+            point(u_center, v_center, 1.0));
+
+            out_u = rot[0];
+            out_v = rot[1];
+    }
+
+    // Don't center transforms when mirrored (3ds max behaviour)
+    if (in_mirrorU)
+        u_center = 0.0;
+    if (in_mirrorV)
+        v_center = 0.0;
+
+    // Apply tiling and offset without considering cropping
+    out_u = (out_u - u_center) * in_tilingU;
+    out_u = (out_u + u_center) - (in_offsetU * in_tilingU);
+
+    out_v = (out_v - v_center) * in_tilingV;
+    out_v = (out_v + v_center) - (in_offsetV * in_tilingV);
+
+    // Apply mirroring
+    if (in_mirrorU)
+    {
+        out_u *= 2;
+        if (mod(out_u, 2) >= 1.0)
+        {
+            out_u = 1 - out_u;
+        }
+    }
+    if (in_mirrorV)
+    {
+        out_v *= 2;
+        if (mod(out_v, 2) >= 1.0)
+        {
+            out_v = 1 - out_v;
+        }
+    }
+
+    // "Manual" periodic tiling required for correct cropping
+    out_u = fmod (out_u, 1.0);
+    out_v = fmod (out_v, 1.0);
+    
+    // Avoid negative values
+    if (out_u < 0)
+        out_u = 1 + out_u;
+    if (out_v < 0)
+        out_v = 1 + out_v;
+
+    // Apply cropping
+    if (in_crop_mode == "crop")
+    {
+        out_u *= in_cropW;
+        out_u += in_cropU;
+    
+        out_v *= in_cropH;
+        out_v -= in_cropV;
+        out_v = out_v + (1 - in_cropH); // Looks like V=0 is bottom left corner, so had to move it to the top to match 3ds max coords
+    }
+    
+    out_U = out_u;
+    out_V = out_v;
+}

--- a/src/appleseed.shaders/src/max/as_max_uv_transform.osl
+++ b/src/appleseed.shaders/src/max/as_max_uv_transform.osl
@@ -26,6 +26,8 @@
 // THE SOFTWARE.
 //
 
+#include "appleseed/gaffer/transform.h"
+
 shader as_max_uv_transform
 (
     float in_coordU = u,
@@ -61,20 +63,13 @@ shader as_max_uv_transform
     float u_center = 0.5;
     float v_center = 0.5;
 
-    // Apply rotation before tiling/offset which is different from 3ds max native bitmap transforms
+    // Apply rotation before tiling/offset which is different from 3ds Max native bitmap transforms.
     if (in_rotateW != 0.0)
     {
-        point rot = rotate(
-            point(out_u, out_v, 0.0),
-            in_rotateW,
-            point(u_center, v_center, 0.0),
-            point(u_center, v_center, 1.0));
-
-            out_u = rot[0];
-            out_v = rot[1];
+        rotate2d(out_u, out_v, in_rotateW, out_u, out_v);
     }
 
-    // Don't center transforms when mirrored (3ds max behaviour)
+    // Don't center transforms when mirrored (3ds Max behaviour).
     if (in_mirrorU)
         u_center = 0.0;
     if (in_mirrorV)
@@ -87,7 +82,7 @@ shader as_max_uv_transform
     out_v = (out_v - v_center) * in_tilingV;
     out_v = (out_v + v_center) - (in_offsetV * in_tilingV);
 
-    // Apply mirroring
+    // Apply mirroring.
     if (in_mirrorU)
     {
         out_u *= 2;
@@ -105,9 +100,9 @@ shader as_max_uv_transform
         }
     }
 
-    // "Manual" periodic tiling required for correct cropping
-    out_u = fmod (out_u, 1.0);
-    out_v = fmod (out_v, 1.0);
+    // "Manual" periodic tiling required for correct cropping.
+    out_u = fmod(out_u, 1.0);
+    out_v = fmod(out_v, 1.0);
     
     // Avoid negative values
     if (out_u < 0)
@@ -115,7 +110,7 @@ shader as_max_uv_transform
     if (out_v < 0)
         out_v = 1 + out_v;
 
-    // Apply cropping
+    // Apply cropping.
     if (in_crop_mode == "crop")
     {
         out_u *= in_cropW;


### PR DESCRIPTION
Hi,
This PR adds as_max_uv_transform shader to 3ds max shaders. It supports following transformations:
* Offset on U and V axis
* Tiling on U and V axis
* Mirror on U and V axis
* Rotation on W axis
* Crop mode with crop offset and sizes

What's not supported:
* It works slightly different from max bitmap texture when texture is rotated and has some offset
* Place mode
* Real-world uv scale
* Rotation on U or V axis
* VW and WU coords
* Blur
* Any mapping mode other than Explicit Map Channel

Thanks for review!