### PR TITLE
Add test for curve self-intersection

### DIFF
--- a/src/appleseed/foundation/math/beziercurve.h
+++ b/src/appleseed/foundation/math/beziercurve.h
@@ -887,12 +887,12 @@ bool BezierCurveIntersector<BezierCurveType>::converge(
         // Compute point on curve.
         const VectorType p = curve.evaluate_point(w);
 
-        // Compare Z distances.
-        if (p.z < ValueType(0.0) || p.z > t)
-            return false;
-
         // Compute curve width.
         const ValueType width = curve.evaluate_width(w);
+
+        // Compare Z distances.
+        if (p.z <= width || p.z > t)
+            return false;
 
         // Compare X-Y distances.
         if (dotxy(p, p) >= ValueType(0.25) * width * width)


### PR DESCRIPTION
This adds a test case to check for self intersection for curve ribbons and fixes the earlier issue.  