### PR TITLE
Revert "OSL tweaks for as standard, texture, triplanar"

### DIFF
--- a/src/appleseed.shaders/include/appleseed/color/as_color_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/color/as_color_helpers.h
@@ -57,8 +57,7 @@ float as_luminance_D65(color in_C, string colorspace)
     {
         coeffs = color(REC601_D65_LUMINANCE_COEFFS);
     }
-    else if (colorspace == "Rec.709" || colorspace == "sRGB" ||
-             colorspace == "sRGB/Rec.709")
+    else if (colorspace == "Rec.709" || colorspace == "sRGB")
     {
         coeffs = color(REC709_D65_LUMINANCE_COEFFS);
     }
@@ -99,8 +98,7 @@ float as_luminance_D60(color in_C, string colorspace)
     {
         coeffs = color(REC601_D60_LUMINANCE_COEFFS);
     }
-    else if (colorspace == "Rec.709" || colorspace == "sRGB" ||
-             colorspace == "sRGB/Rec.709")
+    else if (colorspace == "Rec.709" || colorspace == "sRGB")
     {
         coeffs = color(REC709_D60_LUMINANCE_COEFFS);
     }
@@ -141,8 +139,7 @@ float as_luminance_DCI(color in_C, string colorspace)
     {
         coeffs = color(REC601_DCI_LUMINANCE_COEFFS);
     }
-    else if (colorspace == "Rec.709" || colorspace == "sRGB" ||
-             colorspace == "sRGB/Rec.709")
+    else if (colorspace == "Rec.709" || colorspace == "sRGB")
     {
         coeffs = color(REC709_DCI_LUMINANCE_COEFFS);
     }
@@ -200,51 +197,7 @@ float as_luminance(color in_C, string colorspace, string illuminant)
 
 float as_luminance(color in_C, string colorspace)
 {
-    color coeffs; // assuming input color is in "colorspace" working space
-
-    if (colorspace == "Rec.601")
-    {
-        coeffs = color(REC601_D65_LUMINANCE_COEFFS);
-    }
-    else if (colorspace == "Rec.709" || colorspace == "sRGB" ||
-             colorspace == "sRGB/Rec.709")
-    {
-        coeffs = color(REC709_D65_LUMINANCE_COEFFS);
-    }
-    else if (colorspace == "AdobeRGB")
-    {
-        coeffs = color(ADOBERGB_D65_LUMINANCE_COEFFS);
-    }
-    else if (colorspace == "Rec.2020")
-    {
-        coeffs = color(REC2020_D65_LUMINANCE_COEFFS);
-    }
-    else if (colorspace == "ACES")
-    {
-        coeffs = color(ACES_D60_LUMINANCE_COEFFS);
-    }
-    else if (colorspace == "ACEScg")
-    {
-        coeffs = color(ACESCG_D60_LUMINANCE_COEFFS);
-    }
-    else if (colorspace == "DCI-P3")
-    {
-        coeffs = color(DCIP3_DCI_LUMINANCE_COEFFS);
-    }
-    else
-    {
-        coeffs = color(0);
-#ifdef DEBUG
-        string shadername = "";
-
-        getattribute("shader:shadername", shadername);
-        warning("[DEBUG]: Invalid working space specified in %s, %s:%d\n",
-                shadername, __FILE__, __LINE__);
-#endif
-    }
-    return coeffs[0] * in_C[0] +
-           coeffs[1] * in_C[1] +
-           coeffs[2] * in_C[2];
+    return as_luminance_D65(in_C, colorspace);
 }
 
 void initialize_RGBW_primaries(
@@ -262,8 +215,7 @@ void initialize_RGBW_primaries(
         RGBW_CIExyz[1] = REC601_CHROMATICITIES_Gxyz;
         RGBW_CIExyz[2] = REC601_CHROMATICITIES_Bxyz;
     }
-    else if (RGB_primaries == "Rec.709" || RGB_primaries == "sRGB" ||
-             RGB_primaries == "sRGB/Rec.709")
+    else if (RGB_primaries == "Rec.709" || RGB_primaries == "sRGB")
     {
         RGBW_CIExyz[0] = REC709_CHROMATICITIES_Rxyz;
         RGBW_CIExyz[1] = REC709_CHROMATICITIES_Gxyz;
@@ -323,8 +275,7 @@ void initialize_RGB_primaries(
         RGB_CIExyz[1] = REC601_CHROMATICITIES_Gxyz;
         RGB_CIExyz[2] = REC601_CHROMATICITIES_Bxyz;
     }
-    else if (RGB_primaries == "Rec.709" || RGB_primaries == "sRGB" ||
-             RGB_primaries == "sRGB/Rec.709")
+    else if (RGB_primaries == "Rec.709" || RGB_primaries == "sRGB")
     {
         RGB_CIExyz[0] = REC709_CHROMATICITIES_Rxyz;
         RGB_CIExyz[1] = REC709_CHROMATICITIES_Gxyz;

--- a/src/appleseed.shaders/src/appleseed/as_blackbody.osl
+++ b/src/appleseed.shaders/src/appleseed/as_blackbody.osl
@@ -125,13 +125,13 @@ shader as_blackbody
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0
     ]],
-    float in_specular_weight = 0.0
+    float in_specular_amount = 0.0
     [[
         string as_maya_attribute_name = "specularAmount",
         string as_maya_attribute_short_name = "sam",
         float min = 0.0,
         float max = 1.0,
-        string label = "Specular Weight",
+        string label = "Specular Amount",
         string page = "Specular"
     ]],
     float in_specular_roughness = 0.1
@@ -258,7 +258,7 @@ shader as_blackbody
 
     float transmittance = 1.0;
 
-    if (in_specular_weight > 0.0 && in_ior > 1.0)
+    if (in_specular_amount > 0.0 && in_ior > 1.0)
     {
         // Dielectric coating, so the Schlick approximation suffices.
         vector In = normalize(I);
@@ -271,7 +271,7 @@ shader as_blackbody
 
         transmittance = 1.0 - clamp(Kr, 0.0, 1.0);
 
-        out_color += in_specular_weight *
+        out_color += in_specular_amount *
             as_glossy(
                 "ggx",
                 Nn,

--- a/src/appleseed.shaders/src/appleseed/as_disney_material.osl
+++ b/src/appleseed.shaders/src/appleseed/as_disney_material.osl
@@ -47,22 +47,22 @@ shader as_disney_material
         string label = "Surface Color",
         string page = "Common"
     ]],
-    float in_subsurface_weight = 0.0
+    float in_subsurface_amount = 0.0
     [[
-        string as_maya_attribute_name = "subsurfaceWeight",
+        string as_maya_attribute_name = "subsurfaceAmount",
         string as_maya_attribute_short_name = "ss",
         float min = 0.0,
         float max = 1.0,
-        string label = "Subsurface Weight",
+        string label = "Subsurface Amount",
         string page = "Common"
     ]],
-    float in_specular_weight = 0.5
+    float in_specular_amount = 0.5
     [[
-        string as_maya_attribute_name = "specularWeight",
+        string as_maya_attribute_name = "specularAmount",
         string as_maya_attribute_short_name = "sa",
         float min = 0.0,
         float max = 1.0,
-        string label = "Specular Weight",
+        string label = "Specular Amount",
         string page = "Specular"
     ]],
     float in_roughness = 0.5
@@ -83,9 +83,9 @@ shader as_disney_material
         string label = "Specular Tinting",
         string page = "Specular"
     ]],
-    float in_metallic_weight = 0.0
+    float in_metallic_amount = 0.0
     [[
-        string as_maya_attribute_name = "metallicWeight",
+        string as_maya_attribute_name = "metallicAmount",
         string as_maya_attribute_short_name = "ma",
         float min = 0.0,
         float max = 1.0,
@@ -120,14 +120,14 @@ shader as_disney_material
         string page = "Specular",
         string help = "Vector tangent field map, with XY in R,G channels"
     ]],
-    float in_sheen_weight = 0.0
+    float in_sheen_amount = 0.0
     [[
-        string as_maya_attribute_name = "sheenWeight",
+        string as_maya_attribute_name = "sheenAmount",
         string as_maya_attribute_short_name = "ha",
         float min = 0.0,
         float max = 10.0,
         float softmax = 1.0,
-        string label = "Sheen Weight",
+        string label = "Sheen Amount",
         string page = "Sheen"
     ]],
     float in_sheen_tint = 0.5
@@ -146,7 +146,7 @@ shader as_disney_material
         float min = 0.0,
         float max = 100.0,
         float softmax = 1.0,
-        string label = "Coating Weight",
+        string label = "Coating Amount",
         string page = "Clear Coat"
     ]],
     float in_clear_coat_glossyness = 1.0
@@ -272,7 +272,7 @@ shader as_disney_material
     normal Nn = normalize(in_bump_normal);
     vector tangent = Tn;
 
-    if (max(in_specular_weight) > 0.0 && in_anisotropy_amount > 0.0)
+    if (max(in_specular_amount) > 0.0 && in_anisotropy_amount > 0.0)
     {
         if (isconnected(in_anisotropy_vector_map))
         {
@@ -298,13 +298,13 @@ shader as_disney_material
         Nn,
         tangent,
         in_color,
-        in_subsurface_weight,
-        in_metallic_weight,
-        in_specular_weight,
+        in_subsurface_amount,
+        in_metallic_amount,
+        in_specular_amount,
         in_specular_tint,
         in_anisotropy_amount,
         in_roughness,
-        in_sheen_weight,
+        in_sheen_amount,
         in_sheen_tint,
         in_clear_coat,
         in_clear_coat_glossyness);

--- a/src/appleseed.shaders/src/appleseed/as_glass.osl
+++ b/src/appleseed.shaders/src/appleseed/as_glass.osl
@@ -45,13 +45,13 @@ shader as_glass
         string label = "Transmittance Color",
         string page = "Transmittance"
     ]],
-    float in_transmittance_weight = 0.8
+    float in_transmittance_amount = 0.8
     [[
-        string as_maya_attribute_name = "transmittanceWeight",
+        string as_maya_attribute_name = "transmittanceAmount",
         string as_maya_attribute_short_name = "ta",
         float min = 0.0,
         float max = 1.0,
-        string label = "Transmittance Weight",
+        string label = "Transmittance Amount",
         string page = "Transmittance"
     ]],
     color in_reflection_tint = color(1)
@@ -335,7 +335,7 @@ shader as_glass
         in_distribution,
         Nn,
         tangent,
-        in_transmittance_weight * in_surface_transmittance,
+        in_transmittance_amount * in_surface_transmittance,
         in_reflection_tint,
         in_refraction_tint,
         in_roughness,

--- a/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
@@ -76,14 +76,14 @@ shader as_standard_surface
         string page = "Subsurface",
         int divider = 1
     ]],
-    color in_subsurface_mfp = color(0)
+    color in_sss_mfp = color(0)
     [[
         string as_maya_attribute_name = "subsurfaceMfp",
         string as_maya_attribute_short_name = "mfp",
         string label = "Mean Free Path",
         string page = "Subsurface"
     ]],
-    float in_subsurface_mfp_scale = 1.0
+    float in_sss_mfp_scale = 1.0
     [[
         string as_maya_attribute_name = "subsurfaceMfpScale",
         string as_maya_attribute_short_name = "sfm",
@@ -97,44 +97,30 @@ shader as_standard_surface
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0
     ]],
-    int in_subsurface_profile = 0
+    int in_sss_maximum_ray_depth = 2
     [[
-        string as_maya_attribute_name = "subsurfaceProfile",
-        string as_maya_attribute_short_name = "ssp",
-        string widget = "mapper",
-        string options = "Gaussian:0|Dipole:1|Normalized Diffusion:2|Random Walk:3",
-        string label = "Subsurface Profile",
-        string page = "Subsurface.Advanced",
-        int as_maya_attribute_connectable = 0,
-        int as_maya_attribute_keyable = 0,
-        int as_maya_attribute_hidden = 1,
-        int gafferNoduleLayoutVisible = 0,
-        int divider = 1
-    ]],
-    int in_subsurface_maximum_ray_depth = 2
-    [[
-        string as_maya_attribute_name = "subsurfaceMaximumRayDepth",
+        string as_maya_attribute_name = "sssMaximumRayDepth",
         string as_maya_attribute_short_name = "ssd",
         int min = 1,
         int max = 16,
         int softmax = 8,
-        string label = "Subsurface Ray Depth",
+        string label = "SSS Ray Depth",
         string page = "Subsurface.Advanced",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0
     ]],
-    float in_subsurface_threshold = 0.001
+    float in_sss_threshold = 0.001
     [[
-        string as_maya_attribute_name = "subsurfaceThreshold",
+        string as_maya_attribute_name = "sssThreshold",
         string as_maya_attibute_short_name = "sth",
         float min = 0.0,
         float max = 1.0,
         float softmax = 0.01,
-        string label = "Subsurface Diffuse Threshold",
+        string label = "SSS Diffuse Threshold",
         string page = "Subsurface.Advanced",
-        string help = "Threshold at which Subsurface is replaced by a diffuse term",
+        string help = "Threshold at which SSS is replaced by a diffuse term",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
@@ -265,15 +251,15 @@ shader as_standard_surface
         string page = "Specular.Anisotropy",
         string help = "Anisotropy vector map, with XY encoded in RG channels"
     ]],
-    float in_refraction_weight = 0.0
+    float in_refraction_amount = 0.0
     [[
-        string as_maya_attribute_name = "refractionWeight",
+        string as_maya_attribute_name = "refractionAmount",
         string as_maya_attribute_short_name = "rtw",
         float min = 0.0,
         float max = 1.0,
-        string label = "Refraction Weight",
+        string label = "Refraction Amount",
         string page = "Specular.Refraction",
-        string help = "Refraction weight. Refraction inherits the IOR"
+        string help = "Refraction amount. Refraction inherits the IOR"
     ]],
     color in_refraction_tint = color(1)
     [[
@@ -312,7 +298,7 @@ shader as_standard_surface
         float max = 1.0,
         string label = "Coating Reflectivity",
         string page = "Coating",
-        string help = "Coating specular weight."
+        string help = "Coating specular amount."
     ]],
     float in_coating_roughness = 0.0
     [[
@@ -339,7 +325,7 @@ shader as_standard_surface
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0
     ]],
-    float in_coating_thickness = 0.0
+    float in_coating_depth = 0.0
     [[
         string as_maya_attribute_name = "coatingDepth",
         string as_maya_attribute_short_name = "cod",
@@ -363,7 +349,7 @@ shader as_standard_surface
         string as_maya_attribute_short_name = "inw",
         float min = 0.0,
         float max = 1.0,
-        string label = "Incandescence Weight",
+        string label = "Incandescence Amount",
         string page = "Incandescence"
     ]],
     int in_incandescence_type = 0
@@ -575,7 +561,7 @@ shader as_standard_surface
     // Coating first, with full absorption substrate is not lit.
 
     int compute_coating =
-        (in_coating_reflectivity > 0.0 || in_coating_thickness > 0.0) ? 1 : 0;
+        (in_coating_reflectivity > 0.0 || in_coating_depth > 0.0) ? 1 : 0;
 
     color coating_transmittance = color(1);
 
@@ -614,7 +600,7 @@ shader as_standard_surface
 
             // Arbitrary value, it seems to provide a good (visual) range.
 
-            float max_depth = 10000.0 * sqr(sqr(in_coating_thickness));
+            float max_depth = 10000.0 * sqr(sqr(in_coating_depth));
             float tau = max_depth * (1.0 - max(0.0, costheta_o));
 
             // Restrict range to avoid pure saturated colors.
@@ -635,23 +621,22 @@ shader as_standard_surface
         (in_translucency_weight * max(in_translucency_color) > 0.0) ? 1 : 0;
 
     int compute_transmission =
-        (in_refraction_weight * max(in_refraction_tint) > 0.0) ? 1 : 0;
+        (in_refraction_amount * max(in_refraction_tint) > 0.0) ? 1 : 0;
 
     int compute_specular = max(in_specular_color) > 0.0 ? 1 : 0;
 
     int compute_diffuse = (in_diffuse_weight * max(in_color) > 0.0) ? 1 : 0;
 
     int compute_bssrdf = (
-        ray_depth > in_subsurface_maximum_ray_depth ||
+        ray_depth > in_sss_maximum_ray_depth ||
         compute_transparency || compute_translucency || compute_transmission ||
-        in_subsurface_weight == 0.0 ||
-        max(in_subsurface_mfp) <= in_subsurface_threshold)
+        in_subsurface_weight == 0.0 || max(in_sss_mfp) <= in_sss_threshold)
         ? 0 : 1;
 
     int compute_edf =
         (in_incandescence_amount * max(in_incandescence_color) > 0.0) ? 1 : 0;
 
-    // Specular first, to get the transmittance weight and bailout earlier.
+    // Specular first, to get the transmittance amount and bailout earlier.
 
     color substrate_transmittance = color(1);
     normal Nn = normalize(in_bump_normal_substrate);
@@ -693,9 +678,9 @@ shader as_standard_surface
                     "std",
                     Nn,
                     tangent,
-                    coating_transmittance, // coating_transmittance unsupported
+                    color(1), // coating_transmittance unsupported
                     in_specular_color,
-                    in_refraction_weight * in_refraction_tint,
+                    in_refraction_amount * in_refraction_tint,
                     in_specular_roughness,
                     1.0 - in_specular_spread,
                     in_anisotropy_amount,
@@ -731,7 +716,7 @@ shader as_standard_surface
         }
 
         // In order to layer substrate BxDFs, we need the microfacet Fresnel
-        // transmission weight (and absorption), but lacking that, use viewer.
+        // transmission amount (and absorption), but lacking that, use viewer.
 
         if ((compute_diffuse || compute_bssrdf || compute_edf ||
             compute_translucency) && max(in_specular_color) > 0.0)
@@ -803,34 +788,15 @@ shader as_standard_surface
         {
             albedo = clamp(albedo, 0.01, 0.99);
 
-            string subsurface_profile;
-
-            if (in_subsurface_profile == 0)
-            {
-                subsurface_profile = "gaussian";
-            }
-            else if (in_subsurface_profile == 1)
-            {
-                subsurface_profile = "better_dipole";
-            }
-            else if (in_subsurface_profile == 2)
-            {
-                subsurface_profile = "normalized_diffusion";
-            }
-            else
-            {
-                subsurface_profile = "randomwalk";
-            }
-
             // Disable Fresnel weight since transmittance is computed earlier,
             // but ideally, the BSSRDF should be used.
 
             out_outColor += in_subsurface_weight *
                 as_subsurface(
-                    subsurface_profile,
+                    "normalized_diffusion",
                     Nn,
                     in_diffuse_weight * in_color,
-                    in_subsurface_mfp_scale * in_subsurface_mfp,
+                    in_sss_mfp_scale * in_sss_mfp,
                     in_ior,
                     "fresnel_weight", 0.0);
         }

--- a/src/appleseed.shaders/src/appleseed/as_subsurface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_subsurface.osl
@@ -40,9 +40,9 @@ shader as_subsurface
     string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_subsurface.html#label-as-subsurface"
 ]]
 (
-    int in_subsurface_profile = 0
+    int in_sss_profile = 0
     [[
-        string as_maya_attribute_name = "subsurfaceProfile",
+        string as_maya_attribute_name = "sssProfile",
         string as_maya_attribute_short_name = "ssp",
         string widget = "mapper",
         string options = "Better Dipole:0|Directional Dipole:1|Gaussian:2|Normalized Diffusion:3|Standard Dipole:4|Random Walk:5",
@@ -61,24 +61,24 @@ shader as_subsurface
         string label = "Reflectance",
         string page = "Subsurface"
     ]],
-    float in_subsurface_weight = 1.0
+    float in_sss_amount = 1.0
     [[
-        string as_maya_attribute_name = "subsurfaceWeight",
+        string as_maya_attribute_name = "sssAmount",
         string as_maya_attribute_short_name = "ssa",
         float min = 0.0,
         float max = 1.0,
-        string label = "Subsurface Weight",
+        string label = "SSS Amount",
         string page = "Subsurface",
         int divider = 1
     ]],
-    color in_subsurface_mfp = color(0.13, 0.69, 0.88)
+    color in_sss_mfp = color(0.13, 0.69, 0.88)
     [[
         string as_maya_attribute_name = "meanFreePath",
         string as_maya_attribute_short_name = "mfp",
         string label = "Mean Free Path",
         string page = "Subsurface"
     ]],
-    float in_subsurface_mfp_scale = 1.0
+    float in_sss_mfp_scale = 1.0
     [[
         string as_maya_attribute_name = "mfpScale",
         string as_maya_attribute_short_name = "msc",
@@ -87,14 +87,14 @@ shader as_subsurface
         string label = "MFP Scale",
         string page = "Subsurface"
     ]],
-    int in_subsurface_maximum_ray_depth = 2
+    int in_sss_maximum_ray_depth = 2
     [[
-        string as_maya_attribute_name = "subsurfaceMaximumRayDepth",
+        string as_maya_attribute_name = "sssMaximumRayDepth",
         string as_maya_attribute_short_name = "ssd",
         int min = 1,
         int max = 16,
         int softmax = 8,
-        string label = "Subsurface Ray Depth",
+        string label = "SSS Ray Depth",
         string page = "Subsurface.Advanced",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
@@ -118,7 +118,7 @@ shader as_subsurface
         float max = 1.0,
         string label = "Fresnel Weight",
         string page = "Fresnel.Advanced",
-        string help = "A value of 0.0 disables scaling the subsurface term by the Fresnel. It should match the specular weight ideally."
+        string help = "A value of 0.0 disables scaling the SSS term by the Fresnel. It should match the specular weight ideally."
     ]],
     float in_specular_weight = 1.0
     [[
@@ -273,56 +273,56 @@ shader as_subsurface
         out_outColor += out_outMatteOpacity;
     }
 
-    string subsurface_profile;
+    string sss_profile;
 
-    if (in_subsurface_profile == 0)
+    if (in_sss_profile == 0)
     {
-        subsurface_profile = "better_dipole";
+        sss_profile = "better_dipole";
     }
-    else if (in_subsurface_profile == 1)
+    else if (in_sss_profile == 1)
     {
-        subsurface_profile = "directional_dipole";
+        sss_profile = "directional_dipole";
     }
-    else if (in_subsurface_profile == 2)
+    else if (in_sss_profile == 2)
     {
-        subsurface_profile = "gaussian";
+        sss_profile = "gaussian";
     }
-    else if (in_subsurface_profile == 3)
+    else if (in_sss_profile == 3)
     {
-        subsurface_profile = "normalized_diffusion";
+        sss_profile = "normalized_diffusion";
     }
-    else if (in_subsurface_profile == 4)
+    else if (in_sss_profile == 4)
     {
-        subsurface_profile = "standard_dipole";
+        sss_profile = "standard_dipole";
     }
     else
     {
-        subsurface_profile = "randomwalk";
+        sss_profile = "randomwalk";
     }
 
     normal Nn = normalize(in_bump_normal);
 
-    if (in_subsurface_weight * max(in_color) > 0.0)
+    if (in_sss_amount * max(in_color) > 0.0)
     {
-        color albedo = clamp(in_subsurface_weight * in_color, 0.01, 0.99);
+        color albedo = clamp(in_sss_amount * in_color, 0.01, 0.99);
 
-        if (subsurface_profile == "randomwalk")
+        if (sss_profile == "randomwalk")
         {
             out_outColor += as_subsurface(
-                subsurface_profile,
+                sss_profile,
                 Nn,
                 albedo,
-                in_subsurface_mfp_scale * in_subsurface_mfp,
+                in_sss_mfp_scale * in_sss_mfp,
                 in_ior,
                 "fresnel_weight", in_fresnel_weight);
         }
         else
         {
             out_outColor += as_subsurface(
-                subsurface_profile,
+                sss_profile,
                 Nn,
                 albedo,
-                in_subsurface_mfp_scale * in_subsurface_mfp,
+                in_sss_mfp_scale * in_sss_mfp,
                 in_ior,
                 "fresnel_weight", in_fresnel_weight);
         }

--- a/src/appleseed.shaders/src/appleseed/as_texture.osl
+++ b/src/appleseed.shaders/src/appleseed/as_texture.osl
@@ -406,9 +406,7 @@ shader as_texture
             "twidth", in_t_filter_width,
             "swrap", wrap_mode[0],
             "twrap", wrap_mode[1],
-            "interp", get_interpolation_method(in_interpolation_method));
-
-        out_color = color(out_channel);
+            "interp", get_interpolation_method(in_interpolation_method));     
     }
     else
     {
@@ -426,79 +424,69 @@ shader as_texture
             "missingalpha", in_alpha,
             "alpha", out_alpha,
             "interp", get_interpolation_method(in_interpolation_method));
-        
-        if (in_enable_cms && max(out_color) > 0.0)
+    }
+    
+    if (in_enable_cms && max(out_color) > 0.0)
+    {
+        color linearized_color = color(0);
+
+        if (in_eotf == 0)
         {
-            color linearized_color = color(0);
-
-            if (in_eotf == 0)
-            {
-                linearized_color = out_color;
-            }
-            else if (in_eotf == 1)
-            {
-                linearized_color = sRGB_EOTF(out_color);
-            }
-            else if (in_eotf == 2)
-            {
-                linearized_color == Rec709_EOTF(out_color);
-            }
-            else if (in_eotf == 3)
-            {
-                linearized_color == gamma_CCTF(out_color, 2.2);
-            }
-            else if (in_eotf == 4)
-            {
-                linearized_color == gamma_CCTF(out_color, 2.4);
-            }
-            else if (in_eotf == 5)
-            {
-                linearized_color == gamma_CCTF(out_color, DCIP3_GAMMA);
-            }
-            else if (in_eotf == 6)
-            {
-                linearized_color = Rec1886_EOTF(out_color);
-            }
-            else if (in_eotf == 7)
-            {
-                linearized_color == Rec2020_EOTF(out_color);
-            }
-            else
-            {
-                linearized_color = color(0);
-                
-#ifdef DEBUG
-                string shadername = "";
-                
-                getattribute("shader:shadername", shadername);
-                warning("[WARNING]: Unknown OETF mode %d, in %s, %s:%d\n",
-                in_eotf, shadername, __FILE__, __LINE__);
-#endif
-            }
-
-            if (in_rgb_primaries != "Raw" && max(linearized_color) > 0.0)
-            {
-                linearized_color = transform_colorspace_to_workingspace(
-                    linearized_color,
-                    in_rgb_primaries,
-                    in_workingspace_rgb_primaries);
-            }
-
-            out_color = linearized_color;
-
-            // The output is scene-linear and in the same RGBW primaries as
-            // the working space, so use its (working space) Y coefficients.
-
-            out_channel = as_luminance(
-                linearized_color,
-                in_workingspace_rgb_primaries);
+            linearized_color = out_color;
+        }
+        else if (in_eotf == 1)
+        {
+            linearized_color = sRGB_EOTF(out_color);
+        }
+        else if (in_eotf == 2)
+        {
+            linearized_color == Rec709_EOTF(out_color);
+        }
+        else if (in_eotf == 3)
+        {
+            linearized_color == gamma_CCTF(out_color, 2.2);
+        }
+        else if (in_eotf == 4)
+        {
+            linearized_color == gamma_CCTF(out_color, 2.4);
+        }
+        else if (in_eotf == 5)
+        {
+            linearized_color == gamma_CCTF(out_color, DCIP3_GAMMA);
+        }
+        else if (in_eotf == 6)
+        {
+            linearized_color = Rec1886_EOTF(out_color);
+        }
+        else if (in_eotf == 7)
+        {
+            linearized_color == Rec2020_EOTF(out_color);
         }
         else
         {
-            // Without CMS, no colorimetry information is known, the input is
-            // assumed as raw, no point in using luminance. Use average of RGB.
+            linearized_color = color(0);
             
-            out_channel = (out_color[0] + out_color[1] + out_color[2]) / 3.0;
+#ifdef DEBUG
+            string shadername = "";
+            getattribute("shader:shadername", shadername);
+            warning("[WARNING!]: Unknown OETF mode %d, in %s, %s:%d\n",
+                    in_eotf, shadername, __FILE__, __LINE__);
+#endif
         }
+
+        // We're assuming the ingested material is in [0,1] range, if not,
+        // we need to check the extension (*.hdr, *.exr), and bitdepth, and
+        // transform to a log representation, before applying a xform, then
+        // expanding it back.
+
+        if (in_rgb_primaries != "Raw" && max(linearized_color) > 0.0)
+        {
+            linearized_color = transform_colorspace_to_workingspace(
+                linearized_color,
+                in_rgb_primaries,
+                in_workingspace_rgb_primaries);
+        }
+
+        out_color = linearized_color;
     }
 }

--- a/src/appleseed.shaders/src/appleseed/as_triplanar.osl
+++ b/src/appleseed.shaders/src/appleseed/as_triplanar.osl
@@ -282,7 +282,7 @@ shader as_triplanar
         string as_maya_attribute_short_name = "xeo",
         string label = "Input Transfer Function",
         string page = "Projection.X Axis.Color Management",
-        string widget = "popup",
+        string widget = "mapper",
         string options = "None/Raw|sRGB|Rec.709|Gamma 2.2|Gamma 2.4|Gamma 2.6 (DCI)|Rec.1886|Rec.2020",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,


### PR DESCRIPTION
This reverts commit a4ffae166cc995d515565c38d44343875d825682.

The problem is that it introduces parameter name changes that break compatibility with all existing scenes relying on any of the following shaders:

- as_blackbody.osl
- as_disney_material.osl
- as_glass.osl
- as_standard_surface.osl
- as_subsurface.osl

We must discuss this issue.