### PR TITLE
Fix crash in Disney BRDF in debug builds.

### DIFF
--- a/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
@@ -472,6 +472,9 @@ namespace
                 weights[ClearcoatComponent] = 0.0f;
             }
 
+            if (sample.m_mode == ScatteringMode::None)
+                return;
+
             const Vector3f& outgoing = sample.m_outgoing.get_value();
             const Vector3f& incoming = sample.m_incoming.get_value();
 


### PR DESCRIPTION
If sampling fails, we should not evaluate the other lobes.