### PR TITLE
Flush output when sending hightlight tiles

### DIFF
--- a/src/appleseed.cli/stdouttilecallback.cpp
+++ b/src/appleseed.cli/stdouttilecallback.cpp
@@ -91,6 +91,8 @@ namespace
             const int old_stdout_mode = _setmode(_fileno(stdout), _O_BINARY);
 #endif
             send_highlight_tile(*frame, tile_x, tile_y);
+
+            fflush(stdout);
 #ifdef _WIN32
             _setmode(_fileno(stdout), old_stdout_mode);
 #endif


### PR DESCRIPTION
Sorry for the minimal commit.
Needed otherwise we have to wait the tile to end before seeing the highlight. 