### PR TITLE
Allow sending AOV tiles to stdout

### DIFF
--- a/src/appleseed.cli/main.cpp
+++ b/src/appleseed.cli/main.cpp
@@ -543,7 +543,9 @@ namespace
         }
         else if (g_cl.m_send_to_stdout.is_set())
         {
-            tile_callback_factory.reset(new StdOutTileCallbackFactory(TileOutputOptions::AllAOVs));
+            tile_callback_factory.reset(
+                new StdOutTileCallbackFactory(
+                    StdOutTileCallbackFactory::TileOutputOptions::AllAOVs));
         }
         else if (project->get_display() == nullptr)
         {

--- a/src/appleseed.cli/main.cpp
+++ b/src/appleseed.cli/main.cpp
@@ -543,7 +543,7 @@ namespace
         }
         else if (g_cl.m_send_to_stdout.is_set())
         {
-            tile_callback_factory.reset(new StdOutTileCallbackFactory());
+            tile_callback_factory.reset(new StdOutTileCallbackFactory(TileOutputOptions::AllAOVs));
         }
         else if (project->get_display() == nullptr)
         {

--- a/src/appleseed.cli/stdouttilecallback.h
+++ b/src/appleseed.cli/stdouttilecallback.h
@@ -38,11 +38,17 @@
 namespace appleseed {
 namespace cli {
 
+enum TileOutputOptions
+{
+    BeautyOnly = 1,
+    AllAOVs = 2
+};
+
 class StdOutTileCallbackFactory
   : public renderer::ITileCallbackFactory
 {
   public:
-    StdOutTileCallbackFactory();
+    explicit StdOutTileCallbackFactory(TileOutputOptions export_options);
 
     void release() override;
 

--- a/src/appleseed.cli/stdouttilecallback.h
+++ b/src/appleseed.cli/stdouttilecallback.h
@@ -38,16 +38,16 @@
 namespace appleseed {
 namespace cli {
 
-enum TileOutputOptions
-{
-    BeautyOnly = 1,
-    AllAOVs = 2
-};
-
 class StdOutTileCallbackFactory
   : public renderer::ITileCallbackFactory
 {
   public:
+    enum class TileOutputOptions
+    {
+      BeautyOnly,
+      AllAOVs
+    };
+
     explicit StdOutTileCallbackFactory(TileOutputOptions export_options);
 
     void release() override;

--- a/src/appleseed.cli/stdouttilecallback.h
+++ b/src/appleseed.cli/stdouttilecallback.h
@@ -44,8 +44,8 @@ class StdOutTileCallbackFactory
   public:
     enum class TileOutputOptions
     {
-      BeautyOnly,
-      AllAOVs
+        BeautyOnly,
+        AllAOVs
     };
 
     explicit StdOutTileCallbackFactory(TileOutputOptions export_options);


### PR DESCRIPTION
Issue #1882 

Since there is a need to refactor a lot of things, I am doing this step by step.


I will need to update the protocol so that it supports AOVs. For that, I was thinking of doing as in `houdinitilecallbacks`.

Needs to be merged along with [ Implement protocol v2 decoding and reading #208 ](https://github.com/appleseedhq/blenderseed/pull/208)