### PR TITLE
Fix color field update issue

### DIFF
--- a/src/appleseed.studio/utility/inputwidgetproxies.cpp
+++ b/src/appleseed.studio/utility/inputwidgetproxies.cpp
@@ -239,7 +239,7 @@ ColorPickerProxy::ColorPickerProxy(QLineEdit* line_edit, QToolButton* picker_but
   , m_picker_button(picker_button)
 {
     connect(m_line_edit, SIGNAL(returnPressed()), SIGNAL(signal_changed()));
-    connect(m_line_edit, SIGNAL(textChanged(const QString &)), SLOT(slot_set(const QString &)));
+    connect(m_line_edit, SIGNAL(textChanged(const QString&)), SLOT(slot_set(const QString&)));
 }
 
 namespace

--- a/src/appleseed.studio/utility/inputwidgetproxies.cpp
+++ b/src/appleseed.studio/utility/inputwidgetproxies.cpp
@@ -239,6 +239,7 @@ ColorPickerProxy::ColorPickerProxy(QLineEdit* line_edit, QToolButton* picker_but
   , m_picker_button(picker_button)
 {
     connect(m_line_edit, SIGNAL(returnPressed()), SIGNAL(signal_changed()));
+    connect(m_line_edit, SIGNAL(textChanged(const QString &)), SLOT(slot_set(const QString &)));
 }
 
 namespace


### PR DESCRIPTION
Fixes issue #1789 and changes the picker button color preview when the text changes. Only updates the value once return is pressed as with the other fields. 