### PR TITLE
Add a project migration step 22.

### DIFF
--- a/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
@@ -1585,6 +1585,47 @@ namespace
             }
         }
     };
+
+    //
+    // Update from revision 21 to revision 22.
+    //
+    
+    class UpdateFromRevision_21
+      : public Updater
+    {
+      public:
+        explicit UpdateFromRevision_21(Project& project)
+          : Updater(project, 21)
+        {
+        }
+
+        void update() override
+        {
+            if (Scene* scene = m_project.get_scene())
+            {
+                for (each<CameraContainer> i = scene->cameras(); i; ++i)
+                {
+                    Dictionary& camera_params = i->get_parameters();
+
+                    copy_in_same_path(
+                        camera_params,
+                        "shutter_open_end_time",
+                        "shutter_open_time");
+
+                    copy_in_same_path(
+                        camera_params,
+                        "shutter_close_start_time",
+                        "shutter_close_time");
+                }
+            }
+        }
+
+      private:        
+        void copy_in_same_path(Dictionary& dict, const char* dest_key, const char* src_key){
+            if (!dict.strings().exist(dest_key))
+                copy_if_exist(dict, dest_key, dict, src_key);            
+        }
+    };
 }
 
 bool ProjectFileUpdater::update(
@@ -1638,6 +1679,7 @@ void ProjectFileUpdater::update(
       CASE_UPDATE_FROM_REVISION(18);
       CASE_UPDATE_FROM_REVISION(19);
       CASE_UPDATE_FROM_REVISION(20);
+      CASE_UPDATE_FROM_REVISION(21);
 
       case ProjectFormatRevision:
         // Project is up-to-date.

--- a/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
@@ -156,6 +156,16 @@ namespace
                 dest.strings().insert(dest_key, src.strings().get(src_key));
         }
 
+        // Copy a key from one dictionary to same dictionary.
+        static void copy_if_exist_no_overwrite(
+            Dictionary&         dict, 
+            const char*         dest_key, 
+            const char*         src_key)
+        {
+            if (!dict.strings().exist(dest_key))
+                copy_if_exist(dict, dest_key, dict, src_key);            
+        }
+
         // Move a key from one dictionary to another at a given path.
         static void move_if_exist(
             ParamArray&         dest,
@@ -1607,24 +1617,18 @@ namespace
                 {
                     Dictionary& camera_params = i->get_parameters();
 
-                    copy_in_same_path(
+                    copy_if_exist_no_overwrite(
                         camera_params,
                         "shutter_open_end_time",
                         "shutter_open_time");
 
-                    copy_in_same_path(
+                    copy_if_exist_no_overwrite(
                         camera_params,
                         "shutter_close_start_time",
                         "shutter_close_time");
                 }
             }
-        }
-
-      private:        
-        void copy_in_same_path(Dictionary& dict, const char* dest_key, const char* src_key){
-            if (!dict.strings().exist(dest_key))
-                copy_if_exist(dict, dest_key, dict, src_key);            
-        }
+        }  
     };
 }
 

--- a/src/appleseed/renderer/modeling/project/projectformatrevision.h
+++ b/src/appleseed/renderer/modeling/project/projectformatrevision.h
@@ -39,7 +39,7 @@ namespace renderer
 // when you increment this value.
 //
 
-const size_t ProjectFormatRevision = 21;
+const size_t ProjectFormatRevision = 22;
 
 }       // namespace renderer
 


### PR DESCRIPTION
 - It generate `shutter_open_end_time` and `shutter_close_start_time` as `shutter_open_time` and `shutter_close_time`, if they are not exist.