### PR TITLE
Don't reset trackers when sampling is finished

### DIFF
--- a/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
@@ -241,7 +241,7 @@ namespace
                     trackers[1].insert(shading_result.m_main[1]);
                     trackers[2].insert(shading_result.m_main[2]);
                 }
-                
+
                 // Stop if the variation criterion is met.
                 if (trackers[0].get_variation() <= m_params.m_max_variation &&
                     trackers[1].get_variation() <= m_params.m_max_variation &&

--- a/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
@@ -193,13 +193,6 @@ namespace
                 if (remaining_samples == 0)
                     break;
 
-                // Stop if the variation criterion is met.
-                if (trackers[0].get_size() > 0 &&
-                    trackers[0].get_variation() <= m_params.m_max_variation &&
-                    trackers[1].get_variation() <= m_params.m_max_variation &&
-                    trackers[2].get_variation() <= m_params.m_max_variation)
-                    break;
-
                 trackers[0].reset_variation();
                 trackers[1].reset_variation();
                 trackers[2].reset_variation();
@@ -248,6 +241,12 @@ namespace
                     trackers[1].insert(shading_result.m_main[1]);
                     trackers[2].insert(shading_result.m_main[2]);
                 }
+                
+                // Stop if the variation criterion is met.
+                if (trackers[0].get_variation() <= m_params.m_max_variation &&
+                    trackers[1].get_variation() <= m_params.m_max_variation &&
+                    trackers[2].get_variation() <= m_params.m_max_variation)
+                    break;
             }
 
             // Merge the scratch framebuffer into the output framebuffer.

--- a/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
@@ -187,15 +187,15 @@ namespace
 
             while (true)
             {
-                trackers[0].reset_variation();
-                trackers[1].reset_variation();
-                trackers[2].reset_variation();
-
                 // Don't exceed 'max' samples in total.
                 assert(trackers[0].get_size() <= m_params.m_max_samples);
                 const size_t remaining_samples = m_params.m_max_samples - trackers[0].get_size();
                 if (remaining_samples == 0)
                     break;
+
+                trackers[0].reset_variation();
+                trackers[1].reset_variation();
+                trackers[2].reset_variation();
 
                 // Each batch contains 'min' samples.
                 const size_t batch_size = min(m_params.m_min_samples, remaining_samples);

--- a/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
@@ -193,6 +193,13 @@ namespace
                 if (remaining_samples == 0)
                     break;
 
+                // Stop if the variation criterion is met.
+                if (trackers[0].get_size() > 0 &&
+                    trackers[0].get_variation() <= m_params.m_max_variation &&
+                    trackers[1].get_variation() <= m_params.m_max_variation &&
+                    trackers[2].get_variation() <= m_params.m_max_variation)
+                    break;
+
                 trackers[0].reset_variation();
                 trackers[1].reset_variation();
                 trackers[2].reset_variation();
@@ -241,12 +248,6 @@ namespace
                     trackers[1].insert(shading_result.m_main[1]);
                     trackers[2].insert(shading_result.m_main[2]);
                 }
-
-                // Stop if the variation criterion is met.
-                if (trackers[0].get_variation() <= m_params.m_max_variation &&
-                    trackers[1].get_variation() <= m_params.m_max_variation &&
-                    trackers[2].get_variation() <= m_params.m_max_variation)
-                    break;
             }
 
             // Merge the scratch framebuffer into the output framebuffer.


### PR DESCRIPTION
This is not a fix for #1858 but a fix for a mistake in the adaptive sampler. The trackers were resat before writing them in an image when diagnostic is enabled.