### PR TITLE
Show focal distance or autofocus target input form interactively.

### DIFF
--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -743,7 +743,8 @@ DictionaryArray ThinLensCameraFactory::get_input_metadata() const
             .insert("label", "Enable autofocus")
             .insert("type", "boolean")
             .insert("use", "optional")
-            .insert("default", "true"));
+            .insert("default", "true")
+            .insert("on_change", "rebuild_form"));
 
     metadata.push_back(
         Dictionary()
@@ -751,7 +752,10 @@ DictionaryArray ThinLensCameraFactory::get_input_metadata() const
             .insert("label", "Focal Distance")
             .insert("type", "text")
             .insert("use", "optional")
-            .insert("default", "1.0"));
+            .insert("default", "1.0")
+            .insert("visible_if",
+                Dictionary()
+                    .insert("autofocus_enabled", "false")));
 
     metadata.push_back(
         Dictionary()
@@ -759,7 +763,10 @@ DictionaryArray ThinLensCameraFactory::get_input_metadata() const
             .insert("label", "Autofocus Target")
             .insert("type", "text")
             .insert("use", "optional")
-            .insert("default", "0.5 0.5"));
+            .insert("default", "0.5 0.5")
+            .insert("visible_if",
+                Dictionary()
+                    .insert("autofocus_enabled", "true")));
 
     metadata.push_back(
         Dictionary()


### PR DESCRIPTION
`autofocus_target` shows when `autofocus_enabled` is checked, and `focal_distance` shows when unchecked.