### PR TITLE
OSL related improvements

### DIFF
--- a/src/appleseed.python/bindshadergroup.cpp
+++ b/src/appleseed.python/bindshadergroup.cpp
@@ -111,6 +111,11 @@ namespace
             return m_shader_query->open(shader_name);
         }
 
+        bool open_bytecode(const char* shader_code)
+        {
+            return m_shader_query->open_bytecode(shader_code);
+        }
+
         string get_shader_name() const
         {
             return m_shader_query->get_shader_name();
@@ -142,6 +147,22 @@ namespace
         SearchPaths                     m_search_paths;
         auto_release_ptr<ShaderQuery>   m_shader_query;
     };
+
+    auto_release_ptr<ShaderCompiler> create_shader_compiler(const char* stdosl_path)
+    {
+        return ShaderCompilerFactory::create(stdosl_path);
+    }
+
+    bpy::object compile_buffer(ShaderCompiler* compiler, const std::string& buffer)
+    {
+        APIString result;
+
+        if (compiler->compile_buffer(buffer.c_str(), result))
+            return bpy::str(result.c_str());
+
+        // return None if compilation failed.
+        return bpy::object();
+    }
 }
 
 void bind_shader_group()
@@ -150,19 +171,24 @@ void bind_shader_group()
         .def("__init__", bpy::make_constructor(create_shader_group))
         .def("add_shader", add_shader)
         .def("add_connection", &ShaderGroup::add_connection)
-        .def("clear", &ShaderGroup::clear)
-        ;
+        .def("clear", &ShaderGroup::clear);
+
+    bind_typed_entity_vector<ShaderGroup>("ShaderGroupContainer");
 
     bpy::class_<ShaderQueryWrapper, boost::noncopyable>("ShaderQuery")
         .def(bpy::init<const char*>())
         .def(bpy::init<bpy::list>())
         .def("open", &ShaderQueryWrapper::open)
+        .def("open_bytecode", &ShaderQueryWrapper::open_bytecode)
         .def("get_shader_name", &ShaderQueryWrapper::get_shader_name)
         .def("get_shader_type", &ShaderQueryWrapper::get_shader_type)
         .def("get_num_params", &ShaderQueryWrapper::get_param_count)
         .def("get_param_info", &ShaderQueryWrapper::get_param_info)
-        .def("get_metadata", &ShaderQueryWrapper::get_metadata)
-        ;
+        .def("get_metadata", &ShaderQueryWrapper::get_metadata);
 
-    bind_typed_entity_vector<ShaderGroup>("ShaderGroupContainer");
+    bpy::class_<ShaderCompiler, auto_release_ptr<ShaderCompiler>, boost::noncopyable>("ShaderCompiler", bpy::no_init)
+        .def("__init__", bpy::make_constructor(create_shader_compiler))
+        .def("clear_options", &ShaderCompiler::clear_options)
+        .def("add_option", &ShaderCompiler::add_option)
+        .def("compile_buffer", compile_buffer);
 }

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -1244,8 +1244,6 @@ set (renderer_kernel_shading_sources
     renderer/kernel/shading/directshadingcomponents.h
     renderer/kernel/shading/fastambientocclusion.cpp
     renderer/kernel/shading/fastambientocclusion.h
-    renderer/kernel/shading/oslshadercompiler.cpp
-    renderer/kernel/shading/oslshadercompiler.h
     renderer/kernel/shading/oslshadergroupexec.cpp
     renderer/kernel/shading/oslshadergroupexec.h
     renderer/kernel/shading/oslshadingsystem.cpp
@@ -1870,6 +1868,8 @@ source_group ("renderer\\modeling\\scene" FILES
 set (renderer_modeling_shadergroup
     renderer/modeling/shadergroup/shader.cpp
     renderer/modeling/shadergroup/shader.h
+    renderer/modeling/shadergroup/shadercompiler.cpp
+    renderer/modeling/shadergroup/shadercompiler.h
     renderer/modeling/shadergroup/shaderconnection.cpp
     renderer/modeling/shadergroup/shaderconnection.h
     renderer/modeling/shadergroup/shadergroup.cpp

--- a/src/appleseed/renderer/api/shadergroup.h
+++ b/src/appleseed/renderer/api/shadergroup.h
@@ -31,6 +31,7 @@
 
 // API headers.
 #include "renderer/modeling/shadergroup/shader.h"
+#include "renderer/modeling/shadergroup/shadercompiler.h"
 #include "renderer/modeling/shadergroup/shaderconnection.h"
 #include "renderer/modeling/shadergroup/shadergroup.h"
 #include "renderer/modeling/shadergroup/shadergrouptraits.h"

--- a/src/appleseed/renderer/modeling/shadergroup/shadercompiler.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shadercompiler.cpp
@@ -27,7 +27,7 @@
 //
 
 // Interface header.
-#include "oslshadercompiler.h"
+#include "shadercompiler.h"
 
 // appleseed.renderer headers.
 #include "renderer/kernel/rendering/oiioerrorhandler.h"
@@ -76,6 +76,7 @@ struct ShaderCompiler::Impl
     string              m_stdosl_path;
     OSL::OSLCompiler*   m_compiler;
     OIIOErrorHandler*   m_error_handler;
+    vector<string>      m_options;
 };
 
 ShaderCompiler::ShaderCompiler(const char* stdosl_path)
@@ -93,16 +94,25 @@ void ShaderCompiler::release()
     delete this;
 }
 
+void ShaderCompiler::clear_options()
+{
+    impl->m_options.clear();
+}
+
+void ShaderCompiler::add_option(const char* option)
+{
+    impl->m_options.push_back(option);
+}
+
 bool ShaderCompiler::compile_buffer(
     const char* source_code,
     APIString&  result)
 {
-    vector<string> options;
     string buffer;
     const bool ok = impl->m_compiler->compile_buffer(
         source_code,
         buffer,
-        options,
+        impl->m_options,
         impl->m_stdosl_path.c_str());
 
     if (ok)

--- a/src/appleseed/renderer/modeling/shadergroup/shadercompiler.h
+++ b/src/appleseed/renderer/modeling/shadergroup/shadercompiler.h
@@ -26,12 +26,15 @@
 // THE SOFTWARE.
 //
 
-#ifndef APPLESEED_RENDERER_KERNEL_SHADING_OSLSHADERCOMPILER_H
-#define APPLESEED_RENDERER_KERNEL_SHADING_OSLSHADERCOMPILER_H
+#ifndef APPLESEED_RENDERER_MODELING_SHADERGROUP_SHADERCOMPILER_H
+#define APPLESEED_RENDERER_MODELING_SHADERGROUP_SHADERCOMPILER_H
 
 // appleseed.foundation headers.
 #include "foundation/core/concepts/noncopyable.h"
 #include "foundation/utility/autoreleaseptr.h"
+
+// appleseed.main headers.
+#include "main/dllsymbol.h"
 
 // Forward declarations.
 namespace foundation    { class APIString; }
@@ -43,12 +46,16 @@ namespace renderer
 // Simple wrapper around OSL's OSLCompiler.
 //
 
-class ShaderCompiler
+class APPLESEED_DLLSYMBOL ShaderCompiler
   : public foundation::NonCopyable
 {
   public:
     // Delete this instance.
     void release();
+
+    void clear_options();
+
+    void add_option(const char* option);
 
     bool compile_buffer(
         const char*             source_code,
@@ -64,12 +71,11 @@ class ShaderCompiler
     ~ShaderCompiler();
 };
 
-
-//
+ //
 // ShaderCompiler factory.
 //
 
-class ShaderCompilerFactory
+class APPLESEED_DLLSYMBOL ShaderCompilerFactory
 {
   public:
     // Create a new shader compiler.
@@ -79,4 +85,4 @@ class ShaderCompilerFactory
 
 }       // namespace renderer
 
-#endif  // !APPLESEED_RENDERER_KERNEL_SHADING_OSLSHADERCOMPILER_H
+#endif  // !APPLESEED_RENDERER_MODELING_SHADERGROUP_SHADERCOMPILER_H

--- a/src/appleseed/renderer/modeling/shadergroup/shaderquery.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderquery.cpp
@@ -145,16 +145,34 @@ struct ShaderQuery::Impl
 
     bool open(const char* shader_name)
     {
-        m_metadata = OptionalDictionary();
-        m_param_info.clear();
+        init();
 
-        m_query = OSL::OSLQuery();
         const bool ok = m_query.open(shader_name, m_search_path);
 
         if (ok)
             m_param_info.assign(m_query.nparams(), OptionalDictionary());
 
         return ok;
+    }
+
+    bool open_bytecode(const char* shader_code)
+    {
+        init();
+
+        const bool ok = m_query.open_bytecode(shader_code);
+
+        if (ok)
+            m_param_info.assign(m_query.nparams(), OptionalDictionary());
+
+        return ok;
+    }
+
+    void init()
+    {
+        m_metadata = OptionalDictionary();
+        m_param_info.clear();
+
+        m_query = OSL::OSLQuery();
     }
 };
 
@@ -191,6 +209,11 @@ void ShaderQuery::release()
 bool ShaderQuery::open(const char* shader_name)
 {
     return impl->open(shader_name);
+}
+
+bool ShaderQuery::open_bytecode(const char* shader_code)
+{
+    return impl->open_bytecode(shader_code);
 }
 
 const char* ShaderQuery::get_shader_name() const

--- a/src/appleseed/renderer/modeling/shadergroup/shaderquery.h
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderquery.h
@@ -64,6 +64,9 @@ class APPLESEED_DLLSYMBOL ShaderQuery
     // Open a compiled shader.
     bool open(const char* shader_name);
 
+    // Open a bytecode memory compiled shader.
+    bool open_bytecode(const char* shader_code);
+
     // Return the shader name.
     const char* get_shader_name() const;
 


### PR DESCRIPTION
- Exported OSL ShaderCompiler wrapper and bind it to python.
- Compile OSL to bytecode memory strings.
- Extend ShaderQuery to work with memory compiled shaders.