### PR TITLE
Discover new plugins with a more efficient technique

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,9 @@ set (CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 #--------------------------------------------------------------------------------------------------
 # Platform-specific settings.
 #--------------------------------------------------------------------------------------------------
+
 # This must come after project () otherwise CMAKE_SYSTEM_NAME is undefined.
+add_definitions (-D_GLIBCXX_USE_CXX11_ABI=0)
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     include (cmake/config/win-vs.txt)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,6 @@ set (CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 #--------------------------------------------------------------------------------------------------
 
 # This must come after project () otherwise CMAKE_SYSTEM_NAME is undefined.
-add_definitions (-D_GLIBCXX_USE_CXX11_ABI=0)
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     include (cmake/config/win-vs.txt)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,6 @@ set (CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 #--------------------------------------------------------------------------------------------------
 # Platform-specific settings.
 #--------------------------------------------------------------------------------------------------
-
 # This must come after project () otherwise CMAKE_SYSTEM_NAME is undefined.
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     include (cmake/config/win-vs.txt)

--- a/src/appleseed/renderer/modeling/aov/aovfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/aov/aovfactoryregistrar.cpp
@@ -62,10 +62,10 @@ struct AOVFactoryRegistrar::Impl
     Registrar<IAOVFactory> m_registrar;
 };
 
-AOVFactoryRegistrar::AOVFactoryRegistrar(const SearchPaths& search_paths)
+AOVFactoryRegistrar::AOVFactoryRegistrar()
   : impl(new Impl())
 {
-    reinitialize(search_paths);
+    reinitialize();
 }
 
 AOVFactoryRegistrar::~AOVFactoryRegistrar()
@@ -73,7 +73,7 @@ AOVFactoryRegistrar::~AOVFactoryRegistrar()
     delete impl;
 }
 
-void AOVFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
+void AOVFactoryRegistrar::reinitialize()
 {
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
@@ -94,7 +94,6 @@ void AOVFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
 
     // Register factories defined in plugins.
     register_factories_from_plugins<AOV>(
-        search_paths,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<IAOVFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/aov/aovfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/aov/aovfactoryregistrar.h
@@ -81,7 +81,7 @@ class APPLESEED_DLLSYMBOL AOVFactoryRegistrar
     // Destructor.
     ~AOVFactoryRegistrar();
 
-    // Reinitialize the registrar;
+    // Reinitialize the registrar.
     void reinitialize(
         const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
@@ -95,7 +95,7 @@ class APPLESEED_DLLSYMBOL AOVFactoryRegistrar
     struct Impl;
     Impl* impl;
 
-    // pointer to the loaded libraries in memory
+    // Pointer to the loaded libraries in memory.
     boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
     
     // Register a factory.

--- a/src/appleseed/renderer/modeling/aov/aovfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/aov/aovfactoryregistrar.h
@@ -36,9 +36,20 @@
 #include "foundation/utility/api/apiarray.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/searchpaths.h"
+#include "foundation/platform/sharedlibrary.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
+
+// Boost headers.
+#include "boost/filesystem.hpp"
+#include "boost/make_shared.hpp"
+
+//standard headers
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
 
 // Forward declarations.
 namespace renderer      { class IAOVFactory; }
@@ -71,7 +82,8 @@ class APPLESEED_DLLSYMBOL AOVFactoryRegistrar
     ~AOVFactoryRegistrar();
 
     // Reinitialize the registrar;
-    void reinitialize();
+    void reinitialize(
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;
@@ -83,6 +95,9 @@ class APPLESEED_DLLSYMBOL AOVFactoryRegistrar
     struct Impl;
     Impl* impl;
 
+    // pointer to the loaded libraries in memory
+    boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
+    
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);
 };

--- a/src/appleseed/renderer/modeling/aov/aovfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/aov/aovfactoryregistrar.h
@@ -65,14 +65,13 @@ class APPLESEED_DLLSYMBOL AOVFactoryRegistrar
     typedef AOVFactoryArray FactoryArrayType;
 
     // Constructor.
-    explicit AOVFactoryRegistrar(
-        const foundation::SearchPaths& search_paths = foundation::SearchPaths());
+    explicit AOVFactoryRegistrar();
 
     // Destructor.
     ~AOVFactoryRegistrar();
 
-    // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize(const foundation::SearchPaths& search_paths);
+    // Reinitialize the registrar;
+    void reinitialize();
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;

--- a/src/appleseed/renderer/modeling/bsdf/bsdffactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdffactoryregistrar.cpp
@@ -72,10 +72,10 @@ struct BSDFFactoryRegistrar::Impl
     Registrar<IBSDFFactory> m_registrar;
 };
 
-BSDFFactoryRegistrar::BSDFFactoryRegistrar(const SearchPaths& search_paths)
+BSDFFactoryRegistrar::BSDFFactoryRegistrar()
   : impl(new Impl())
 {
-    reinitialize(search_paths);
+    reinitialize();
 }
 
 BSDFFactoryRegistrar::~BSDFFactoryRegistrar()
@@ -83,7 +83,7 @@ BSDFFactoryRegistrar::~BSDFFactoryRegistrar()
     delete impl;
 }
 
-void BSDFFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
+void BSDFFactoryRegistrar::reinitialize()
 {
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
@@ -109,7 +109,6 @@ void BSDFFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
 
     // Register factories defined in plugins.
     register_factories_from_plugins<BSDF>(
-        search_paths,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<IBSDFFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/bsdf/bsdffactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdffactoryregistrar.h
@@ -37,9 +37,20 @@
 #include "foundation/utility/api/apiarray.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/searchpaths.h"
+#include "foundation/platform/sharedlibrary.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
+
+// Boost headers.
+#include "boost/filesystem.hpp"
+#include "boost/make_shared.hpp"
+
+//standard headers
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
 
 // Forward declarations.
 namespace renderer      { class IBSDFFactory; }
@@ -72,7 +83,8 @@ class APPLESEED_DLLSYMBOL BSDFFactoryRegistrar
     ~BSDFFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize();
+    void reinitialize(
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;
@@ -83,6 +95,9 @@ class APPLESEED_DLLSYMBOL BSDFFactoryRegistrar
   private:
     struct Impl;
     Impl* impl;
+
+    //loaded libraries in memory
+    boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
 
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);

--- a/src/appleseed/renderer/modeling/bsdf/bsdffactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdffactoryregistrar.h
@@ -82,7 +82,7 @@ class APPLESEED_DLLSYMBOL BSDFFactoryRegistrar
     // Destructor.
     ~BSDFFactoryRegistrar();
 
-    // Reinitialize the registrar; load plugins found in provided search paths.
+    // Reinitialize the registrar. load plugins found in provided search paths.
     void reinitialize(
         const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 

--- a/src/appleseed/renderer/modeling/bsdf/bsdffactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdffactoryregistrar.h
@@ -66,14 +66,13 @@ class APPLESEED_DLLSYMBOL BSDFFactoryRegistrar
     typedef BSDFFactoryArray FactoryArrayType;
 
     // Constructor.
-    explicit BSDFFactoryRegistrar(
-        const foundation::SearchPaths& search_paths = foundation::SearchPaths());
+    explicit BSDFFactoryRegistrar();
 
     // Destructor.
     ~BSDFFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize(const foundation::SearchPaths& search_paths);
+    void reinitialize();
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;

--- a/src/appleseed/renderer/modeling/bssrdf/bssrdffactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/bssrdffactoryregistrar.cpp
@@ -61,10 +61,10 @@ struct BSSRDFFactoryRegistrar::Impl
     Registrar<IBSSRDFFactory> m_registrar;
 };
 
-BSSRDFFactoryRegistrar::BSSRDFFactoryRegistrar(const SearchPaths& search_paths)
+BSSRDFFactoryRegistrar::BSSRDFFactoryRegistrar()
   : impl(new Impl())
 {
-    reinitialize(search_paths);
+    reinitialize();
 }
 
 BSSRDFFactoryRegistrar::~BSSRDFFactoryRegistrar()
@@ -72,7 +72,7 @@ BSSRDFFactoryRegistrar::~BSSRDFFactoryRegistrar()
     delete impl;
 }
 
-void BSSRDFFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
+void BSSRDFFactoryRegistrar::reinitialize()
 {
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
@@ -88,7 +88,6 @@ void BSSRDFFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
 
     // Register factories defined in plugins.
     register_factories_from_plugins<BSSRDF>(
-        search_paths,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<IBSSRDFFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/bssrdf/bssrdffactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/bssrdffactoryregistrar.cpp
@@ -62,9 +62,10 @@ struct BSSRDFFactoryRegistrar::Impl
 };
 
 BSSRDFFactoryRegistrar::BSSRDFFactoryRegistrar()
-  : impl(new Impl())
+  : impl(new Impl()),
+    m_loaded_libraries(boost::make_shared<loaded_libs_container>())
 {
-    reinitialize();
+    reinitialize(m_loaded_libraries);
 }
 
 BSSRDFFactoryRegistrar::~BSSRDFFactoryRegistrar()
@@ -72,8 +73,11 @@ BSSRDFFactoryRegistrar::~BSSRDFFactoryRegistrar()
     delete impl;
 }
 
-void BSSRDFFactoryRegistrar::reinitialize()
+void BSSRDFFactoryRegistrar::reinitialize(
+    const boost::shared_ptr<loaded_libs_container> loaded_libraries)
 {
+    m_loaded_libraries = loaded_libraries;
+    
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
     unload_all_plugins();
@@ -88,6 +92,7 @@ void BSSRDFFactoryRegistrar::reinitialize()
 
     // Register factories defined in plugins.
     register_factories_from_plugins<BSSRDF>(
+        m_loaded_libraries,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<IBSSRDFFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/bssrdf/bssrdffactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/bssrdf/bssrdffactoryregistrar.h
@@ -36,9 +36,15 @@
 #include "foundation/utility/api/apiarray.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/searchpaths.h"
+#include "foundation/platform/sharedlibrary.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
+
+//standard headers
+#include <string>
+#include <vector>
+#include <memory>
 
 // Forward declarations.
 namespace renderer      { class IBSSRDFFactory; }
@@ -71,7 +77,8 @@ class APPLESEED_DLLSYMBOL BSSRDFFactoryRegistrar
     ~BSSRDFFactoryRegistrar() override;
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize();
+    void reinitialize(
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;
@@ -82,6 +89,9 @@ class APPLESEED_DLLSYMBOL BSSRDFFactoryRegistrar
   private:
     struct Impl;
     Impl* impl;
+
+    //loaded libraries in memory
+    boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
 
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);

--- a/src/appleseed/renderer/modeling/bssrdf/bssrdffactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/bssrdf/bssrdffactoryregistrar.h
@@ -65,14 +65,13 @@ class APPLESEED_DLLSYMBOL BSSRDFFactoryRegistrar
     typedef BSSRDFFactoryArray FactoryArrayType;
 
     // Constructor.
-    explicit BSSRDFFactoryRegistrar(
-        const foundation::SearchPaths& search_paths = foundation::SearchPaths());
+    explicit BSSRDFFactoryRegistrar();
 
     // Destructor.
     ~BSSRDFFactoryRegistrar() override;
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize(const foundation::SearchPaths& search_paths);
+    void reinitialize();
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;

--- a/src/appleseed/renderer/modeling/bssrdf/bssrdffactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/bssrdf/bssrdffactoryregistrar.h
@@ -76,7 +76,7 @@ class APPLESEED_DLLSYMBOL BSSRDFFactoryRegistrar
     // Destructor.
     ~BSSRDFFactoryRegistrar() override;
 
-    // Reinitialize the registrar; load plugins found in provided search paths.
+    // Reinitialize the registrar. load plugins found in provided search paths.
     void reinitialize(
         const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 

--- a/src/appleseed/renderer/modeling/camera/camerafactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/camera/camerafactoryregistrar.cpp
@@ -60,10 +60,10 @@ struct CameraFactoryRegistrar::Impl
     Registrar<ICameraFactory> m_registrar;
 };
 
-CameraFactoryRegistrar::CameraFactoryRegistrar(const SearchPaths& search_paths)
+CameraFactoryRegistrar::CameraFactoryRegistrar()
   : impl(new Impl())
 {
-    reinitialize(search_paths);
+    reinitialize();
 }
 
 CameraFactoryRegistrar::~CameraFactoryRegistrar()
@@ -71,7 +71,7 @@ CameraFactoryRegistrar::~CameraFactoryRegistrar()
     delete impl;
 }
 
-void CameraFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
+void CameraFactoryRegistrar::reinitialize()
 {
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
@@ -85,7 +85,6 @@ void CameraFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
 
     // Register factories defined in plugins.
     register_factories_from_plugins<Camera>(
-        search_paths,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<ICameraFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/camera/camerafactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/camera/camerafactoryregistrar.h
@@ -37,9 +37,17 @@
 #include "foundation/utility/api/apiarray.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/searchpaths.h"
+#include "foundation/platform/sharedlibrary.h"
+
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
+
+//standard headers
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
 
 // Forward declarations.
 namespace renderer      { class ICameraFactory; }
@@ -72,7 +80,8 @@ class APPLESEED_DLLSYMBOL CameraFactoryRegistrar
     ~CameraFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize();
+    void reinitialize(
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;
@@ -83,6 +92,9 @@ class APPLESEED_DLLSYMBOL CameraFactoryRegistrar
   private:
     struct Impl;
     Impl* impl;
+
+    //loaded libraries in memory
+    boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
 
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);

--- a/src/appleseed/renderer/modeling/camera/camerafactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/camera/camerafactoryregistrar.h
@@ -66,14 +66,13 @@ class APPLESEED_DLLSYMBOL CameraFactoryRegistrar
     typedef CameraFactoryArray FactoryArrayType;
 
     // Constructor.
-    explicit CameraFactoryRegistrar(
-        const foundation::SearchPaths& search_paths = foundation::SearchPaths());
+    explicit CameraFactoryRegistrar();
 
     // Destructor.
     ~CameraFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize(const foundation::SearchPaths& search_paths);
+    void reinitialize();
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;

--- a/src/appleseed/renderer/modeling/camera/camerafactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/camera/camerafactoryregistrar.h
@@ -39,7 +39,6 @@
 #include "foundation/utility/searchpaths.h"
 #include "foundation/platform/sharedlibrary.h"
 
-
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
@@ -79,7 +78,7 @@ class APPLESEED_DLLSYMBOL CameraFactoryRegistrar
     // Destructor.
     ~CameraFactoryRegistrar();
 
-    // Reinitialize the registrar; load plugins found in provided search paths.
+    // Reinitialize the registrar. load plugins found in provided search paths.
     void reinitialize(
         const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 

--- a/src/appleseed/renderer/modeling/edf/edffactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/edf/edffactoryregistrar.cpp
@@ -58,10 +58,10 @@ struct EDFFactoryRegistrar::Impl
     Registrar<IEDFFactory> m_registrar;
 };
 
-EDFFactoryRegistrar::EDFFactoryRegistrar(const SearchPaths& search_paths)
+EDFFactoryRegistrar::EDFFactoryRegistrar()
   : impl(new Impl())
 {
-    reinitialize(search_paths);
+    reinitialize();
 }
 
 EDFFactoryRegistrar::~EDFFactoryRegistrar()
@@ -69,7 +69,7 @@ EDFFactoryRegistrar::~EDFFactoryRegistrar()
     delete impl;
 }
 
-void EDFFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
+void EDFFactoryRegistrar::reinitialize()
 {
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
@@ -81,7 +81,6 @@ void EDFFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
 
     // Register factories defined in plugins.
     register_factories_from_plugins<EDF>(
-        search_paths,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<IEDFFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/edf/edffactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/edf/edffactoryregistrar.cpp
@@ -59,9 +59,10 @@ struct EDFFactoryRegistrar::Impl
 };
 
 EDFFactoryRegistrar::EDFFactoryRegistrar()
-  : impl(new Impl())
+  : impl(new Impl()),
+    m_loaded_libraries(boost::make_shared<loaded_libs_container>())
 {
-    reinitialize();
+    reinitialize(m_loaded_libraries);
 }
 
 EDFFactoryRegistrar::~EDFFactoryRegistrar()
@@ -69,8 +70,11 @@ EDFFactoryRegistrar::~EDFFactoryRegistrar()
     delete impl;
 }
 
-void EDFFactoryRegistrar::reinitialize()
+void EDFFactoryRegistrar::reinitialize(
+    const boost::shared_ptr<loaded_libs_container> loaded_libraries)
 {
+    m_loaded_libraries = loaded_libraries;
+
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
     unload_all_plugins();
@@ -81,6 +85,7 @@ void EDFFactoryRegistrar::reinitialize()
 
     // Register factories defined in plugins.
     register_factories_from_plugins<EDF>(
+        m_loaded_libraries,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<IEDFFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/edf/edffactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/edf/edffactoryregistrar.h
@@ -66,14 +66,13 @@ class APPLESEED_DLLSYMBOL EDFFactoryRegistrar
     typedef EDFFactoryArray FactoryArrayType;
 
     // Constructor.
-    explicit EDFFactoryRegistrar(
-        const foundation::SearchPaths& search_paths = foundation::SearchPaths());
+    explicit EDFFactoryRegistrar();
 
     // Destructor.
     ~EDFFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize(const foundation::SearchPaths& search_paths);
+    void reinitialize();
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;

--- a/src/appleseed/renderer/modeling/edf/edffactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/edf/edffactoryregistrar.h
@@ -37,9 +37,20 @@
 #include "foundation/utility/api/apiarray.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/searchpaths.h"
+#include "foundation/platform/sharedlibrary.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
+
+// Boost headers.
+#include "boost/filesystem.hpp"
+#include "boost/make_shared.hpp"
+
+//standard headers
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
 
 // Forward declarations.
 namespace renderer      { class IEDFFactory; }
@@ -72,7 +83,9 @@ class APPLESEED_DLLSYMBOL EDFFactoryRegistrar
     ~EDFFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize();
+     void reinitialize(
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries);
+
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;
@@ -83,6 +96,9 @@ class APPLESEED_DLLSYMBOL EDFFactoryRegistrar
   private:
     struct Impl;
     Impl* impl;
+
+    // pointer to the loaded libraries in memory
+    boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
 
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);

--- a/src/appleseed/renderer/modeling/edf/edffactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/edf/edffactoryregistrar.h
@@ -82,7 +82,7 @@ class APPLESEED_DLLSYMBOL EDFFactoryRegistrar
     // Destructor.
     ~EDFFactoryRegistrar();
 
-    // Reinitialize the registrar; load plugins found in provided search paths.
+    // Reinitialize the registrar. load plugins found in provided search paths.
      void reinitialize(
         const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
@@ -97,7 +97,7 @@ class APPLESEED_DLLSYMBOL EDFFactoryRegistrar
     struct Impl;
     Impl* impl;
 
-    // pointer to the loaded libraries in memory
+    // Pointer to the loaded libraries in memory.
     boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
 
     // Register a factory.

--- a/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.cpp
@@ -89,13 +89,9 @@ void EntityFactoryRegistrar::discover_plugins(
         if (!bf::exists(search_path) || !bf::is_directory(search_path))
             continue;
 
-
-
         // Iterate over all files in this directory.
         for (bf::directory_iterator j(search_path), f; j != f; ++j)
         {
-
-            //iterate over entities;
 
             // Only consider shared library files.
             if (!bf::is_regular_file(*j) ||
@@ -105,7 +101,6 @@ void EntityFactoryRegistrar::discover_plugins(
             const std::string plugin_path = j->path().string();
             
             //load plugin into memory 
-            //foundation::SharedLibrary s(plugin_path.c_str());
             try
             {
                 unique_ptr<foundation::SharedLibrary> library(new foundation::SharedLibrary(plugin_path.c_str()));
@@ -116,9 +111,7 @@ void EntityFactoryRegistrar::discover_plugins(
                 RENDERER_LOG_DEBUG("could not open shared library %s: %s.",
                     plugin_path.c_str(), e.what());
                 continue;
-            }
-            //iterate over all  plugins  ( because now we are in the path )
-          
+            }          
         }
     }
 }

--- a/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.cpp
@@ -35,10 +35,6 @@
 // appleseed.foundation headers.
 #include "foundation/utility/searchpaths.h"
 
-// Standard headers.
-#include <vector>
-#include <iostream>
-
 using namespace renderer;
 using namespace std;
 

--- a/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.cpp
@@ -75,9 +75,11 @@ EntityFactoryRegistrar::~EntityFactoryRegistrar()
 
 boost::shared_ptr<loaded_libs_container> EntityFactoryRegistrar::discover_plugins(
     const foundation::SearchPaths&          search_paths){
+
     namespace bf = boost::filesystem;
-    loaded_libs_container loaded_libs;
+
     boost::shared_ptr<loaded_libs_container> lb(boost::make_shared<loaded_libs_container>());
+   
     // Iterate over all search paths.
     for (size_t i = 0, e = search_paths.get_path_count(); i < e; ++i)
     {
@@ -94,7 +96,6 @@ boost::shared_ptr<loaded_libs_container> EntityFactoryRegistrar::discover_plugin
         // Iterate over all files in this directory.
         for (bf::directory_iterator j(search_path), f; j != f; ++j)
         {
-
             // Only consider shared library files.
             if (!bf::is_regular_file(*j) ||
                 j->path().extension() != foundation::SharedLibrary::get_default_file_extension())
@@ -102,7 +103,7 @@ boost::shared_ptr<loaded_libs_container> EntityFactoryRegistrar::discover_plugin
 
             const std::string plugin_path = j->path().string();
             
-            //load plugin into memory 
+            // Load plugin into memory. 
             try
             {
                 unique_ptr<foundation::SharedLibrary> library(new foundation::SharedLibrary(plugin_path.c_str()));
@@ -116,10 +117,7 @@ boost::shared_ptr<loaded_libs_container> EntityFactoryRegistrar::discover_plugin
             } 
         }
     }
-    std::cout<<"in in in \n";
-    //boost::shared_ptr<loaded_libs_container> lb(new loaded_libs_container);
-    std::cout<<"size "<<lb->size();
-    std::cout<<"out out out \n";
+    
     return lb;
 }
 
@@ -133,5 +131,4 @@ void EntityFactoryRegistrar::store_plugin(Plugin* plugin)
     impl->m_plugins.push_back(plugin);
 }
 
-//std::vector<std::pair<std::unique_ptr<foundation::SharedLibrary>, std::string>> EntityFactoryRegistrar::loaded_libraries;
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.cpp
@@ -37,6 +37,7 @@
 
 // Standard headers.
 #include <vector>
+#include <iostream>
 
 using namespace renderer;
 using namespace std;
@@ -72,10 +73,11 @@ EntityFactoryRegistrar::~EntityFactoryRegistrar()
     delete impl;
 }
 
-void EntityFactoryRegistrar::discover_plugins(
+boost::shared_ptr<loaded_libs_container> EntityFactoryRegistrar::discover_plugins(
     const foundation::SearchPaths&          search_paths){
     namespace bf = boost::filesystem;
-
+    loaded_libs_container loaded_libs;
+    boost::shared_ptr<loaded_libs_container> lb(boost::make_shared<loaded_libs_container>());
     // Iterate over all search paths.
     for (size_t i = 0, e = search_paths.get_path_count(); i < e; ++i)
     {
@@ -104,16 +106,21 @@ void EntityFactoryRegistrar::discover_plugins(
             try
             {
                 unique_ptr<foundation::SharedLibrary> library(new foundation::SharedLibrary(plugin_path.c_str()));
-                loaded_libraries.push_back(std::make_pair(std::move(library),plugin_path));
+                lb->push_back(std::make_pair(std::move(library),plugin_path));
             }
             catch (const foundation::ExceptionCannotLoadSharedLib& e)
             {
                 RENDERER_LOG_DEBUG("could not open shared library %s: %s.",
                     plugin_path.c_str(), e.what());
                 continue;
-            }          
+            } 
         }
     }
+    std::cout<<"in in in \n";
+    //boost::shared_ptr<loaded_libs_container> lb(new loaded_libs_container);
+    std::cout<<"size "<<lb->size();
+    std::cout<<"out out out \n";
+    return lb;
 }
 
 void EntityFactoryRegistrar::unload_all_plugins()
@@ -126,5 +133,5 @@ void EntityFactoryRegistrar::store_plugin(Plugin* plugin)
     impl->m_plugins.push_back(plugin);
 }
 
-std::vector<std::pair<std::unique_ptr<foundation::SharedLibrary>, std::string>> EntityFactoryRegistrar::loaded_libraries;
+//std::vector<std::pair<std::unique_ptr<foundation::SharedLibrary>, std::string>> EntityFactoryRegistrar::loaded_libraries;
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.cpp
@@ -70,8 +70,8 @@ EntityFactoryRegistrar::~EntityFactoryRegistrar()
 }
 
 boost::shared_ptr<loaded_libs_container> EntityFactoryRegistrar::discover_plugins(
-    const foundation::SearchPaths&          search_paths){
-
+    const foundation::SearchPaths&          search_paths)
+{
     namespace bf = boost::filesystem;
 
     boost::shared_ptr<loaded_libs_container> lb(boost::make_shared<loaded_libs_container>());

--- a/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.h
@@ -43,6 +43,7 @@
 
 // Boost headers.
 #include "boost/filesystem.hpp"
+#include "boost/make_shared.hpp"
 
 // Standard headers.
 #include <cstddef>
@@ -58,6 +59,9 @@ namespace renderer      { class Plugin; }
 namespace renderer
 {
 
+//define loaded libraries container structure
+typedef  std::vector<std::pair<std::unique_ptr<foundation::SharedLibrary>, std::string> >  loaded_libs_container;
+
 //
 // Base class for factory registrars.
 //
@@ -67,8 +71,9 @@ class APPLESEED_DLLSYMBOL EntityFactoryRegistrar
 {
   public:
     //search for plugins and load them
-    static void discover_plugins(
+    static boost::shared_ptr<loaded_libs_container> discover_plugins(
         const foundation::SearchPaths&          search_paths);
+  
   protected:
     // Constructor.
     EntityFactoryRegistrar();
@@ -79,7 +84,8 @@ class APPLESEED_DLLSYMBOL EntityFactoryRegistrar
     // Register factories from plugins found in search paths.
     template <typename Entity>
     void register_factories_from_plugins(
-        const std::function<void (void*)>&  register_factory);
+        const boost::shared_ptr<loaded_libs_container>  loaded_libraries,
+        const std::function<void (void*)>&        register_factory);
 
     // Unload all plugins loaded by `register_factories_from_plugins()`.
     void unload_all_plugins();
@@ -87,9 +93,6 @@ class APPLESEED_DLLSYMBOL EntityFactoryRegistrar
   private:
     struct Impl;
     Impl* impl;
-
-    static std::vector<std::pair<std::unique_ptr<foundation::SharedLibrary>, std::string> > loaded_libraries;
-
 
     // Store a plugin in order to keep it alive while the registrar exists.
     void store_plugin(renderer::Plugin* plugin);

--- a/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.h
@@ -30,18 +30,26 @@
 #define APPLESEED_RENDERER_MODELING_ENTITY_ENTITYFACTORYREGISTRAR_H
 
 // appleseed.renderer headers.
+#include "renderer/global/globallogger.h"
 #include "renderer/modeling/entity/entitytraits.h"
 
 // appleseed.foundation headers.
 #include "foundation/core/concepts/noncopyable.h"
 #include "foundation/utility/autoreleaseptr.h"
+#include "foundation/platform/sharedlibrary.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
+// Boost headers.
+#include "boost/filesystem.hpp"
+
 // Standard headers.
 #include <cstddef>
+#include <string>
+#include <vector>
 #include <functional>
+#include <memory>
 
 // Forward declarations.
 namespace foundation    { class SearchPaths; }
@@ -57,6 +65,10 @@ namespace renderer
 class APPLESEED_DLLSYMBOL EntityFactoryRegistrar
   : public foundation::NonCopyable
 {
+  public:
+    //search for plugins and load them
+    static void discover_plugins(
+        const foundation::SearchPaths&          search_paths);
   protected:
     // Constructor.
     EntityFactoryRegistrar();
@@ -67,7 +79,6 @@ class APPLESEED_DLLSYMBOL EntityFactoryRegistrar
     // Register factories from plugins found in search paths.
     template <typename Entity>
     void register_factories_from_plugins(
-        const foundation::SearchPaths&      search_paths,
         const std::function<void (void*)>&  register_factory);
 
     // Unload all plugins loaded by `register_factories_from_plugins()`.
@@ -76,6 +87,9 @@ class APPLESEED_DLLSYMBOL EntityFactoryRegistrar
   private:
     struct Impl;
     Impl* impl;
+
+    static std::vector<std::pair<std::unique_ptr<foundation::SharedLibrary>, std::string> > loaded_libraries;
+
 
     // Store a plugin in order to keep it alive while the registrar exists.
     void store_plugin(renderer::Plugin* plugin);

--- a/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/entity/entityfactoryregistrar.h
@@ -84,8 +84,8 @@ class APPLESEED_DLLSYMBOL EntityFactoryRegistrar
     // Register factories from plugins found in search paths.
     template <typename Entity>
     void register_factories_from_plugins(
-        const boost::shared_ptr<loaded_libs_container>  loaded_libraries,
-        const std::function<void (void*)>&        register_factory);
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries,
+        const std::function<void (void*)>&             register_factory);
 
     // Unload all plugins loaded by `register_factories_from_plugins()`.
     void unload_all_plugins();

--- a/src/appleseed/renderer/modeling/entity/registerentityfactories.h
+++ b/src/appleseed/renderer/modeling/entity/registerentityfactories.h
@@ -85,7 +85,7 @@ void EntityFactoryRegistrar::register_factories_from_plugins(
             continue;
         }
 
-        // Load the plugin into the cache and retrieve its entry point
+        // Load the plugin into the cache and retrieve its entry point.
         foundation::auto_release_ptr<Plugin> plugin(PluginCache::load(loaded_libraries->at(i).second.c_str()));
         void* plugin_entry_point = plugin->get_symbol(entry_point_name.c_str());
         if (plugin_entry_point == nullptr)

--- a/src/appleseed/renderer/modeling/entity/registerentityfactories.h
+++ b/src/appleseed/renderer/modeling/entity/registerentityfactories.h
@@ -94,69 +94,6 @@ void EntityFactoryRegistrar::register_factories_from_plugins(
         RENDERER_LOG_INFO("registering %s plugin %s...", entity_type_name.c_str(), loaded_libraries[i].second.c_str());
         register_factory(plugin_entry_point);        
     }
-    // Iterate over all search paths.
-   /* for (size_t i = 0, e = search_paths.get_path_count(); i < e; ++i)
-    {
-        bf::path search_path(search_paths.get_path(i));
-
-        // Make the search path absolute if it isn't already.
-        if (!search_path.is_absolute() && search_paths.has_root_path())
-            search_path = search_paths.get_root_path().c_str() / search_path;
-
-        // Only consider directories.
-        if (!bf::exists(search_path) || !bf::is_directory(search_path))
-            continue;
-
-        const std::string entity_type_name =
-            foundation::lower_case(EntityTraits<Entity>::get_human_readable_entity_type_name());
-
-        RENDERER_LOG_DEBUG("scanning %s in search of %s plugins...",
-            search_path.string().c_str(),
-            entity_type_name.c_str());
-
-        // Iterate over all files in this directory.
-        for (bf::directory_iterator j(search_path), f; j != f; ++j)
-        {
-            // Only consider shared library files.
-            if (!bf::is_regular_file(*j) ||
-                j->path().extension() != foundation::SharedLibrary::get_default_file_extension())
-                continue;
-
-            const std::string plugin_path = j->path().string();
-
-            // Only consider libraries that can be loaded and define the right magic symbol.
-            try
-            {
-                foundation::SharedLibrary library(plugin_path.c_str());
-                library.get_symbol(entry_point_name.c_str(), false);
-            }
-            catch (const foundation::ExceptionCannotLoadSharedLib& e)
-            {
-                RENDERER_LOG_DEBUG("could not open shared library %s: %s.",
-                    plugin_path.c_str(), e.what());
-                continue;
-            }
-            catch (const foundation::ExceptionSharedLibCannotGetSymbol&)
-            {
-                RENDERER_LOG_DEBUG("shared library %s is not an appleseed %s plugin because it does not export a %s() function.",
-                    plugin_path.c_str(), entity_type_name.c_str(), entry_point_name.c_str());
-                continue;
-            }
-
-            // Load the plugin into the cache and retrieve its entry point.
-            foundation::auto_release_ptr<Plugin> plugin(PluginCache::load(plugin_path.c_str()));
-            void* plugin_entry_point = plugin->get_symbol(entry_point_name.c_str());
-            if (plugin_entry_point == nullptr)
-                continue;
-
-            // Store the plugin to keep it alive.
-            store_plugin(plugin.release());
-
-            // Let the caller handle the discovered plugin.
-            RENDERER_LOG_INFO("registering %s plugin %s...", entity_type_name.c_str(), plugin_path.c_str());
-            register_factory(plugin_entry_point);
-        }
-    }*/
 }
 
 }       // namespace renderer

--- a/src/appleseed/renderer/modeling/environmentedf/environmentedffactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/environmentedffactoryregistrar.cpp
@@ -65,9 +65,10 @@ struct EnvironmentEDFFactoryRegistrar::Impl
 };
 
 EnvironmentEDFFactoryRegistrar::EnvironmentEDFFactoryRegistrar()
-  : impl(new Impl())
+  : impl(new Impl()),
+    m_loaded_libraries(boost::make_shared<loaded_libs_container>())
 {
-    reinitialize();
+    reinitialize(m_loaded_libraries);
 }
 
 EnvironmentEDFFactoryRegistrar::~EnvironmentEDFFactoryRegistrar()
@@ -75,8 +76,11 @@ EnvironmentEDFFactoryRegistrar::~EnvironmentEDFFactoryRegistrar()
     delete impl;
 }
 
-void EnvironmentEDFFactoryRegistrar::reinitialize()
+void EnvironmentEDFFactoryRegistrar::reinitialize(
+    const boost::shared_ptr<loaded_libs_container> loaded_libraries)
 {
+    m_loaded_libraries = loaded_libraries;
+
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
     unload_all_plugins();
@@ -93,6 +97,7 @@ void EnvironmentEDFFactoryRegistrar::reinitialize()
 
     // Register factories defined in plugins.
     register_factories_from_plugins<EnvironmentEDF>(
+        m_loaded_libraries,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<IEnvironmentEDFFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/environmentedf/environmentedffactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/environmentedffactoryregistrar.cpp
@@ -64,10 +64,10 @@ struct EnvironmentEDFFactoryRegistrar::Impl
     Registrar<IEnvironmentEDFFactory> m_registrar;
 };
 
-EnvironmentEDFFactoryRegistrar::EnvironmentEDFFactoryRegistrar(const SearchPaths& search_paths)
+EnvironmentEDFFactoryRegistrar::EnvironmentEDFFactoryRegistrar()
   : impl(new Impl())
 {
-    reinitialize(search_paths);
+    reinitialize();
 }
 
 EnvironmentEDFFactoryRegistrar::~EnvironmentEDFFactoryRegistrar()
@@ -75,7 +75,7 @@ EnvironmentEDFFactoryRegistrar::~EnvironmentEDFFactoryRegistrar()
     delete impl;
 }
 
-void EnvironmentEDFFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
+void EnvironmentEDFFactoryRegistrar::reinitialize()
 {
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
@@ -93,7 +93,6 @@ void EnvironmentEDFFactoryRegistrar::reinitialize(const SearchPaths& search_path
 
     // Register factories defined in plugins.
     register_factories_from_plugins<EnvironmentEDF>(
-        search_paths,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<IEnvironmentEDFFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/environmentedf/environmentedffactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/environmentedf/environmentedffactoryregistrar.h
@@ -82,7 +82,7 @@ class APPLESEED_DLLSYMBOL EnvironmentEDFFactoryRegistrar
     // Destructor.
     ~EnvironmentEDFFactoryRegistrar();
 
-    // Reinitialize the registrar; load plugins found in provided search paths.
+    // Reinitialize the registrar. load plugins found in provided search paths.
     void reinitialize(
         const boost::shared_ptr<loaded_libs_container> loaded_libraries);
     
@@ -96,7 +96,7 @@ class APPLESEED_DLLSYMBOL EnvironmentEDFFactoryRegistrar
     struct Impl;
     Impl* impl;
 
-    // pointer to the loaded libraries in memory
+    // Pointer to the loaded libraries in memory.
     boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
 
     // Register a factory.

--- a/src/appleseed/renderer/modeling/environmentedf/environmentedffactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/environmentedf/environmentedffactoryregistrar.h
@@ -66,14 +66,13 @@ class APPLESEED_DLLSYMBOL EnvironmentEDFFactoryRegistrar
     typedef EnvironmentEDFFactoryArray FactoryArrayType;
 
     // Constructor.
-    explicit EnvironmentEDFFactoryRegistrar(
-        const foundation::SearchPaths& search_paths = foundation::SearchPaths());
+    explicit EnvironmentEDFFactoryRegistrar();
 
     // Destructor.
     ~EnvironmentEDFFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize(const foundation::SearchPaths& search_paths);
+    void reinitialize();
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;

--- a/src/appleseed/renderer/modeling/environmentedf/environmentedffactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/environmentedf/environmentedffactoryregistrar.h
@@ -37,9 +37,20 @@
 #include "foundation/utility/api/apiarray.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/searchpaths.h"
+#include "foundation/platform/sharedlibrary.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
+
+// Boost headers.
+#include "boost/filesystem.hpp"
+#include "boost/make_shared.hpp"
+
+//standard headers
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
 
 // Forward declarations.
 namespace renderer      { class IEnvironmentEDFFactory; }
@@ -72,8 +83,9 @@ class APPLESEED_DLLSYMBOL EnvironmentEDFFactoryRegistrar
     ~EnvironmentEDFFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize();
-
+    void reinitialize(
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries);
+    
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;
 
@@ -83,6 +95,9 @@ class APPLESEED_DLLSYMBOL EnvironmentEDFFactoryRegistrar
   private:
     struct Impl;
     Impl* impl;
+
+    // pointer to the loaded libraries in memory
+    boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
 
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);

--- a/src/appleseed/renderer/modeling/environmentshader/environmentshaderfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/environmentshader/environmentshaderfactoryregistrar.cpp
@@ -58,10 +58,10 @@ struct EnvironmentShaderFactoryRegistrar::Impl
     Registrar<IEnvironmentShaderFactory> m_registrar;
 };
 
-EnvironmentShaderFactoryRegistrar::EnvironmentShaderFactoryRegistrar(const SearchPaths& search_paths)
+EnvironmentShaderFactoryRegistrar::EnvironmentShaderFactoryRegistrar()
   : impl(new Impl())
 {
-    reinitialize(search_paths);
+    reinitialize();
 }
 
 EnvironmentShaderFactoryRegistrar::~EnvironmentShaderFactoryRegistrar()
@@ -69,7 +69,7 @@ EnvironmentShaderFactoryRegistrar::~EnvironmentShaderFactoryRegistrar()
     delete impl;
 }
 
-void EnvironmentShaderFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
+void EnvironmentShaderFactoryRegistrar::reinitialize()
 {
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
@@ -81,7 +81,6 @@ void EnvironmentShaderFactoryRegistrar::reinitialize(const SearchPaths& search_p
 
     // Register factories defined in plugins.
     register_factories_from_plugins<EnvironmentShader>(
-        search_paths,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<IEnvironmentShaderFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/environmentshader/environmentshaderfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/environmentshader/environmentshaderfactoryregistrar.h
@@ -66,14 +66,13 @@ class APPLESEED_DLLSYMBOL EnvironmentShaderFactoryRegistrar
     typedef EnvironmentShaderFactoryArray FactoryArrayType;
 
     // Constructor.
-    explicit EnvironmentShaderFactoryRegistrar(
-        const foundation::SearchPaths& search_paths = foundation::SearchPaths());
+    explicit EnvironmentShaderFactoryRegistrar();
 
     // Destructor.
     ~EnvironmentShaderFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize(const foundation::SearchPaths& search_paths);
+    void reinitialize();
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;

--- a/src/appleseed/renderer/modeling/environmentshader/environmentshaderfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/environmentshader/environmentshaderfactoryregistrar.h
@@ -82,7 +82,7 @@ class APPLESEED_DLLSYMBOL EnvironmentShaderFactoryRegistrar
     // Destructor.
     ~EnvironmentShaderFactoryRegistrar();
 
-    // Reinitialize the registrar; load plugins found in provided search paths.
+    // Reinitialize the registrar. load plugins found in provided search paths.
     void reinitialize(
         const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
@@ -96,7 +96,7 @@ class APPLESEED_DLLSYMBOL EnvironmentShaderFactoryRegistrar
     struct Impl;
     Impl* impl;
 
-    // pointer to the loaded libraries in memory
+    // Pointer to the loaded libraries in memory.
     boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
     
     // Register a factory.

--- a/src/appleseed/renderer/modeling/environmentshader/environmentshaderfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/environmentshader/environmentshaderfactoryregistrar.h
@@ -37,9 +37,20 @@
 #include "foundation/utility/api/apiarray.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/searchpaths.h"
+#include "foundation/platform/sharedlibrary.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
+
+// Boost headers.
+#include "boost/filesystem.hpp"
+#include "boost/make_shared.hpp"
+
+//standard headers
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
 
 // Forward declarations.
 namespace renderer      { class IEnvironmentShaderFactory; }
@@ -72,7 +83,8 @@ class APPLESEED_DLLSYMBOL EnvironmentShaderFactoryRegistrar
     ~EnvironmentShaderFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize();
+    void reinitialize(
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;
@@ -84,6 +96,9 @@ class APPLESEED_DLLSYMBOL EnvironmentShaderFactoryRegistrar
     struct Impl;
     Impl* impl;
 
+    // pointer to the loaded libraries in memory
+    boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
+    
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);
 };

--- a/src/appleseed/renderer/modeling/light/lightfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/light/lightfactoryregistrar.cpp
@@ -62,10 +62,10 @@ struct LightFactoryRegistrar::Impl
     Registrar<ILightFactory> m_registrar;
 };
 
-LightFactoryRegistrar::LightFactoryRegistrar(const SearchPaths& search_paths)
+LightFactoryRegistrar::LightFactoryRegistrar()
   : impl(new Impl())
 {
-    reinitialize(search_paths);
+    reinitialize();
 }
 
 LightFactoryRegistrar::~LightFactoryRegistrar()
@@ -73,7 +73,7 @@ LightFactoryRegistrar::~LightFactoryRegistrar()
     delete impl;
 }
 
-void LightFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
+void LightFactoryRegistrar::reinitialize()
 {
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
@@ -89,7 +89,6 @@ void LightFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
 
     // Register factories defined in plugins.
     register_factories_from_plugins<Light>(
-        search_paths,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<ILightFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/light/lightfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/light/lightfactoryregistrar.h
@@ -82,7 +82,7 @@ class APPLESEED_DLLSYMBOL LightFactoryRegistrar
     // Destructor.
     ~LightFactoryRegistrar();
 
-    // Reinitialize the registrar; load plugins found in provided search paths.
+    // Reinitialize the registrar. load plugins found in provided search paths.
     void reinitialize(
         const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
@@ -96,7 +96,7 @@ class APPLESEED_DLLSYMBOL LightFactoryRegistrar
     struct Impl;
     Impl* impl;
 
-    // pointer to the loaded libraries in memory
+    // Pointer to the loaded libraries in memory.
     boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
     
     // Register a factory.

--- a/src/appleseed/renderer/modeling/light/lightfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/light/lightfactoryregistrar.h
@@ -66,14 +66,13 @@ class APPLESEED_DLLSYMBOL LightFactoryRegistrar
     typedef LightFactoryArray FactoryArrayType;
 
     // Constructor.
-    explicit LightFactoryRegistrar(
-        const foundation::SearchPaths& search_paths = foundation::SearchPaths());
+    explicit LightFactoryRegistrar();
 
     // Destructor.
     ~LightFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize(const foundation::SearchPaths& search_paths);
+    void reinitialize();
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;

--- a/src/appleseed/renderer/modeling/light/lightfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/light/lightfactoryregistrar.h
@@ -37,9 +37,20 @@
 #include "foundation/utility/api/apiarray.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/searchpaths.h"
+#include "foundation/platform/sharedlibrary.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
+
+// Boost headers.
+#include "boost/filesystem.hpp"
+#include "boost/make_shared.hpp"
+
+//standard headers
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
 
 // Forward declarations.
 namespace renderer      { class ILightFactory; }
@@ -72,7 +83,8 @@ class APPLESEED_DLLSYMBOL LightFactoryRegistrar
     ~LightFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize();
+    void reinitialize(
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;
@@ -84,6 +96,9 @@ class APPLESEED_DLLSYMBOL LightFactoryRegistrar
     struct Impl;
     Impl* impl;
 
+    // pointer to the loaded libraries in memory
+    boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
+    
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);
 };

--- a/src/appleseed/renderer/modeling/material/materialfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/material/materialfactoryregistrar.cpp
@@ -61,10 +61,10 @@ struct MaterialFactoryRegistrar::Impl
     Registrar<IMaterialFactory> m_registrar;
 };
 
-MaterialFactoryRegistrar::MaterialFactoryRegistrar(const SearchPaths& search_paths)
+MaterialFactoryRegistrar::MaterialFactoryRegistrar()
   : impl(new Impl())
 {
-    reinitialize(search_paths);
+    reinitialize();
 }
 
 MaterialFactoryRegistrar::~MaterialFactoryRegistrar()
@@ -72,7 +72,7 @@ MaterialFactoryRegistrar::~MaterialFactoryRegistrar()
     delete impl;
 }
 
-void MaterialFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
+void MaterialFactoryRegistrar::reinitialize()
 {
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
@@ -87,7 +87,6 @@ void MaterialFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
 
     // Register factories defined in plugins.
     register_factories_from_plugins<Material>(
-        search_paths,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<IMaterialFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/material/materialfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/material/materialfactoryregistrar.h
@@ -66,14 +66,13 @@ class APPLESEED_DLLSYMBOL MaterialFactoryRegistrar
     typedef MaterialFactoryArray FactoryArrayType;
 
     // Constructor.
-    explicit MaterialFactoryRegistrar(
-        const foundation::SearchPaths& search_paths = foundation::SearchPaths());
+    explicit MaterialFactoryRegistrar();
 
     // Destructor.
     ~MaterialFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize(const foundation::SearchPaths& search_paths);
+    void reinitialize();
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;

--- a/src/appleseed/renderer/modeling/material/materialfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/material/materialfactoryregistrar.h
@@ -82,7 +82,7 @@ class APPLESEED_DLLSYMBOL MaterialFactoryRegistrar
     // Destructor.
     ~MaterialFactoryRegistrar();
 
-    // Reinitialize the registrar;
+    // Reinitialize the registrar.
     void reinitialize(
         const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
@@ -96,7 +96,7 @@ class APPLESEED_DLLSYMBOL MaterialFactoryRegistrar
     struct Impl;
     Impl* impl;
 
-    // pointer to the loaded libraries in memory
+    // Pointer to the loaded libraries in memory.
     boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
     
     // Register a factory.

--- a/src/appleseed/renderer/modeling/material/materialfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/material/materialfactoryregistrar.h
@@ -37,9 +37,20 @@
 #include "foundation/utility/api/apiarray.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/searchpaths.h"
+#include "foundation/platform/sharedlibrary.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
+
+// Boost headers.
+#include "boost/filesystem.hpp"
+#include "boost/make_shared.hpp"
+
+//standard headers
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
 
 // Forward declarations.
 namespace renderer      { class IMaterialFactory; }
@@ -71,8 +82,9 @@ class APPLESEED_DLLSYMBOL MaterialFactoryRegistrar
     // Destructor.
     ~MaterialFactoryRegistrar();
 
-    // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize();
+    // Reinitialize the registrar;
+    void reinitialize(
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;
@@ -84,6 +96,9 @@ class APPLESEED_DLLSYMBOL MaterialFactoryRegistrar
     struct Impl;
     Impl* impl;
 
+    // pointer to the loaded libraries in memory
+    boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
+    
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);
 };

--- a/src/appleseed/renderer/modeling/object/objectfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/object/objectfactoryregistrar.cpp
@@ -57,10 +57,10 @@ struct ObjectFactoryRegistrar::Impl
     Registrar<IObjectFactory> m_registrar;
 };
 
-ObjectFactoryRegistrar::ObjectFactoryRegistrar(const SearchPaths& search_paths)
+ObjectFactoryRegistrar::ObjectFactoryRegistrar()
   : impl(new Impl())
 {
-    reinitialize(search_paths);
+    reinitialize();
 }
 
 ObjectFactoryRegistrar::~ObjectFactoryRegistrar()
@@ -68,7 +68,7 @@ ObjectFactoryRegistrar::~ObjectFactoryRegistrar()
     delete impl;
 }
 
-void ObjectFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
+void ObjectFactoryRegistrar::reinitialize()
 {
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
@@ -80,7 +80,6 @@ void ObjectFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
 
     // Register factories defined in plugins.
     register_factories_from_plugins<Object>(
-        search_paths,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<IObjectFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/object/objectfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/object/objectfactoryregistrar.h
@@ -36,9 +36,20 @@
 #include "foundation/utility/api/apiarray.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/searchpaths.h"
+#include "foundation/platform/sharedlibrary.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
+
+// Boost headers.
+#include "boost/filesystem.hpp"
+#include "boost/make_shared.hpp"
+
+//standard headers
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
 
 // Forward declarations.
 namespace renderer      { class IObjectFactory; }
@@ -71,7 +82,8 @@ class APPLESEED_DLLSYMBOL ObjectFactoryRegistrar
     ~ObjectFactoryRegistrar() override;
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize();
+    void reinitialize(
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;
@@ -82,6 +94,9 @@ class APPLESEED_DLLSYMBOL ObjectFactoryRegistrar
   private:
     struct Impl;
     Impl* impl;
+
+    // pointer to the loaded libraries in memory
+    boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
 
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);

--- a/src/appleseed/renderer/modeling/object/objectfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/object/objectfactoryregistrar.h
@@ -65,14 +65,13 @@ class APPLESEED_DLLSYMBOL ObjectFactoryRegistrar
     typedef ObjectFactoryArray FactoryArrayType;
 
     // Constructor.
-    explicit ObjectFactoryRegistrar(
-        const foundation::SearchPaths& search_paths = foundation::SearchPaths());
+    explicit ObjectFactoryRegistrar();
 
     // Destructor.
     ~ObjectFactoryRegistrar() override;
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize(const foundation::SearchPaths& search_paths);
+    void reinitialize();
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;

--- a/src/appleseed/renderer/modeling/object/objectfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/object/objectfactoryregistrar.h
@@ -81,7 +81,7 @@ class APPLESEED_DLLSYMBOL ObjectFactoryRegistrar
     // Destructor.
     ~ObjectFactoryRegistrar() override;
 
-    // Reinitialize the registrar; load plugins found in provided search paths.
+    // Reinitialize the registrar. load plugins found in provided search paths.
     void reinitialize(
         const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
@@ -95,7 +95,7 @@ class APPLESEED_DLLSYMBOL ObjectFactoryRegistrar
     struct Impl;
     Impl* impl;
 
-    // pointer to the loaded libraries in memory
+    // Pointer to the loaded libraries in memory.
     boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
 
     // Register a factory.

--- a/src/appleseed/renderer/modeling/project/project.cpp
+++ b/src/appleseed/renderer/modeling/project/project.cpp
@@ -38,6 +38,8 @@
 #include "renderer/modeling/environment/environment.h"
 #include "renderer/modeling/environmentedf/environmentedf.h"
 #include "renderer/modeling/environmentshader/environmentshader.h"
+#include "renderer/modeling/entity/entityfactoryregistrar.h"
+
 #include "renderer/modeling/frame/frame.h"
 #include "renderer/modeling/light/light.h"
 #include "renderer/modeling/material/material.h"
@@ -208,20 +210,22 @@ void Project::add_default_configurations()
 
 void Project::reinitialize_factory_registrars()
 {
-    m_aov_factory_registrar.reinitialize(impl->m_search_paths);
-    m_assembly_factory_registrar.reinitialize(impl->m_search_paths);
-    m_bsdf_factory_registrar.reinitialize(impl->m_search_paths);
-    m_bssrdf_factory_registrar.reinitialize(impl->m_search_paths);
-    m_camera_factory_registrar.reinitialize(impl->m_search_paths);
-    m_edf_factory_registrar.reinitialize(impl->m_search_paths);
-    m_environment_edf_factory_registrar.reinitialize(impl->m_search_paths);
-    m_environment_shader_factory_registrar.reinitialize(impl->m_search_paths);
-    m_light_factory_registrar.reinitialize(impl->m_search_paths);
-    m_material_factory_registrar.reinitialize(impl->m_search_paths);
-    m_object_factory_registrar.reinitialize(impl->m_search_paths);
-    m_surface_shader_factory_registrar.reinitialize(impl->m_search_paths);
-    m_texture_factory_registrar.reinitialize(impl->m_search_paths);
-    m_volume_factory_registrar.reinitialize(impl->m_search_paths);
+    EntityFactoryRegistrar::discover_plugins(impl->m_search_paths);
+
+    m_aov_factory_registrar.reinitialize();
+    m_assembly_factory_registrar.reinitialize();
+    m_bsdf_factory_registrar.reinitialize();
+    m_bssrdf_factory_registrar.reinitialize();
+    m_camera_factory_registrar.reinitialize();
+    m_edf_factory_registrar.reinitialize();
+    m_environment_edf_factory_registrar.reinitialize();
+    m_environment_shader_factory_registrar.reinitialize();
+    m_light_factory_registrar.reinitialize();
+    m_material_factory_registrar.reinitialize();
+    m_object_factory_registrar.reinitialize();
+    m_surface_shader_factory_registrar.reinitialize();
+    m_texture_factory_registrar.reinitialize();
+    m_volume_factory_registrar.reinitialize();
 }
 
 bool Project::has_trace_context() const

--- a/src/appleseed/renderer/modeling/project/project.cpp
+++ b/src/appleseed/renderer/modeling/project/project.cpp
@@ -210,9 +210,9 @@ void Project::add_default_configurations()
 
 void Project::reinitialize_factory_registrars()
 {
-    // load all libraries once and return a pointer to the container of loaded libraries
+    // Load all libraries once and return a pointer to the container of loaded libraries.
     boost::shared_ptr<loaded_libs_container> loaded_libraries = EntityFactoryRegistrar::discover_plugins(impl->m_search_paths);
-    
+
     m_aov_factory_registrar.reinitialize(loaded_libraries);
     m_assembly_factory_registrar.reinitialize(loaded_libraries);
     m_bsdf_factory_registrar.reinitialize(loaded_libraries);

--- a/src/appleseed/renderer/modeling/project/project.cpp
+++ b/src/appleseed/renderer/modeling/project/project.cpp
@@ -210,22 +210,23 @@ void Project::add_default_configurations()
 
 void Project::reinitialize_factory_registrars()
 {
-    EntityFactoryRegistrar::discover_plugins(impl->m_search_paths);
-
-    m_aov_factory_registrar.reinitialize();
-    m_assembly_factory_registrar.reinitialize();
-    m_bsdf_factory_registrar.reinitialize();
-    m_bssrdf_factory_registrar.reinitialize();
-    m_camera_factory_registrar.reinitialize();
-    m_edf_factory_registrar.reinitialize();
-    m_environment_edf_factory_registrar.reinitialize();
-    m_environment_shader_factory_registrar.reinitialize();
-    m_light_factory_registrar.reinitialize();
-    m_material_factory_registrar.reinitialize();
-    m_object_factory_registrar.reinitialize();
-    m_surface_shader_factory_registrar.reinitialize();
-    m_texture_factory_registrar.reinitialize();
-    m_volume_factory_registrar.reinitialize();
+    // load all libraries once and return a pointer to the container of loaded libraries
+    boost::shared_ptr<loaded_libs_container> loaded_libraries = EntityFactoryRegistrar::discover_plugins(impl->m_search_paths);
+    
+    m_aov_factory_registrar.reinitialize(loaded_libraries);
+    m_assembly_factory_registrar.reinitialize(loaded_libraries);
+    m_bsdf_factory_registrar.reinitialize(loaded_libraries);
+    m_bssrdf_factory_registrar.reinitialize(loaded_libraries);
+    m_camera_factory_registrar.reinitialize(loaded_libraries);
+    m_edf_factory_registrar.reinitialize(loaded_libraries);
+    m_environment_edf_factory_registrar.reinitialize(loaded_libraries);
+    m_environment_shader_factory_registrar.reinitialize(loaded_libraries);
+    m_light_factory_registrar.reinitialize(loaded_libraries);
+    m_material_factory_registrar.reinitialize(loaded_libraries);
+    m_object_factory_registrar.reinitialize(loaded_libraries);
+    m_surface_shader_factory_registrar.reinitialize(loaded_libraries);
+    m_texture_factory_registrar.reinitialize(loaded_libraries);
+    m_volume_factory_registrar.reinitialize(loaded_libraries);
 }
 
 bool Project::has_trace_context() const

--- a/src/appleseed/renderer/modeling/project/project.cpp
+++ b/src/appleseed/renderer/modeling/project/project.cpp
@@ -39,7 +39,6 @@
 #include "renderer/modeling/environmentedf/environmentedf.h"
 #include "renderer/modeling/environmentshader/environmentshader.h"
 #include "renderer/modeling/entity/entityfactoryregistrar.h"
-
 #include "renderer/modeling/frame/frame.h"
 #include "renderer/modeling/light/light.h"
 #include "renderer/modeling/material/material.h"

--- a/src/appleseed/renderer/modeling/project/project.h
+++ b/src/appleseed/renderer/modeling/project/project.h
@@ -67,12 +67,16 @@
 #include "foundation/platform/compiler.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/uid.h"
+#include "foundation/platform/sharedlibrary.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
 // Standard headers.
 #include <cstddef>
+
+//typedef
+typedef  std::vector<std::pair<std::unique_ptr<foundation::SharedLibrary>, std::string> >  loaded_libs_container;
 
 // Forward declarations.
 namespace foundation    { class SearchPaths; }

--- a/src/appleseed/renderer/modeling/scene/assemblyfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/scene/assemblyfactoryregistrar.cpp
@@ -58,10 +58,10 @@ struct AssemblyFactoryRegistrar::Impl
     Registrar<IAssemblyFactory> m_registrar;
 };
 
-AssemblyFactoryRegistrar::AssemblyFactoryRegistrar(const SearchPaths& search_paths)
+AssemblyFactoryRegistrar::AssemblyFactoryRegistrar()
   : impl(new Impl())
 {
-    reinitialize(search_paths);
+    reinitialize();
 }
 
 AssemblyFactoryRegistrar::~AssemblyFactoryRegistrar()
@@ -69,7 +69,7 @@ AssemblyFactoryRegistrar::~AssemblyFactoryRegistrar()
     delete impl;
 }
 
-void AssemblyFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
+void AssemblyFactoryRegistrar::reinitialize()
 {
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
@@ -81,7 +81,6 @@ void AssemblyFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
 
     // Register factories defined in plugins.
     register_factories_from_plugins<Assembly>(
-        search_paths,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<IAssemblyFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/scene/assemblyfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/scene/assemblyfactoryregistrar.h
@@ -80,7 +80,7 @@ class APPLESEED_DLLSYMBOL AssemblyFactoryRegistrar
     // Destructor.
     ~AssemblyFactoryRegistrar();
 
-    // Reinitialize the registrar;
+    // Reinitialize the registrar.
     void reinitialize(
         const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
@@ -94,10 +94,9 @@ class APPLESEED_DLLSYMBOL AssemblyFactoryRegistrar
     struct Impl;
     Impl* impl;
     
-    // pointer to the loaded libraries in memory
+    // Pointer to the loaded libraries in memory.
     boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
     
-
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);
 };

--- a/src/appleseed/renderer/modeling/scene/assemblyfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/scene/assemblyfactoryregistrar.h
@@ -40,6 +40,16 @@
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
+// Boost headers.
+#include "boost/filesystem.hpp"
+#include "boost/make_shared.hpp"
+
+//standard headers
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
+
 // Forward declarations.
 namespace renderer      { class IAssemblyFactory; }
 
@@ -70,8 +80,9 @@ class APPLESEED_DLLSYMBOL AssemblyFactoryRegistrar
     // Destructor.
     ~AssemblyFactoryRegistrar();
 
-    // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize();
+    // Reinitialize the registrar;
+    void reinitialize(
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;
@@ -82,6 +93,10 @@ class APPLESEED_DLLSYMBOL AssemblyFactoryRegistrar
   private:
     struct Impl;
     Impl* impl;
+    
+    // pointer to the loaded libraries in memory
+    boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
+    
 
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);

--- a/src/appleseed/renderer/modeling/scene/assemblyfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/scene/assemblyfactoryregistrar.h
@@ -65,14 +65,13 @@ class APPLESEED_DLLSYMBOL AssemblyFactoryRegistrar
     typedef AssemblyFactoryArray FactoryArrayType;
 
     // Constructor.
-    explicit AssemblyFactoryRegistrar(
-        const foundation::SearchPaths& search_paths = foundation::SearchPaths());
+    explicit AssemblyFactoryRegistrar();
 
     // Destructor.
     ~AssemblyFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize(const foundation::SearchPaths& search_paths);
+    void reinitialize();
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;

--- a/src/appleseed/renderer/modeling/surfaceshader/surfaceshaderfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/surfaceshaderfactoryregistrar.cpp
@@ -61,9 +61,10 @@ struct SurfaceShaderFactoryRegistrar::Impl
 };
 
 SurfaceShaderFactoryRegistrar::SurfaceShaderFactoryRegistrar()
-  : impl(new Impl())
+  : impl(new Impl()),
+    m_loaded_libraries(boost::make_shared<loaded_libs_container>())
 {
-    reinitialize();
+    reinitialize(m_loaded_libraries);
 }
 
 SurfaceShaderFactoryRegistrar::~SurfaceShaderFactoryRegistrar()
@@ -71,8 +72,11 @@ SurfaceShaderFactoryRegistrar::~SurfaceShaderFactoryRegistrar()
     delete impl;
 }
 
-void SurfaceShaderFactoryRegistrar::reinitialize()
+void SurfaceShaderFactoryRegistrar::reinitialize(
+    const boost::shared_ptr<loaded_libs_container> loaded_libraries)
 {
+    m_loaded_libraries = loaded_libraries;
+
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
     unload_all_plugins();
@@ -85,6 +89,7 @@ void SurfaceShaderFactoryRegistrar::reinitialize()
 
     // Register factories defined in plugins.
     register_factories_from_plugins<SurfaceShader>(
+        m_loaded_libraries,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<ISurfaceShaderFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/surfaceshader/surfaceshaderfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/surfaceshaderfactoryregistrar.cpp
@@ -60,10 +60,10 @@ struct SurfaceShaderFactoryRegistrar::Impl
     Registrar<ISurfaceShaderFactory> m_registrar;
 };
 
-SurfaceShaderFactoryRegistrar::SurfaceShaderFactoryRegistrar(const SearchPaths& search_paths)
+SurfaceShaderFactoryRegistrar::SurfaceShaderFactoryRegistrar()
   : impl(new Impl())
 {
-    reinitialize(search_paths);
+    reinitialize();
 }
 
 SurfaceShaderFactoryRegistrar::~SurfaceShaderFactoryRegistrar()
@@ -71,7 +71,7 @@ SurfaceShaderFactoryRegistrar::~SurfaceShaderFactoryRegistrar()
     delete impl;
 }
 
-void SurfaceShaderFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
+void SurfaceShaderFactoryRegistrar::reinitialize()
 {
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
@@ -85,7 +85,6 @@ void SurfaceShaderFactoryRegistrar::reinitialize(const SearchPaths& search_paths
 
     // Register factories defined in plugins.
     register_factories_from_plugins<SurfaceShader>(
-        search_paths,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<ISurfaceShaderFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/surfaceshader/surfaceshaderfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/surfaceshader/surfaceshaderfactoryregistrar.h
@@ -37,9 +37,20 @@
 #include "foundation/utility/api/apiarray.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/searchpaths.h"
+#include "foundation/platform/sharedlibrary.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
+
+// Boost headers.
+#include "boost/filesystem.hpp"
+#include "boost/make_shared.hpp"
+
+//standard headers
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
 
 // Forward declarations.
 namespace renderer      { class ISurfaceShaderFactory; }
@@ -71,8 +82,9 @@ class APPLESEED_DLLSYMBOL SurfaceShaderFactoryRegistrar
     // Destructor.
     ~SurfaceShaderFactoryRegistrar();
 
-    // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize();
+    // Reinitialize the registrar;
+    void reinitialize(
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;
@@ -83,6 +95,9 @@ class APPLESEED_DLLSYMBOL SurfaceShaderFactoryRegistrar
   private:
     struct Impl;
     Impl* impl;
+
+    // pointer to the loaded libraries in memory
+    boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
 
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);

--- a/src/appleseed/renderer/modeling/surfaceshader/surfaceshaderfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/surfaceshader/surfaceshaderfactoryregistrar.h
@@ -82,7 +82,7 @@ class APPLESEED_DLLSYMBOL SurfaceShaderFactoryRegistrar
     // Destructor.
     ~SurfaceShaderFactoryRegistrar();
 
-    // Reinitialize the registrar;
+    // Reinitialize the registrar.
     void reinitialize(
         const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
@@ -96,7 +96,7 @@ class APPLESEED_DLLSYMBOL SurfaceShaderFactoryRegistrar
     struct Impl;
     Impl* impl;
 
-    // pointer to the loaded libraries in memory
+    // Pointer to the loaded libraries in memory.
     boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
 
     // Register a factory.

--- a/src/appleseed/renderer/modeling/surfaceshader/surfaceshaderfactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/surfaceshader/surfaceshaderfactoryregistrar.h
@@ -66,14 +66,13 @@ class APPLESEED_DLLSYMBOL SurfaceShaderFactoryRegistrar
     typedef SurfaceShaderFactoryArray FactoryArrayType;
 
     // Constructor.
-    explicit SurfaceShaderFactoryRegistrar(
-        const foundation::SearchPaths& search_paths = foundation::SearchPaths());
+    explicit SurfaceShaderFactoryRegistrar();
 
     // Destructor.
     ~SurfaceShaderFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize(const foundation::SearchPaths& search_paths);
+    void reinitialize();
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;

--- a/src/appleseed/renderer/modeling/texture/texturefactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/texture/texturefactoryregistrar.cpp
@@ -58,10 +58,10 @@ struct TextureFactoryRegistrar::Impl
     Registrar<ITextureFactory> m_registrar;
 };
 
-TextureFactoryRegistrar::TextureFactoryRegistrar(const SearchPaths& search_paths)
+TextureFactoryRegistrar::TextureFactoryRegistrar()
   : impl(new Impl())
 {
-    reinitialize(search_paths);
+    reinitialize();
 }
 
 TextureFactoryRegistrar::~TextureFactoryRegistrar()
@@ -69,7 +69,7 @@ TextureFactoryRegistrar::~TextureFactoryRegistrar()
     delete impl;
 }
 
-void TextureFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
+void TextureFactoryRegistrar::reinitialize()
 {
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
@@ -81,7 +81,6 @@ void TextureFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
 
     // Register factories defined in plugins.
     register_factories_from_plugins<Texture>(
-        search_paths,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<ITextureFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/texture/texturefactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/texture/texturefactoryregistrar.h
@@ -66,14 +66,13 @@ class APPLESEED_DLLSYMBOL TextureFactoryRegistrar
     typedef TextureFactoryArray FactoryArrayType;
 
     // Constructor.
-    explicit TextureFactoryRegistrar(
-        const foundation::SearchPaths& search_paths = foundation::SearchPaths());
+    explicit TextureFactoryRegistrar();
 
     // Destructor.
     ~TextureFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize(const foundation::SearchPaths& search_paths);
+    void reinitialize();
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;

--- a/src/appleseed/renderer/modeling/texture/texturefactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/texture/texturefactoryregistrar.h
@@ -37,9 +37,20 @@
 #include "foundation/utility/api/apiarray.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/searchpaths.h"
+#include "foundation/platform/sharedlibrary.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
+
+// Boost headers.
+#include "boost/filesystem.hpp"
+#include "boost/make_shared.hpp"
+
+//standard headers
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
 
 // Forward declarations.
 namespace renderer      { class ITextureFactory; }
@@ -71,8 +82,9 @@ class APPLESEED_DLLSYMBOL TextureFactoryRegistrar
     // Destructor.
     ~TextureFactoryRegistrar();
 
-    // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize();
+    // Reinitialize the registrar;
+    void reinitialize(
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;
@@ -83,6 +95,9 @@ class APPLESEED_DLLSYMBOL TextureFactoryRegistrar
   private:
     struct Impl;
     Impl* impl;
+
+    // pointer to the loaded libraries in memory
+    boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
 
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);

--- a/src/appleseed/renderer/modeling/texture/texturefactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/texture/texturefactoryregistrar.h
@@ -82,7 +82,7 @@ class APPLESEED_DLLSYMBOL TextureFactoryRegistrar
     // Destructor.
     ~TextureFactoryRegistrar();
 
-    // Reinitialize the registrar;
+    // Reinitialize the registrar.
     void reinitialize(
         const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
@@ -96,7 +96,7 @@ class APPLESEED_DLLSYMBOL TextureFactoryRegistrar
     struct Impl;
     Impl* impl;
 
-    // pointer to the loaded libraries in memory
+    // Pointer to the loaded libraries in memory.
     boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
 
     // Register a factory.

--- a/src/appleseed/renderer/modeling/volume/volumefactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/volume/volumefactoryregistrar.cpp
@@ -56,10 +56,10 @@ struct VolumeFactoryRegistrar::Impl
     Registrar<IVolumeFactory> m_registrar;
 };
 
-VolumeFactoryRegistrar::VolumeFactoryRegistrar(const SearchPaths& search_paths)
+VolumeFactoryRegistrar::VolumeFactoryRegistrar()
   : impl(new Impl())
 {
-    reinitialize(search_paths);
+    reinitialize();
 }
 
 VolumeFactoryRegistrar::~VolumeFactoryRegistrar()
@@ -67,7 +67,7 @@ VolumeFactoryRegistrar::~VolumeFactoryRegistrar()
     delete impl;
 }
 
-void VolumeFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
+void VolumeFactoryRegistrar::reinitialize()
 {
     // The registrar must be cleared before the plugins are unloaded.
     impl->m_registrar.clear();
@@ -78,7 +78,6 @@ void VolumeFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
 
     // Register factories defined in plugins.
     register_factories_from_plugins<Volume>(
-        search_paths,
         [this](void* plugin_entry_point)
         {
             auto create_fn = reinterpret_cast<IVolumeFactory* (*)()>(plugin_entry_point);

--- a/src/appleseed/renderer/modeling/volume/volumefactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/volume/volumefactoryregistrar.h
@@ -65,14 +65,13 @@ class APPLESEED_DLLSYMBOL VolumeFactoryRegistrar
     typedef VolumeFactoryArray FactoryArrayType;
 
     // Constructor.
-    explicit VolumeFactoryRegistrar(
-        const foundation::SearchPaths& search_paths = foundation::SearchPaths());
+    explicit VolumeFactoryRegistrar();
 
     // Destructor.
     ~VolumeFactoryRegistrar();
 
     // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize(const foundation::SearchPaths& search_paths);
+    void reinitialize();
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;

--- a/src/appleseed/renderer/modeling/volume/volumefactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/volume/volumefactoryregistrar.h
@@ -81,7 +81,7 @@ class APPLESEED_DLLSYMBOL VolumeFactoryRegistrar
     // Destructor.
     ~VolumeFactoryRegistrar();
 
-    // Reinitialize the registrar;
+    // Reinitialize the registrar.
     void reinitialize(
         const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
@@ -95,7 +95,7 @@ class APPLESEED_DLLSYMBOL VolumeFactoryRegistrar
     struct Impl;
     Impl* impl;
 
-    // pointer to the loaded libraries in memory
+    // Pointer to the loaded libraries in memory.
     boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
     
     // Register a factory.

--- a/src/appleseed/renderer/modeling/volume/volumefactoryregistrar.h
+++ b/src/appleseed/renderer/modeling/volume/volumefactoryregistrar.h
@@ -36,9 +36,20 @@
 #include "foundation/utility/api/apiarray.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/searchpaths.h"
+#include "foundation/platform/sharedlibrary.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
+
+// Boost headers.
+#include "boost/filesystem.hpp"
+#include "boost/make_shared.hpp"
+
+//standard headers
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
 
 // Forward declarations.
 namespace renderer      { class IVolumeFactory; }
@@ -70,8 +81,9 @@ class APPLESEED_DLLSYMBOL VolumeFactoryRegistrar
     // Destructor.
     ~VolumeFactoryRegistrar();
 
-    // Reinitialize the registrar; load plugins found in provided search paths.
-    void reinitialize();
+    // Reinitialize the registrar;
+    void reinitialize(
+        const boost::shared_ptr<loaded_libs_container> loaded_libraries);
 
     // Retrieve the registered factories.
     FactoryArrayType get_factories() const;
@@ -83,6 +95,9 @@ class APPLESEED_DLLSYMBOL VolumeFactoryRegistrar
     struct Impl;
     Impl* impl;
 
+    // pointer to the loaded libraries in memory
+    boost::shared_ptr<loaded_libs_container> m_loaded_libraries;
+    
     // Register a factory.
     void register_factory(foundation::auto_release_ptr<FactoryType> factory);
 };


### PR DESCRIPTION
issue: Optimize plugins discovery #1733
brief about the proposed technique :
1- Load all plugins once.
2-Every plugin type should register its own plugins that are already loaded.