### PR TITLE
Add rayswitch, layerShader, vectorField nodes

### DIFF
--- a/src/appleseed.shaders/CMakeLists.txt
+++ b/src/appleseed.shaders/CMakeLists.txt
@@ -417,6 +417,7 @@ source_group ("src\\maya" FILES
 )
 
 set (src_appleseed_sources
+     src/appleseed/as_anisotropy_vector_field.osl
      src/appleseed/as_attributes.osl
      src/appleseed/as_color_transform.osl
      src/appleseed/as_create_mask.osl
@@ -426,11 +427,13 @@ set (src_appleseed_sources
      src/appleseed/as_glass.osl
      src/appleseed/as_globals.osl
      src/appleseed/as_id_manifold.osl
+     src/appleseed/as_layer_shader.osl
      src/appleseed/as_luminance.osl
      src/appleseed/as_metal.osl
      src/appleseed/as_noise2d.osl
      src/appleseed/as_noise3d.osl
      src/appleseed/as_plastic.osl
+     src/appleseed/as_ray_switch.osl
      src/appleseed/as_space_transform.osl
      src/appleseed/as_standard_surface.osl
      src/appleseed/as_swizzle.osl

--- a/src/appleseed.shaders/src/appleseed/as_anisotropy_vector_field.osl
+++ b/src/appleseed.shaders/src/appleseed/as_anisotropy_vector_field.osl
@@ -1,0 +1,182 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+shader as_anisotropy_vector_field
+[[
+    string as_maya_node_name = "asAnisotropyVectorField",
+    string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
+    string help = "Anisotropy vector field node.",
+    string icon = "asAnisotropyVectorField.png",
+    int as_maya_type_id = 0x001278e0
+]]
+(
+    float in_rotation_angle = 0.0
+    [[
+        string as_maya_attribute_name = "rotationAngle",
+        string as_maya_attribute_short_name = "rta",
+        float min = -360.0,
+        float max = 360.0,
+        string widget = "angle",
+        string label = "Rotation Angle",
+        string page = "Field",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 1,
+        int as_maya_attribute_hidden = 0,
+        int gafferNoduleLayoutVisible = 1
+    ]],
+    color in_color = color(1)
+    [[
+        string as_maya_attribute_name = "color",
+        string as_maya_attribute_short_name = "c",
+        string label = "Front Color",
+        string page = "Field"
+    ]],
+    int in_field_mode = 0
+    [[
+        string as_maya_attribute_name = "fieldMode",
+        string as_maya_attribute_short_name = "fm",
+        string widget = "mapper",
+        string options = "Red/Green as XY:0|Red/Blue as XY:1",
+        string label = "Field Mode",
+        string page = "Field",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    float in_rotation_value = 0.0
+    [[
+        string as_maya_attribute_name = "rotationValue",
+        string as_maya_attribute_short_name = "rtv",
+        float min = 0.0,
+        float max = 1.0,
+        string help = "Rotation value, mapping [0,1] to [0,360] degrees",
+        string label = "Rotation Value",
+        string page = "Rotation"
+    ]],
+    int in_rotation_mode = 0
+    [[
+        string as_maya_attribute_name = "rotationMode",
+        string as_maya_attribute_short_name = "rtm",
+        string widget = "mapper",
+        string options = "Centered:0|Absolute:1",
+        string help = "Scale the rotation value to [-1,1] and apply rotation to both directions around the main anisotropy vector,\n or leave it at [0,1] range, and add it.",
+        string label = "Rotation Mode",
+        string page = "Rotation",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    int in_normalize_output = 1
+    [[
+        string as_maya_attribute_name = "normalizeOutput",
+        string as_maya_attribute_short_name = "no",
+        string widget = "checkBox",
+        string label = "Normalize Output",
+        string page = "Output",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    normal in_surface_normal = N
+    [[
+        string as_maya_attribute_name = "normalCamera",
+        string as_maya_attribute_short_name = "n",
+        string label = "Surface Normal",
+        string page = "Normal"
+    ]],
+    vector Tn = vector(0)
+    [[
+        int lockgeom = 0,
+        string widget = "null",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    vector Bn = vector(0)
+    [[
+        int lockgeom = 0,
+        string widget = "null",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+
+    output vector out_anisotropy_vector = vector(0)
+    [[
+        string as_maya_attribute_name = "anisotropyVector",
+        string as_maya_attribute_short_name = "av",
+        string label = "Anisotropy Vector"
+    ]]     
+)
+{
+    normal Nn = normalize(in_surface_normal);
+    vector tangent = Tn;
+
+    if (in_rotation_angle != 0.0)
+    {
+        tangent = rotate(
+            tangent,
+            radians(in_rotation_angle),
+            point(0),
+            point(Nn));
+    }
+    
+    if (isconnected(in_color))
+    {
+        vector vector_map = normalize((vector) in_color * 2.0 - 1.0);
+
+        tangent = normalize(
+            vector_map[0] * Tn +
+            vector_map[1] * Bn + 
+            vector_map[2] * Nn);
+    }
+
+    if (in_rotation_value > 0.0 || isconnected(in_rotation_value))
+    {
+        float offset = (in_rotation_mode == 0)
+            ? (in_rotation_value * 2.0 - 1.0) * M_2PI
+            : in_rotation_value * M_2PI;
+
+        if (offset != 0)
+        {
+            tangent = rotate(tangent, offset, point(0), point(Nn));
+        }
+    }
+
+    if (in_normalize_output)
+    {
+        tangent = normalize(tangent);
+    }
+
+    out_anisotropy_vector = tangent;
+}

--- a/src/appleseed.shaders/src/appleseed/as_attributes.osl
+++ b/src/appleseed.shaders/src/appleseed/as_attributes.osl
@@ -31,6 +31,7 @@ shader as_attributes
     string as_maya_node_name = "asAttributes",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
     string help = "OSL and appleseed attributes.",
+    string icon = "asAttributes.png",
     int as_maya_type_id = 0x001279f8
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_color_transform.osl
+++ b/src/appleseed.shaders/src/appleseed/as_color_transform.osl
@@ -34,6 +34,7 @@ shader as_color_transform
     string as_maya_node_name = "asColorTransform",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
     string help = "Transforms a color to another color model. Input color MUST be linearized.",
+    string icon = "asColorTransform.png",
     int as_maya_type_id = 0x001279c8
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_create_mask.osl
+++ b/src/appleseed.shaders/src/appleseed/as_create_mask.osl
@@ -35,6 +35,7 @@ shader as_create_mask
     string as_maya_node_name = "asCreateMask",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
     string help = "Creates a greyscale mask from an input color or grey value.",
+    string icon = "asCreateMask",
     int as_maya_type_id = 0x001279e1
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_disney_material.osl
+++ b/src/appleseed.shaders/src/appleseed/as_disney_material.osl
@@ -33,6 +33,7 @@ shader as_disney_material
     string as_maya_node_name = "asDisneyMaterial",
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
     string help = "Disney material",
+    string icon = "asDisneyMaterial.png",
     int as_maya_type_id = 0x001279c3
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_double_shade.osl
+++ b/src/appleseed.shaders/src/appleseed/as_double_shade.osl
@@ -31,6 +31,7 @@ shader as_double_shade
     string as_maya_node_name = "asDoubleShade",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
     string help = "Double shading node.",
+    string icon = "asDoubleShade.png",
     int as_maya_type_id = 0x001279db
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_falloff_angle.osl
+++ b/src/appleseed.shaders/src/appleseed/as_falloff_angle.osl
@@ -33,6 +33,7 @@ shader as_falloff_angle
     string as_maya_node_name = "asFalloffAngle",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
     string help = "Double shading node.",
+    string icon = "asFalloffAngle",
     int as_maya_type_id = 0x001279f7
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_glass.osl
+++ b/src/appleseed.shaders/src/appleseed/as_glass.osl
@@ -31,6 +31,7 @@ shader as_glass
     string as_maya_node_name = "asGlass",
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
     string help = "Glass material",
+    string icon = "asGlass",
     int as_maya_type_id = 0x001279c4
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_globals.osl
+++ b/src/appleseed.shaders/src/appleseed/as_globals.osl
@@ -31,6 +31,7 @@ shader as_globals
     string as_maya_node_name = "asGlobals",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
     string help = "OSL global variables.",
+    string icon = "asGlobals.png",
     int as_maya_type_id = 0x001279ef
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_id_manifold.osl
+++ b/src/appleseed.shaders/src/appleseed/as_id_manifold.osl
@@ -33,7 +33,7 @@ shader as_id_manifold
     string as_maya_node_name = "asIdManifold",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
     string help = "ID manifold utility shader",
-    string URL = "https://appleseedhq.net",
+    string icon = "asIdManifold",
     int as_maya_type_id = 0x001279d9
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_layer_shader.osl
+++ b/src/appleseed.shaders/src/appleseed/as_layer_shader.osl
@@ -1,0 +1,316 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+shader as_layer_shader
+[[
+    string as_maya_node_name = "asLayerShader",
+    string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
+    string help = "Shader layering node.",
+    string icon = "asLayerShader.png",
+    int as_maya_type_id = 0x001279dd
+]]
+(
+    closure color in_color = 0
+    [[
+        string as_maya_attribute_name = "color",
+        string as_maya_attribute_short_name = "c",
+        string label = "Layer 0",
+        string page = "Layers"
+    ]],
+    float in_weight = 1.0
+    [[
+        string as_maya_attribute_name = "weight",
+        string as_maya_attribute_short_name = "w",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Layer 0 Weight",
+        string page = "Layers"
+    ]],
+    int in_layer_visibility = 1
+    [[
+        string as_maya_attribute_name = "layerVisibility",
+        string as_maya_attribute_short_name = "lv",
+        string widget = "checkBox",
+        string label = "Layer 0 Visibility",
+        string page = "Layers",
+        int divider = 1,
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    closure color in_color1 = 0
+    [[
+        string as_maya_attribute_name = "color1",
+        string as_maya_attribute_short_name = "c1",
+        string label = "Layer 1",
+        string page = "Layers"
+    ]],
+    float in_weight1 = 1.0
+    [[
+        string as_maya_attribute_name = "weight1",
+        string as_maya_attribute_short_name = "w1",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Layer 1 Weight",
+        string page = "Layers"
+    ]],
+    int in_layer_visibility1 = 0
+    [[
+        string as_maya_attribute_name = "layerVisibility1",
+        string as_maya_attribute_short_name = "lv1",
+        string widget = "checkBox",
+        string label = "Layer 1 Visibility",
+        string page = "Layers",
+        int divider = 1,
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],  
+    closure color in_color2 = 0
+    [[
+        string as_maya_attribute_name = "color2",
+        string as_maya_attribute_short_name = "c2",
+        string label = "Layer 2",
+        string page = "Layers"
+    ]],
+    float in_weight2 = 1.0
+    [[
+        string as_maya_attribute_name = "weight2",
+        string as_maya_attribute_short_name = "w2",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Layer 2 Weight",
+        string page = "Layers"
+    ]],
+    int in_layer_visibility2 = 0
+    [[
+        string as_maya_attribute_name = "layerVisibility2",
+        string as_maya_attribute_short_name = "lv2",
+        string widget = "checkBox",
+        string label = "Layer 2 Visibility",
+        string page = "Layers",
+        int divider = 2,
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    closure color in_color3 = 0
+    [[
+        string as_maya_attribute_name = "color3",
+        string as_maya_attribute_short_name = "c3",
+        string label = "Layer 3",
+        string page = "Layers"
+    ]],
+    float in_weight3 = 1.0
+    [[
+        string as_maya_attribute_name = "weight3",
+        string as_maya_attribute_short_name = "w3",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Layer 3 Weight",
+        string page = "Layers"
+    ]],
+    int in_layer_visibility3 = 0
+    [[
+        string as_maya_attribute_name = "layerVisibility3",
+        string as_maya_attribute_short_name = "lv3",
+        string widget = "checkBox",
+        string label = "Layer 3 Visibility",
+        string page = "Layers",
+        int divider = 3,
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    closure color in_color4 = 0
+    [[
+        string as_maya_attribute_name = "color4",
+        string as_maya_attribute_short_name = "c4",
+        string label = "Layer 4",
+        string page = "Layers"
+    ]],
+    float in_weight4 = 1.0
+    [[
+        string as_maya_attribute_name = "weight4",
+        string as_maya_attribute_short_name = "w4",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Layer 4 Weight",
+        string page = "Layers"
+    ]],
+    int in_layer_visibility4 = 0
+    [[
+        string as_maya_attribute_name = "layerVisibility4",
+        string as_maya_attribute_short_name = "lv4",
+        string widget = "checkBox",
+        string label = "Layer 4 Visibility",
+        string page = "Layers",
+        int divider = 4,
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    closure color in_color5 = 0
+    [[
+        string as_maya_attribute_name = "color5",
+        string as_maya_attribute_short_name = "c5",
+        string label = "Layer 5",
+        string page = "Layers"
+    ]],
+    float in_weight5 = 1.0
+    [[
+        string as_maya_attribute_name = "weight5",
+        string as_maya_attribute_short_name = "w5",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Layer 5 Weight",
+        string page = "Layers"
+    ]],
+    int in_layer_visibility5 = 0
+    [[
+        string as_maya_attribute_name = "layerVisibility5",
+        string as_maya_attribute_short_name = "lv5",
+        string widget = "checkBox",
+        string label = "Layer 5 Visibility",
+        string page = "Layers",
+        int divider = 5,
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]], 
+    closure color in_color6 = 0
+    [[
+        string as_maya_attribute_name = "color6",
+        string as_maya_attribute_short_name = "c6",
+        string label = "Layer 6",
+        string page = "Layers"
+    ]],
+    float in_weight6 = 1.0
+    [[
+        string as_maya_attribute_name = "weight6",
+        string as_maya_attribute_short_name = "w6",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Layer 6 Weight",
+        string page = "Layers"
+    ]],
+    int in_layer_visibility6 = 0
+    [[
+        string as_maya_attribute_name = "layerVisibility6",
+        string as_maya_attribute_short_name = "lv6",
+        string widget = "checkBox",
+        string label = "Layer 6 Visibility",
+        string page = "Layers",
+        int divider = 6,
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]], 
+    closure color in_color7 = 0
+    [[
+        string as_maya_attribute_name = "color7",
+        string as_maya_attribute_short_name = "c7",
+        string label = "Layer 7",
+        string page = "Layers"
+    ]],
+    float in_weight7 = 1.0
+    [[
+        string as_maya_attribute_name = "weight7",
+        string as_maya_attribute_short_name = "w7",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Layer 7 Weight",
+        string page = "Layers"
+    ]],
+    int in_layer_visibility7 = 0
+    [[
+        string as_maya_attribute_name = "layerVisibility7",
+        string as_maya_attribute_short_name = "lv7",
+        string widget = "checkBox",
+        string label = "Layer 7 Visibility",
+        string page = "Layers",
+        int divider = 7,
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+
+    output closure color out_color = 0
+    [[
+        string as_maya_attribute_name = "outColor",
+        string as_maya_attribute_short_name = "oc",
+        string widget = "null",
+        string label = "Output"
+    ]]
+)
+{
+    closure color result = 0;
+
+    if (in_layer_visibility)
+    {
+        result += in_weight * in_color;
+    }
+    if (in_layer_visibility1)
+    {
+        result = mix(result, in_color1, in_weight1);
+    }
+    if (in_layer_visibility2)
+    {
+        result = mix(result, in_color2, in_weight2);
+    }
+    if (in_layer_visibility3)
+    {
+        result = mix(result, in_color3, in_weight3);
+    }
+    if (in_layer_visibility4)
+    {
+        result = mix(result, in_color4, in_weight4);
+    }
+    if (in_layer_visibility5)
+    {
+        result = mix(result, in_color5, in_weight5);
+    }
+    if (in_layer_visibility6)
+    {
+        result = mix(result, in_color6, in_weight6);
+    }
+    if (in_layer_visibility7)
+    {
+        result = mix(result, in_color7, in_weight7);
+    }
+
+    out_color = result;
+}

--- a/src/appleseed.shaders/src/appleseed/as_luminance.osl
+++ b/src/appleseed.shaders/src/appleseed/as_luminance.osl
@@ -35,6 +35,7 @@ shader as_luminance
     string as_maya_node_name = "asLuminance",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
     string help = "Primaries and illuminants aware relative luminance node",
+    string icon = "asLuminance.png",
     int as_maya_type_id = 0x001279cd
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_metal.osl
+++ b/src/appleseed.shaders/src/appleseed/as_metal.osl
@@ -33,6 +33,7 @@ shader as_metal
     string as_maya_node_name = "asMetal",
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
     string help = "Metal material",
+    string icon = "asMetal.png",
     int as_maya_type_id = 0x001279f9
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_noise2d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_noise2d.osl
@@ -37,6 +37,7 @@ shader as_noise2d
     string as_maya_node_name = "asNoise2D",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/texture/2d:swatch/AppleseedRenderSwatch:texture",
     int as_maya_type_id = 0x001279cb,
+    string icon = "asNoise2d.png",
     string URL = "http://appleseedhq.net/"
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_noise3d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_noise3d.osl
@@ -37,6 +37,7 @@ shader as_noise3d
     string as_maya_node_name = "asNoise3D",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/texture/3d:swatch/AppleseedRenderSwatch:texture",
     int as_maya_type_id = 0x001279ca,
+    string icon = "asNoise3d",
     string URL = "http://appleseedhq.net/"
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_plastic.osl
+++ b/src/appleseed.shaders/src/appleseed/as_plastic.osl
@@ -31,6 +31,7 @@ shader as_plastic
     string as_maya_node_name = "asPlastic",
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
     string help = "Plastic material",
+    string icon = "asPlastic.png",
     int as_maya_type_id = 0x001279d7
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_ray_switch.osl
+++ b/src/appleseed.shaders/src/appleseed/as_ray_switch.osl
@@ -148,7 +148,7 @@ shader as_ray_switch
 #ifdef DEBUG
         string shadername = "";
         getattribute("shader:shadername", shadername);
-        warning("[DEBUG!]: Unknown Ray Type in %s, %s:%d\n",
+        warning("[WARNING]: Unknown Ray Type in %s, %s:%d\n",
                 shadername, __FILE__, __LINE__);
 #endif
     }

--- a/src/appleseed.shaders/src/appleseed/as_ray_switch.osl
+++ b/src/appleseed.shaders/src/appleseed/as_ray_switch.osl
@@ -1,0 +1,155 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+shader as_ray_switch
+[[
+    string as_maya_node_name = "asRaySwitch",
+    string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
+    string help = "Ray switch utility node.",
+    string icon = "asRaySwitch.png",
+    int as_maya_type_id = 0x001279dc
+]]
+(
+    color in_color = color(1)
+    [[
+        string as_maya_attribute_name = "color",
+        string as_maya_attribute_short_name = "c",
+        string label = "Camera Ray Color",
+        string page = "Color"
+    ]],
+    color in_color_light = color(0)
+    [[
+        string as_maya_attribute_name = "colorLight",
+        string as_maya_attribute_short_name = "cli",
+        string label = "Light Ray Color",
+        string page = "Color"
+    ]],
+    color in_color_shadow = color(0)
+    [[
+        string as_maya_attribute_name = "colorShadow",
+        string as_maya_attribute_short_name = "csh",
+        string label = "Shadow Ray Color",
+        string page = "Color"
+    ]],
+    color in_color_transparency = color(0)
+    [[
+        string as_maya_attribute_name = "colorTransparency",
+        string as_maya_attribute_short_name = "ctr",
+        string label = "Transparency Ray Color",
+        string page = "Color"
+    ]],
+    color in_color_probe = color(0)
+    [[
+        string as_maya_attribute_name = "colorProbe",
+        string as_maya_attribute_short_name = "cpr",
+        string label = "Probe Ray Color",
+        string page = "Color"
+    ]],
+    color in_color_diffuse = color(0)
+    [[
+        string as_maya_attribute_name = "colorDiffuse",
+        string as_maya_attribute_short_name = "cde",
+        string label = "Diffuse Ray Color",
+        string page = "Color"
+    ]],
+    color in_color_glossy = color(0)
+    [[
+        string as_maya_attribute_name = "colorGlossy",
+        string as_maya_attribute_short_name = "cgl",
+        string label = "Glossy Ray Color",
+        string page = "Color"
+    ]],
+    color in_color_specular = color(0)
+    [[
+        string as_maya_attribute_name = "colorSpecular",
+        string as_maya_attribute_short_name = "csp",
+        string label = "Specular Ray Color",
+        string page = "Color"
+    ]],
+    color in_color_subsurface = color(0)
+    [[
+        string as_maya_attribute_name = "colorSubsurface",
+        string as_maya_attribute_short_name = "csu",
+        string label = "Subsurface Ray Color",
+        string page = "Color"
+    ]],
+
+    output color out_color = color(0)
+    [[
+        string as_maya_attribute_name = "outColor",
+        string as_maya_attribute_short_name = "oc",
+        string label = "Output Color"
+    ]]      
+)
+{
+    if (raytype("camera"))
+    {
+        out_color = in_color;
+    }
+    else if (raytype("light"))
+    {
+        out_color = in_color_light;
+    }
+    else if (raytype("shadow"))
+    {
+        out_color = in_color_shadow;
+    }
+    else if (raytype("transparency"))
+    {
+        out_color = in_color_transparency;
+    }
+    else if (raytype("probe"))
+    {
+        out_color = in_color_probe;
+    }
+    else if (raytype("diffuse"))
+    {
+        out_color = in_color_diffuse;
+    }
+    else if (raytype("glossy"))
+    {
+        out_color = in_color_glossy;
+    }
+    else if (raytype("specular"))
+    {
+        out_color = in_color_specular;
+    }
+    else if (raytype("subsurface"))
+    {
+        out_color = in_color_subsurface;
+    }
+    else
+    {
+#ifdef DEBUG
+        string shadername = "";
+        getattribute("shader:shadername", shadername);
+        warning("[DEBUG!]: Unknown Ray Type in %s, %s:%d\n",
+                shadername, __FILE__, __LINE__);
+#endif
+    }
+}

--- a/src/appleseed.shaders/src/appleseed/as_space_transform.osl
+++ b/src/appleseed.shaders/src/appleseed/as_space_transform.osl
@@ -31,6 +31,7 @@ shader as_space_transform
     string as_maya_node_name = "asSpaceTransform",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
     string help = "Coordinate system transform node.",
+    string icon = "asSpaceTransform.png",
     int as_maya_type_id = 0x001279f0
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
@@ -34,6 +34,7 @@ shader as_standard_surface
     string as_maya_node_name = "asStandardSurface",
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
     string help = "Standard Surface Shader",
+    string icon = "asStandardSurface",
     int as_maya_type_id = 0x001279d4
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_swizzle.osl
+++ b/src/appleseed.shaders/src/appleseed/as_swizzle.osl
@@ -31,6 +31,7 @@ shader as_swizzle
     string as_maya_node_name = "asSwizzle",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
     string help = "RGBA or vector swizzle node.",
+    string icon = "asSwizzle.png",
     int as_maya_type_id = 0x001279f2
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_vary_color.osl
+++ b/src/appleseed.shaders/src/appleseed/as_vary_color.osl
@@ -35,7 +35,7 @@ shader as_varyColor
     string as_maya_node_name = "asVaryColor",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility:swatch/AppleseedRenderSwatch",
     string help = "Color variation utility shader",
-    string URL = "https://appleseedhq.net",
+    string icon = "asVaryColor.png",
     int as_maya_type_id = 0x001279d3
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_voronoi2d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_voronoi2d.osl
@@ -35,6 +35,7 @@ shader as_voronoi2d
 [[
     string as_maya_node_name = "asVoronoi2D",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/texture/2d:swatch/AppleseedRenderSwatch:texture",
+    string icon = "asVoronoi2d",
     int as_maya_type_id = 0x001279c7
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_voronoi3d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_voronoi3d.osl
@@ -35,6 +35,7 @@ shader as_voronoi3d
 [[
     string as_maya_node_name = "asVoronoi3D",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/texture/3d:swatch/AppleseedRenderSwatch:texture",
+    string icon = "asVoronoi3d",
     int as_maya_type_id = 0x001279c6
 ]]
 (


### PR DESCRIPTION
And icon metadata to the core OSL nodes. It has no effect in Maya, and
is meant only for Gaffer. The main idea here being sharing the core
nodes with all DCC apps.