### PR TITLE
Add new attributes, ID/variation nodes, update OSL

### DIFF
--- a/src/appleseed.shaders/CMakeLists.txt
+++ b/src/appleseed.shaders/CMakeLists.txt
@@ -138,6 +138,16 @@ source_group ("include\\appleseed\\pattern" FILES
     ${include_appleseed_pattern_sources}
 )
 
+set (include_appleseed_transform_sources
+    include/appleseed/transform/as_transform_helpers.h
+)
+list (APPEND osl_headers
+    ${include_appleseed_transform_sources}
+)
+source_group ("include\\appleseed\\transform" FILES
+    ${include_appleseed_transform_sources}
+)
+
 
 #--------------------------------------------------------------------------------------------------
 # Source files.
@@ -407,14 +417,24 @@ source_group ("src\\maya" FILES
 )
 
 set (src_appleseed_sources
+     src/appleseed/as_attributes.osl
      src/appleseed/as_color_transform.osl
+     src/appleseed/as_create_mask.osl
      src/appleseed/as_disney_material.osl
+     src/appleseed/as_double_shade.osl
+     src/appleseed/as_falloff_angle.osl
      src/appleseed/as_glass.osl
+     src/appleseed/as_globals.osl
+     src/appleseed/as_id_manifold.osl
      src/appleseed/as_luminance.osl
+     src/appleseed/as_metal.osl
      src/appleseed/as_noise2d.osl
      src/appleseed/as_noise3d.osl
      src/appleseed/as_plastic.osl
+     src/appleseed/as_space_transform.osl
      src/appleseed/as_standard_surface.osl
+     src/appleseed/as_swizzle.osl
+     src/appleseed/as_vary_color.osl
      src/appleseed/as_voronoi2d.osl
      src/appleseed/as_voronoi3d.osl
 )

--- a/src/appleseed.shaders/include/appleseed/pattern/as_pattern_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/pattern/as_pattern_helpers.h
@@ -176,7 +176,7 @@ float smootherstep(float edge0, float edge1, float x)
 float smootheststep(float edge0, float edge1, float x)
 {
     x = clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
-    return x * x * x * x *(x *(x * (-20.0 * x + 70.0) - 84.0) + 35.0);
+    return x * x * x * x * (x * (x * (-20.0 * x + 70.0) - 84.0) + 35.0);
 }
 
 #endif // !AS_PATTERN_HELPERS_H

--- a/src/appleseed.shaders/include/appleseed/pattern/as_pattern_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/pattern/as_pattern_helpers.h
@@ -159,4 +159,24 @@ float filtered_pulsetrain(
     }
 }
 
+//
+// Reference:
+//
+//      Improving Noise, Ken Perlin
+//      http://mrl.nyu.edu/~perlin/paper445.pdf
+//      http://www.iquilezles.org/www/articles/functions/functions.htm
+//
+
+float smootherstep(float edge0, float edge1, float x)
+{
+    x = clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
+    return x * x * x * (x * (x * 6.0 - 15.0) + 10.0);
+}
+
+float smootheststep(float edge0, float edge1, float x)
+{
+    x = clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
+    return x * x * x * x *(x *(x * (-20.0 * x + 70.0) - 84.0) + 35.0);
+}
+
 #endif // !AS_PATTERN_HELPERS_H

--- a/src/appleseed.shaders/include/appleseed/transform/as_transform_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/transform/as_transform_helpers.h
@@ -1,0 +1,113 @@
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef AS_TRANSFORM_HELPERS_H
+#define AS_TRANSFORM_HELPERS_H
+
+void compute_id_manifold(
+    int manifold_type,
+    int domain,
+    int seed,
+    string expression,
+    output int hash_id,
+    output color color_id,
+    output float greyscale_id)
+{
+    string manifold_str = "";
+
+    hash_id = 0;
+    color_id = color(0);
+    greyscale_id = 0.0;
+
+    if (manifold_type == 0)
+    {
+        getattribute("object:object_name", manifold_str);
+        hash_id = hash(manifold_str);
+    }
+    else if (manifold_type == 1)
+    {
+        getattribute("object:object_instance_name", manifold_str);
+        hash_id= hash(manifold_str);
+    }
+    else if (manifold_type == 2)
+    {
+        getattribute("object:assembly_name", manifold_str);
+        hash_id = hash(manifold_str);
+    }
+    else if (manifold_type == 3)
+    {
+        getattribute("object:assembly_instance_name", manifold_str);
+        hash_id = hash(manifold_str);
+    }
+    else if (manifold_type == 4)
+    {
+        getattribute("object:face_id", hash_id);
+    }
+    else if (expression != "")
+    {
+        if (domain == 0)
+        {
+            getattribute("object:object_name", manifold_str);
+        }
+        else if (domain == 1)
+        {
+            getattribute("object:object_instance_name", manifold_str);
+        }
+        else if (domain == 2)
+        {
+            getattribute("object:assembly_name", manifold_str);
+        }
+        else
+        {
+            getattribute("object:assembly_instance_name", manifold_str);
+        }
+
+        if (manifold_type == 5)
+        {
+            if (startswith(manifold_str, expression))
+            {
+                hash_id = hash(seed);
+            }
+        }
+        else if (manifold_type == 6)
+        {
+            if (endswith(manifold_str, expression))
+            {
+                hash_id = hash(seed);
+            }
+        }
+        else if (regex_search(manifold_str, expression))
+        {
+            hash_id = hash(seed);
+        }
+    }
+
+    greyscale_id = (float) cellnoise(hash_id);
+    color_id = (color) cellnoise(hash_id);
+}
+
+#endif // !AS_TRANSFORM_HELPERS_H

--- a/src/appleseed.shaders/src/appleseed/as_attributes.osl
+++ b/src/appleseed.shaders/src/appleseed/as_attributes.osl
@@ -1,0 +1,245 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+shader as_attributes
+[[
+    string as_maya_node_name = "asAttributes",
+    string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
+    string help = "OSL and appleseed attributes.",
+    int as_maya_type_id = 0x001279f8
+]]
+(
+    output int out_object_instance_id = 0
+    [[
+        string as_maya_attribute_name = "objectInstanceId",
+        string as_maya_attribute_short_name = "oid",
+        string label = "Object Instance ID"
+    ]],
+    output int out_object_instance_index = 0
+    [[
+        string as_maya_attribute_name = "objectInstanceIndex",
+        string as_maya_attribute_short_name = "odx",
+        string label = "Object Instance Index"
+    ]],
+    output string out_object_instance_name = ""
+    [[
+        string as_maya_attribute_name = "objectInstanceName",
+        string as_maya_attribute_short_name = "oin",
+        string label = "Object Instance Name"
+    ]],
+    output string out_object_name = ""
+    [[
+        string as_maya_attribute_name = "objectName",
+        string as_maya_attribute_short_name = "onn",
+        string label = "Object Name"
+    ]],
+    output int out_assembly_instance_id = 0
+    [[
+        string as_maya_attribute_name = "assemblyInstanceId",
+        string as_maya_attribute_short_name = "aid",
+        string label = "Assembly Instance ID"
+    ]],
+    output string out_assembly_name = ""
+    [[
+        string as_maya_attribute_name = "assemblyName",
+        string as_maya_attribute_short_name = "asn",
+        string label = "Assembly Name"
+    ]],
+    output string out_assembly_instance_name = ""
+    [[
+        string as_maya_attribute_name = "assemblyInstanceName",
+        string as_maya_attribute_short_name = "ain",
+        string label = "Assembly Instance Name"
+    ]],
+    // A float[2], but we can't connect array elements yet.
+    output int out_camera_resolution[2] = {0, 0}
+    [[
+        string as_maya_attribute_name = "cameraResolution",
+        string as_maya_attribute_short_name = "crs",
+        string label = "Camera Resolution"
+    ]],
+    output int out_camera_resolution_x = 0
+    [[
+        string as_maya_attribute_name = "cameraResolutionX",
+        string as_maya_attribute_short_name = "crx",
+        string label = "Camera Resolution X"
+    ]],
+    output int out_camera_resolution_y = 0
+    [[
+        string as_maya_attribute_name = "cameraResolutionY",
+        string as_maya_attribute_short_name = "cry",
+        string label = "Camera Resolution Y"
+    ]],
+    output string out_camera_projection = ""
+    [[
+        string as_maya_attribute_name = "cameraProjection",
+        string as_maya_attribute_short_name = "cpr",
+        string label = "Camera Projection"
+    ]],
+    output float out_camera_pixel_aspect = 1.0
+    [[
+        string as_maya_attribute_name = "cameraPixelAspect",
+        string as_maya_attribute_short_name = "cpa",
+        string label = "Camera Pixel Aspect"
+    ]],
+    // This should be a float[4], but we can't connect array elements yet.
+    output int out_camera_screen_window[4] = {0, 0, 0, 0}
+    [[
+        string as_maya_attribute_name = "cameraScreenWindow",
+        string as_maya_attribute_short_name = "csw",
+        string label = "Camera Screen Window"
+    ]],
+    output float out_camera_screen_window_xmin = 0.0
+    [[
+        string as_maya_attribute_name = "cameraScreenWindowXMin",
+        string as_maya_attribute_short_name = "xmi",
+        string label = "Screen Window X Min"
+    ]],
+    output float out_camera_screen_window_ymin = 0.0
+    [[
+        string as_maya_attribute_name = "cameraScreenWindowYMin",
+        string as_maya_attribute_short_name = "ymi",
+        string label = "Screen Window Y Min"
+    ]],
+    output float out_camera_screen_window_xmax = 0.0
+    [[
+        string as_maya_attribute_name = "cameraScreenWindowXMax",
+        string as_maya_attribute_short_name = "xma",
+        string label = "Screen Window X Max"
+    ]],
+    output float out_camera_screen_window_ymax = 0.0
+    [[
+        string as_maya_attribute_name = "cameraScreenWindowYMax",
+        string as_maya_attribute_short_name = "yma",
+        string label = "Screen Window Y Max"
+    ]],
+    output float out_camera_fov = 0.0
+    [[
+        string as_maya_attribute_name = "cameraFOV",
+        string as_maya_attribute_short_name = "cfo",
+        string label = "Camera FOV"
+    ]],
+    // No array elements connections yet, but this is near and far elements.
+    output float out_camera_clip[2] = {0.0, 0.0}
+    [[
+        string as_maya_attribute_name = "cameraClip",
+        string as_maya_attribute_short_name = "cli",
+        string label = "Camera Clip Range"
+    ]],
+    output float out_camera_clip_near = 0.0
+    [[
+        string as_maya_attribute_name = "cameraClipNear",
+        string as_maya_attribute_short_name = "cne",
+        string label = "Camera Clip Near"
+    ]],
+    output float out_camera_clip_far = 0.0
+    [[
+        string as_maya_attribute_name = "cameraClipFar",
+        string as_maya_attribute_short_name = "cnf",
+        string label = "Camera Clip Far"
+    ]],
+    // No array elements connections yet, but open/close times are below.
+    output float out_camera_shutter[2] = {0.0, 0.0}
+    [[
+        string as_maya_attribute_name = "cameraShutter",
+        string as_maya_attribute_short_name = "csu",
+        string label = "Camera Shutter"
+    ]],
+    output float out_camera_shutter_open = 0.0
+    [[
+        string as_maya_attribute_name = "cameraShutterOpen",
+        string as_maya_attribute_short_name = "sop",
+        string label = "Shutter Open Time"
+    ]],
+    output float out_camera_shutter_close = 0.0
+    [[
+        string as_maya_attribute_name = "cameraShutterClose",
+        string as_maya_attribute_short_name = "scl",
+        string label = "Shutter Close Time"
+    ]],
+    output int out_path_ray_depth = 0
+    [[
+        string as_maya_attribute_name = "pathRayDepth",
+        string as_maya_attribute_short_name = "prd",
+        string label = "Ray Depth"
+    ]],
+    output int out_path_has_ray_differentials = 0
+    [[
+        string as_maya_attribute_name = "pathHasRayDifferentials",
+        string as_maya_attribute_short_name = "phd",
+        string label = "Ray Differentials"
+    ]],
+    output float out_path_ray_length = 0.0
+    [[
+        string as_maya_attribute_name = "pathRayLength",
+        string as_maya_attribute_short_name = "prl",
+        string label = "Ray Length"
+    ]],
+    output float out_path_ray_ior = 0.0
+    [[
+        string as_maya_attribute_name = "pathRayIOR",
+        string as_maya_attribute_short_name = "pri",
+        string label = "Ray IOR"
+    ]]
+)
+{
+    getattribute("object:object_instance_id", out_object_instance_id);
+    getattribute("object:object_instance_index", out_object_instance_index);
+    getattribute("object:object_instance_name", out_object_instance_name);
+    getattribute("object:object_name", out_object_name);
+
+    getattribute("object:assembly_instance_id", out_assembly_instance_id);
+    getattribute("object:assembly_name", out_assembly_name);
+    getattribute("object:assembly_instance_name", out_assembly_instance_name);
+
+    getattribute("camera:resolution", out_camera_resolution);
+    out_camera_resolution_x = out_camera_resolution[0];
+    out_camera_resolution_y = out_camera_resolution[1];
+
+    getattribute("camera:projection", out_camera_projection);
+    getattribute("camera:pixelaspect", out_camera_pixel_aspect);
+
+    getattribute("camera:screen_window", out_camera_screen_window);
+    out_camera_screen_window_xmin = out_camera_screen_window[0];
+    out_camera_screen_window_ymin = out_camera_screen_window[1];
+    out_camera_screen_window_xmax = out_camera_screen_window[2];
+    out_camera_screen_window_ymax = out_camera_screen_window[3];
+
+    getattribute("camera:fov", out_camera_fov);
+    getattribute("camera:clip", out_camera_clip);
+    getattribute("camera:clip_near", out_camera_clip_near);
+    getattribute("camera:clip_far", out_camera_clip_far);
+    getattribute("camera:shutter", out_camera_shutter);
+    getattribute("camera:shutter_open", out_camera_shutter_open);
+    getattribute("camera:shutter_close", out_camera_shutter_close);
+
+    getattribute("path:ray_depth", out_path_ray_depth);
+    getattribute("path:ray_has_differentials", out_path_has_ray_differentials);
+    getattribute("path:ray_length", out_path_ray_length);
+    getattribute("path:ray_ior", out_path_ray_ior);
+}

--- a/src/appleseed.shaders/src/appleseed/as_create_mask.osl
+++ b/src/appleseed.shaders/src/appleseed/as_create_mask.osl
@@ -1,0 +1,289 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "appleseed/color/as_color_helpers.h"
+#include "appleseed/color/as_color_transforms.h"
+#include "appleseed/pattern/as_pattern_helpers.h"
+
+shader as_create_mask
+[[
+    string as_maya_node_name = "asCreateMask",
+    string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
+    string help = "Creates a greyscale mask from an input color or grey value.",
+    int as_maya_type_id = 0x001279e1
+]]
+(
+    color in_color = color(1)
+    [[
+        string as_maya_attribute_name = "color",
+        string as_maya_attribute_short_name = "c",
+        string label = "Color",
+        string page = "Color",
+        string help = "Color value to create mask from. It expects scene-linear values."
+    ]],
+    float in_alpha = 0.0
+    [[
+        string as_maya_attribute_name = "greyscale",
+        string as_maya_attribute_short_name = "a",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Alpha",
+        string page = "Color",
+        int divider = 1
+    ]],
+    int in_threshold_channel = 0
+    [[
+        string as_maya_attribute_name = "thresholdChannel",
+        string as_maya_attribute_short_name = "thr",
+        string widget = "mapper",
+        string options =
+        "Red:0|Green:1|Blue:2|Alpha:3|Hue:4|Saturation:5|Value:6|CIELAB L*:7|CIELAB a*:8|CIELAB b*:9|Average:10|Luminance:11",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Threshold Channel",
+        string page = "Color",
+        int divider = 1
+    ]],
+    float in_threshold_value = 0.5
+    [[
+        string as_maya_attribute_name = "thresholdValue",
+        string as_maya_attribute_short_name = "thv",
+        float softmin = 0.0,
+        float softmax = 1.0,
+        string label = "Threshold Value",
+        string page = "Color"
+    ]],
+    int in_threshold_function = 0
+    [[
+        string as_maya_attribute_name = "thresholdFunction",
+        string as_maya_attribute_short_name = "thf",
+        string widget = "mapper",
+        string options = "None:0|Step:1|Linear Step:2|Smooth Step:3|Exponential:4|Double Circled Seat:5|Double Circled Sigmoid:6|Smoother Step:7|Smoothest Step:8",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Threshold Function",
+        string page = "Color"
+    ]],
+    float in_threshold_contrast = 0.25
+    [[
+        string as_maya_attribute_name = "thresholdContrast",
+        string as_maya_attribute_short_name = "tct",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Threshold Contrast",
+        string page = "Color"
+    ]],
+    float in_threshold_lower_bound = 0.15
+    [[
+        string as_maya_attribute_name = "thresholdLowerBound",
+        string as_maya_attribute_short_name = "tlb",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Smoothstep Lower Bound",
+        string page = "Color.Step Bounds"
+    ]],
+    float in_threshold_upper_bound = 0.85
+    [[
+        string as_maya_attribute_name = "thresholdUpperBound",
+        string as_maya_attribute_short_name = "tub",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Smoothstep Upper Bound",
+        string page = "Color.Step Bounds"
+    ]],
+
+    output float out_result = 0.0
+    [[
+        string as_maya_attribute_name = "result",
+        string as_maya_attribute_short_name = "res",
+        string label = "Output Value"
+    ]]      
+)
+{
+    if (in_color == 0.0 && in_alpha == 0.0)
+    {
+        return;
+    }
+
+    float x;
+
+    if (in_threshold_channel == 0)
+    {
+        x = in_color[0];
+    }
+    else if (in_threshold_channel == 1)
+    {
+        x = in_color[1];
+    }
+    else if (in_threshold_channel == 2)
+    {
+        x = in_color[2];
+    }
+    else if (in_threshold_channel == 3)
+    {
+        x = in_alpha;
+    }
+    else if (in_threshold_channel >= 4 && in_threshold_channel <= 6)
+    {
+        color hsv = transformc("rgb", "hsv", in_color);
+
+        if (in_threshold_channel == 4)
+        {
+            x = hsv[0];
+        }
+        else if (in_threshold_channel == 5)
+        {
+            x = hsv[1];
+        }
+        else
+        {
+            x = hsv[2];
+        }
+    }
+    else if (in_threshold_channel >= 7 && in_threshold_channel <= 9)
+    {
+        // Once the working/rendering space information is added, we update
+        // the RGB primaries and whitepoint. Use defaults for now.
+
+        color cielab = transform_linear_RGB_to_Lab(
+            in_color,
+            "Rec.709",
+            "D65");
+
+        if (in_threshold_channel == 7)
+        {
+            x = cielab[0];
+        }
+        else if (in_threshold_channel == 8)
+        {
+            x = cielab[1];
+        }
+        else
+        {
+            x = cielab[2];
+        }
+    }
+    else if (in_threshold_channel == 10)
+    {
+        x = (in_color[0] + in_color[1] + in_color[2]) / 3;
+    }
+    else if (in_threshold_channel == 11)
+    {
+        // The same color space awareness as required by the CIELAB transform
+        // is required here. Use the defaults for now.
+
+        x = as_luminance(in_color, "Rec.709", "D65");
+    }
+    else
+    {
+        x = 0.0;
+#ifdef DEBUG
+        string shadername = "";
+        getattribute("shader:shadername", shadername);
+        warning("[DEBUG!]: Invalid threshold channel %d in %s, %s:%d\n",
+                in_threshold_channel, shadername, __FILE__, __LINE__);
+#endif
+    }
+
+    float mask_value;
+
+    if (in_threshold_function == 0)
+    {
+        mask_value = x;
+    }
+    else if (in_threshold_function == 1)
+    {
+        mask_value = aastep(in_threshold_value, x);
+    }
+    else if (in_threshold_function == 2)
+    {
+        mask_value = linearstep(
+            in_threshold_lower_bound,
+            in_threshold_upper_bound,
+            x);
+    }
+    else if (in_threshold_function == 3)
+    {
+        mask_value = smoothstep(
+            in_threshold_lower_bound,
+            in_threshold_upper_bound,
+            x);
+
+    }
+    else if (in_threshold_function == 4)
+    {
+        float exponent = clamp(in_threshold_contrast, 0.0001, 0.9999);
+
+        if (exponent < 0.5)
+        {
+            exponent *= 2.0;
+            mask_value = pow(x, exponent);
+        }
+        else
+        {
+            exponent = 2.0 * (exponent - 0.5);
+            mask_value = pow(x, 1.0 / (1.0 - exponent));
+        }
+    }
+    else if (in_threshold_function == 5)
+    {
+        float exponent = clamp(in_threshold_contrast, 0.0001, 0.9999);
+
+        mask_value = (x <= 0.5)
+            ? pow(2.0 * x, 1.0 - exponent) / 2.0
+            : 1.0 - pow(2.0 * (1.0 - x), 1.0 - exponent) / 2.0;
+    }
+    else if (in_threshold_function == 6)
+    {
+        float exponent = 1.0 - clamp(in_threshold_contrast, 0.0001, 0.9999);
+
+        mask_value = (x <= 0.5)
+            ? pow(2.0 * x, 1.0 / exponent) / 2.0
+            : 1.0 - pow(2.0 * (1.0 - x), 1.0 / exponent) / 2.0;
+    }
+    else if (in_threshold_function == 7)
+    {
+        mask_value = smootherstep(
+            in_threshold_lower_bound,
+            in_threshold_upper_bound,
+            x);
+    }
+    else
+    {
+        mask_value = smootheststep(
+            in_threshold_lower_bound,
+            in_threshold_upper_bound,
+            x);
+    }
+
+    out_result = mask_value;
+}

--- a/src/appleseed.shaders/src/appleseed/as_double_shade.osl
+++ b/src/appleseed.shaders/src/appleseed/as_double_shade.osl
@@ -1,0 +1,61 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+shader as_double_shade
+[[
+    string as_maya_node_name = "asDoubleShade",
+    string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
+    string help = "Double shading node.",
+    int as_maya_type_id = 0x001279db
+]]
+(
+    color in_color = color(1)
+    [[
+        string as_maya_attribute_name = "color",
+        string as_maya_attribute_short_name = "c",
+        string label = "Front Color",
+        string page = "Color"
+    ]],
+    color in_color2 = color(0)
+    [[
+        string as_maya_attribute_name = "color2",
+        string as_maya_attribute_short_name = "c2",
+        string label = "Back Color",
+        string page = "Color"
+    ]],
+
+    output color out_color = color(0)
+    [[
+        string as_maya_attribute_name = "outColor",
+        string as_maya_attribute_short_name = "oc",
+        string label = "Output Color"
+    ]]      
+)
+{
+    out_color = backfacing() ? in_color2 : in_color;
+}

--- a/src/appleseed.shaders/src/appleseed/as_falloff_angle.osl
+++ b/src/appleseed.shaders/src/appleseed/as_falloff_angle.osl
@@ -117,11 +117,11 @@ shader as_falloff_angle
     ]]
 )
 {
-    vector v1 = (in_normalize_input_1)
+    vector v1 = in_normalize_input_1
         ? normalize(in_vector_1)
         : in_vector_1;
 
-    vector v2 = (in_normalize_input_2)
+    vector v2 = in_normalize_input_2
         ? normalize(in_vector_2)
         : in_vector_2;
 

--- a/src/appleseed.shaders/src/appleseed/as_falloff_angle.osl
+++ b/src/appleseed.shaders/src/appleseed/as_falloff_angle.osl
@@ -1,0 +1,146 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "appleseed/pattern/as_pattern_helpers.h"
+
+shader as_falloff_angle
+[[
+    string as_maya_node_name = "asFalloffAngle",
+    string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
+    string help = "Double shading node.",
+    int as_maya_type_id = 0x001279f7
+]]
+(
+    vector in_vector_1 = vector(0,1,0)
+    [[
+        string as_maya_attribute_name = "vector1",
+        string as_maya_attribute_short_name = "v1",
+        string label = "Vector 1",
+        string page = "Input"
+    ]],
+    int in_normalize_input_1 = 0
+    [[
+        string as_maya_attribute_name = "normalizeInput1",
+        string as_maya_attribute_short_name = "ni1",
+        string label = "Normalize Input 1",
+        string page = "Input",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        int divider = 1
+    ]],
+    vector in_vector_2 = vector(N)
+    [[
+        string as_maya_attribute_name = "vector2",
+        string as_maya_attribute_short_name = "v2",
+        string label = "Vector 2",
+        string page = "Input"
+    ]],
+    int in_normalize_input_2 = 0
+    [[
+        string as_maya_attribute_name = "normalizeInput2",
+        string as_maya_attribute_short_name = "ni2",
+        string label = "Normalize Input 2",
+        string page = "Input",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 2,
+        int gafferNoduleLayoutVisible = 0,
+        int divider = 2,
+    ]],
+    float in_smooth_lower_bound = 0.25
+    [[
+        string as_maya_attribute_name = "smoothLowerBound",
+        string as_maya_attribute_short_name = "slb",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Smoothstep Lower Bound",
+        string page = "Interpolation"
+    ]],
+    float in_smooth_upper_bound = 0.75
+    [[
+        string as_maya_attribute_name = "smoothUpperBound",
+        string as_maya_attribute_short_name = "sub",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Smoothstep Upper Bound",
+        string page = "Interpolation",
+        int divider = 1
+    ]],
+    int in_smooth_function = 0
+    [[
+        string as_maya_attribute_name = "smoothFunction",
+        string as_maya_attribute_short_name = "smo",
+        string label = "Smoothstep Function",
+        string page = "Interpolation",
+        string widget = "mapper",
+        string options = "Smooth step:0|Smoother step:1|Smoothest Step:2",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+
+    output float out_result = 0.0
+    [[
+        string as_maya_attribute_name = "result",
+        string as_maya_attribute_short_name = "rel",
+        string label = "Result"
+    ]]
+)
+{
+    vector v1 = (in_normalize_input_1)
+        ? normalize(in_vector_1)
+        : in_vector_1;
+
+    vector v2 = (in_normalize_input_2)
+        ? normalize(in_vector_2)
+        : in_vector_2;
+
+    float angle = dot(v1, v2);
+
+    float x = max(0.0, angle);
+
+    if (in_smooth_function == 0)
+    {
+        x = smoothstep(in_smooth_lower_bound, in_smooth_upper_bound, x);
+    }
+    else if (in_smooth_function == 1)
+    {
+        x = smootherstep(in_smooth_lower_bound, in_smooth_upper_bound, x);
+    }
+    else
+    {
+        x = smootheststep(in_smooth_lower_bound, in_smooth_upper_bound, x);
+    }
+
+    out_result = x;
+}

--- a/src/appleseed.shaders/src/appleseed/as_globals.osl
+++ b/src/appleseed.shaders/src/appleseed/as_globals.osl
@@ -171,5 +171,4 @@ shader as_globals
     ]]
 )
 {
-    ;
 }

--- a/src/appleseed.shaders/src/appleseed/as_globals.osl
+++ b/src/appleseed.shaders/src/appleseed/as_globals.osl
@@ -1,0 +1,175 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+shader as_globals
+[[
+    string as_maya_node_name = "asGlobals",
+    string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
+    string help = "OSL global variables.",
+    int as_maya_type_id = 0x001279ef
+]]
+(
+    output point out_world_P = P
+    [[
+        string as_maya_attribute_name = "worldP",
+        string as_maya_attribute_short_name = "wp",
+        string label = "Surface Position"
+    ]],
+    output point out_world_Ps = Ps
+    [[
+        string as_maya_attribute_name = "worldPs",
+        string as_maya_attribute_short_name = "wps",
+        string label = "Light Point Position",
+        int divider = 1
+    ]],
+    output normal out_world_N = N
+    [[
+        string as_maya_attribute_name = "worldN",
+        string as_maya_attribute_short_name = "n",
+        string label = "Shading Normal"
+    ]],
+    output normal out_world_Ng = Ng
+    [[
+        string as_maya_attribute_name = "worldNg",
+        string as_maya_attribute_short_name = "ng",
+        string label = "Geometric Normal",
+        int divider = 1
+    ]],
+    output vector out_world_I = I
+    [[
+        string as_maya_attribute_name = "worldI",
+        string as_maya_attribute_short_name = "wri",
+        string label = "Viewer Vector",
+        int divider = 1
+    ]],
+    output vector out_world_dPdu = dPdu
+    [[
+        string as_maya_attribute_name = "worldDPdu",
+        string as_maya_attribute_short_name = "dpu",
+        string label = "dP/du",
+        string help = "Partial derivative of P along the U direction."
+    ]],
+    output vector out_world_dPdv = dPdv
+    [[
+        string as_maya_attribute_name = "worldDPdv",
+        string as_maya_attribute_short_name = "dpv",
+        string label = "dP/dv",
+        string help = "Partial derivative of P along the V direction.",
+        int divider = 1
+    ]],
+    output vector out_world_dPdx = Dx(P)
+    [[
+        string as_maya_attribute_name = "worldDPdx",
+        string as_maya_attribute_short_name = "dpx",
+        string label = "dP/dx",
+        string help = "Partial derivative of P along the X direction."
+    ]],
+    output vector out_world_dPdy = Dy(P)
+    [[
+        string as_maya_attribute_name = "worldDPdy",
+        string as_maya_attribute_short_name = "dpy",
+        string label = "dP/dy",
+        string help = "Partial derivative of P along the Y direction."
+    ]],
+    output vector out_world_dPdz = Dz(P)
+    [[
+        string as_maya_attribute_name = "worldDPdz",
+        string as_maya_attribute_short_name = "dpz",
+        string label = "dP/dz",
+        string help = "Partial derivative of P along the Z direction.",
+        int divider = 1
+    ]],
+    output normal out_world_dNdu = 0
+    [[
+        int lockgeom = 0,
+        string as_maya_attribute_name = "worldDNdu",
+        string as_maya_attribute_short_name = "dnu",
+        string label = "dN/du",
+        string help = "Partial derivative of N along the V direction."
+    ]],
+    output normal out_world_dNdv = 0
+    [[
+        int lockgeom = 0,
+        string as_maya_attribute_name = "worldDNdv",
+        string as_maya_attribute_short_name = "dnv",
+        string label = "dN/dv",
+        string help = "Partial derivative of N along the U direction.",
+        int divider = 1
+    ]],
+    output vector out_world_Tn = 0
+    [[
+        int lockgeom = 0,
+        string as_maya_attribute_name = "worldTn",
+        string as_maya_attribute_short_name = "tn",
+        string label = "Tangent Vector"
+    ]],
+    output vector out_world_Bn = 0
+    [[
+        int lockgeom = 0,
+        string as_maya_attribute_name = "worldBn",
+        string as_maya_attribute_short_name = "bn",
+        string label = "Bitangent Vector",
+        int divider = 1
+    ]],
+    output float out_u_coord = u
+    [[
+        string as_maya_attribute_name = "uCoord",
+        string as_maya_attribute_short_name = "uu",
+        string label = "U Coordinate"
+    ]],
+    output float out_v_coord = v
+    [[
+        string as_maya_attribute_name = "vCoord",
+        string as_maya_attribute_short_name = "vv",
+        string label = "V Coordinate",
+        int divider = 1
+    ]],
+    output float out_time = time
+    [[
+        string as_maya_attribute_name = "time",
+        string as_maya_attribute_short_name = "tim",
+        string label = "Shutter Time"
+    ]],
+    output float out_dtime = dtime
+    [[
+        string as_maya_attribute_name = "dtime",
+        string as_maya_attribute_short_name = "dti",
+        string label = "Time Amount",
+        string help = "The amount of time covered by this shading sample."
+    ]],
+    output vector out_world_dPdtime = dPdtime
+    [[
+        string as_maya_attribute_name = "worldDPdtime",
+        string as_maya_attribute_short_name = "dpt",
+        string label = "dP/dtime",
+        string help = "Derivative of P along time, or how P changes per unit time."
+    ]]
+)
+{
+    ;
+}

--- a/src/appleseed.shaders/src/appleseed/as_id_manifold.osl
+++ b/src/appleseed.shaders/src/appleseed/as_id_manifold.osl
@@ -1,0 +1,132 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "appleseed/transform/as_transform_helpers.h"
+
+shader as_id_manifold
+[[
+    string as_maya_node_name = "asIdManifold",
+    string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
+    string help = "ID manifold utility shader",
+    string URL = "https://appleseedhq.net",
+    int as_maya_type_id = 0x001279d9
+]]
+(
+    int in_manifold_type = 0
+    [[
+        string as_maya_attribute_name = "manifoldType",
+        string as_maya_attribute_short_name = "mty",
+        string widget = "mapper",
+        string options = "Object Name:0|Object Instance Name:1|Assembly Name:2|Assembly Instance Name:3|Face ID:4|String Prefix:5|String Suffix:6|Find String:7",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Type",
+        string page = "Manifold",
+        int divider = 1
+    ]],
+    string in_expression = ""
+    [[
+        string as_maya_attribute_name = "expression",
+        string as_maya_attribute_short_name = "xpr",
+        string widget = "string",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Expression",
+        string page = "Manifold.String",
+        string help = "String expression to search in the object or object instance name"
+    ]],
+    int in_domain = 0
+    [[
+        string as_maya_attribute_name = "domain",
+        string as_maya_attribute_short_name = "dmn",
+        string widget = "mapper",
+        string options = "Object Name:0|Object Instance Name:1|Assembly Name:2|Assembly Instance Name:3",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Domain",
+        string page = "Manifold.String",
+        int divider = 1
+    ]],
+    int in_seed = 0xcafe
+    [[
+        string as_maya_attribute_name = "seed",
+        string as_maya_attribute_short_name = "see",
+        string widget = "number",
+        int min = 0,
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 1,
+        int as_maya_attribute_hidden = 0,
+        int gafferNoduleLayoutVisible = 1,
+        string label = "Seed",
+        string page = "Manifold.String"
+    ]],
+    int in_output_mode = 1
+    [[
+        string as_maya_attribute_name = "outputMode",
+        string as_maya_attribute_short_name = "grs",
+        string widget = "mapper",
+        string options = "Hash Only:0|Hash & Greyscale Value:1|Hash, Greyscale & Color ID:2",
+        string label = "Output Mode",
+        string page = "Manifold.Output"
+    ]],
+
+    output int out_outHash = 0
+    [[
+        string as_maya_attribute_name = "outHash",
+        string as_maya_attribute_short_name = "osh",
+        string label = "Output Hash"
+    ]],
+    output color out_outID = color(0)
+    [[
+        string as_maya_attribute_name = "outID",
+        string as_maya_attribute_short_name = "oid",
+        string label = "Output ID"
+    ]],
+    output float out_outGreyscale = 0.0
+    [[
+        string as_maya_attribute_name = "outGreyscale",
+        string as_maya_attribute_short_name = "ogr",
+        string label = "Output Greyscale"
+    ]]
+)
+{
+    compute_id_manifold(
+        in_manifold_type,
+        in_domain,
+        in_seed,
+        in_expression,
+        out_outHash,
+        out_outID,
+        out_outGreyscale);
+}

--- a/src/appleseed.shaders/src/appleseed/as_metal.osl
+++ b/src/appleseed.shaders/src/appleseed/as_metal.osl
@@ -1,0 +1,338 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "appleseed/math/as_math_helpers.h"
+
+shader as_metal
+[[
+    string as_maya_node_name = "asMetal",
+    string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
+    string help = "Metal material",
+    int as_maya_type_id = 0x001279f9
+]]
+(
+    color in_face_reflectance = color(0.96, 0.8, 0.05)
+    [[
+        string as_maya_attribute_name = "faceReflectance",
+        string as_maya_attribute_short_name = "f0",
+        string label = "Face Reflectance",
+        string page = "Fresnel",
+        string help = "Reflectance at normal incidence."
+    ]],
+    color in_edge_reflectance = color(1)
+    [[
+        string as_maya_attribute_name = "edgeReflectance",
+        string as_maya_attribute_short_name = "f90",
+        string label = "Edge Reflectance",
+        string page = "Fresnel",
+        string help = "Reflectance at grazing incidence."
+    ]],
+    int in_distribution = 0
+    [[
+        string as_maya_attribute_name = "distribution",
+        string as_maya_attribute_short_name = "mdf",
+        string widget = "mapper",
+        string options = "Beckmann:0|GGX:1",
+        string label = "Distribution",
+        string page = "Specular",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        int divider = 1
+    ]],
+    float in_roughness = 0.25
+    [[
+        string as_maya_attribute_name = "roughness",
+        string as_maya_attribute_short_name = "ro",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Roughness",
+        string page = "Specular"
+    ]],
+    float in_energy_compensation = 1.0
+    [[
+        string as_maya_attribute_name = "energyCompensation",
+        string as_maya_attribute_short_name = "ec",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Energy Compensation",
+        string page = "Specular",
+        string help = "Energy compensation, to account for energy loss with high roughness. Valid for Beckmann and GGX MDF only."
+    ]],
+    float in_anisotropy_amount = 0.0
+    [[
+        string as_maya_attribute_name = "anisotropyAmount",
+        string as_maya_attribute_short_name = "anw",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Anisotropy Amount",
+        string page = "Specular.Anisotropy"
+    ]],
+    float in_anisotropy_angle = 0.0
+    [[
+        string as_maya_attribute_name = "anisotropyAngle",
+        string as_maya_attribute_short_name = "ana",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Anisotropy Angle",
+        string page = "Specular.Anisotropy",
+        string help = "Anisotropy angle in [0,1], mapping to [0,360] degrees"
+    ]],
+    color in_anisotropy_map = color(0)
+    [[
+        string as_maya_attribute_name = "anisotropyMap",
+        string as_maya_attribute_short_name = "ama",
+        string label = "Anisotropy Vector Map",
+        string page = "Specular.Anisotropy",
+        string help = "Anisotropy vector map, with XY encoded in RG channels"
+    ]],
+#if 0
+    float in_thinfilm_thickness = 0.0
+    [[
+        string as_maya_attribute_name = "thinFilmThickness",
+        string as_maya_attribute_short_name = "tft",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Thinfilm Thickness",
+        string page = "Oxidation",
+        int divider = 1
+    ]],
+    float in_thinfilm_ior = 1.41534
+    [[
+        string as_maya_attribute_name = "thinFilmIor",
+        string as_maya_attribute_short_name = "tet",
+        float min = 1.0,
+        float softmax = 2.0,
+        float max = 3.0,
+        string label = "Thinfilm IOR",
+        string page = "Oxidation",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],       
+    int in_thinfilm_min = 380
+    [[
+        string as_maya_attribute_name = "thinFilmMin",
+        string as_maya_attribute_short_name = "tmi",
+        int min = 380,
+        int max = 780,
+        string label = "Thinfilm Lower Bound",
+        string page = "Oxidation",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string help = "Thin film thickness lower bound, in nanometers."
+    ]],
+    int in_thinfilm_max = 780
+    [[
+        string as_maya_attribute_name = "thinFilmMax",
+        string as_maya_attribute_short_name = "tma",
+        int min = 380,
+        int max = 780,
+        string label = "Thinfilm Upper Bound",
+        string page = "Oxidation",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string help = "Thin film thickness upper bound, in nanometers."
+    ]],
+#endif
+    normal in_bump_normal = N
+    [[
+        string as_maya_attribute_name = "normalCamera",
+        string as_maya_attribute_short_name = "n",
+        string label = "Bump Normal",
+        string page = "Bump",
+        string help = "The default bump normal."
+    ]],
+    int in_enable_matte = 0
+    [[
+        string as_maya_attribute_name = "enableMatte",
+        string as_maya_attribute_short_name = "ema",
+        string widget = "checkBox",
+        string label = "Enable Matte Opacity",
+        string page = "Matte Opacity",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        int divider = 1
+    ]],
+    float in_matte_opacity = 0.0
+    [[
+        string as_maya_attribute_name = "matteOpacity",
+        string as_maya_attribute_short_name = "mao",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Matte Opacity",
+        string page = "Matte Opacity",
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    color in_matte_opacity_color = color(1,0.5,0)
+    [[
+        string as_maya_attribute_name = "matteOpacityColor",
+        string as_maya_attribute_short_name = "mac",
+        string label = "Matte Opacity Color",
+        string page = "Matte Opacity",
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    int in_maximum_ray_depth = 8
+    [[
+        string as_maya_attribute_name = "maximumRayDepth",
+        string as_maya_attribute_short_name = "mrd",
+        int min = 0,
+        int max = 32,
+        int softmax = 8,
+        string label = "Ray Depth",
+        string page = "Advanced",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    vector Tn = vector(0)
+    [[
+        int lockgeom = 0,
+        int as_maya_attribute_hidden = 1,
+        string widget = "null",
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    vector Bn = vector(0)
+    [[
+        int lockgeom = 0,
+        int as_maya_attribute_hidden = 1,
+        string widget = "null",
+        int gafferNoduleLayoutVisible = 0
+    ]],
+
+    output closure color out_outColor = 0
+    [[
+        string as_maya_attribute_name = "outColor",
+        string as_maya_attribute_short_name = "oc",
+        string widget = "null"
+    ]],
+    output closure color out_outTransparency = 0
+    [[
+        string as_maya_attribute_name = "outTransparency",
+        string as_maya_attribute_short_name = "ot",
+        string widget = "null"
+    ]],
+    output closure color out_outMatteOpacity = 0
+    [[
+        string as_maya_attribute_name = "outMatteOpacity",
+        string as_maya_attribute_short_name = "om",
+        string widget = "null",
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]]
+)
+{
+    if (raytype("shadow") || raytype("transparency"))
+    {
+        return;
+    }
+
+    int ray_depth = 0;
+    int status = getattribute("path:ray_depth", ray_depth);
+
+    if (!status || ray_depth > in_maximum_ray_depth)
+    {
+        return;
+    }
+
+    if (in_enable_matte)
+    {
+        out_outMatteOpacity = in_matte_opacity *
+            in_matte_opacity_color * holdout();
+
+        out_outColor += out_outMatteOpacity;
+    }
+
+    string distribution;
+
+    if (in_distribution == 0)
+    {
+        distribution = "beckmann";
+    }
+    else if (in_distribution == 1)
+    {
+        distribution = "ggx";
+    }
+    else
+    {
+#ifdef DEBUG
+        string shadername = "";
+        getattribute("shader:shadername", shadername);
+        warning("[WARNING]: Invalid MDF in %s,\t%s:%d\n",
+                shadername, __FILE__, __LINE__);
+#endif
+    }
+
+    // Layer EDF later, but eta+k must change with temperature.
+
+    vector tangent = Tn;
+    normal Nn = normalize(in_bump_normal);
+
+    if (in_anisotropy_amount > 0.0)
+    {
+        if (isconnected(in_anisotropy_map))
+        {
+            vector vector_map = normalize(
+                (vector) in_anisotropy_map * 2.0 - 1.0);
+
+            tangent = normalize(
+                vector_map[0] * Tn +
+                vector_map[1] * Bn +
+                vector_map[2] * Nn);
+        }
+
+        if (in_anisotropy_angle > 0.0)
+        {
+            tangent = rotate(
+                tangent,
+                in_anisotropy_angle * M_2PI,
+                point(0),
+                point(Nn));
+        }
+    }
+
+    out_outColor += as_metal(
+        distribution,
+        Nn,
+        tangent,
+        in_face_reflectance,
+        in_edge_reflectance,
+        in_roughness,
+        0.0, // specular spread, used in Student's t MDF only (unused)
+        in_anisotropy_amount,
+        "energy_compensation", in_energy_compensation);
+}

--- a/src/appleseed.shaders/src/appleseed/as_space_transform.osl
+++ b/src/appleseed.shaders/src/appleseed/as_space_transform.osl
@@ -1,0 +1,135 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+shader as_space_transform
+[[
+    string as_maya_node_name = "asSpaceTransform",
+    string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
+    string help = "Coordinate system transform node.",
+    int as_maya_type_id = 0x001279f0
+]]
+(
+    point in_point = point(0)
+    [[
+        string as_maya_attribute_name = "point",
+        string as_maya_attribute_short_name = "p",
+        string label = "Point to Transform",
+        string page = "Input"
+    ]],
+    normal in_normal = normal(0)
+    [[
+        string as_maya_attribute_name = "normal",
+        string as_maya_attribute_short_name = "n",
+        string label = "Normal to Transform",
+        string page = "Input"
+    ]],
+    vector in_vector = vector(0)
+    [[
+        string as_maya_attribute_name = "vector",
+        string as_maya_attribute_short_name = "ive",
+        string label = "Vector to Transform",
+        string page = "Input",
+        int divider = 1
+    ]],
+    string in_from_space = "common"
+    [[
+        string as_maya_attribute_name = "fromSpace",
+        string as_maya_attribute_short_name = "fsp",
+        string widget = "popup",
+        string options = "common|object|shader|world|camera|screen|raster|NDC",
+        string label = "From Space",
+        string page = "Space",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    string in_to_space = "common"
+    [[
+        string as_maya_attribute_name = "toSpace",
+        string as_maya_attribute_short_name = "tsp",
+        string widget = "popup",
+        string options = "common|object|shader|world|camera|screen|raster|NDC",
+        string label = "To Space",
+        string page = "Space",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        int divider = 1
+    ]],
+    int in_normalize_vectors = 0
+    [[
+        string as_maya_attribute_name = "normalizeVectors",
+        string as_maya_attribute_sort_name = "nve",
+        string widget = "checkBox",
+        string label = "Normalize Output Vectors",
+        string page = "Space",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        int divider = 1
+    ]],
+
+    output point out_transformed_point = point(0)
+    [[
+        string as_maya_attribute_name = "outTransformedPoint",
+        string as_maya_attribute_short_name = "tpo",
+        string label = "Transformed Point"
+    ]],
+    output normal out_transformed_normal = normal(0)
+    [[
+        string as_maya_attribute_name = "outTransformedNormal",
+        string as_maya_attribute_short_name = "tno",
+        string label = "Transformed Normal"
+    ]],
+    output vector out_transformed_vector = vector(0)
+    [[
+        string as_maya_attribute_name = "outTransformedVector",
+        string as_maya_attribute_short_name = "tve",
+        string label = "Transformed Vector"
+    ]],
+    output matrix out_transform_matrix = matrix(1)
+    [[
+        string as_maya_attribute_name = "outTransformMatrix",
+        string as_maya_attribute_short_name = "oma",
+        string label = "Transform Matrix"
+    ]]
+)
+{
+    out_transformed_point = transform(in_from_space, in_to_space, in_point);
+    out_transformed_normal = transform(in_from_space, in_to_space, in_normal);
+    out_transformed_vector = transform(in_from_space, in_to_space, in_vector);
+
+    if (in_normalize_vectors)
+    {
+        out_transformed_normal = normalize(out_transformed_normal);
+        out_transformed_vector = normalize(out_transformed_vector);
+    }
+}

--- a/src/appleseed.shaders/src/appleseed/as_swizzle.osl
+++ b/src/appleseed.shaders/src/appleseed/as_swizzle.osl
@@ -1,0 +1,277 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+shader as_swizzle
+[[
+    string as_maya_node_name = "asSwizzle",
+    string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
+    string help = "RGBA or vector swizzle node.",
+    int as_maya_type_id = 0x001279f2
+]]
+(
+    color in_color = color(1)
+    [[
+        string as_maya_attribute_name = "color",
+        string as_maya_attribute_short_name = "c",
+        string label = "Color",
+        string page = "Color"
+    ]],
+    float in_alpha = 1.0
+    [[
+        string as_maya_attribute_name = "alpha",
+        string as_maya_attribute_short_name = "a",
+        string label = "Alpha Channel",
+        string page = "Color",
+        int divider = 1
+    ]],
+    int in_red_channel = 0
+    [[
+        string as_maya_attribute_name = "redChannel",
+        string as_maya_attribute_short_name = "rch",
+        string widget = "mapper",
+        string options = "Red:0|Green:1|Blue:2|Alpha:3",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Red Channel",
+        string page = "Color"
+    ]],
+    int in_green_channel = 1
+    [[
+        string as_maya_attribute_name = "greenChannel",
+        string as_maya_attribute_short_name = "gch",
+        string widget = "mapper",
+        string options = "Red:0|Green:1|Blue:2|Alpha:3",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Green Channel",
+        string page = "Color"
+    ]],
+    int in_blue_channel = 2
+    [[
+        string as_maya_attribute_name = "blueChannel",
+        string as_maya_attribute_short_name = "bch",
+        string widget = "mapper",
+        string options = "Red:0|Green:1|Blue:2|Alpha:3",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Blue Channel",
+        string page = "Color"
+    ]],    
+    int in_alpha_channel = 3
+    [[
+        string as_maya_attribute_name = "alphaChannel",
+        string as_maya_attribute_short_name = "ach",
+        string widget = "mapper",
+        string options = "Red:0|Green:1|Blue:2|Alpha:3",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Alpha Channel",
+        string page = "Color",
+        int divider = 1
+    ]],
+    int in_invert_red = 0
+    [[
+        string as_maya_attribute_name = "invertRed",
+        string as_maya_attribute_short_name = "inr",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Invert Red",
+        string page = "Color"
+    ]],
+    int in_invert_green = 0
+    [[
+        string as_maya_attribute_name = "invertgreen",
+        string as_maya_attribute_short_name = "ing",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Invert Green",
+        string page = "Color"
+    ]],
+    int in_invert_blue = 0
+    [[
+        string as_maya_attribute_name = "invertBlue",
+        string as_maya_attribute_short_name = "inb",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Invert Blue",
+        string page = "Color"
+    ]],
+    int in_invert_alpha = 0
+    [[
+        string as_maya_attribute_name = "invertAlpha",
+        string as_maya_attribute_short_name = "ina",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Invert Alpha",
+        string page = "Color"
+    ]], 
+    vector in_vector = vector(0)
+    [[
+        string as_maya_attribute_name = "vector",
+        string as_maya_attribute_short_name = "vec",
+        string label = "Vector Type",
+        string page = "Vector",
+        int divider = 1
+    ]],
+    int in_x_channel = 0
+    [[
+        string as_maya_attribute_name = "xChannel",
+        string as_maya_attribute_short_name = "xch",
+        string widget = "mapper",
+        string options = "X:0|Y:1|Z:2",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "X Component",
+        string page = "Vector"
+    ]],
+    int in_y_channel = 1
+    [[
+        string as_maya_attribute_name = "yChannel",
+        string as_maya_attribute_short_name = "ych",
+        string widget = "mapper",
+        string options = "X:0|Y:1|Z:2",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Y Component",
+        string page = "Vector"
+    ]],
+    int in_z_channel = 2
+    [[
+        string as_maya_attribute_name = "zChannel",
+        string as_maya_attribute_short_name = "zch",
+        string widget = "mapper",
+        string options = "X:0|Y:1|Z:2",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Z Component",
+        string page = "Vector",
+        int divider = 1
+    ]],
+    int in_invert_x = 0
+    [[
+        string as_maya_attribute_name = "invertX",
+        string as_maya_attribute_short_name = "inx",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Invert X",
+        string page = "Vector"
+    ]], 
+    int in_invert_y = 0
+    [[
+        string as_maya_attribute_name = "invertY",
+        string as_maya_attribute_short_name = "iny",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Invert Y",
+        string page = "Vector"
+    ]],
+    int in_invert_z = 0
+    [[
+        string as_maya_attribute_name = "invertZ",
+        string as_maya_attribute_short_name = "inz",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Invert Z",
+        string page = "Vector"
+    ]],
+
+    output color out_color = color(0)
+    [[
+        string as_maya_attribute_name = "outColor",
+        string as_maya_attribute_short_name = "oc",
+        string label = "Output Color"
+    ]],
+    output float out_alpha = 1.0
+    [[
+        string as_maya_attribute_name = "outAlpha",
+        string as_maya_attribute_short_name = "oa",
+        string label = "Output Alpha"
+    ]],
+    output vector out_vector = vector(0)
+    [[
+        string as_maya_attribute_name = "outVector",
+        string as_maya_attribute_short_name = "ov",
+        string label = "Output Vector"
+    ]]
+)
+{
+    if (isconnected(in_color) || isconnected(in_alpha))
+    {
+        float RGBA[4] = {in_color[0], in_color[1], in_color[2], in_alpha};
+        
+        out_color = color(
+            RGBA[in_red_channel],
+            RGBA[in_green_channel],
+            RGBA[in_blue_channel]);
+        
+        out_alpha = RGBA[in_alpha_channel];
+    }
+
+    if (isconnected(in_vector))
+    {
+        out_vector = vector(
+            in_vector[in_x_channel],
+            in_vector[in_y_channel],
+            in_vector[in_z_channel]);
+    }
+}

--- a/src/appleseed.shaders/src/appleseed/as_vary_color.osl
+++ b/src/appleseed.shaders/src/appleseed/as_vary_color.osl
@@ -1,0 +1,314 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "appleseed/color/as_color_transforms.h"
+#include "appleseed/math/as_math_helpers.h"
+#include "appleseed/transform/as_transform_helpers.h"
+
+shader as_varyColor
+[[
+    string as_maya_node_name = "asVaryColor",
+    string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
+    string help = "Color variation utility shader",
+    string URL = "https://appleseedhq.net",
+    int as_maya_type_id = 0x001279d3
+]]
+(
+    color in_color = color(0)
+    [[
+        string as_maya_attribute_name = "color",
+        string as_maya_attribute_short_name = "c",
+        string label = "Input Color",
+        string page = "Color",
+        string help = "Scene-linear input color.",
+        int divider = 1
+    ]],
+    int in_color_mode = 0
+    [[
+        string as_maya_attribute_name = "colorMode",
+        string as_maya_attribute_short_name = "icm",
+        string widget = "mapper",
+        string options = "Add:0|Scale:1|Override:2",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Color Mode",
+        string page = "Color",
+        string help ="Add manifold generated color to input color. Or scale it, or ignore it, setting as output the manifold generated color."
+    ]],
+    int in_manifold_type = 0
+    [[
+        string as_maya_attribute_name = "manifoldType",
+        string as_maya_attribute_short_name = "mty",
+        string widget = "mapper",
+        string options = "Object Name:0|Object Instance Name:1|Assembly Name:2|Assembly Instance Name:3|Face ID:4|String Prefix:5|String Suffix:6|Find String:7",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Type",
+        string page = "Manifold",
+        int divider = 1
+    ]],
+    string in_expression = ""
+    [[
+        string as_maya_attribute_name = "expression",
+        string as_maya_attribute_short_name = "xpr",
+        string widget = "string",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Expression",
+        string page = "Manifold.String",
+        string help = "String expression to search in the object or object instance name"
+    ]],
+    int in_domain = 0
+    [[
+        string as_maya_attribute_name = "domain",
+        string as_maya_attribute_short_name = "dmn",
+        string widget = "mapper",
+        string options = "Object Name:0|Object Instance Name:1|Assembly Name:2|Assembly Instance Name:3",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Domain",
+        string page = "Manifold.String",
+        int divider = 1
+    ]],
+    int in_seed = 0xcafe
+    [[
+        string as_maya_attribute_name = "seed",
+        string as_maya_attribute_short_name = "see",
+        string widget = "number",
+        int min = 0,
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 1,
+        int as_maya_attribute_hidden = 0,
+        int gafferNoduleLayoutVisible = 1,
+        string label = "Seed",
+        string page = "Manifold.String"
+    ]],
+    int in_variation_mode = 0
+    [[
+        string as_maya_attribute_name = "variationMode",
+        string as_maya_attribute_short_name = "vmd",
+        string widget = "mapper",
+        string options = "HSV:0|RGB:1|CIE L*a*b* 1976:2",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Variation Mode",
+        string page = "Variation"
+    ]],
+    float in_vary_hue = 0.0
+    [[
+        string as_maya_attribute_name = "varyHue",
+        string as_maya_attribute_short_name = "vhu",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Vary Hue",
+        string page = "Variation.HSV"
+    ]],
+    float in_vary_saturation = 0.0
+    [[
+        string as_maya_attribute_name = "varySaturation",
+        string as_maya_attribute_short_name = "vsa",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Vary Saturation",
+        string page = "Variation.HSV"
+    ]],
+    float in_vary_value = 0.0
+    [[
+        string as_maya_attribute_name = "varyValue",
+        string as_maya_attribute_short_name = "vva",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Vary Value",
+        string page = "Variation.HSV"
+    ]],
+    float in_vary_red = 0.0
+    [[
+        string as_maya_attribute_name = "varyRed",
+        string as_maya_attribute_short_name = "vre",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Vary Red",
+        string page = "Variation.RGB"
+    ]],
+    float in_vary_green = 0.0
+    [[
+        string as_maya_attribute_name = "varyGreen",
+        string as_maya_attribute_short_name = "vgr",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Vary Green",
+        string page = "Variation.RGB"
+    ]],
+    float in_vary_blue = 0.0
+    [[
+        string as_maya_attribute_name = "varyBlue",
+        string as_maya_attribute_short_name = "vbl",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Vary Blue",
+        string page = "Variation.RGB"
+    ]],
+    float in_vary_lstar = 0.0
+    [[
+        string as_maya_attribute_name = "varyLStar",
+        string as_maya_attribute_short_name = "vls",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Vary L*",
+        string page = "Variation.CIE L*a*b* 1976"
+    ]],
+    float in_vary_astar = 0.0
+    [[
+        string as_maya_attribute_name = "varyAStar",
+        string as_maya_attribute_short_name = "vas",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Vary a*",
+        string page = "Variation.CIE L*a*b* 1976"
+    ]],
+    float in_vary_bstar = 0.0
+    [[
+        string as_maya_attribute_name = "varyBStar",
+        string as_maya_attribute_short_name = "vbs",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Vary b*",
+        string page = "Variation.CIE L*a*b* 1976"
+    ]],
+    output color out_outColor = color(0)
+    [[
+        string as_maya_attribute_name = "outColor",
+        string as_maya_attribute_short_name = "oc",
+        string label = "Output Color"
+    ]],
+    output int out_outHash = 0
+    [[
+        string as_maya_attribute_name = "outHash",
+        string as_maya_attribute_short_name = "osh",
+        string label = "Output Hash"
+    ]],
+    output color out_outID = color(0)
+    [[
+        string as_maya_attribute_name = "outID",
+        string as_maya_attribute_short_name = "oid",
+        string label = "Output ID"
+    ]],
+    output float out_outGreyscale = 0.0
+    [[
+        string as_maya_attribute_name = "outGreyscale",
+        string as_maya_attribute_short_name = "ogr",
+        string label = "Output Greyscale"
+    ]]
+)
+{
+    if (in_color == color(0) && in_color_mode == 1)
+    {
+        out_outColor = color(0); // scaling mode w/input color zero
+        return;
+    }
+
+    compute_id_manifold(
+        in_manifold_type,
+        in_domain,
+        in_seed,
+        in_expression,
+        out_outHash,
+        out_outID,
+        out_outGreyscale);
+    
+    // Input color has a <color model> offset, generated the manifold IDs,
+    // whose offset is scaled on a per-component basis, and can then be
+    // added back to the original color, scale it, or override it.
+
+    color offset_color = out_outID;
+
+    if (in_variation_mode == 0)
+    {
+        color offset_hsv = transform_RGB_to_HSV(offset_color);
+
+        offset_hsv *= color(in_vary_hue, in_vary_saturation, in_vary_value);
+
+        offset_color = transform_HSV_to_RGB(offset_hsv);
+    }
+    else if (in_variation_mode == 1)
+    {
+        offset_color *= color(in_vary_red, in_vary_green, in_vary_blue);
+    }
+    else if (in_variation_mode == 2)
+    {
+        // We have to get the working space RGBW primaries. For now, set
+        // RGB primaries to sRGB|Rec.709, white point to D65.
+        //
+        color CIELAB = transform_linear_RGB_to_Lab(
+            in_color,
+            "Rec.709",
+            "D65");
+
+        CIELAB *= color(in_vary_lstar, in_vary_astar, in_vary_bstar);
+
+        offset_color *= transform_Lab_to_linear_RGB(
+            CIELAB,
+            "Rec.709",
+            "D65");
+    }
+    else
+    {
+#ifdef DEBUG
+        string shadername = "";
+        getattribute("shader:shadername", shadername);
+
+        warning("[WARNING]: Invalid variation mode set in %s,\t%s:%d\n",
+                shadername, __FILE__, __LINE__);
+#endif
+    }
+    
+    if (in_color_mode == 0)
+    {
+        out_outColor = in_color + offset_color;
+    }
+    else if (in_color_mode == 1)
+    {
+        out_outColor = in_color * offset_color;
+    }
+    else
+    {
+        out_outColor = offset_color;
+    }
+
+    out_outColor = clamp(out_outColor, color(0), color(1));
+}

--- a/src/appleseed.shaders/stdosl.h
+++ b/src/appleseed.shaders/stdosl.h
@@ -237,7 +237,7 @@ void fresnel (vector I, normal N, float eta,
         F *= sqr (beta / (g+c));
         Kr = F;
         Kt = (1.0 - Kr) * eta*eta;
-        // OPT: the following recomputes some of the above values, but it 
+        // OPT: the following recomputes some of the above values, but it
         // gives us the same result as if the shader-writer called refract()
         T = refract(I, N, eta);
     } else {
@@ -425,7 +425,7 @@ color transformc (string from, string to, color x)
     return transformc (to, r);
 }
 
- 
+
 
 // Matrix functions
 

--- a/src/appleseed.shaders/stdosl.h
+++ b/src/appleseed.shaders/stdosl.h
@@ -97,6 +97,7 @@ PERCOMP1 (cosh)
 PERCOMP1 (sinh)
 PERCOMP1 (tanh)
 PERCOMP2F (pow)
+PERCOMP2 (pow)
 PERCOMP1 (exp)
 PERCOMP1 (exp2)
 PERCOMP1 (expm1)
@@ -164,6 +165,23 @@ color  mix (color  x, color  y, color  a) BUILTIN;
 color  mix (color  x, color  y, float  a) BUILTIN;
 float  mix (float  x, float  y, float  a) BUILTIN;
 #endif
+closure color mix (closure color x, closure color y, float a) { return x*(1-a) + y*a; }
+closure color mix (closure color x, closure color y, color a) { return x*(1-a) + y*a; }
+
+normal select (normal x, normal y, normal cond) BUILTIN;
+vector select (vector x, vector y, vector cond) BUILTIN;
+point  select (point  x, point  y, point  cond) BUILTIN;
+color  select (color  x, color  y, color  cond) BUILTIN;
+float  select (float  x, float  y, float  cond) BUILTIN;
+normal select (normal x, normal y, float cond) BUILTIN;
+vector select (vector x, vector y, float cond) BUILTIN;
+point  select (point  x, point  y, float cond) BUILTIN;
+color  select (color  x, color  y, float cond) BUILTIN;
+normal select (normal x, normal y, int cond) BUILTIN;
+vector select (vector x, vector y, int cond) BUILTIN;
+point  select (point  x, point  y, int cond) BUILTIN;
+color  select (color  x, color  y, int cond) BUILTIN;
+float  select (float  x, float  y, int cond) BUILTIN;
 int isnan (float x) BUILTIN;
 int isinf (float x) BUILTIN;
 int isfinite (float x) BUILTIN;
@@ -187,8 +205,14 @@ float distance (point a, point b, point q)
 }
 normal normalize (normal v) BUILTIN;
 vector normalize (vector v) BUILTIN;
-vector faceforward (vector N, vector I, vector Nref) BUILTIN;
-vector faceforward (vector N, vector I) BUILTIN;
+vector faceforward (vector N, vector I, vector Nref)
+{
+    return (dot(I, Nref) > 0) ? -N : N;
+}
+vector faceforward (vector N, vector I)
+{
+    return faceforward(N, I, Ng);
+}
 vector reflect (vector I, vector N) { return I - 2*dot(N,I)*N; }
 vector refract (vector I, vector N, float eta) {
     float IdotN = dot (I, N);
@@ -213,7 +237,7 @@ void fresnel (vector I, normal N, float eta,
         F *= sqr (beta / (g+c));
         Kr = F;
         Kt = (1.0 - Kr) * eta*eta;
-        // OPT: the following recomputes some of the above values, but it
+        // OPT: the following recomputes some of the above values, but it 
         // gives us the same result as if the shader-writer called refract()
         T = refract(I, N, eta);
     } else {
@@ -401,7 +425,7 @@ color transformc (string from, string to, color x)
     return transformc (to, r);
 }
 
-
+ 
 
 // Matrix functions
 
@@ -418,6 +442,19 @@ vector step (vector edge, vector x) BUILTIN;
 normal step (normal edge, normal x) BUILTIN;
 float step (float edge, float x) BUILTIN;
 float smoothstep (float edge0, float edge1, float x) BUILTIN;
+
+color smoothstep (color edge0, color edge1, color in)
+{
+    return color (smoothstep(edge0[0], edge1[0], in[0]),
+                  smoothstep(edge0[1], edge1[1], in[1]),
+                  smoothstep(edge0[2], edge1[2], in[2]));
+}
+vector smoothstep (vector edge0, vector edge1, vector in)
+{
+    return vector (smoothstep(edge0[0], edge1[0], in[0]),
+                   smoothstep(edge0[1], edge1[1], in[1]),
+                   smoothstep(edge0[2], edge1[2], in[2]));
+}
 
 float linearstep (float edge0, float edge1, float x) {
     float result;
@@ -462,6 +499,14 @@ float aastep (float edge, float s) {
     return aastep (edge, s, filterwidth(edge), filterwidth(s));
 }
 
+
+// Noise and related functions
+
+int hash (int u) BUILTIN;
+int hash (float u) BUILTIN;
+int hash (float u, float v) BUILTIN;
+int hash (point p) BUILTIN;
+int hash (point p, float t) BUILTIN;
 
 // Derivatives and area operators
 
@@ -510,6 +555,7 @@ closure color diffuse(normal N) BUILTIN;
 closure color oren_nayar (normal N, float sigma) BUILTIN;
 closure color translucent(normal N) BUILTIN;
 closure color phong(normal N, float exponent) BUILTIN;
+//closure color ward(normal N, vector T,float ax, float ay) BUILTIN;
 closure color microfacet(
     string  distribution,
     normal  N,
@@ -566,7 +612,6 @@ closure color microfacet(
         eta,
         refr);
 }
-
 closure color reflection(normal N, float eta) BUILTIN;
 closure color reflection(normal N) { return reflection (N, 50.0); }
 closure color refraction(normal N, float eta)
@@ -592,9 +637,6 @@ closure color subsurface(float eta, float g, color mfp, color albedo)
 {
     return as_subsurface("better_dipole", N, albedo, mfp, eta);
 }
-
-// Not supported.
-//closure color ward(normal N, vector T,float ax, float ay) BUILTIN;
 
 // Renderer state
 int backfacing () BUILTIN;

--- a/src/appleseed/renderer/kernel/rendering/rendererservices.cpp
+++ b/src/appleseed/renderer/kernel/rendering/rendererservices.cpp
@@ -102,6 +102,8 @@ RendererServices::RendererServices(
     m_global_attr_getters[OIIO::ustring("object:object_instance_id")] = &RendererServices::get_attr_object_instance_id;
     m_global_attr_getters[OIIO::ustring("object:object_instance_index")] = &RendererServices::get_attr_object_instance_index;
     m_global_attr_getters[OIIO::ustring("object:assembly_instance_id")] = &RendererServices::get_attr_assembly_instance_id;
+    m_global_attr_getters[OIIO::ustring("object:assembly_name")] = &RendererServices::get_attr_assembly_name;
+    m_global_attr_getters[OIIO::ustring("object:assembly_instance_name")] = &RendererServices::get_attr_assembly_instance_name;
     m_global_attr_getters[OIIO::ustring("object:object_instance_name")] = &RendererServices::get_attr_object_instance_name;
     m_global_attr_getters[OIIO::ustring("object:object_name")] = &RendererServices::get_attr_object_name;
     m_global_attr_getters[OIIO::ustring("camera:resolution")] = &RendererServices::get_attr_camera_resolution;
@@ -611,6 +613,50 @@ IMPLEMENT_ATTR_GETTER(assembly_instance_id)
             reinterpret_cast<const ShadingPoint*>(sg->renderstate);
         reinterpret_cast<int*>(val)[0] =
             static_cast<int>(shading_point->get_assembly_instance().get_uid());
+
+        if (derivs)
+            clear_derivatives(type, val);
+
+        return true;
+    }
+
+    return false;
+}
+
+IMPLEMENT_ATTR_GETTER(assembly_instance_name)
+{
+    if (type == OIIO::TypeDesc::TypeString)
+    {
+        const ShadingPoint* shading_point =
+            reinterpret_cast<const ShadingPoint*>(sg->renderstate);
+
+        const AssemblyInstance& assembly_instance = shading_point->get_assembly_instance();
+        const OIIO::ustring* name =
+            reinterpret_cast<const OIIO::ustring*>(assembly_instance.get_name_as_ustring());
+
+        reinterpret_cast<OIIO::ustring*>(val)[0] = *name;
+
+        if (derivs)
+            clear_derivatives(type, val);
+
+        return true;
+    }
+
+    return false;
+}
+
+IMPLEMENT_ATTR_GETTER(assembly_name)
+{
+    if (type == OIIO::TypeDesc::TypeString)
+    {
+        const ShadingPoint* shading_point =
+            reinterpret_cast<const ShadingPoint*>(sg->renderstate);
+
+        const Assembly& assembly = shading_point->get_assembly();
+        const OIIO::ustring* name =
+            reinterpret_cast<const OIIO::ustring*>(assembly.get_name_as_ustring());
+
+        reinterpret_cast<OIIO::ustring*>(val)[0] = *name;
 
         if (derivs)
             clear_derivatives(type, val);

--- a/src/appleseed/renderer/kernel/rendering/rendererservices.h
+++ b/src/appleseed/renderer/kernel/rendering/rendererservices.h
@@ -303,6 +303,8 @@ class RendererServices
     DECLARE_ATTR_GETTER(object_instance_id);
     DECLARE_ATTR_GETTER(object_instance_index);
     DECLARE_ATTR_GETTER(assembly_instance_id);
+    DECLARE_ATTR_GETTER(assembly_instance_name);    
+    DECLARE_ATTR_GETTER(assembly_name);
     DECLARE_ATTR_GETTER(object_instance_name);
     DECLARE_ATTR_GETTER(object_name);
 


### PR DESCRIPTION
In order to have color, texture variation nodes, we need also the instance and assembly names for getattribute(). With OSL 1.9 our closure mix() is removed since this now a builtin. The hash(), hashnoise() are required for further work on fractal nodes as well.