### PR TITLE
Line  numbers in python editor changed to dark gray

### DIFF
--- a/src/appleseed.studio/mainwindow/pythonconsole/linenumberarea.cpp
+++ b/src/appleseed.studio/mainwindow/pythonconsole/linenumberarea.cpp
@@ -96,7 +96,7 @@ void LineNumberArea::paintEvent(QPaintEvent* event)
         if (block.isVisible() && bottom >= event->rect().top())
         {
             QString number = QString::number(block_number + 1);
-            painter.setPen(QColor(24, 120, 120));
+            painter.setPen(QColor(169, 169, 169));
             painter.drawText(0, top, width(), fontMetrics().height(),
                              Qt::AlignRight, number);
         }


### PR DESCRIPTION
Issue #1521 
[`link`](https://github.com/appleseedhq/appleseed/issues/1521).
I have changed the RGB values for line numbers  from blue to dark gray