### PR TITLE
Wire up correctly OSL's printf() to the renderer's logger (#1617)

### DIFF
--- a/src/appleseed/renderer/kernel/rendering/oiioerrorhandler.cpp
+++ b/src/appleseed/renderer/kernel/rendering/oiioerrorhandler.cpp
@@ -45,11 +45,16 @@ namespace renderer
 // OIIOErrorHandler class implementation.
 //
 
+OIIOErrorHandler::OIIOErrorHandler()
+{
+	verbosity(VERBOSE);
+}
+
 void OIIOErrorHandler::operator()(int errcode, const string& msg)
 {
     const string modified_msg = prefix_all_lines(trim_both(msg), "osl: ");
 
-    switch (errcode)
+    switch (errcode & ErrorCodeMask)
     {
       case EH_WARNING:
         RENDERER_LOG_WARNING("%s", modified_msg.c_str());
@@ -63,10 +68,12 @@ void OIIOErrorHandler::operator()(int errcode, const string& msg)
         RENDERER_LOG_FATAL("%s", modified_msg.c_str());
         break;
 
-      case EH_DEBUG:
-        RENDERER_LOG_DEBUG("%s", modified_msg.c_str());
+      case EH_MESSAGE:
+      case EH_INFO:
+        RENDERER_LOG_INFO("%s", modified_msg.c_str());
         break;
 
+      case EH_DEBUG:
       default:
         RENDERER_LOG_DEBUG("%s", modified_msg.c_str());
         break;

--- a/src/appleseed/renderer/kernel/rendering/oiioerrorhandler.h
+++ b/src/appleseed/renderer/kernel/rendering/oiioerrorhandler.h
@@ -51,7 +51,12 @@ class OIIOErrorHandler
   : public OIIO::ErrorHandler
 {
   public:
+    OIIOErrorHandler();
+
     void operator()(int errcode, const std::string& msg) override;
+
+  private:
+    static const int ErrorCodeMask = 0xffff0000;
 };
 
 }       // namespace renderer


### PR DESCRIPTION
Issue #1617 
It now works correctly.
Tested on the scene `osl/01 - lambertian ....` with the shader `matte.osl` edited like this:
```

surface matte(float Kd = 1, color Cs = 0)
{
	printf("This is a printf that should appear in the log\n");
	error("This error should appear in the log");
	warning("This warning should appear");
    Ci = Kd * Cs * diffuse(N);
}
```

And here is the output on a 1 by 1 image:
```
2018-03-04T11:25:07.167967Z <004>   147 MB info    | osl: This is a printf that should appear in the log
2018-03-04T11:25:07.168097Z <004>   147 MB error   | osl: Shader error [matte]: This error should appear in the log
2018-03-04T11:25:07.168142Z <004>   147 MB warning | osl: Shader warning [matte]: This warning should appear
2018-03-04T11:25:07.169069Z <004>   147 MB info    | osl: This is a printf that should appear in the log
2018-03-04T11:25:07.169466Z <004>   147 MB info    | osl: This is a printf that should appear in the log
```

I am wondering if we should do something to avoid concurrence. As you can see, the printf appears more than once. 