### PR TITLE
Remove slider_min/max for Colormaps and add exposure multiplier

### DIFF
--- a/src/appleseed.studio/mainwindow/project/entityeditor.cpp
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.cpp
@@ -484,32 +484,23 @@ unique_ptr<IInputWidgetProxy> EntityEditor::create_colormap_input_widgets(const 
 {
     const string name = metadata.get<string>("name");
 
-    double slider_min, slider_max;
     double validator_min, validator_max;
 
     if (metadata.dictionaries().exist("min"))
     {
         const Dictionary& min = metadata.dictionary("min");
-        slider_min = min.get<double>("value");
-        validator_min = min.get<string>("type") == "hard" ? slider_min : -numeric_limits<double>::max();
+        validator_min = min.get<string>("type") == "hard" ? min.get<double>("value") : -numeric_limits<double>::max();
     }
     else
-    {
-        slider_min = 0.0;
         validator_min = -numeric_limits<double>::max();
-    }
 
     if (metadata.dictionaries().exist("max"))
     {
         const Dictionary& max = metadata.dictionary("max");
-        slider_max = max.get<double>("value");
-        validator_max = max.get<string>("type") == "hard" ? slider_max : +numeric_limits<double>::max();
+        validator_max = max.get<string>("type") == "hard" ? max.get<double>("value") : +numeric_limits<double>::max();
     }
     else
-    {
-        slider_max = 1.0;
         validator_max = +numeric_limits<double>::max();
-    }
 
     const QString default_value = metadata.strings().exist("default") ? metadata.get<QString>("default") : "";
 

--- a/src/appleseed/renderer/modeling/environmentedf/mirrorballmapenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/mirrorballmapenvironmentedf.cpp
@@ -87,6 +87,8 @@ namespace
         {
             m_inputs.declare("radiance", InputFormatSpectralIlluminance);
             m_inputs.declare("radiance_multiplier", InputFormatFloat, "1.0");
+            m_inputs.declare("exposure", InputFormatFloat, "0.0");
+            m_inputs.declare("exposure_multiplier", InputFormatFloat, "1.0");
         }
 
         void release() override
@@ -172,6 +174,8 @@ namespace
         {
             Spectrum    m_radiance;             // emitted radiance in W.m^-2.sr^-1
             float       m_radiance_multiplier;  // emitted radiance multiplier
+            float       m_exposure;             // emitted radiance multiplier in f-stops
+            float       m_exposure_multiplier;  // emitted radiance exposure multiplier
         };
 
         void lookup_envmap(
@@ -190,7 +194,7 @@ namespace
             if (is_finite(values.m_radiance))
             {
                 value = values.m_radiance;
-                value *= values.m_radiance_multiplier;
+                value *= values.m_radiance_multiplier * pow(2.0f, values.m_exposure * values.m_exposure_multiplier);
             }
             else value.set(0.0f);
         }
@@ -248,6 +252,35 @@ DictionaryArray MirrorBallMapEnvironmentEDFFactory::get_input_metadata() const
             .insert("use", "optional")
             .insert("default", "1.0")
             .insert("help", "Environment texture radiance multiplier"));
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "exposure")
+            .insert("label", "Exposure")
+            .insert("type", "colormap")
+            .insert("entity_types",
+                Dictionary()
+                    .insert("texture_instance", "Textures"))
+            .insert("use", "required")
+            .insert("default", "0.0")
+            .insert("help", "Environment exposure"));
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "exposure_multiplier")
+            .insert("label", "Exposure Multiplier")
+            .insert("type", "numeric")
+            .insert("min",
+                Dictionary()
+                    .insert("value", "-64.0")
+                    .insert("type", "soft"))
+            .insert("max",
+                Dictionary()
+                    .insert("value", "64.0")
+                    .insert("type", "soft"))
+            .insert("default", "1.0")
+            .insert("use", "optional")
+            .insert("help", "Environment exposure multiplier"));
 
     return metadata;
 }


### PR DESCRIPTION
EntityEditor takes in "min" and "max" parameters to set the slider range for colormaps as seen in the code below but it doesn't pass the values to the ColorMapInputWidget class nor was there a function to set the slider range in ColorMapInputWidget. So, I've added the function to set the slider range as well as passing the min/max values to that function in EntityEditor. 

I think this is the bug referenced in #1727 
  https://github.com/appleseedhq/appleseed/blob/f051daff605b4ca945659e4942eca8a24e61e908/src/appleseed.studio/mainwindow/project/entityeditor.cpp#L490-L519