### PR TITLE
Use fast colorspace conversion

### DIFF
--- a/src/appleseed/foundation/image/text/textrenderer.cpp
+++ b/src/appleseed/foundation/image/text/textrenderer.cpp
@@ -255,13 +255,13 @@ void TextRenderer::draw_string(
                 if (image_color_space == ColorSpaceSRGB)
                 {
                     // Convert background color from sRGB to linear RGB.
-                    background.rgb() = srgb_to_linear_rgb(background.rgb());
+                    background.rgb() = fast_srgb_to_linear_rgb(background.rgb());
                 }
 
                 Color4f pixel = color_srgb;
 
                 // Convert text color from sRGB to linear RGB.
-                pixel.rgb() = srgb_to_linear_rgb(pixel.rgb());
+                pixel.rgb() = fast_srgb_to_linear_rgb(pixel.rgb());
 
                 // Premultiply text color.
                 pixel *= pixel.a * alpha;

--- a/src/appleseed/renderer/kernel/texturing/texturestore.cpp
+++ b/src/appleseed/renderer/kernel/texturing/texturestore.cpp
@@ -118,7 +118,7 @@ namespace
             {
                 Color3f color;
                 tile.get_pixel(i, color);
-                tile.set_pixel(i, srgb_to_linear_rgb(color));
+                tile.set_pixel(i, fast_srgb_to_linear_rgb(color));
             }
         }
         else
@@ -127,7 +127,7 @@ namespace
             {
                 Color4f color;
                 tile.get_pixel(i, color);
-                color.rgb() = srgb_to_linear_rgb(color.rgb());
+                color.rgb() = fast_srgb_to_linear_rgb(color.rgb());
                 tile.set_pixel(i, color);
             }
         }

--- a/src/appleseed/renderer/modeling/bsdf/disneylayeredbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/disneylayeredbrdf.cpp
@@ -128,7 +128,7 @@ void* DisneyLayeredBRDF::evaluate_inputs(
     // Colors in SeExpr are always in the sRGB color space.
     // todo: convert colors earlier so that all math is done in linear space.
     values->m_base_color.set(
-        srgb_to_linear_rgb(base_color),
+        fast_srgb_to_linear_rgb(base_color),
         g_std_lighting_conditions,
         Spectrum::Reflectance);
 

--- a/src/appleseed/renderer/modeling/input/colorsource.cpp
+++ b/src/appleseed/renderer/modeling/input/colorsource.cpp
@@ -142,7 +142,7 @@ void ColorSource::initialize_from_color3(const ColorEntity& color_entity)
         break;
 
       case ColorSpaceSRGB:
-        m_linear_rgb = srgb_to_linear_rgb(color);
+        m_linear_rgb = fast_srgb_to_linear_rgb(color);
         break;
 
       case ColorSpaceCIEXYZ:

--- a/src/appleseed/renderer/modeling/material/disneymaterial.cpp
+++ b/src/appleseed/renderer/modeling/material/disneymaterial.cpp
@@ -199,7 +199,7 @@ namespace
 
                 // Colors in SeExpr are always in the sRGB color space.
                 if (!m_texture_is_srgb)
-                    color = linear_rgb_to_srgb(color);
+                    color = fast_linear_rgb_to_srgb(color);
 
                 return color;
             }


### PR DESCRIPTION
#1908 
I just use `fast_...` where it wasn't used before. I'm sure there is some places where it's not correct, but I would like to know what is your opinion.
Btw, `convert_tile_srgb_to_linear_rgb` in `texturestore.cpp` seems to never be used. 