### PR TITLE
Fix cameras' print_settings()

### DIFF
--- a/src/appleseed/renderer/modeling/camera/orthographiccamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/orthographiccamera.cpp
@@ -251,14 +251,18 @@ namespace
                 "  film height                   %f\n"
                 "  near z                        %f\n"
                 "  shutter open                  %f\n"
-                "  shutter close                 %f",
+                "  shutter close                 %f\n"
+                "  shutter open end              %f\n"
+                "  shutter close start           %f",
                 get_path().c_str(),
                 Model,
                 m_film_dimensions[0],
                 m_film_dimensions[1],
                 m_near_z,
                 m_shutter_open_time,
-                m_shutter_close_time);
+                m_shutter_close_time,
+                m_shutter_open_end_time,
+                m_shutter_close_start_time);
         }
 
         Vector3d ndc_to_camera(const Vector2d& point) const

--- a/src/appleseed/renderer/modeling/camera/orthographiccamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/orthographiccamera.cpp
@@ -250,10 +250,10 @@ namespace
                 "  film width                    %f\n"
                 "  film height                   %f\n"
                 "  near z                        %f\n"
-                "  shutter open                  %f\n"
-                "  shutter close                 %f\n"
+                "  shutter open start            %f\n"
                 "  shutter open end              %f\n"
-                "  shutter close start           %f",
+                "  shutter close start           %f\n"
+                "  shutter close end             %f",
                 get_path().c_str(),
                 Model,
                 m_film_dimensions[0],

--- a/src/appleseed/renderer/modeling/camera/orthographiccamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/orthographiccamera.cpp
@@ -260,9 +260,9 @@ namespace
                 m_film_dimensions[1],
                 m_near_z,
                 m_shutter_open_time,
-                m_shutter_close_time,
                 m_shutter_open_end_time,
-                m_shutter_close_start_time);
+                m_shutter_close_start_time,
+                m_shutter_close_time);
         }
 
         Vector3d ndc_to_camera(const Vector2d& point) const

--- a/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
@@ -285,7 +285,9 @@ namespace
                 "  focal length                  %f\n"
                 "  near z                        %f\n"
                 "  shutter open                  %f\n"
-                "  shutter close                 %f",
+                "  shutter close                 %f\n"
+                "  shutter open end              %f\n"
+                "  shutter close start           %f",
                 get_path().c_str(),
                 Model,
                 m_film_dimensions[0],
@@ -293,7 +295,9 @@ namespace
                 m_focal_length,
                 m_near_z,
                 m_shutter_open_time,
-                m_shutter_close_time);
+                m_shutter_close_time,
+                m_shutter_open_end_time,
+                m_shutter_close_start_time);
         }
 
         Vector3d ndc_to_camera(const Vector2d& point) const

--- a/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
@@ -295,9 +295,9 @@ namespace
                 m_focal_length,
                 m_near_z,
                 m_shutter_open_time,
-                m_shutter_close_time,
                 m_shutter_open_end_time,
-                m_shutter_close_start_time);
+                m_shutter_close_start_time,
+                m_shutter_close_time);
         }
 
         Vector3d ndc_to_camera(const Vector2d& point) const

--- a/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
@@ -284,10 +284,10 @@ namespace
                 "  film height                   %f\n"
                 "  focal length                  %f\n"
                 "  near z                        %f\n"
-                "  shutter open                  %f\n"
-                "  shutter close                 %f\n"
+                "  shutter open start            %f\n"
                 "  shutter open end              %f\n"
-                "  shutter close start           %f",
+                "  shutter close start           %f\n"
+                "  shutter close end             %f",
                 get_path().c_str(),
                 Model,
                 m_film_dimensions[0],

--- a/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
@@ -217,9 +217,9 @@ namespace
                 get_path().c_str(),
                 Model,
                 m_shutter_open_time,
-                m_shutter_close_time,
                 m_shutter_open_end_time,
-                m_shutter_close_start_time);
+                m_shutter_close_start_time,
+                m_shutter_close_time);
         }
 
         static Vector3d ndc_to_camera(const Vector2d& point)

--- a/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
@@ -210,10 +210,10 @@ namespace
             RENDERER_LOG_INFO(
                 "camera \"%s\" settings:\n"
                 "  model                         %s\n"
-                "  shutter open                  %f\n"
-                "  shutter close                 %f\n"
+                "  shutter open start            %f\n"
                 "  shutter open end              %f\n"
-                "  shutter close start           %f",
+                "  shutter close start           %f\n"
+                "  shutter close end             %f",
                 get_path().c_str(),
                 Model,
                 m_shutter_open_time,

--- a/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
@@ -211,11 +211,15 @@ namespace
                 "camera \"%s\" settings:\n"
                 "  model                         %s\n"
                 "  shutter open                  %f\n"
-                "  shutter close                 %f",
+                "  shutter close                 %f\n"
+                "  shutter open end              %f\n"
+                "  shutter close start           %f",
                 get_path().c_str(),
                 Model,
                 m_shutter_open_time,
-                m_shutter_close_time);
+                m_shutter_close_time,
+                m_shutter_open_end_time,
+                m_shutter_close_start_time);
         }
 
         static Vector3d ndc_to_camera(const Vector2d& point)

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -572,9 +572,9 @@ namespace
                 m_diaphragm_tilt_angle,
                 m_near_z,
                 m_shutter_open_time,
-                m_shutter_close_time,
                 m_shutter_open_end_time,
-                m_shutter_close_start_time);
+                m_shutter_close_start_time,
+                m_shutter_close_time);
         }
 
         Vector3d ndc_to_camera(const Vector2d& point) const

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -555,10 +555,10 @@ namespace
                 "  diaphragm blades              %s\n"
                 "  diaphragm angle               %f\n"
                 "  near z                        %f\n"
-                "  shutter open                  %f\n"
-                "  shutter close                 %f\n"
+                "  shutter open start            %f\n"
                 "  shutter open end              %f\n"
-                "  shutter close start           %f",
+                "  shutter close start           %f\n"
+                "  shutter close end             %f",
                 get_path().c_str(),
                 Model,
                 m_film_dimensions[0],

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -556,7 +556,9 @@ namespace
                 "  diaphragm angle               %f\n"
                 "  near z                        %f\n"
                 "  shutter open                  %f\n"
-                "  shutter close                 %f",
+                "  shutter close                 %f\n"
+                "  shutter open end              %f\n"
+                "  shutter close start           %f",
                 get_path().c_str(),
                 Model,
                 m_film_dimensions[0],
@@ -570,7 +572,9 @@ namespace
                 m_diaphragm_tilt_angle,
                 m_near_z,
                 m_shutter_open_time,
-                m_shutter_close_time);
+                m_shutter_close_time,
+                m_shutter_open_end_time,
+                m_shutter_close_start_time);
         }
 
         Vector3d ndc_to_camera(const Vector2d& point) const


### PR DESCRIPTION
I add 2 extra lines to print `shutter open end` and `shutter close start` which are in src/appleseed/renderer/modeling/camera/

- "thinlencamera.cpp" at 560, 561 line
- "sphericalcamera.cpp" at 215, 216 line
- "orthographiccamera.cpp" at 255, 256 line
- "pinholecamera.cpp" at 289, 290 line
#1892 