### PR TITLE
3ds Max metadata in appleseed shaders, fix subsurface, fix uv_transform, add closure2surface

### DIFF
--- a/src/appleseed.shaders/CMakeLists.txt
+++ b/src/appleseed.shaders/CMakeLists.txt
@@ -314,6 +314,7 @@ source_group ("src\\gaffer\\vector" FILES
 set (src_max_sources
      src/max/as_max_blend_material.osl
      src/max/as_max_bump_map.osl
+     src/max/as_max_closure2surface.osl
      src/max/as_max_color_texture.osl
      src/max/as_max_disney_material.osl
      src/max/as_max_float_texture.osl
@@ -324,7 +325,6 @@ set (src_max_sources
      src/max/as_max_plastic_material.osl
      src/max/as_max_srgb_to_linear_rgb.osl
      src/max/as_max_sss_material.osl
-     src/max/as_max_standard_material.osl
      src/max/as_max_uv_transform.osl
 )
 list (APPEND osl_sources

--- a/src/appleseed.shaders/src/appleseed/as_anisotropy_vector_field.osl
+++ b/src/appleseed.shaders/src/appleseed/as_anisotropy_vector_field.osl
@@ -32,7 +32,9 @@ shader as_anisotropy_vector_field
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "Anisotropy vector field node.",
     string icon = "asAnisotropyVectorField.png",
-    int as_maya_type_id = 0x001278e0
+    int as_maya_type_id = 0x001278e0,
+    string as_max_class_id = "755844571 356534419",
+    string as_max_plugin_type = "texture"
 ]]
 (
     float in_rotation_angle = 0.0

--- a/src/appleseed.shaders/src/appleseed/as_attributes.osl
+++ b/src/appleseed.shaders/src/appleseed/as_attributes.osl
@@ -32,7 +32,9 @@ shader as_attributes
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "OSL and appleseed attributes.",
     string icon = "asAttributes.png",
-    int as_maya_type_id = 0x001279f8
+    int as_maya_type_id = 0x001279f8,
+    string as_max_class_id = "1006520102 421015477",
+    string as_max_plugin_type = "texture"
 ]]
 (
     output int out_object_instance_id = 0

--- a/src/appleseed.shaders/src/appleseed/as_blackbody.osl
+++ b/src/appleseed.shaders/src/appleseed/as_blackbody.osl
@@ -35,7 +35,9 @@ shader as_blackbody
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
     string help = "Blackbody Shader",
     string icon = "asBlackbody",
-    int as_maya_type_id = 0x001279d0
+    int as_maya_type_id = 0x001279d0,
+    string as_max_class_id = "1182349026 1064055537",
+    string as_max_plugin_type = "texture"
 ]]
 (
     int in_incandescence_type = 0

--- a/src/appleseed.shaders/src/appleseed/as_blend_color.osl
+++ b/src/appleseed.shaders/src/appleseed/as_blend_color.osl
@@ -34,7 +34,9 @@ shader as_blend_color
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "Color blend utility node.",
     string icon = "asBlendColor.png",
-    int as_maya_type_id = 0x001279d1
+    int as_maya_type_id = 0x001279d1,
+    string as_max_class_id = "1219385486 1257456227",
+    string as_max_plugin_type = "texture"
 ]]
 (
     color in_color = color(0)

--- a/src/appleseed.shaders/src/appleseed/as_color_transform.osl
+++ b/src/appleseed.shaders/src/appleseed/as_color_transform.osl
@@ -35,7 +35,9 @@ shader as_color_transform
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "Transforms a color to another color model. Input color MUST be linearized.",
     string icon = "asColorTransform.png",
-    int as_maya_type_id = 0x001279c8
+    int as_maya_type_id = 0x001279c8,
+    string as_max_class_id = "1025180725 1433928109",
+    string as_max_plugin_type = "texture"
 ]]
 (
     color in_color = color(0.5)

--- a/src/appleseed.shaders/src/appleseed/as_composite_color.osl
+++ b/src/appleseed.shaders/src/appleseed/as_composite_color.osl
@@ -34,7 +34,9 @@ shader as_composite_color
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "Porter-Duff Compositing operators node.",
     string icon = "asCompositeColor.png",
-    int as_maya_type_id = 0x001279fd
+    int as_maya_type_id = 0x001279fd,
+    string as_max_class_id = "1878686041 1992629660",
+    string as_max_plugin_type = "texture"
 ]]
 (
     color in_color = color(0)

--- a/src/appleseed.shaders/src/appleseed/as_create_mask.osl
+++ b/src/appleseed.shaders/src/appleseed/as_create_mask.osl
@@ -36,7 +36,9 @@ shader as_create_mask
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "Creates a greyscale mask from an input color or grey value.",
     string icon = "asCreateMask",
-    int as_maya_type_id = 0x001279e1
+    int as_maya_type_id = 0x001279e1,
+    string as_max_class_id = "1539538401 1875248143",
+    string as_max_plugin_type = "texture"
 ]]
 (
     color in_color = color(1)

--- a/src/appleseed.shaders/src/appleseed/as_disney_material.osl
+++ b/src/appleseed.shaders/src/appleseed/as_disney_material.osl
@@ -34,7 +34,9 @@ shader as_disney_material
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
     string help = "Disney material",
     string icon = "asDisneyMaterial.png",
-    int as_maya_type_id = 0x001279c3
+    int as_maya_type_id = 0x001279c3,
+    string as_max_class_id = "151203281 494163155",
+    string as_max_plugin_type = "material"
 ]]
 (
     color in_color = color(0.5)

--- a/src/appleseed.shaders/src/appleseed/as_double_shade.osl
+++ b/src/appleseed.shaders/src/appleseed/as_double_shade.osl
@@ -32,7 +32,9 @@ shader as_double_shade
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "Double shading node.",
     string icon = "asDoubleShade.png",
-    int as_maya_type_id = 0x001279db
+    int as_maya_type_id = 0x001279db,
+    string as_max_class_id = "2002473132 6900182",
+    string as_max_plugin_type = "texture"
 ]]
 (
     color in_color = color(1)

--- a/src/appleseed.shaders/src/appleseed/as_falloff_angle.osl
+++ b/src/appleseed.shaders/src/appleseed/as_falloff_angle.osl
@@ -34,7 +34,9 @@ shader as_falloff_angle
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "Double shading node.",
     string icon = "asFalloffAngle",
-    int as_maya_type_id = 0x001279f7
+    int as_maya_type_id = 0x001279f7,
+    string as_max_class_id = "2015842098 354230760",
+    string as_max_plugin_type = "texture"
 ]]
 (
     vector in_vector_1 = vector(0,1,0)

--- a/src/appleseed.shaders/src/appleseed/as_fresnel.osl
+++ b/src/appleseed.shaders/src/appleseed/as_fresnel.osl
@@ -36,7 +36,9 @@ shader as_fresnel
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "A viewer Fresnel term node",
     string icon = "asFresnel.png",
-    int as_maya_type_id = 0x001279f1
+    int as_maya_type_id = 0x001279f1,
+    string as_max_class_id = "1608738100 1656300655", 
+    string as_max_plugin_type = "texture"
 ]]
 (
     string in_fresnel_type = "Simple Dielectric"

--- a/src/appleseed.shaders/src/appleseed/as_glass.osl
+++ b/src/appleseed.shaders/src/appleseed/as_glass.osl
@@ -32,7 +32,9 @@ shader as_glass
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
     string help = "Glass material",
     string icon = "asGlass",
-    int as_maya_type_id = 0x001279c4
+    int as_maya_type_id = 0x001279c4,
+    string as_max_class_id = "1785798004 1778718452",
+    string as_max_plugin_type = "material"
 ]]
 (
     color in_surface_transmittance = color(1.0)

--- a/src/appleseed.shaders/src/appleseed/as_globals.osl
+++ b/src/appleseed.shaders/src/appleseed/as_globals.osl
@@ -32,7 +32,9 @@ shader as_globals
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "OSL global variables.",
     string icon = "asGlobals.png",
-    int as_maya_type_id = 0x001279ef
+    int as_maya_type_id = 0x001279ef,
+    string as_max_class_id = "2058487770 898187197",
+    string as_max_plugin_type = "texture"
 ]]
 (
     output point out_world_P = P

--- a/src/appleseed.shaders/src/appleseed/as_id_manifold.osl
+++ b/src/appleseed.shaders/src/appleseed/as_id_manifold.osl
@@ -34,7 +34,9 @@ shader as_id_manifold
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "ID manifold utility shader",
     string icon = "asIdManifold",
-    int as_maya_type_id = 0x001279d9
+    int as_maya_type_id = 0x001279d9,
+    string as_max_class_id = "1097742994 1256943621",
+    string as_max_plugin_type = "texture"
 ]]
 (
     int in_manifold_type = 0

--- a/src/appleseed.shaders/src/appleseed/as_layer_shader.osl
+++ b/src/appleseed.shaders/src/appleseed/as_layer_shader.osl
@@ -32,7 +32,9 @@ shader as_layer_shader
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
     string help = "Shader layering node.",
     string icon = "asLayerShader.png",
-    int as_maya_type_id = 0x001279dd
+    int as_maya_type_id = 0x001279dd,
+    string as_max_class_id = "966011775 1721377247", 
+    string as_max_plugin_type = "material"
 ]]
 (
     closure color in_color = 0

--- a/src/appleseed.shaders/src/appleseed/as_luminance.osl
+++ b/src/appleseed.shaders/src/appleseed/as_luminance.osl
@@ -36,7 +36,9 @@ shader as_luminance
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "Primaries and illuminants aware relative luminance node",
     string icon = "asLuminance.png",
-    int as_maya_type_id = 0x001279cd
+    int as_maya_type_id = 0x001279cd,
+    string as_max_class_id = "1648771987 792674094",
+    string as_max_plugin_type = "texture"
 ]]
 (
     color in_color = color(0.5)

--- a/src/appleseed.shaders/src/appleseed/as_metal.osl
+++ b/src/appleseed.shaders/src/appleseed/as_metal.osl
@@ -34,7 +34,9 @@ shader as_metal
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
     string help = "Metal material",
     string icon = "asMetal.png",
-    int as_maya_type_id = 0x001279f9
+    int as_maya_type_id = 0x001279f9,
+    string as_max_class_id = "121203873 1478432054",
+    string as_max_plugin_type = "material"
 ]]
 (
     color in_face_reflectance = color(0.96, 0.8, 0.05)

--- a/src/appleseed.shaders/src/appleseed/as_noise2d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_noise2d.osl
@@ -38,7 +38,9 @@ shader as_noise2d
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/texture/2d:swatch/AppleseedRenderSwatch:texture",
     int as_maya_type_id = 0x001279cb,
     string icon = "asNoise2D.png",
-    string URL = "http://appleseedhq.net/"
+    string URL = "http://appleseedhq.net/",
+    string as_max_class_id = "981826223 274675317",
+    string as_max_plugin_type = "texture"
 ]]
 (
     color in_color1 = color(0)

--- a/src/appleseed.shaders/src/appleseed/as_noise3d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_noise3d.osl
@@ -38,6 +38,8 @@ shader as_noise3d
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/texture/3d:swatch/AppleseedRenderSwatch:texture",
     int as_maya_type_id = 0x001279ca,
     string icon = "asNoise3D.png",
+    string as_max_class_id = "729771265 1595816139",
+    string as_max_plugin_type = "texture",
     string URL = "http://appleseedhq.net/"
 ]]
 (

--- a/src/appleseed.shaders/src/appleseed/as_plastic.osl
+++ b/src/appleseed.shaders/src/appleseed/as_plastic.osl
@@ -32,7 +32,9 @@ shader as_plastic
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
     string help = "Plastic material",
     string icon = "asPlastic.png",
-    int as_maya_type_id = 0x001279d7
+    int as_maya_type_id = 0x001279d7,
+    string as_max_class_id = "1525511449 941587614",
+    string as_max_plugin_type = "material"
 ]]
 (
     color in_color = color(0.5)

--- a/src/appleseed.shaders/src/appleseed/as_ray_switch.osl
+++ b/src/appleseed.shaders/src/appleseed/as_ray_switch.osl
@@ -32,7 +32,9 @@ shader as_ray_switch
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "Ray switch utility node.",
     string icon = "asRaySwitch.png",
-    int as_maya_type_id = 0x001279dc
+    int as_maya_type_id = 0x001279dc,
+    string as_max_class_id = "553479896 1617499966",
+    string as_max_plugin_type = "texture"
 ]]
 (
     color in_color = color(1)

--- a/src/appleseed.shaders/src/appleseed/as_space_transform.osl
+++ b/src/appleseed.shaders/src/appleseed/as_space_transform.osl
@@ -32,7 +32,9 @@ shader as_space_transform
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "Coordinate system transform node.",
     string icon = "asSpaceTransform.png",
-    int as_maya_type_id = 0x001279f0
+    int as_maya_type_id = 0x001279f0,
+    string as_max_class_id = "170548947 1158424113",
+    string as_max_plugin_type = "texture"
 ]]
 (
     point in_point = point(0)

--- a/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
@@ -35,7 +35,9 @@ shader as_standard_surface
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
     string help = "Standard Surface Shader",
     string icon = "asStandardSurface",
-    int as_maya_type_id = 0x001279d4
+    int as_maya_type_id = 0x001279d4,
+    string as_max_class_id = "651059681 943276521",
+    string as_max_plugin_type = "material"
 ]]
 (
     float in_diffuse_weight = 1.0

--- a/src/appleseed.shaders/src/appleseed/as_subsurface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_subsurface.osl
@@ -34,7 +34,9 @@ shader as_subsurface
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
     string help = "SubSurface Scattering material",
     string icon = "asSubsurface.png",
-    int as_maya_type_id = 0x001279e4
+    int as_maya_type_id = 0x001279e4,
+    string as_max_class_id = "492524175 1093340697",
+    string as_max_plugin_type = "material"
 ]]
 (
     int in_sss_profile = 0

--- a/src/appleseed.shaders/src/appleseed/as_switch_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_switch_surface.osl
@@ -28,13 +28,15 @@
 
 #include "appleseed/transform/as_transform_helpers.h"
 
-shader asSwitchSurface
+shader as_switch_surface
 [[
     string as_maya_node_name = "asSwitchSurface",
     string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch",
     string help = "Material variation utility shader",
     string icon = "asSwitchSurface.png",
-    int as_maya_type_id = 0x001279fe
+    int as_maya_type_id = 0x001279fe,
+    string as_max_class_id = "133437029 1618300620",
+    string as_max_plugin_type = "material"
 ]]
 (
     closure color in_color = 0

--- a/src/appleseed.shaders/src/appleseed/as_switch_texture.osl
+++ b/src/appleseed.shaders/src/appleseed/as_switch_texture.osl
@@ -28,13 +28,15 @@
 
 #include "appleseed/transform/as_transform_helpers.h"
 
-shader asSwitchTexture
+shader as_switch_texture
 [[
     string as_maya_node_name = "asSwitchTexture",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "Texture variation utility shader",
     string icon = "asSwitchTexture.png",
-    int as_maya_type_id = 0x001279da
+    int as_maya_type_id = 0x001279da,
+    string as_max_class_id = "2082364340 1882157436",
+    string as_max_plugin_type = "texture"
 ]]
 (
     color in_color = color(0.9, 0.2, 0.1)

--- a/src/appleseed.shaders/src/appleseed/as_swizzle.osl
+++ b/src/appleseed.shaders/src/appleseed/as_swizzle.osl
@@ -32,7 +32,9 @@ shader as_swizzle
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "RGBA or vector swizzle node.",
     string icon = "asSwizzle.png",
-    int as_maya_type_id = 0x001279f2
+    int as_maya_type_id = 0x001279f2,
+    string as_max_class_id = "373182418 1670521488",
+    string as_max_plugin_type = "texture"
 ]]
 (
     color in_color = color(1)

--- a/src/appleseed.shaders/src/appleseed/as_texture3d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_texture3d.osl
@@ -36,7 +36,9 @@ shader as_texture3d
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/texture/3d:swatch/AppleseedRenderSwatch:texture",
     string help = "A field3d format 3D texture lookup node",
     string icon = "asTexture3D.png",
-    int as_maya_type_id = 0x001279ff
+    int as_maya_type_id = 0x001279ff,
+    string as_max_class_id = "2105412220 306260647",
+    string as_max_plugin_type = "texture"
 ]]
 (
 

--- a/src/appleseed.shaders/src/appleseed/as_texture_info.osl
+++ b/src/appleseed.shaders/src/appleseed/as_texture_info.osl
@@ -32,7 +32,9 @@ shader as_texture_info
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "Texture Information node",
     string icon = "asTextureInfo.png",
-    int as_maya_type_id = 0x001279fc
+    int as_maya_type_id = 0x001279fc,
+    string as_max_class_id = "177883955 1775919360",
+    string as_max_plugin_type = "texture"
 ]]
 (
     string in_texture_file = ""

--- a/src/appleseed.shaders/src/appleseed/as_vary_color.osl
+++ b/src/appleseed.shaders/src/appleseed/as_vary_color.osl
@@ -30,13 +30,15 @@
 #include "appleseed/math/as_math_helpers.h"
 #include "appleseed/transform/as_transform_helpers.h"
 
-shader as_varyColor
+shader as_vary_color
 [[
     string as_maya_node_name = "asVaryColor",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility",
     string help = "Color variation utility shader",
     string icon = "asVaryColor.png",
-    int as_maya_type_id = 0x001279d3
+    int as_maya_type_id = 0x001279d3,
+    string as_max_class_id = "1398541016 1578641387",
+    string as_max_plugin_type = "texture"
 ]]
 (
     color in_color = color(0)

--- a/src/appleseed.shaders/src/appleseed/as_voronoi2d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_voronoi2d.osl
@@ -36,7 +36,9 @@ shader as_voronoi2d
     string as_maya_node_name = "asVoronoi2D",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/texture/2d:swatch/AppleseedRenderSwatch:texture",
     string icon = "asVoronoi2D.png",
-    int as_maya_type_id = 0x001279c7
+    int as_maya_type_id = 0x001279c7,
+    string as_max_class_id = "636365878 67180647",
+    string as_max_plugin_type = "texture"
 ]]
 (
     color in_color1 = color(1, 0.3, 0.05)

--- a/src/appleseed.shaders/src/appleseed/as_voronoi3d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_voronoi3d.osl
@@ -36,7 +36,9 @@ shader as_voronoi3d
     string as_maya_node_name = "asVoronoi3D",
     string as_maya_classification = "drawdb/shader:rendernode/appleseed/texture/3d:swatch/AppleseedRenderSwatch:texture",
     string icon = "asVoronoi3D.png",
-    int as_maya_type_id = 0x001279c6
+    int as_maya_type_id = 0x001279c6,
+    string as_max_class_id = "332490071 1665409453",
+    string as_max_plugin_type = "texture"
 ]]
 (
     color in_color1 = color(1, 0.3, 0.05)

--- a/src/appleseed.shaders/src/max/as_max_blend_material.osl
+++ b/src/appleseed.shaders/src/max/as_max_blend_material.osl
@@ -85,6 +85,4 @@ surface as_max_blend_material
         ClosureOut = mix(ClosureOut, LayerMtl_8, (MixAmount_8 * MaskColor_8));
     if (LayerMtl_9)
         ClosureOut = mix(ClosureOut, LayerMtl_9, (MixAmount_9 * MaskColor_9));
-
-    Ci = ClosureOut;
 }

--- a/src/appleseed.shaders/src/max/as_max_closure2surface.osl
+++ b/src/appleseed.shaders/src/max/as_max_closure2surface.osl
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2017 Sergo Pogosyan, The appleseedhq Organization
+// Copyright (c) 2016 Esteban Tovagliari, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,19 +26,10 @@
 // THE SOFTWARE.
 //
 
-shader as_max_light_material
+surface as_max_closure2surface
 (
-    closure color        BSDF = 0,
-    float                Emission = 1.0,
-    color                Color = 1.0,
-    output closure color ClosureOut = 0
+    closure color in_input = 0
 )
 {
-    if (raytype("light"))
-    {
-        color E = Emission * Color;
-        ClosureOut = E * emission();
-    }
-    else
-        ClosureOut = BSDF;
+    Ci = in_input;
 }

--- a/src/appleseed.shaders/src/max/as_max_disney_material.osl
+++ b/src/appleseed.shaders/src/max/as_max_disney_material.osl
@@ -61,5 +61,4 @@ surface as_max_disney_material
         SheenTint,
         Clearcoat,
         ClearcoatGloss);
-    Ci = ClosureOut;
 }

--- a/src/appleseed.shaders/src/max/as_max_glass_material.osl
+++ b/src/appleseed.shaders/src/max/as_max_glass_material.osl
@@ -55,5 +55,4 @@ shader as_max_glass_material
         Ior,
         VolumeTransmittance,
         VolumeTransmittanceDistance);
-    Ci = ClosureOut;
 }

--- a/src/appleseed.shaders/src/max/as_max_metal_material.osl
+++ b/src/appleseed.shaders/src/max/as_max_metal_material.osl
@@ -84,5 +84,4 @@ shader as_max_metal_material
         microfacet_roughness(Roughness, RoughnessDepthScale),
         0.5,    // Highlight falloff.
         Anisotropic);
-    Ci = ClosureOut;
 }

--- a/src/appleseed.shaders/src/max/as_max_plastic_material.osl
+++ b/src/appleseed.shaders/src/max/as_max_plastic_material.osl
@@ -87,5 +87,4 @@ shader as_max_plastic_material
         DiffuseColor,
         DiffuseWeight,
         Scattering);
-    Ci = ClosureOut;
 }

--- a/src/appleseed.shaders/src/max/as_max_sss_material.osl
+++ b/src/appleseed.shaders/src/max/as_max_sss_material.osl
@@ -80,5 +80,4 @@ shader as_max_sss_material
         Ior);
 
     ClosureOut = BSSRDF + BRDF;
-    Ci = ClosureOut;
 }

--- a/src/appleseed.shaders/src/max/as_max_uv_transform.osl
+++ b/src/appleseed.shaders/src/max/as_max_uv_transform.osl
@@ -56,6 +56,9 @@ shader as_max_uv_transform
 
     output float out_U = 0.0,
     output float out_V = 0.0,
+
+    output float out_outUV[2] = {0.0, 0.0},
+    output float out_outUvFilterSize[2] = {-1, -1},
 )
 {
     float out_u = in_coordU;
@@ -66,7 +69,14 @@ shader as_max_uv_transform
     // Apply rotation before tiling/offset which is different from 3ds Max native bitmap transforms.
     if (in_rotateW != 0.0)
     {
-        rotate2d(out_u, out_v, in_rotateW, out_u, out_v);
+        point rot = rotate(
+            point(out_u, out_v, 0.0),
+            radians(in_rotateW),
+            point(0.5, 0.5, 0.0),
+            point(0.5, 0.5, 1.0));
+
+        out_u = rot[0];
+        out_v = rot[1];
     }
 
     // Don't center transforms when mirrored (3ds Max behaviour).
@@ -121,6 +131,12 @@ shader as_max_uv_transform
         out_v = out_v + (1 - in_cropH); // Looks like V=0 is bottom left corner, so had to move it to the top to match 3ds max coords
     }
     
+    out_outUvFilterSize[0] = filterwidth(out_u);
+    out_outUvFilterSize[1] = filterwidth(out_v);
+    
+    out_outUV[0] = out_u;
+    out_outUV[1] = out_v;
+
     out_U = out_u;
     out_V = out_v;
 }


### PR DESCRIPTION
Hi,
This PR:
1. adds 3ds max metadata to all the shaders in order to build osl plugins by parsing shader files.
2. fixes some bugs in uv_transform shader and fixes a bug in as_subsurface closure.
3. updates existing 3ds max osl shaders and this requires modifications of the plugin. I'll post PR to support this change later.

Thanks,
Sergo.