### PR TITLE
Add triplanar normal mode, update references

### DIFF
--- a/src/appleseed.shaders/include/appleseed/color/as_color_blend_modes.h
+++ b/src/appleseed.shaders/include/appleseed/color/as_color_blend_modes.h
@@ -35,6 +35,7 @@
 #include "appleseed/color/as_color_transforms.h"
 #include "appleseed/math/as_math_helpers.h"
 
+
 //
 // References:
 //
@@ -213,6 +214,7 @@ color blendmode_linear_light(color A, color B)
     }
     return rgb;
 }
+
 
 //
 // Note:
@@ -447,6 +449,7 @@ color blend_color(string mode, color A, color B)
     }
     return rgb;
 }
+
 
 //
 // References:

--- a/src/appleseed.shaders/include/appleseed/color/as_color_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/color/as_color_helpers.h
@@ -39,6 +39,7 @@
 #define NCOMPS  3
 #endif
 
+
 //
 //  The luminance coefficients Y are provided by the RGB<>XYZ matrices, which
 //  depend on the CIE xy chromaticity coordinates of the RGB primaries and

--- a/src/appleseed.shaders/include/appleseed/color/as_color_transforms.h
+++ b/src/appleseed.shaders/include/appleseed/color/as_color_transforms.h
@@ -135,6 +135,7 @@ vector get_illuminant_CIExyz(string illuminant, float white_CIExy[2])
         : transform_CIExy_to_CIExyz(white_CIExy);
 }
 
+
 //
 // Reference:
 //
@@ -169,6 +170,7 @@ vector transform_CIEXYZ_to_CIExyY(color XYZ, string illuminant)
     return transform_CIEXYZ_to_CIExyY(XYZ, white_CIExy);
 }
 
+
 //
 // Reference:
 //
@@ -196,13 +198,12 @@ color get_illuminant_CIEXYZ(string illuminant)
     return transform_CIExyY_to_CIEXYZ(get_illuminant_CIExyY(illuminant));
 }
 
-//
-// Pre-computed RGB->XYZ matrices, chromatically adapted where appropriate
-// with the Bradford CAT.
-//
+
 //  Reference:
 //
 //      http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+//
+//      Precomputed RGB<>CIEXYZ matrices data created with Colour,
 //      http://colour-science.org/
 //
 
@@ -267,13 +268,13 @@ void get_RGB_to_XYZ_matrix(
     }
 }    
 
-//
-// Pre-computed XYZ->RGB matrices, chromatically adapted where appropriate
-// with the Bradford CAT.
+
 //
 //  Reference:
 //
 //      http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+//
+//      Precomputed RGB<>CIEXYZ matrices data created with Colour,
 //      http://colour-science.org/
 //
 
@@ -338,6 +339,7 @@ void get_XYZ_to_RGB_matrix(
     }
 }
 
+
 //
 // Reference:
 //
@@ -390,11 +392,6 @@ color transform_linear_RGB_to_CIEXYZ(
     return max(0.0, CIEXYZ);
 }
 
-//
-// Precomputed RGB to XYZ matrix, chromatically adapt with default "Bradford"
-// chromatic adaptation transform.
-//
-
 color transform_linear_RGB_to_CIEXYZ(
     color linear_RGB_color,
     string color_space,
@@ -407,10 +404,11 @@ color transform_linear_RGB_to_CIEXYZ(
         "Bradford");
 }
 
+
 //
 // Reference:
 //
-//      XYZ to RGB conversion, and chromatic adaptation
+//      XYZ to RGB conversion, with choice of chromatic adaptation transform.
 //
 //      http://www.brucelindbloom.com/index.html?Eqn_XYZ_to_RGB.html
 //      http://www.brucelindbloom.com/Eqn_ChromAdapt.html
@@ -462,11 +460,6 @@ color transform_CIEXYZ_to_linear_RGB(
     return max(0.0, linear_RGB);
 }
 
-//
-// Precomputed XYZ to RGB matrix, chromatically adapt with default "Bradford"
-// chromatic adaptation transform.
-//
-
 color transform_CIEXYZ_to_linear_RGB(
     color linear_XYZ_color,
     string color_space,
@@ -478,6 +471,7 @@ color transform_CIEXYZ_to_linear_RGB(
         target_illuminant,
         "Bradford");
 }
+
 
 //
 // Overloaded RGB<>XYZ transformations, assuming identical white points.
@@ -522,6 +516,7 @@ color transform_CIEXYZ_to_linear_RGB(
 
     return max(0.0, linear_RGB);
 }
+
 
 //
 // Create a RGB->XYZ transformation matrix, given the set of RGB primaries
@@ -583,6 +578,7 @@ matrix create_RGB_to_XYZ_matrix(
     return CAT_matrix * M;
 }    
 
+
 //
 // Reference:
 //
@@ -642,6 +638,7 @@ void get_CIExy_from_CCT_Kang(int CCT, output float CIExy[2])
     CIExy[1] = y;
 }
 
+
 //
 // Reference:
 //
@@ -693,6 +690,7 @@ color transform_CIEXYZ_to_CIELAB(
         linear_XYZ_color,
         get_illuminant_CIExyY(illuminant));
 }
+
 
 //
 // Reference:
@@ -812,6 +810,8 @@ color transform_CIEXYZ_to_CIELUV(
         linear_XYZ_color,
         get_illuminant_CIExyY(illuminant));
 }
+
+
 //
 // Reference:
 //
@@ -871,6 +871,7 @@ color transform_CIELUV_to_CIEXYZ(
         CIELUV,
         get_illuminant_CIExyY(illuminant));
 }
+
 
 //
 // Reference:
@@ -958,6 +959,7 @@ color transform_CIELCh_ab_to_linear_RGB(
         target_illuminant);
 }
 
+
 //
 // Reference:
 //
@@ -1044,6 +1046,7 @@ color transform_CIELCh_uv_to_linear_RGB(
         target_illuminant);
 }
 
+
 //
 // CIELAB, CIELUV, have values in range L [0,100], a,b [-128,128]
 // and u,v ([-134,220],[-140,122])
@@ -1085,6 +1088,7 @@ color inverse_remap_CIELUV(color CIELUV)
     return color(L, u, v);
 }
 
+
 //
 // LCh (ab, uv), has values L in [0,100] range, chroma in [0,100] range
 // and hue in [0,360] degrees range.
@@ -1118,7 +1122,6 @@ color inverse_remap_CIELCh(color CIELCh)
 //
 // Note: hue values are in [0,1], instead of [0,360] degrees
 //
-
 
 float get_hue_angle(color C, float value, float rgbmin, float chroma)
 {
@@ -1299,6 +1302,7 @@ color transform_HSL_to_RGB(color HSL)
     return color(r, g, b);
 }
 
+
 //
 // Reference:
 //
@@ -1439,6 +1443,7 @@ float deltaE_CIEDE2000(
 
     return deltaE_00;
 }
+
 
 //
 // Overloaded deltaE CIEDE2000, taking as reference and samples,

--- a/src/appleseed.shaders/include/appleseed/color/as_colorimetry.h
+++ b/src/appleseed.shaders/include/appleseed/color/as_colorimetry.h
@@ -29,6 +29,7 @@
 #ifndef AS_COLORIMETRY_H
 #define AS_COLORIMETRY_H
 
+
 //
 // Reference:
 //
@@ -39,6 +40,7 @@
 
 #define CIE_E   (216.0 / 24389.0)
 #define CIE_K   (24389.0 / 27.0)
+
 
 //
 // Reference:
@@ -69,6 +71,7 @@
 #define ILLUMINANT_E_WHITEPOINT_xy          0.33333, 0.33333
 #define ILLUMINANT_E_WHITEPOINT_xyz         0.33333, 0.33333, 0.33333
 
+
 //
 // Reference:
 //
@@ -82,6 +85,7 @@
 #define REC601_CHROMATICITIES_Gxyz          0.290, 0.600, 0.110
 #define REC601_CHROMATICITIES_Bxyz          0.150, 0.060, 0.790
 #define REC601_CHROMATICITIES_Wxyz          D65_WHITEPOINT_CIE1931_2DEG_xyz
+
 
 //
 // Reference:
@@ -97,6 +101,7 @@
 #define REC709_CHROMATICITIES_Bxyz          0.150, 0.060, 0.790
 #define REC709_CHROMATICITIES_Wxyz          D65_WHITEPOINT_CIE1931_2DEG_xyz
 
+
 //
 // Reference:
 //
@@ -109,6 +114,7 @@
 #define ADOBERGB98_CHROMATICITIES_Gxyz      0.210, 0.710, 0.080
 #define ADOBERGB98_CHROMATICITIES_Bxyz      0.150, 0.060, 0.790
 #define ADOBERGB98_CHROMATICITIES_Wxyz      D65_WHITEPOINT_CIE1931_2DEG_xyz
+
 
 //
 // Reference:
@@ -124,6 +130,7 @@
 #define REC2020_CHROMATICITIES_Bxyz         0.131, 0.046, 0.823
 #define REC2020_CHROMATICITIES_Wxyz         D65_WHITEPOINT_CIE1931_2DEG_xyz
 
+
 //
 // Reference:
 //
@@ -138,6 +145,7 @@
 #define ACES_AP0_CHROMATICITIES_Bxyz        0.0001, -0.077, 1.0769
 #define ACES_AP0_CHROMATICITIES_Wxyz        D60_WHITEPOINT_CIE1931_2DEG_xyz
 
+
 //
 // Reference:
 //
@@ -150,6 +158,7 @@
 #define ACESCG_AP1_CHROMATICITIES_Gxyz      0.1650, 0.8300, 0.0050
 #define ACESCG_AP1_CHROMATICITIES_Bxyz      0.1280, 0.0440, 0.8280
 #define ACESCG_AP1_CHROMATICITIES_Wxyz      D60_WHITEPOINT_CIE1931_2DEG_xyz
+
 
 //
 // Reference:
@@ -164,10 +173,17 @@
 #define DCIP3_CHROMATICITIES_Bxyz           0.1500, 0.0600, 0.7900
 #define DCIP3_CHROMATICITIES_Wxyz           DCIP3_WHITEPOINT_CIE1931_2DEG_xyz
 
+
 //
-// Precomputed RGB<>XYZ matrices, chromatically adapted using the Bradford
-// chromatic adaptation transform, and respective relative luminance
-// coefficients.
+// Precomputed RGB<>CIEXYZ matrices
+//
+//      Created with Colour, http://colour-science.org/
+//      with special thanks to Thomas Mansecal and the Colour developers.
+//
+//      Matrices chromatically adapted using the Bradford CAT where appropriate.
+//
+
+
 //
 // Rec.601: D65, D65 to D60, D65 to DCI, and system default
 //
@@ -211,6 +227,7 @@
 #define XYZ_TO_RGB_REC601_R2            XYZ_TO_RGB_REC601_D65_R2
 
 #define REC601_LUMINANCE_COEFFS         RGB_TO_XYZ_REC601_R1
+
 
 //
 // Rec.709: D65, D65 to D60, D65 to DCI, and system default
@@ -256,6 +273,7 @@
 
 #define REC709_LUMINANCE_COEFFS         RGB_TO_XYZ_REC709_R1
 
+
 //
 // Adobe RGB (1998): D65, D65 to D60, D65 to DCI, and system default
 //
@@ -300,6 +318,7 @@
 
 #define ADOBERGB_LUMINANCE_COEFFS       RGB_TO_XYZ_ADOBERGB_R1
 
+
 //
 // Rec.2020: D65, D65 to D60, D65 to DCI, and system default
 //
@@ -343,6 +362,8 @@
 #define XYZ_TO_RGB_REC2020_R2           XYZ_TO_RGB_REC2020_D65_R2
 
 #define REC2020_LUMINANCE_COEFFS        RGB_TO_XYZ_REC2020_R1
+
+
 //
 // ACES 2065-1 AP0: D60 to D65, D60, D60 to DCI, and system default
 //
@@ -386,6 +407,7 @@
 #define XYZ_TO_RGB_ACES_R2              XYZ_TO_RGB_ACES_D60_R2
 
 #define ACES_LUMINANCE_COEFFS           RGB_TO_XYZ_ACES_R1
+
 
 //
 // ACEScg AP1: D60 to D65, D60, D60 to DCI, and system default
@@ -431,6 +453,7 @@
 
 #define ACESCG_LUMINANCE_COEFFS         RGB_TO_XYZ_ACESCG_R1
 
+
 //
 // DCI-P3: DCI to D65, DCI to D60, DCI, and system default
 //
@@ -475,10 +498,17 @@
 
 #define DCIP3_LUMINANCE_COEFFS          RGB_TO_XYZ_DCIP3_R1
 
+
 //
-// Precomputed RGB<>RGB matrices, chromatically adapted using the Bradford
-// chromatic adaptation transform, and respective relative luminance
-// coefficients.
+// Precomputed RGB<>RGB matrices
+//
+//      Created with Colour, http://colour-science.org/
+//      with special thanks to Thomas Mansecal and the Colour developers.
+//
+//      Matrices chromatically adapted using the Bradford CAT where appropriate.
+//  
+
+
 //
 // Source:  ACES 2065-1 AP0 D60
 // Target:  ACEScg AP1 D60
@@ -502,6 +532,7 @@
 #define ACES_TO_REC709_X        2.52168619, -1.13413099,  -0.387555200
 #define ACES_TO_REC709_Y       -0.27647991,  1.37271909,  -0.096239170
 #define ACES_TO_REC709_Z       -0.01537806, -0.15297534,   1.168353400
+
 
 //
 // Source:  ACEScg AP1 D60
@@ -527,6 +558,7 @@
 #define ACESCG_TO_REC709_Y     -0.13025642,  1.14080474, -0.010548320
 #define ACESCG_TO_REC709_Z     -0.02400336, -0.12896898,  1.152972330
 
+
 //
 // Source:  DCI-P3 DCI
 // Target:  ACES 2065-1 AP0 D60
@@ -534,7 +566,7 @@
 //          Rec.2020 D65
 //          Rec.709 D60
 //
-//
+
 #define DCIP3_TO_ACES_X         0.48978665,  0.31837604,  0.191837310
 #define DCIP3_TO_ACES_Y         0.06841295,  0.82898907,  0.102597970
 #define DCIP3_TO_ACES_Z        -0.00004500,  0.04547649,  0.954568500
@@ -550,6 +582,7 @@
 #define DCIP3_TO_REC709_X       1.15751641, -0.15496238, -0.002554030
 #define DCIP3_TO_REC709_Y      -0.04150007,  1.04556792, -0.004067850
 #define DCIP3_TO_REC709_Z      -0.01805004, -0.07857827,  1.096628310
+
 
 //
 // Source:  Rec.2020 D65
@@ -575,6 +608,7 @@
 #define REC2020_TO_REC709_Y    -0.12455047,  1.13289990, -0.008349420
 #define REC2020_TO_REC709_Z    -0.01815076, -0.10057809,  1.118729660
 
+
 //
 // Source:  Rec.709 D65
 // Target:  ACES 2065-1 AP0 D60
@@ -598,6 +632,7 @@
 #define REC709_TO_REC2020_X     0.62740390,  0.32928304,  0.043313070
 #define REC709_TO_REC2020_Y     0.06909729,  0.91954040,  0.011362320
 #define REC709_TO_REC2020_Z     0.01639144,  0.08801331,  0.895595250
+
 
 //
 // Source:  AdobeRGB D65

--- a/src/appleseed.shaders/include/appleseed/fractal/as_fractal_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/fractal/as_fractal_helpers.h
@@ -26,6 +26,7 @@
 // THE SOFTWARE.
 //
 
+
 //
 // Reference:
 //
@@ -70,6 +71,7 @@ float fBm(
     }
     return sum;
 }
+
 
 //
 // Reference:
@@ -410,6 +412,7 @@ void voronoi_3D(
     }
 }
 
+
 // 
 // Reference:
 //
@@ -481,6 +484,7 @@ float voronoise3d(point Pp, float jittering, float smoothness)
     return (normalization > 0.0) ? distance_avg / normalization : 0.0;
 }
 
+
 //
 // Reference:
 //
@@ -508,6 +512,7 @@ float value_noise2d(float x, float y)
 
     return mix(a, b, uu[1]);
 }
+
 
 //
 // Reference:

--- a/src/appleseed.shaders/include/appleseed/material/as_material_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/material/as_material_helpers.h
@@ -55,6 +55,7 @@ float ior_from_normal_reflectance(float f0)
     return (sqrt_f0 + 1) / (1 - sqrt_f0);
 }
 
+
 //
 // Reference:
 //
@@ -90,6 +91,7 @@ color get_kappa(color f0, color eta)
                  get_kappa(f0[1], eta[1]),
                  get_kappa(f0[2], eta[2]));
 }
+
 
 //
 //  Reference:

--- a/src/appleseed.shaders/include/appleseed/math/as_math_complex.h
+++ b/src/appleseed.shaders/include/appleseed/math/as_math_complex.h
@@ -34,6 +34,7 @@ struct Complex
     float imag;
 };
 
+
 //
 // Reference:
 //

--- a/src/appleseed.shaders/include/appleseed/math/as_math_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/math/as_math_helpers.h
@@ -35,6 +35,7 @@
 float sqr(float x) { return x * x; }
 vector sqr(vector x) { return x * x; }
 
+
 //
 // Reference:
 //
@@ -56,6 +57,7 @@ float gain(float value, float g)
         : 1 - bias(2 - (value * 2), 1 - g) * 0.5;
 }
 
+
 //
 // Reference:
 //
@@ -75,6 +77,7 @@ float fast_gain(float value, float g)
         ? fast_bias(value * 2, g) * 0.5
         : fast_bias(value * 2 - 1, 1 - g) * 0.5 + 0.5;
 }
+
 
 //
 // Reference:

--- a/src/appleseed.shaders/include/appleseed/pattern/as_pattern_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/pattern/as_pattern_helpers.h
@@ -43,6 +43,7 @@
 
 #include "appleseed/math/as_math_helpers.h"
 
+
 //
 // Reference:
 //
@@ -158,6 +159,7 @@ float filtered_pulsetrain(
         return (x0 - floor(x0) < nedge) ? 0 : 1;
     }
 }
+
 
 //
 // Reference:

--- a/src/appleseed.shaders/src/appleseed/as_triplanar.osl
+++ b/src/appleseed.shaders/src/appleseed/as_triplanar.osl
@@ -37,9 +37,24 @@ shader as_triplanar
     string help = "Tri-planar projection node.",
     string icon = "asTriPlanar.png",
     int as_maya_type_id = 0x001279e5,
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_triplanar.html#label-as-triplanar"      
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_triplanar.html#label-as-triplanar"
 ]]
 (
+    string in_blend_mode = "Color"
+    [[
+        string as_maya_attribute_name = "blendMode",
+        string as_maya_attribute_short_name = "blm",
+        string widget = "popup",
+        string options = "Color|Tangent Normal",
+        string label = "Blend Mode",
+        string page = "Projection",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int gafferNoduleLayoutVisible = 0,
+        string help = "Blend colors, or tangent space normal maps using reoriented normal mapping.",
+        int divider = 1
+    ]],
     float in_blend_softness = 0.1
     [[
         string as_maya_attribute_name = "blendSoftness",
@@ -664,9 +679,23 @@ shader as_triplanar
         string as_maya_attribute_short_name = "oa",
         string label = "Output Alpha",
         string widget = "null"
+    ]],
+    output normal out_normal = normal(0)
+    [[
+        string as_maya_attribute_name = "outNormal",
+        string as_maya_attribute_short_name = "on",
+        string label = "Output Normal",
+        string widget = "null"
     ]]
 )
 {
+    normal rnm_blend(normal A, normal B)
+    {
+        normal a = A + normal(0.0, 0.0, 1.0);
+        normal b = B * normal(-1.0, -1.0, 1.0);
+        return a * dot(a, b) / a[2] - b;
+    }
+    
     normal Nn = normalize(in_normal);
     point Pp = in_surface_point;
 
@@ -728,8 +757,11 @@ shader as_triplanar
         Nn = rotate(Nn, angle[2], O, Z);
         Nn = normalize(Nn);
     }
-    
-    vector blending = pow(abs(Nn), (1.0 - in_blend_softness) * 16);
+
+    normal normal_sign = sign(Nn);
+    normal abs_normal = abs(Nn);
+
+    vector blending = pow(abs_normal, (1.0 - in_blend_softness) * 16);
     blending = blending / (blending[0] + blending[1] + blending[2]);
     
     float x_alpha, y_alpha, z_alpha;
@@ -760,18 +792,30 @@ shader as_triplanar
                 in_x_axis_tflip,
                 x_alpha);
 
-            if (in_enable_cms && max(in_x_axis_color) > 0.0 &&
-                max(x_axis) > 0.0)
+            if (in_blend_mode == "Tangent Normal")
             {
-                x_axis = apply_color_management(
-                    x_axis,
-                    in_x_tex_eotf,
-                    in_x_tex_rgb_primaries,
-                    in_workingspace_rgb_primaries);  
-            }
+                normal X = rnm_blend(
+                    normal(Nn[2], Nn[1], abs_normal[0]),
+                    normal(x_axis) * 2.0 - 1.0);
 
-            out_color += blending[0] * in_x_axis_color * x_axis;
-            out_alpha += blending[0] * x_alpha;
+                X[2] *= normal_sign[0];
+                
+                out_normal += blending[0] * X;
+            }
+            else
+            {
+                if (in_enable_cms && max(in_x_axis_color) > 0.0 &&
+                        max(x_axis) > 0.0)
+                {
+                    x_axis = apply_color_management(
+                        x_axis,
+                        in_x_tex_eotf,
+                        in_x_tex_rgb_primaries,
+                        in_workingspace_rgb_primaries);  
+                }
+                out_color += blending[0] * in_x_axis_color * x_axis;
+                out_alpha += blending[0] * x_alpha;
+            }
         }
     }
     else
@@ -805,19 +849,31 @@ shader as_triplanar
                 in_y_axis_sflip,
                 in_y_axis_tflip,
                 y_alpha);
-            
-            if (in_enable_cms && max(in_y_axis_color) > 0.0 &&
-                max(y_axis) > 0.0)
+
+            if (in_blend_mode == "Tangent Normal")
             {
-                y_axis = apply_color_management(
-                    y_axis,
-                    in_y_tex_eotf,
-                    in_y_tex_rgb_primaries,
-                    in_workingspace_rgb_primaries); 
+                normal Y = rnm_blend(
+                    normal(Nn[0], Nn[2], abs_normal[1]),
+                    normal(y_axis) * 2.0 - 1.0);
+
+                Y[2] *= normal_sign[1];
+
+                out_normal += blending[1] * Y;
             }
-            
-            out_color += blending[1] * in_y_axis_color * y_axis;
-            out_alpha += blending[1] * y_alpha;
+            else
+            {            
+                if (in_enable_cms && max(in_y_axis_color) > 0.0 &&
+                    max(y_axis) > 0.0)
+                {
+                    y_axis = apply_color_management(
+                        y_axis,
+                        in_y_tex_eotf,
+                        in_y_tex_rgb_primaries,
+                        in_workingspace_rgb_primaries); 
+                }                
+                out_color += blending[1] * in_y_axis_color * y_axis;
+                out_alpha += blending[1] * y_alpha;
+            }
         }
     }
     else
@@ -852,18 +908,30 @@ shader as_triplanar
                 in_z_axis_tflip,
                 z_alpha);
 
-            if (in_enable_cms && max(in_z_axis_color) > 0.0 &&
-                max(z_axis) > 0.0)
+            if (in_blend_mode == "Tangent Normal")
             {
-                z_axis = apply_color_management(
-                    z_axis,
-                    in_z_tex_eotf,
-                    in_z_tex_rgb_primaries,
-                    in_workingspace_rgb_primaries);
+                normal Z = rnm_blend(
+                    normal(Nn[0], Nn[1], abs_normal[2]),
+                    normal(z_axis) * 2.0 - 1.0);
+
+                Z[2] *= normal_sign[2];
+                
+                out_normal += blending[2] * Z;
             }
-            
-            out_color += blending[2] * in_z_axis_color * z_axis;
-            out_alpha += blending[2] * z_alpha;
+            else
+            {
+                if (in_enable_cms && max(in_z_axis_color) > 0.0 &&
+                    max(z_axis) > 0.0)
+                {
+                    z_axis = apply_color_management(
+                        z_axis,
+                        in_z_tex_eotf,
+                        in_z_tex_rgb_primaries,
+                        in_workingspace_rgb_primaries);
+                }                
+                out_color += blending[2] * in_z_axis_color * z_axis;
+                out_alpha += blending[2] * z_alpha;
+            }
         }
     }
     else
@@ -871,4 +939,5 @@ shader as_triplanar
         out_color += blending[2] * in_z_axis_color;
         out_alpha += blending[2];
     }
+    out_normal = normalize(out_normal + Nn);
 }


### PR DESCRIPTION
Add [Colour](https://github.com/colour-science/colour) reference since it was used to precompute the RGB<>XYZ and RGB<>RGB matrices.