### PR TITLE
Fix maya attribute name collision for uvCoord

### DIFF
--- a/src/appleseed.shaders/src/appleseed/as_globals.osl
+++ b/src/appleseed.shaders/src/appleseed/as_globals.osl
@@ -166,20 +166,20 @@ shader as_globals
     ]],
     output float out_u_coord = u
     [[
-        string as_maya_attribute_name = "uCoord",
-        string as_maya_attribute_short_name = "uu",
+        string as_maya_attribute_name = "outUCoord",
+        string as_maya_attribute_short_name = "ouu",
         string label = "U Coordinate"
     ]],
     output float out_v_coord = v
     [[
-        string as_maya_attribute_name = "vCoord",
-        string as_maya_attribute_short_name = "vv",
+        string as_maya_attribute_name = "outVCoord",
+        string as_maya_attribute_short_name = "ovv",
         string label = "V Coordinate"
     ]],
     output float out_uv_coord[2] = {out_u_coord, out_v_coord}
     [[
-        string as_maya_attribute_name = "uvCoord",
-        string as_maya_attribute_short_name = "uv",
+        string as_maya_attribute_name = "outUVCoords",
+        string as_maya_attribute_short_name = "ouv",
         string label = "UV Coords",
         int divider = 1
     ]],


### PR DESCRIPTION
This is a name used by the 2D nodes. Use some other attribute name for
the output U, V, UV coords for asGlobals maya attribute.
Without this, maya will refuse loading some nodes.