### PR TITLE
appleseed.python blenderseed work.

### DIFF
--- a/src/appleseed.python/CMakeLists.txt
+++ b/src/appleseed.python/CMakeLists.txt
@@ -80,6 +80,7 @@ set (sources
     bindmaterial.cpp
     bindmatrix.cpp
     bindmeshobject.cpp
+    bindmurmurhash.cpp
     bindobject.cpp
     bindproject.cpp
     bindquaternion.cpp

--- a/src/appleseed.python/bindassembly.cpp
+++ b/src/appleseed.python/bindassembly.cpp
@@ -117,6 +117,11 @@ namespace
         return instance->transform_sequence();
     }
 
+    void set_transform_sequence(AssemblyInstance* instance, const TransformSequence& seq)
+    {
+        instance->transform_sequence() = seq;
+    }
+
     string get_assembly_name(AssemblyInstance* instance)
     {
         return instance->get_assembly_name();
@@ -153,6 +158,7 @@ void bind_assembly()
     bpy::class_<AssemblyInstance, auto_release_ptr<AssemblyInstance>, bpy::bases<Entity>, boost::noncopyable>("AssemblyInstance", bpy::no_init)
         .def("__init__", bpy::make_constructor(create_assembly_instance))
         .def("transform_sequence", get_transform_sequence, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("set_transform_sequence", set_transform_sequence)
         .def("get_vis_flags", &AssemblyInstance::get_vis_flags)
         .def("compute_parent_bbox", &AssemblyInstance::compute_parent_bbox)
         .def("get_assembly_name", &get_assembly_name)

--- a/src/appleseed.python/bindcamera.cpp
+++ b/src/appleseed.python/bindcamera.cpp
@@ -86,6 +86,11 @@ namespace
     {
         return &(camera->transform_sequence());
     }
+
+    void camera_set_transform_sequence(Camera* camera, const TransformSequence& seq)
+    {
+        camera->transform_sequence() = seq;
+    }
 }
 
 void bind_camera()
@@ -96,6 +101,7 @@ void bind_camera()
         .def("__init__", bpy::make_constructor(create_camera))
         .def("get_model", &Camera::get_model)
         .def("transform_sequence", camera_get_transform_sequence, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("set_transform_sequence", camera_set_transform_sequence)
         .def("get_shutter_open_begin_time", &Camera::get_shutter_open_begin_time)
         .def("get_shutter_open_end_time", &Camera::get_shutter_open_end_time)
         .def("get_shutter_close_begin_time", &Camera::get_shutter_close_begin_time)

--- a/src/appleseed.python/bindenvironment.cpp
+++ b/src/appleseed.python/bindenvironment.cpp
@@ -92,6 +92,11 @@ namespace
         return &(environment->transform_sequence());
     }
 
+    void environment_edf_set_transform_sequence(EnvironmentEDF* environment, const TransformSequence& seq)
+    {
+        environment->transform_sequence() = seq;
+    }
+
     auto_release_ptr<EnvironmentShader> create_environment_shader(
         const string&       env_shader_type,
         const string&       name,
@@ -134,7 +139,8 @@ void bind_environment()
         .def("get_input_metadata", &detail::get_entity_input_metadata<EnvironmentEDFFactoryRegistrar>).staticmethod("get_input_metadata")
         .def("__init__", bpy::make_constructor(create_environment_edf))
         .def("get_model", &EnvironmentEDF::get_model)
-        .def("transform_sequence", environment_edf_get_transform_sequence, bpy::return_value_policy<bpy::reference_existing_object>());
+        .def("transform_sequence", environment_edf_get_transform_sequence, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("set_transform_sequence", environment_edf_set_transform_sequence);
 
     bind_typed_entity_vector<EnvironmentEDF>("EnvironmentEDFContainer");
 

--- a/src/appleseed.python/bindmeshobject.cpp
+++ b/src/appleseed.python/bindmeshobject.cpp
@@ -36,6 +36,7 @@
 
 // appleseed.foundation headers.
 #include "foundation/platform/python.h"
+#include "foundation/utility/murmurhash.h"
 #include "foundation/utility/searchpaths.h"
 
 // Standard headers.
@@ -130,6 +131,11 @@ namespace
     {
         return create_primitive_mesh(name.c_str(), bpy_dict_to_param_array(params));
     }
+
+    void compute_mesh_signature(MurmurHash& hash, const MeshObject* mesh)
+    {
+        compute_signature(hash, *mesh);
+    }
 }
 
 void bind_mesh_object()
@@ -205,5 +211,6 @@ void bind_mesh_object()
 
     bpy::def("compute_smooth_vertex_normals", compute_smooth_vertex_normals);
     bpy::def("compute_smooth_vertex_tangents", compute_smooth_vertex_tangents);
+    bpy::def("compute_signature", compute_mesh_signature);
     bpy::def("create_primitive_mesh", create_mesh_prim);
 }

--- a/src/appleseed.python/bindmurmurhash.cpp
+++ b/src/appleseed.python/bindmurmurhash.cpp
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2014-2018 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,31 +26,31 @@
 // THE SOFTWARE.
 //
 
-#ifndef APPLESEED_RENDERER_MODELING_OBJECT_MESHOBJECTOPERATIONS_H
-#define APPLESEED_RENDERER_MODELING_OBJECT_MESHOBJECTOPERATIONS_H
+// appleseed.foundation headers.
+#include "foundation/platform/python.h"
+#include "foundation/utility/murmurhash.h"
 
-// appleseed.main headers.
-#include "main/dllsymbol.h"
+namespace bpy = boost::python;
+using namespace foundation;
 
-// Forward declarations.
-namespace foundation { class MurmurHash; }
-namespace renderer   { class MeshObject; }
-
-namespace renderer
+namespace
 {
 
-// Compute smooth vertex normal vectors for a mesh object.
-// The mesh object must not already have normals.
-APPLESEED_DLLSYMBOL void compute_smooth_vertex_normals(MeshObject& object);
+    static std::string repr(const MurmurHash& hash)
+    {
+        return "appleseed.MurmurHash(\"" + hash.to_string() + "\")";
+    }
 
-// Compute smooth vertex tangent vectors for a mesh object.
-// The mesh object must not already have tangent vectors.
-// The mesh object must have texture coordinates.
-APPLESEED_DLLSYMBOL void compute_smooth_vertex_tangents(MeshObject& object);
+}
 
-// Compute a hash for a mesh object.
-APPLESEED_DLLSYMBOL void compute_signature(foundation::MurmurHash& hash, const MeshObject& object);
-
-}       // namespace renderer
-
-#endif  // !APPLESEED_RENDERER_MODELING_OBJECT_MESHOBJECTOPERATIONS_H
+void bind_murmurhash()
+{
+    bpy::class_<MurmurHash>("MurmurHash")
+        .def(bpy::init<>())
+        .def(bpy::self == bpy::self)
+        .def(bpy::self != bpy::self)
+        .def(bpy::self <  bpy::self)
+        .def("__repr__", &repr)
+        .def("__str__", &MurmurHash::to_string)
+        .def("to_string", &MurmurHash::to_string);
+}

--- a/src/appleseed.python/bindtransform.cpp
+++ b/src/appleseed.python/bindtransform.cpp
@@ -146,6 +146,8 @@ void bind_transform()
         .def("size", &TransformSequence::size)
         .def("clear", &TransformSequence::clear)
 
+        .def("optimize", &TransformSequence::optimize)
+
         .def("transforms", &transform_seq_as_list)
 
         .def(bpy::self * bpy::self)

--- a/src/appleseed.python/module.cpp
+++ b/src/appleseed.python/module.cpp
@@ -55,6 +55,7 @@ void bind_master_renderer();
 void bind_material();
 void bind_matrix();
 void bind_mesh_object();
+void bind_murmurhash();
 void bind_object();
 void bind_project();
 void bind_quaternion();
@@ -78,6 +79,7 @@ extern "C" void bind_appleseed_python_classes()
     boost::python::scope().attr("APPLESEED_VERSION_STRING") = APPLESEED_VERSION_STRING;
 
     bind_utility();
+    bind_murmurhash();
     bind_logger();
 
     bind_vector();

--- a/src/appleseed.studio/CMakeLists.txt
+++ b/src/appleseed.studio/CMakeLists.txt
@@ -244,6 +244,7 @@ set (appleseedpython_sources
     ../appleseed.python/bindmaterial.cpp
     ../appleseed.python/bindmatrix.cpp
     ../appleseed.python/bindmeshobject.cpp
+    ../appleseed.python/bindmurmurhash.cpp
     ../appleseed.python/bindobject.cpp
     ../appleseed.python/bindproject.cpp
     ../appleseed.python/bindquaternion.cpp

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -818,6 +818,8 @@ set (foundation_utility_sources
     foundation/utility/makevector.h
     foundation/utility/memory.cpp
     foundation/utility/memory.h
+    foundation/utility/murmurhash.cpp
+    foundation/utility/murmurhash.h
     foundation/utility/numerictype.h
     foundation/utility/otherwise.h
     foundation/utility/poison.h

--- a/src/appleseed/foundation/utility/murmurhash.cpp
+++ b/src/appleseed/foundation/utility/murmurhash.cpp
@@ -1,0 +1,165 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "murmurhash.h"
+
+// appleseed.foundation headers.
+#include "foundation/math/scalar.h"
+
+// Standard headers.
+#include <cstring>
+
+namespace foundation
+{
+namespace
+{
+
+uint64 fmix(uint64 k)
+{
+    k ^= k >> 33;
+    k *= 0xff51afd7ed558ccd;
+    k ^= k >> 33;
+    k *= 0xc4ceb9fe1a85ec53;
+    k ^= k >> 33;
+
+    return k;
+}
+
+}
+
+MurmurHash::MurmurHash()
+  : m_h1(0)
+  , m_h2(0)
+{
+}
+
+void MurmurHash::append(const void* data, const size_t bytes)
+{
+    const int nBlocks = static_cast<int>(bytes) / 16;
+
+    const uint64 c1 = 0x87c37b91114253d5;
+    const uint64 c2 = 0x4cf5ad432745937f;
+
+    // local copies of m_h1, and m_h2. we'll work
+    // with these before copying back at the end.
+    // this gives the optimiser more freedom to do
+    // its thing.
+    uint64 h1 = m_h1;
+    uint64 h2 = m_h2;
+
+    // body
+
+    const uint64* blocks = reinterpret_cast<const uint64*>(data);
+    for (int i = 0; i < nBlocks; i++)
+    {
+        uint64 k1 = blocks[i*2];
+        uint64 k2 = blocks[i*2+1];
+
+        k1 *= c1; k1  = rotl64(k1, 31); k1 *= c2; h1 ^= k1;
+
+        h1 = rotl64(h1, 27); h1 += h2; h1 = h1*5 + 0x52dce729;
+
+        k2 *= c2; k2  = rotl64(k2, 33); k2 *= c1; h2 ^= k2;
+
+        h2 = rotl64(h2, 31); h2 += h1; h2 = h2*5 + 0x38495ab5;
+    }
+
+    // tail
+
+    const uint64 * tail = (reinterpret_cast<const uint64*>(data)) + nBlocks*16;
+
+    uint64 k1 = 0;
+    uint64 k2 = 0;
+
+    switch(bytes & 15)
+    {
+    case 15: k2 ^= uint64(tail[14]) << 48;
+    case 14: k2 ^= uint64(tail[13]) << 40;
+    case 13: k2 ^= uint64(tail[12]) << 32;
+    case 12: k2 ^= uint64(tail[11]) << 24;
+    case 11: k2 ^= uint64(tail[10]) << 16;
+    case 10: k2 ^= uint64(tail[ 9]) << 8;
+    case  9: k2 ^= uint64(tail[ 8]) << 0;
+           k2 *= c2; k2  = rotl64(k2,33); k2 *= c1; h2 ^= k2;
+
+    case  8: k1 ^= uint64(tail[ 7]) << 56;
+    case  7: k1 ^= uint64(tail[ 6]) << 48;
+    case  6: k1 ^= uint64(tail[ 5]) << 40;
+    case  5: k1 ^= uint64(tail[ 4]) << 32;
+    case  4: k1 ^= uint64(tail[ 3]) << 24;
+    case  3: k1 ^= uint64(tail[ 2]) << 16;
+    case  2: k1 ^= uint64(tail[ 1]) << 8;
+    case  1: k1 ^= uint64(tail[ 0]) << 0;
+           k1 *= c1; k1  = rotl64(k1,31); k1 *= c2; h1 ^= k1;
+    };
+
+    // finalisation
+
+    h1 ^= bytes; h2 ^= bytes;
+
+    h1 += h2;
+    h2 += h1;
+
+    h1 = fmix(h1);
+    h2 = fmix(h2);
+
+    h1 += h2;
+    h2 += h1;
+
+    m_h1 = h1;
+    m_h2 = h2;
+}
+
+void MurmurHash::append(const char* str)
+{
+    append(str, strlen(str));
+}
+
+bool MurmurHash::operator==(const MurmurHash& other) const
+{
+    return m_h1 == other.m_h1 && m_h2 == other.m_h2;
+}
+
+bool MurmurHash::operator!=(const MurmurHash& other) const
+{
+    return m_h1 != other.m_h1 || m_h2 != other.m_h2;
+}
+
+bool MurmurHash::operator<(const MurmurHash& other) const
+{
+    return m_h1 < other.m_h1 || (m_h1 == other.m_h1 && m_h2 < other.m_h2);
+}
+
+std::ostream& operator<<(std::ostream& o, const MurmurHash& hash)
+{
+    o << hash.to_string();
+    return o;
+}
+
+}   // namespace foundation

--- a/src/appleseed/foundation/utility/murmurhash.h
+++ b/src/appleseed/foundation/utility/murmurhash.h
@@ -1,0 +1,113 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef APPLESEED_FOUNDATION_UTILITY_MURMURHASH_H
+#define APPLESEED_FOUNDATION_UTILITY_MURMURHASH_H
+
+// appleseed.foundation headers.
+#include "foundation/platform/types.h"
+
+// appleseed.main headers.
+#include "main/dllsymbol.h"
+
+// Standard headers.
+#include <cstddef>
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+namespace foundation
+{
+
+//
+// MurmurHash.
+//
+// A nice class for hashing arbitrary chunks of data, based on
+// code available at https://github.com/aappleby/smhasher.
+//
+// From that page :
+//
+// "All MurmurHash versions are public domain software, and the
+// author disclaims all copyright to their code."
+//
+
+class APPLESEED_DLLSYMBOL MurmurHash
+{
+  public:
+    MurmurHash();
+
+    bool operator==(const MurmurHash& other) const;
+    bool operator!=(const MurmurHash& other) const;
+    bool operator<(const MurmurHash& other) const;
+
+    template <typename T>
+    void append(const T& x);
+
+    void append(const char* str);
+
+    void append(const std::string& str);
+
+    std::string to_string() const;
+
+  private:
+    void append(const void* data, const size_t bytes);
+
+    uint64 m_h1;
+    uint64 m_h2;
+};
+
+std::ostream& operator<<(std::ostream& o, const MurmurHash& hash);
+
+
+//
+// MurmurHash class implementation.
+//
+
+template <typename T>
+inline void MurmurHash::append(const T& x)
+{
+    append(&x, sizeof(T));
+}
+
+inline void MurmurHash::append(const std::string& str)
+{
+    append(str.c_str(), str.size());
+}
+
+inline std::string MurmurHash::to_string() const
+{
+    std::stringstream s;
+    s << std::hex << std::setfill('0')
+      << std::setw(16) << m_h1
+      << std::setw(16) << m_h2;
+    return s.str();
+}
+
+}       // namespace foundation
+
+#endif  // !APPLESEED_FOUNDATION_UTILITY_MURMURHASH_H

--- a/src/appleseed/renderer/modeling/object/meshobjectoperations.cpp
+++ b/src/appleseed/renderer/modeling/object/meshobjectoperations.cpp
@@ -37,6 +37,7 @@
 
 // appleseed.foundation headers.
 #include "foundation/math/vector.h"
+#include "foundation/utility/murmurhash.h"
 
 // Standard headers.
 #include <cassert>
@@ -221,6 +222,50 @@ void compute_smooth_vertex_tangents(MeshObject& object)
 
     for (size_t i = 0; i < object.get_motion_segment_count(); ++i)
         compute_smooth_vertex_tangents_pose(object, i);
+}
+
+void compute_signature(MurmurHash& hash, const MeshObject& object)
+{
+    // Static attributes.
+
+    hash.append(object.get_triangle_count());
+    for (size_t i = 0, e = object.get_triangle_count(); i < e; ++i)
+        hash.append(object.get_triangle(i));
+
+    hash.append(object.get_material_slot_count());
+    for (size_t i = 0, e = object.get_material_slot_count(); i < e; ++i)
+        hash.append(object.get_material_slot(i));
+
+    hash.append(object.get_vertex_count());
+    for (size_t i = 0, e = object.get_vertex_count(); i < e; ++i)
+        hash.append(object.get_vertex(i));
+
+    hash.append(object.get_tex_coords_count());
+    for (size_t i = 0, e = object.get_tex_coords_count(); i < e; ++i)
+        hash.append(object.get_tex_coords(i));
+
+    hash.append(object.get_vertex_normal_count());
+    for (size_t i = 0, e = object.get_vertex_normal_count(); i < e; ++i)
+        hash.append(object.get_vertex_normal(i));
+
+    hash.append(object.get_vertex_tangent_count());
+    for (size_t i = 0, e = object.get_vertex_tangent_count(); i < e; ++i)
+        hash.append(object.get_vertex_tangent(i));
+
+    // Poses.
+
+    hash.append(object.get_motion_segment_count());
+    for (size_t j = 0, je = object.get_motion_segment_count(); j < je; ++j)
+    {
+        for (size_t i = 0, e = object.get_vertex_count(); i < e; ++i)
+            object.get_vertex_pose(i, j);
+
+        for (size_t i = 0, e = object.get_vertex_normal_count(); i < e; ++i)
+            object.get_vertex_normal_pose(i, j);
+
+        for (size_t i = 0, e = object.get_vertex_tangent_count(); i < e; ++i)
+            object.get_vertex_tangent_pose(i, j);
+    }
 }
 
 }   // namespace renderer


### PR DESCRIPTION
Added MurmurHash to foundation and compute_mesh_signature (from appleseed.maya)
- useful to generate mesh filenames, auto-instancing and possibly other use cases.

Added missing transform related methods to appleseed.python

