### PR TITLE
Add camera shutter times check

### DIFF
--- a/src/appleseed/renderer/modeling/camera/camera.cpp
+++ b/src/appleseed/renderer/modeling/camera/camera.cpp
@@ -83,6 +83,9 @@ bool Camera::on_render_begin(
     m_shutter_open_end_time = m_params.get_optional<float>("shutter_open_end_time", 0.0f);
     m_shutter_close_start_time = m_params.get_optional<float>("shutter_close_start_time", 1.0f);
     m_shutter_close_time = m_params.get_optional<float>("shutter_close_time", 1.0f);
+
+    check_shutter_times_for_consistency();
+
     m_shutter_open_time_interval = m_shutter_close_time - m_shutter_open_time;
     m_normalized_open_end_time = inverse_lerp(m_shutter_open_time, m_shutter_close_time, m_shutter_open_end_time);
     m_normalized_open_end_time_half = m_normalized_open_end_time / 2;
@@ -408,6 +411,27 @@ double Camera::get_greater_than_zero(
     return value;
 }
 
+void Camera::check_shutter_times_for_consistency() const
+{
+    if (m_shutter_open_end_time < m_shutter_open_time)
+        RENDERER_LOG_WARNING("shutter open time of camera \"%s\" is greater than shutter open end time", get_path().c_str());
+
+    if (m_shutter_close_start_time < m_shutter_open_end_time)
+        RENDERER_LOG_WARNING("shutter open end time of camera \"%s\" is greater than shutter close start time", get_path().c_str());
+
+    if (m_shutter_close_start_time < m_shutter_open_time)
+        RENDERER_LOG_WARNING("shutter open time of camera \"%s\" is greater than shutter close start time", get_path().c_str());
+
+    if (m_shutter_close_time < m_shutter_open_time)
+        RENDERER_LOG_WARNING("shutter open time of camera \"%s\" is greater than shutter close time", get_path().c_str());
+
+    if (m_shutter_close_time < m_shutter_open_end_time)
+        RENDERER_LOG_WARNING("shutter open end time of camera \"%s\" is greater than shutter close time", get_path().c_str());
+
+    if (m_shutter_close_time < m_shutter_close_start_time)
+        RENDERER_LOG_WARNING("shutter close start time of camera \"%s\" is greater than shutter close time", get_path().c_str());
+
+}
 
 //
 // CameraFactory class implementation.

--- a/src/appleseed/renderer/modeling/camera/camera.cpp
+++ b/src/appleseed/renderer/modeling/camera/camera.cpp
@@ -80,9 +80,9 @@ bool Camera::on_render_begin(
     IAbortSwitch*           abort_switch)
 {
     m_shutter_open_time = m_params.get_optional<float>("shutter_open_time", 0.0f);
-    m_shutter_open_end_time = m_params.get_optional<float>("shutter_open_end_time", 0.0f);
-    m_shutter_close_start_time = m_params.get_optional<float>("shutter_close_start_time", 1.0f);
+    m_shutter_open_end_time = m_params.get_optional<float>("shutter_open_end_time", m_shutter_open_time);
     m_shutter_close_time = m_params.get_optional<float>("shutter_close_time", 1.0f);
+    m_shutter_close_start_time = m_params.get_optional<float>("shutter_close_start_time", m_shutter_close_time);
 
     check_shutter_times_for_consistency();
 

--- a/src/appleseed/renderer/modeling/camera/camera.h
+++ b/src/appleseed/renderer/modeling/camera/camera.h
@@ -204,6 +204,9 @@ class APPLESEED_DLLSYMBOL Camera
     double get_greater_than_zero(
         const char*                     name,
         const double                    default_value) const;
+
+    // Checks shutter times and emits warnings if needed
+    void check_shutter_times_for_consistency() const;
 };
 
 //


### PR DESCRIPTION
Please, review;
Also in the scope of this issue I suggest to change m_shutter_open_end_time default value to m_shutter_open_time and m_shutter_close_start default value to m_shutter_close_time; In this case there won't be any warnings if start/close values are set and open end/ close start values are missing;
![screenshot from 2018-03-01 14-02-38](https://user-images.githubusercontent.com/36549098/36841399-42097b56-1d59-11e8-9e46-2b1e73fff8ca.png)
