### PR TITLE
Change default max_diffuse_bounces to 3

### DIFF
--- a/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
+++ b/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
@@ -790,13 +790,19 @@ namespace
             const bool              allow_unlimited = true)
         {
             const int DefaultMaxBounces = 8;
+            const int DefaultMaxDiffuseBounces = 3;
 
             const int max_bounces =
                 get_config<int>(config, construct_bounce_param_path(bounce_type), -1);
 
+            const string widget_max_bounce_key = widget_key_prefix + ".bounces.max_" + bounce_type + "_bounces";
+
             if (allow_unlimited)
                 set_widget(widget_key_prefix + ".bounces.unlimited_" + bounce_type + "_bounces", max_bounces == -1);
-            set_widget(widget_key_prefix + ".bounces.max_" + bounce_type + "_bounces", max_bounces == -1 ? DefaultMaxBounces : max_bounces);
+            if (bounce_type == "diffuse") 
+                set_widget(widget_max_bounce_key, max_bounces == -1 ? DefaultMaxDiffuseBounces : max_bounces);
+            else
+                set_widget(widget_max_bounce_key, max_bounces == -1 ? DefaultMaxBounces : max_bounces);
         }
 
         void save_separate_bounce_settings(

--- a/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.cpp
@@ -1043,7 +1043,7 @@ Dictionary PTLightingEngineFactory::get_params_metadata()
         "max_diffuse_bounces",
         Dictionary()
             .insert("type", "int")
-            .insert("default", "8")
+            .insert("default", "3")
             .insert("unlimited", "true")
             .insert("min", "0")
             .insert("label", "Max Diffuse Bounces")


### PR DESCRIPTION
Changed default max_diffuse_bounces to 3 as required in #1848 
I'm not sure if I have found every instance of where the default value is set. 
Would you want the default setting to be unlimited bounces or just 3 bounces? I can make the change to the commit if that's the case. 