### PR TITLE
Fix motion blur related crash in debug builds. Small tweaks

### DIFF
--- a/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
@@ -168,7 +168,7 @@ shader as_standard_surface
         string page = "Specular",
         string help = "Specular spread, controls the tails of the highlights.",
         int divider = 1
-    ]],  
+    ]],
     int in_fresnel_type = 0
     [[
         string as_maya_attribute_name = "fresnelType",
@@ -672,7 +672,7 @@ shader as_standard_surface
 
         if (in_fresnel_type == 0)
         {
-            if (!compute_coating && compute_transmission)
+            if (compute_transmission)
             {
                 out_outColor += opacity * as_glass(
                     "std",
@@ -772,7 +772,7 @@ shader as_standard_surface
         if (compute_edf && in_tonemap_edf)
         {
             edf_color /= luminance(edf_color) + 1.0;
-        }        
+        }
         if (compute_edf && max(edf_color) > 0.0)
         {
             out_outColor += transmittance * opacity *

--- a/src/appleseed/renderer/modeling/camera/camera.h
+++ b/src/appleseed/renderer/modeling/camera/camera.h
@@ -168,8 +168,9 @@ class APPLESEED_DLLSYMBOL Camera
     float               m_open_linear_curve_slope;
     float               m_close_linear_curve_slope;
     float               m_shutter_pdf_max_height;
-    float               m_inverse_cdf_open_point; 
+    float               m_inverse_cdf_open_point;
     float               m_inverse_cdf_close_point;
+    bool                m_motion_blur_enabled;
 
     // Utility function to retrieve the film dimensions (in meters) from the camera parameters.
     foundation::Vector2d extract_film_dimensions() const;


### PR DESCRIPTION
- Fix crash in debug builds when shutter time interval is zero.
- Enabled coating over glass in std surface.
