### PR TITLE
Fix warning when building.

### DIFF
--- a/src/appleseed/renderer/kernel/lighting/bdpt/bdptlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/bdpt/bdptlightingengine.cpp
@@ -164,8 +164,8 @@ namespace
                 }
             }
 
-            delete camera_vertices;
-            delete light_vertices;
+            delete[] camera_vertices;
+            delete[] light_vertices;
         }
 
         // todo: use an output parameter instead of returning a spectrum.


### PR DESCRIPTION
Here is message :

_renderer/kernel/lighting/bdpt/bdptlightingengine.cpp:168:13: 
warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'?_ 

