### PR TITLE
Split unfiltered AOV filter images

### DIFF
--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
@@ -136,8 +136,11 @@ namespace
 // UnfilteredAOVAccumulator class implementation.
 //
 
-UnfilteredAOVAccumulator::UnfilteredAOVAccumulator(Image& image)
+UnfilteredAOVAccumulator::UnfilteredAOVAccumulator(
+    Image& image,
+    Image& filter_image)
   : m_image(image)
+  , m_filter_image(filter_image)
 {
 }
 
@@ -150,6 +153,7 @@ void UnfilteredAOVAccumulator::on_tile_begin(
     // Fetch the destination tile.
     const CanvasProperties& props = frame.image().properties();
     m_tile = &m_image.tile(tile_x, tile_y);
+    m_filter_tile = &m_filter_image.tile(tile_x, tile_y);
 
     // Fetch the tile bounds (inclusive).
     m_tile_origin_x = static_cast<int>(tile_x * props.m_tile_width);

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.h
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.h
@@ -115,7 +115,9 @@ class UnfilteredAOVAccumulator
   : public AOVAccumulator
 {
   public:
-    explicit UnfilteredAOVAccumulator(foundation::Image& image);
+    UnfilteredAOVAccumulator(
+        foundation::Image& image,
+        foundation::Image& filter_image);
 
     void on_tile_begin(
         const Frame&                frame,
@@ -126,12 +128,17 @@ class UnfilteredAOVAccumulator
   protected:
     foundation::Image&  m_image;
     foundation::Tile*   m_tile;
+
+    foundation::Image&  m_filter_image;
+    foundation::Tile*   m_filter_tile;
+
     int                 m_tile_origin_x;
     int                 m_tile_origin_y;
     int                 m_tile_end_x;
     int                 m_tile_end_y;
 
     foundation::Tile& get_tile() const;
+    foundation::Tile& get_filter_tile() const;
 
     bool outside_tile(const foundation::Vector2i& pi) const;
 
@@ -210,6 +217,11 @@ class AOVAccumulatorContainer
 inline foundation::Tile& UnfilteredAOVAccumulator::get_tile() const
 {
     return *m_tile;
+}
+
+inline foundation::Tile& UnfilteredAOVAccumulator::get_filter_tile() const
+{
+    return *m_filter_tile;
 }
 
 inline bool UnfilteredAOVAccumulator::outside_tile(

--- a/src/appleseed/renderer/modeling/aov/aov.cpp
+++ b/src/appleseed/renderer/modeling/aov/aov.cpp
@@ -71,11 +71,11 @@ void AOV::release()
 }
 
 void AOV::create_image(
-    const size_t    canvas_width,
-    const size_t    canvas_height,
-    const size_t    tile_width,
-    const size_t    tile_height,
-    ImageStack&     aov_images)
+    const size_t        canvas_width,
+    const size_t        canvas_height,
+    const size_t        tile_width,
+    const size_t        tile_height,
+    ImageStack&         aov_images)
 {
     m_image_index = aov_images.append(
         get_name(),
@@ -131,12 +131,14 @@ bool ColorAOV::has_color_data() const
 
 UnfilteredAOV::UnfilteredAOV(const char* name, const ParamArray& params)
   : AOV(name, params)
+  , m_filter_image(nullptr)
 {
 }
 
 UnfilteredAOV::~UnfilteredAOV()
 {
     delete m_image;
+    delete m_filter_image;
 }
 
 bool UnfilteredAOV::has_color_data() const
@@ -145,23 +147,30 @@ bool UnfilteredAOV::has_color_data() const
 }
 
 void UnfilteredAOV::create_image(
-    const size_t canvas_width,
-    const size_t canvas_height,
-    const size_t tile_width,
-    const size_t tile_height,
-    ImageStack& aov_images)
+    const size_t        canvas_width,
+    const size_t        canvas_height,
+    const size_t        tile_width,
+    const size_t        tile_height,
+    ImageStack&         aov_images)
 {
-    // Add one extra channel to keep track of the distance
-    // to the nearest sample for each pixel.
-    const size_t num_channels = get_channel_count() + 1;
-
     m_image =
         new Image(
             canvas_width,
             canvas_height,
             tile_width,
             tile_height,
-            num_channels,
+            get_channel_count(),
+            PixelFormatFloat);
+
+    // Extra image to keep track of the distance
+    // to the nearest sample for each pixel.
+    m_filter_image =
+        new Image(
+            canvas_width,
+            canvas_height,
+            tile_width,
+            tile_height,
+            1,
             PixelFormatFloat);
 
     // We need to clear the image because the default channel value

--- a/src/appleseed/renderer/modeling/aov/aov.h
+++ b/src/appleseed/renderer/modeling/aov/aov.h
@@ -152,6 +152,8 @@ class UnfilteredAOV
     bool has_color_data() const override;
 
   protected:
+    foundation::Image*  m_filter_image;
+
     void create_image(
         const size_t    canvas_width,
         const size_t    canvas_height,

--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -67,8 +67,8 @@ namespace
       : public UnfilteredAOVAccumulator
     {
       public:
-        explicit DepthAOVAccumulator(Image& image)
-          : UnfilteredAOVAccumulator(image)
+        DepthAOVAccumulator(Image& image, Image& filter_image)
+          : UnfilteredAOVAccumulator(image, filter_image)
         {
         }
 
@@ -87,7 +87,10 @@ namespace
             float* p = reinterpret_cast<float*>(
                 get_tile().pixel(pi.x - m_tile_origin_x, pi.y - m_tile_origin_y));
 
-            const float min_sample_square_distance = p[1];
+            float* f = reinterpret_cast<float*>(
+                get_filter_tile().pixel(pi.x - m_tile_origin_x, pi.y - m_tile_origin_y));
+
+            const float min_sample_square_distance = *f;
             const float sample_square_distance =
                 square_distance_to_pixel_center(pixel_context.get_sample_position());
 
@@ -97,8 +100,8 @@ namespace
                     ? static_cast<float>(shading_point.get_distance())
                     : numeric_limits<float>::max();
 
-                p[0] = depth;
-                p[1] = sample_square_distance;
+                *p = depth;
+                *f = sample_square_distance;
             }
         }
     };
@@ -142,12 +145,14 @@ namespace
 
         void clear_image() override
         {
-            m_image->clear(Vector2f(numeric_limits<float>::max()));
+            m_image->clear(Color<float, 1>(numeric_limits<float>::max()));
+            m_filter_image->clear(Color<float, 1>(numeric_limits<float>::max()));
         }
 
         auto_release_ptr<AOVAccumulator> create_accumulator() const override
         {
-            return auto_release_ptr<AOVAccumulator>(new DepthAOVAccumulator(get_image()));
+            return auto_release_ptr<AOVAccumulator>(
+                new DepthAOVAccumulator(get_image(), *m_filter_image));
         }
     };
 }

--- a/src/appleseed/renderer/modeling/aov/uvaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/uvaov.cpp
@@ -63,8 +63,8 @@ namespace
       : public UnfilteredAOVAccumulator
     {
       public:
-        explicit UVAOVAccumulator(Image& image)
-          : UnfilteredAOVAccumulator(image)
+        UVAOVAccumulator(Image& image, Image& filter_image)
+          : UnfilteredAOVAccumulator(image, filter_image)
         {
         }
 
@@ -83,7 +83,10 @@ namespace
             float* p = reinterpret_cast<float*>(
                 get_tile().pixel(pi.x - m_tile_origin_x, pi.y - m_tile_origin_y));
 
-            const float min_sample_square_distance = p[3];
+            float* f = reinterpret_cast<float*>(
+                get_filter_tile().pixel(pi.x - m_tile_origin_x, pi.y - m_tile_origin_y));
+
+            const float min_sample_square_distance = *f;
             const float sample_square_distance =
                 square_distance_to_pixel_center(pixel_context.get_sample_position());
 
@@ -95,14 +98,14 @@ namespace
                     p[0] = uv[0];
                     p[1] = uv[1];
                     p[2] = 0.0f;
-                    p[3] = sample_square_distance;
+                    *f = sample_square_distance;
                 }
                 else
                 {
                     p[0] = 0.0f;
                     p[1] = 0.0f;
                     p[2] = 0.0f;
-                    p[3] = sample_square_distance;
+                    *f = sample_square_distance;
                 }
             }
         }
@@ -147,12 +150,14 @@ namespace
 
         void clear_image() override
         {
-            m_image->clear(Color4f(0.0f, 0.0f, 0.0f, numeric_limits<float>::max()));
+            m_image->clear(Color3f(0.0f, 0.0f, 0.0f));
+            m_filter_image->clear(Color<float, 1>(numeric_limits<float>::max()));
         }
 
         auto_release_ptr<AOVAccumulator> create_accumulator() const override
         {
-            return auto_release_ptr<AOVAccumulator>(new UVAOVAccumulator(get_image()));
+            return auto_release_ptr<AOVAccumulator>(
+                new UVAOVAccumulator(get_image(), *m_filter_image));
         }
     };
 }


### PR DESCRIPTION
Move the nearest distance channel to its own image.
Avoids having to skip channels when sending the image to blender in the stdout tile callback.