### PR TITLE
Include scenepicker.h only where needed.

### DIFF
--- a/src/appleseed.studio/mainwindow/rendering/cameracontroller.h
+++ b/src/appleseed.studio/mainwindow/rendering/cameracontroller.h
@@ -32,6 +32,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/api/rendering.h"
+#include "renderer/api/scenepicker.h"
 
 // appleseed.foundation headers.
 #include "foundation/math/vector.h"

--- a/src/appleseed.studio/mainwindow/rendering/scenepickinghandler.h
+++ b/src/appleseed.studio/mainwindow/rendering/scenepickinghandler.h
@@ -32,6 +32,7 @@
 
 // appleseed.renderer headers.
 #include "renderer/api/rendering.h"
+#include "renderer/api/scenepicker.h"
 
 // appleseed.foundation headers.
 #include "foundation/platform/compiler.h"

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -900,6 +900,7 @@ set (renderer_api_sources
     renderer/api/rasterization.h
     renderer/api/rendering.h
     renderer/api/scene.h
+    renderer/api/scenepicker.h
     renderer/api/shadergroup.h
     renderer/api/source.h
     renderer/api/surfaceshader.h

--- a/src/appleseed/renderer/api/scenepicker.h
+++ b/src/appleseed/renderer/api/scenepicker.h
@@ -5,8 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2010-2013 Francois Beaune, Jupiter Jazz Limited
-// Copyright (c) 2014-2018 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -27,25 +26,10 @@
 // THE SOFTWARE.
 //
 
-#ifndef APPLESEED_RENDERER_API_RENDERING_H
-#define APPLESEED_RENDERER_API_RENDERING_H
+#ifndef APPLESEED_RENDERER_API_SCENEPICKER_H
+#define APPLESEED_RENDERER_API_SCENEPICKER_H
 
 // API headers.
-#include "renderer/kernel/rendering/debug/blanktilerenderer.h"
-#include "renderer/kernel/rendering/debug/debugtilerenderer.h"
-#include "renderer/kernel/rendering/defaultrenderercontroller.h"
-#include "renderer/kernel/rendering/generic/genericframerenderer.h"
-#include "renderer/kernel/rendering/generic/genericsamplerenderer.h"
-#include "renderer/kernel/rendering/generic/generictilerenderer.h"
-#include "renderer/kernel/rendering/iframerenderer.h"
-#include "renderer/kernel/rendering/irenderercontroller.h"
-#include "renderer/kernel/rendering/isamplerenderer.h"
-#include "renderer/kernel/rendering/itilecallback.h"
-#include "renderer/kernel/rendering/itilerenderer.h"
-#include "renderer/kernel/rendering/masterrenderer.h"
-#include "renderer/kernel/rendering/nulltilecallback.h"
-#include "renderer/kernel/rendering/progressive/progressiveframerenderer.h"
-#include "renderer/kernel/rendering/tilecallbackbase.h"
-#include "renderer/kernel/rendering/timedrenderercontroller.h"
+#include "renderer/kernel/rendering/scenepicker.h"
 
-#endif  // !APPLESEED_RENDERER_API_RENDERING_H
+#endif  // !APPLESEED_RENDERER_API_SCENEPICKER_H


### PR DESCRIPTION
The header indirectly includes OSL headers and it is only used inside studio.
After removing the include from api/rendering.h, the Maya plugin can be built without OSL dependencies.
