### PR TITLE
Rayswitch probe fix, metal transparency

### DIFF
--- a/src/appleseed.shaders/src/appleseed/as_metal.osl
+++ b/src/appleseed.shaders/src/appleseed/as_metal.osl
@@ -266,12 +266,6 @@ shader as_metal
         string as_maya_attribute_short_name = "oc",
         string widget = "null"
     ]],
-    output closure color out_outTransparency = 0
-    [[
-        string as_maya_attribute_name = "outTransparency",
-        string as_maya_attribute_short_name = "ot",
-        string widget = "null"
-    ]],
     output closure color out_outMatteOpacity = 0
     [[
         string as_maya_attribute_name = "outMatteOpacity",

--- a/src/appleseed.shaders/src/appleseed/as_ray_switch.osl
+++ b/src/appleseed.shaders/src/appleseed/as_ray_switch.osl
@@ -63,13 +63,6 @@ shader as_ray_switch
         string label = "Transparency Ray Color",
         string page = "Color"
     ]],
-    color in_color_probe = color(0)
-    [[
-        string as_maya_attribute_name = "colorProbe",
-        string as_maya_attribute_short_name = "cpr",
-        string label = "Probe Ray Color",
-        string page = "Color"
-    ]],
     color in_color_diffuse = color(0)
     [[
         string as_maya_attribute_name = "colorDiffuse",
@@ -122,10 +115,6 @@ shader as_ray_switch
     else if (raytype("transparency"))
     {
         out_color = in_color_transparency;
-    }
-    else if (raytype("probe"))
-    {
-        out_color = in_color_probe;
     }
     else if (raytype("diffuse"))
     {


### PR DESCRIPTION
Rays of type *probe* are never evaluated in OSL, so this was non functional.
Metal transparency is also unnecessary, for now at least, since one can use alpha masking to have metal mesh, and so on.