### PR TITLE
Linux appleseed.python3 build fixes.

### DIFF
--- a/src/appleseed.python/CMakeLists.txt
+++ b/src/appleseed.python/CMakeLists.txt
@@ -198,6 +198,12 @@ if (WITH_PYTHON3_BINDINGS)
         appleseed
         ${PYTHON3_LIBRARIES}
     )
+
+     if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        target_link_libraries (appleseed.python3
+            util
+        )
+     endif ()
 endif ()
 
 #--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
When building using a static python3 library (for Blender) we need to link with libutil (a system lib).