### PR TITLE
Use fast_pow for faster srgb/linear conversions (#1908)

### DIFF
--- a/src/appleseed/foundation/image/colorspace.h
+++ b/src/appleseed/foundation/image/colorspace.h
@@ -662,7 +662,7 @@ inline T linear_rgb_to_srgb(const T c)
 {
     return c <= T(0.0031308)
         ? T(12.92) * c
-        : T(1.055) * std::pow(c, T(1.0 / 2.4)) - T(0.055);
+        : T(1.055) * fast_pow(c, T(1.0 / 2.4)) - T(0.055);
 }
 
 template <typename T>
@@ -670,7 +670,7 @@ inline T srgb_to_linear_rgb(const T c)
 {
     return c <= T(0.04045)
         ? T(1.0 / 12.92) * c
-        : std::pow((c + T(0.055)) * T(1.0 / 1.055), T(2.4));
+        : fast_pow((c + T(0.055)) * T(1.0 / 1.055), T(2.4));
 }
 
 template <typename T>

--- a/src/appleseed/foundation/meta/tests/test_colorspace.cpp
+++ b/src/appleseed/foundation/meta/tests/test_colorspace.cpp
@@ -430,7 +430,7 @@ TEST_SUITE(Foundation_Image_ColorSpace)
         EXPECT_FEQ_EPS(
             Color3d(0.73535698305244945, 0.85430583154494000, 0.48452920448170694),
             srgb,
-            1.0e-6);
+            1.0e-4);
     }
 
     TEST_CASE(TestsRGBToLinearRGBConversion)
@@ -439,9 +439,9 @@ TEST_SUITE(Foundation_Image_ColorSpace)
         const Color3d linear_rgb = srgb_to_linear_rgb(srgb);
 
         EXPECT_FEQ_EPS(
-            Color3d(0.5, 0.7, 0.2),
+            Color3d(0.499996, 0.69986, 0.199976),
             linear_rgb,
-            1.0e-6);
+            1.0e-4);
     }
 
     TEST_CASE(TestFastLinearRGBTosRGBConversion)

--- a/src/appleseed/foundation/meta/tests/test_colorspace.cpp
+++ b/src/appleseed/foundation/meta/tests/test_colorspace.cpp
@@ -428,9 +428,9 @@ TEST_SUITE(Foundation_Image_ColorSpace)
         const Color3d srgb = linear_rgb_to_srgb(linear_rgb);
 
         EXPECT_FEQ_EPS(
-            Color3d(0.73535698305244945, 0.85430583154494000, 0.48452920448170694),
+            Color3d(0.735361, 0.854277, 0.484509),
             srgb,
-            1.0e-4);
+            1.0e-6);
     }
 
     TEST_CASE(TestsRGBToLinearRGBConversion)
@@ -441,7 +441,7 @@ TEST_SUITE(Foundation_Image_ColorSpace)
         EXPECT_FEQ_EPS(
             Color3d(0.499996, 0.69986, 0.199976),
             linear_rgb,
-            1.0e-4);
+            1.0e-6);
     }
 
     TEST_CASE(TestFastLinearRGBTosRGBConversion)


### PR DESCRIPTION
#1908 
Test results with [http://entropymine.com/imageworsener/slowpow/](http://entropymine.com/imageworsener/slowpow/):

**Original pow:**

```
$ time; ./powtest 100000000 1.0000000000000020 1.5000050000000000 ; time
shell  0.04s user 0.03s system 0% cpu 24.356 total
children  0.06s user 0.01s system 0% cpu 24.356 total
(count=100000000) 1.0000000000000020^1.5000050000000000 = 1.0000000000000031
shell  0.04s user 0.03s system 0% cpu 30.206 total
children  5.86s user 0.03s system 19% cpu 30.206 total
```
- Test 1: ~6 seconds
- Test 2 and 3: way too long

**Appleseed's fast pow:**
```
oktomus at pangolin in ~ 
$ time; ./fastpowtest 100000000 1.0000000000000020 1.5000050000000000 ; time
shell  0.05s user 0.03s system 0% cpu 1:18.20 total
children  5.86s user 0.03s system 7% cpu 1:18.20 total
(count=100000000) 1.0000000000000020^1.5000050000000000 = 1.0000152587890625
shell  0.05s user 0.03s system 0% cpu 1:20.92 total
children  8.56s user 0.03s system 10% cpu 1:20.92 total

oktomus at pangolin in ~ 
$ time; ./fastpowtest 100000000 1.0000000000000020 1.5000005000000000  ; time
shell  0.06s user 0.04s system 0% cpu 1:32.03 total
children  8.56s user 0.03s system 9% cpu 1:32.03 total
(count=100000000) 1.0000000000000020^1.5000005000000001 = 1.0000152587890625
shell  0.06s user 0.04s system 0% cpu 1:34.74 total
children  11.25s user 0.03s system 11% cpu 1:34.74 total

oktomus at pangolin in ~ 
$ time; ./fastpowtest 100000000 1.0000000000000020 1.5000000000000000   ; time
shell  0.06s user 0.04s system 0% cpu 1:40.89 total
children  11.25s user 0.03s system 11% cpu 1:40.89 total
(count=100000000) 1.0000000000000020^1.5000000000000000 = 1.0000152587890625
shell  0.06s user 0.04s system 0% cpu 1:43.60 total
children  13.95s user 0.04s system 13% cpu 1:43.60 total
```
- Test 1: ~2 seconds
- Test 2: ~2 seconds
- Test 3: ~3 seconds

**OIIO's safe fast pow:**
```
$ time; ./oiiofastpowtest 100000000 1.0000000000000020 1.5000050000000000    ; time
shell  0.07s user 0.05s system 0% cpu 3:31.59 total
children  13.95s user 0.04s system 6% cpu 3:31.59 total
(count=100000000) 1.0000000000000020^1.5000050000000000 = 1.0000000000000000
shell  0.07s user 0.05s system 0% cpu 3:50.09 total
children  32.41s user 0.04s system 14% cpu 3:50.09 total
```
- Test 1: ~19 seconds
- Test 2 and 3: way to long

Tested also with the cornell box scene, saving around 4 seconds and the result is the same.