### PR TITLE
Small camera refactoring and bug fixes.

### DIFF
--- a/src/appleseed/renderer/modeling/camera/camera.h
+++ b/src/appleseed/renderer/modeling/camera/camera.h
@@ -201,10 +201,14 @@ class APPLESEED_DLLSYMBOL Camera
     // Check shutter times and emit warnings if needed.
     void check_shutter_times_for_consistency() const;
 
+    void initialize_shutter_curve_bezier();
+
+    void initialize_shutter_curve_linear();
+
     void initialize_shutter_curve_bezier_cdfs(
         const float                     ot,
         const float                     oet,
-        const float                     cst,
+        const float                     cbt,
         const float                     ct,
         const float                     t00,
         const float                     t01,


### PR DESCRIPTION
- Refactor camera initialization & fix bad naming
- Initialize motion blur related variables only if they are required
- Linear shutter curve now uses normalized time for time mapping