### PR TITLE
Type conversion errors fixed.

### DIFF
--- a/src/appleseed/renderer/modeling/aov/denoiseraov.cpp
+++ b/src/appleseed/renderer/modeling/aov/denoiseraov.cpp
@@ -362,13 +362,13 @@ void DenoiserAOV::fill_empty_samples() const
         for (int i = 0; i < w; ++i)
         {
             const int num_samples =
-                impl->m_histograms.get(j, i, samples_channel_index);
+                static_cast<const int>(impl->m_histograms.get(j, i, samples_channel_index));
 
             if (num_samples == 0)
             {
                 impl->m_histograms.get(j, i, 0) = 1.0f;
-                impl->m_histograms.get(j, i, impl->m_num_bins) = 1.0f;
-                impl->m_histograms.get(j, i, impl->m_num_bins * 2) = 1.0f;
+                impl->m_histograms.get(j, i, static_cast<int>(impl->m_num_bins)) = 1.0f;
+                impl->m_histograms.get(j, i, static_cast<int>(impl->m_num_bins * 2)) = 1.0f;
 
                 impl->m_histograms.get(j, i, samples_channel_index) = 1;
             }

--- a/src/bcd/bcd/DenoisingUnit.cpp
+++ b/src/bcd/bcd/DenoisingUnit.cpp
@@ -129,7 +129,7 @@ void DenoisingUnit::selectSimilarPatches()
             m_similarPatchesCenters.push_back(neighborPixel);
     }
 
-    m_nbOfSimilarPatches = m_similarPatchesCenters.size();
+    m_nbOfSimilarPatches = static_cast<int>(m_similarPatchesCenters.size());
     assert(m_nbOfSimilarPatches > 0);
 
     m_nbOfSimilarPatchesInv = 1.0f / m_nbOfSimilarPatches;


### PR DESCRIPTION
Incorrect type conversion produces an error message in visual studio with the "Treat Warning As Errors" flag.