### PR TITLE
Delete default autofocus_target value in thin lens camera

### DIFF
--- a/sandbox/tests/unit tests/inputs/test_projectfilereader_configurationblocks.appleseed
+++ b/sandbox/tests/unit tests/inputs/test_projectfilereader_configurationblocks.appleseed
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project format_revision="22">
+<project format_revision="23">
     <scene>
         <camera name="camera" model="pinhole_camera">
             <parameter name="film_dimensions" value="0.025 0.025" />

--- a/src/appleseed/renderer/modeling/camera/camera.cpp
+++ b/src/appleseed/renderer/modeling/camera/camera.cpp
@@ -240,7 +240,7 @@ double Camera::extract_f_stop() const
 }
 
 void Camera::extract_focal_distance(
-    const bool&             autofocus_enabled,
+    const bool              autofocus_enabled,
     Vector2d&               autofocus_target,
     double&                 focal_distance) const
 {
@@ -249,35 +249,37 @@ void Camera::extract_focal_distance(
 
     if (autofocus_enabled)
     {
-        if (!has_param("autofocus_target"))
+        if (has_param("autofocus_target"))
+            autofocus_target = m_params.get_required<Vector2d>("autofocus_target", DefaultAFTarget);
+        
+        else
         {
             RENDERER_LOG_ERROR(
                 "while defining camera \"%s\": no \"autofocus_target\" parameter found; "
-                "using default autofocus_target value \"%f, %f\".",
+                "using default value \"%f, %f\".",
                 get_path().c_str(),
                 DefaultAFTarget[0],
                 DefaultAFTarget[1]);
             autofocus_target = DefaultAFTarget;
         }
-        else
-            autofocus_target = m_params.get_required<Vector2d>("autofocus_target", DefaultAFTarget);
 
-        focal_distance = 0.0;
+        focal_distance = DefaultFocalDistance;
     }
     else
     {
-        if (!has_param("focal_distance"))
+        if (has_param("focal_distance"))
+            focal_distance = m_params.get_required<double>("focal_distance", DefaultFocalDistance);
+
+        else
         {
             RENDERER_LOG_ERROR(
                 "while defining camera \"%s\": no \"focal_distance\" parameter found; "
-                "using default focal distance value \"%f\".",
+                "using default value \"%f\".",
                 get_path().c_str(),
                 DefaultFocalDistance);
             focal_distance = DefaultFocalDistance;
         }
-        else
-            focal_distance = m_params.get_required<double>("focal_distance", DefaultFocalDistance);
-            
+
         autofocus_target = DefaultAFTarget;
     }
 }

--- a/src/appleseed/renderer/modeling/camera/camera.cpp
+++ b/src/appleseed/renderer/modeling/camera/camera.cpp
@@ -251,7 +251,6 @@ void Camera::extract_focal_distance(
     {
         if (has_param("autofocus_target"))
             autofocus_target = m_params.get_required<Vector2d>("autofocus_target", DefaultAFTarget);
-        
         else
         {
             RENDERER_LOG_ERROR(
@@ -269,7 +268,6 @@ void Camera::extract_focal_distance(
     {
         if (has_param("focal_distance"))
             focal_distance = m_params.get_required<double>("focal_distance", DefaultFocalDistance);
-
         else
         {
             RENDERER_LOG_ERROR(

--- a/src/appleseed/renderer/modeling/camera/camera.cpp
+++ b/src/appleseed/renderer/modeling/camera/camera.cpp
@@ -240,50 +240,45 @@ double Camera::extract_f_stop() const
 }
 
 void Camera::extract_focal_distance(
-    bool&                   autofocus_enabled,
+    const bool&             autofocus_enabled,
     Vector2d&               autofocus_target,
     double&                 focal_distance) const
 {
     const Vector2d DefaultAFTarget(0.5);        // in NDC
     const double DefaultFocalDistance = 1.0;    // in meters
 
-    if (has_param("focal_distance"))
+    if (autofocus_enabled)
     {
-        if (has_param("autofocus_target"))
+        if (!has_param("autofocus_target"))
         {
-            RENDERER_LOG_WARNING(
-                "while defining camera \"%s\": autofocus is enabled; \"focal_distance\" parameter "
-                "will be ignored.",
-                get_path().c_str());
-
-            autofocus_enabled = true;
-            autofocus_target = m_params.get_required<Vector2d>("autofocus_target", DefaultAFTarget);
-            focal_distance = 0.0;
+            RENDERER_LOG_ERROR(
+                "while defining camera \"%s\": no \"autofocus_target\" parameter found; "
+                "using default autofocus_target value \"%f, %f\".",
+                get_path().c_str(),
+                DefaultAFTarget[0],
+                DefaultAFTarget[1]);
+            autofocus_target = DefaultAFTarget;
         }
         else
-        {
-            autofocus_enabled = false;
-            autofocus_target = DefaultAFTarget;
-            focal_distance = m_params.get_required<double>("focal_distance", DefaultFocalDistance);
-        }
-    }
-    else if (has_param("autofocus_target"))
-    {
-        autofocus_enabled = true;
-        autofocus_target = m_params.get_required<Vector2d>("autofocus_target", DefaultAFTarget);
+            autofocus_target = m_params.get_required<Vector2d>("autofocus_target", DefaultAFTarget);
+
         focal_distance = 0.0;
     }
     else
     {
-        RENDERER_LOG_ERROR(
-            "while defining camera \"%s\": no \"focal_distance\" or \"autofocus_target\" parameter found; "
-            "using default focal distance value \"%f\".",
-            get_path().c_str(),
-            DefaultFocalDistance);
-
-        autofocus_enabled = false;
+        if (!has_param("focal_distance"))
+        {
+            RENDERER_LOG_ERROR(
+                "while defining camera \"%s\": no \"focal_distance\" parameter found; "
+                "using default focal distance value \"%f\".",
+                get_path().c_str(),
+                DefaultFocalDistance);
+            focal_distance = DefaultFocalDistance;
+        }
+        else
+            focal_distance = m_params.get_required<double>("focal_distance", DefaultFocalDistance);
+            
         autofocus_target = DefaultAFTarget;
-        focal_distance = DefaultFocalDistance;
     }
 }
 

--- a/src/appleseed/renderer/modeling/camera/camera.h
+++ b/src/appleseed/renderer/modeling/camera/camera.h
@@ -182,7 +182,7 @@ class APPLESEED_DLLSYMBOL Camera
 
     // Utility function to retrieve the focal distance (in meters) from the camera parameters.
     void extract_focal_distance(
-        const bool&                     autofocus_enabled,
+        const bool                      autofocus_enabled,
         foundation::Vector2d&           autofocus_target,
         double&                         focal_distance) const;
 

--- a/src/appleseed/renderer/modeling/camera/camera.h
+++ b/src/appleseed/renderer/modeling/camera/camera.h
@@ -182,7 +182,7 @@ class APPLESEED_DLLSYMBOL Camera
 
     // Utility function to retrieve the focal distance (in meters) from the camera parameters.
     void extract_focal_distance(
-        bool&                           autofocus_enabled,
+        const bool&                     autofocus_enabled,
         foundation::Vector2d&           autofocus_target,
         double&                         focal_distance) const;
 

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -757,7 +757,7 @@ DictionaryArray ThinLensCameraFactory::get_input_metadata() const
 
     metadata.push_back(
         Dictionary()
-            .insert("name", "extract_focal_distance")
+            .insert("name", "autofocus_target")
             .insert("label", "Autofocus Target")
             .insert("type", "text")
             .insert("use", "optional")

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -750,7 +750,8 @@ DictionaryArray ThinLensCameraFactory::get_input_metadata() const
             .insert("name", "focal_distance")
             .insert("label", "Focal Distance")
             .insert("type", "text")
-            .insert("use", "optional"));
+            .insert("use", "optional")
+            .insert("default", "1.0"));
 
     metadata.push_back(
         Dictionary()

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -747,8 +747,7 @@ DictionaryArray ThinLensCameraFactory::get_input_metadata() const
             .insert("name", "autofocus_target")
             .insert("label", "Autofocus Target")
             .insert("type", "text")
-            .insert("use", "optional")
-            .insert("default", "0.5 0.5"));
+            .insert("use", "optional"));
 
     metadata.push_back(
         Dictionary()

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -747,7 +747,8 @@ DictionaryArray ThinLensCameraFactory::get_input_metadata() const
             .insert("name", "autofocus_target")
             .insert("label", "Autofocus Target")
             .insert("type", "text")
-            .insert("use", "optional"));
+            .insert("use", "optional")
+            .insert("default", "0.5 0.5"));
 
     metadata.push_back(
         Dictionary()

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -750,10 +750,7 @@ DictionaryArray ThinLensCameraFactory::get_input_metadata() const
             .insert("name", "focal_distance")
             .insert("label", "Focal Distance")
             .insert("type", "text")
-            .insert("use", "optional")
-            .insert("visible_if",
-                Dictionary()
-                    .insert("autofocus_enabled", "false")));
+            .insert("use", "optional"));
 
     metadata.push_back(
         Dictionary()
@@ -761,10 +758,7 @@ DictionaryArray ThinLensCameraFactory::get_input_metadata() const
             .insert("label", "Autofocus Target")
             .insert("type", "text")
             .insert("use", "optional")
-            .insert("default", "0.5 0.5")
-            .insert("visible_if",
-                Dictionary()
-                    .insert("autofocus_enabled", "true")));
+            .insert("default", "0.5 0.5"));
 
     metadata.push_back(
         Dictionary()

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -201,6 +201,8 @@ namespace
             if (!Camera::on_render_begin(project, abort_switch))
                 return false;
 
+            m_autofocus_enabled = m_params.get_optional<bool>("autofocus_enabled", true);
+
             // Extract the film dimensions from the camera parameters.
             m_film_dimensions = extract_film_dimensions();
 
@@ -737,18 +739,32 @@ DictionaryArray ThinLensCameraFactory::get_input_metadata() const
 
     metadata.push_back(
         Dictionary()
-            .insert("name", "focal_distance")
-            .insert("label", "Focal Distance")
-            .insert("type", "text")
-            .insert("use", "optional"));
+            .insert("name", "autofocus_enabled")
+            .insert("label", "Enable autofocus")
+            .insert("type", "boolean")
+            .insert("use", "optional")
+            .insert("default", "true"));
 
     metadata.push_back(
         Dictionary()
-            .insert("name", "autofocus_target")
+            .insert("name", "focal_distance")
+            .insert("label", "Focal Distance")
+            .insert("type", "text")
+            .insert("use", "optional")
+            .insert("visible_if",
+                Dictionary()
+                    .insert("autofocus_enabled", "false")));
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "extract_focal_distance")
             .insert("label", "Autofocus Target")
             .insert("type", "text")
             .insert("use", "optional")
-            .insert("default", "0.5 0.5"));
+            .insert("default", "0.5 0.5")
+            .insert("visible_if",
+                Dictionary()
+                    .insert("autofocus_enabled", "true")));
 
     metadata.push_back(
         Dictionary()

--- a/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
@@ -1630,6 +1630,38 @@ namespace
             }
         }  
     };
+
+    //
+    // Update from revision 22 to revision 23.
+    //
+    
+    class UpdateFromRevision_22
+      : public Updater
+    {
+      public:
+        explicit UpdateFromRevision_22(Project& project)
+          : Updater(project, 22)
+        {
+        }
+
+        void update() override
+        {
+            if (Scene* scene = m_project.get_scene())
+            {
+                for (each<CameraContainer> i = scene->cameras(); i; ++i)
+                {
+                    Dictionary& camera_params = i->get_parameters();
+
+                    if (camera_params.strings().exist("autofocus_target"))
+                        camera_params.strings().insert("autofocus_enabled", true);
+
+                    // camera_params include "focal_distance"
+                    else
+                        camera_params.strings().insert("autofocus_enabled", false);                        
+                }
+            }
+        }  
+    };
 }
 
 bool ProjectFileUpdater::update(
@@ -1684,6 +1716,7 @@ void ProjectFileUpdater::update(
       CASE_UPDATE_FROM_REVISION(19);
       CASE_UPDATE_FROM_REVISION(20);
       CASE_UPDATE_FROM_REVISION(21);
+      CASE_UPDATE_FROM_REVISION(22);
 
       case ProjectFormatRevision:
         // Project is up-to-date.

--- a/src/appleseed/renderer/modeling/project/projectformatrevision.h
+++ b/src/appleseed/renderer/modeling/project/projectformatrevision.h
@@ -39,7 +39,7 @@ namespace renderer
 // when you increment this value.
 //
 
-const size_t ProjectFormatRevision = 22;
+const size_t ProjectFormatRevision = 23;
 
 }       // namespace renderer
 


### PR DESCRIPTION
Delete default value because studio make default `autofocus_target` after edit even if there is no `autofocus_target ` in .studio file.

This makes studio preserve blurry effect in `test scene/cameras/01`.