### PR TITLE
Travis use release dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ addons:
       - python2.7-dev
       - libqt4-dev
 
-before_install:
-  - if [ $TRAVIS_OS_NAME == linux ]; then git clone https://github.com/appleseedhq/prebuilt-linux-deps.git ; fi
-
 install:
   - if [ -n "$GCC_VERSION" ]; then export CC="${CC}-${GCC_VERSION}"; fi
   - if [ -n "$GCC_VERSION" ]; then export CXX="${CXX}-${GCC_VERSION}"; fi

--- a/travis/build-linux.sh
+++ b/travis/build-linux.sh
@@ -2,6 +2,14 @@
 
 set -e
 
+# Download dependencies
+
+curl -L "https://github.com/appleseedhq/prebuilt-linux-deps/releases/download/binaries/appleseed-deps-shared-2.0.tgz" > deps.tgz
+tar xfz deps.tgz
+rm deps.tgz
+
+# Configure cmake
+
 THISDIR=`pwd`
 APPLESEED_DEPENDENCIES=$THISDIR/prebuilt-linux-deps
 

--- a/travis/build-macos.sh
+++ b/travis/build-macos.sh
@@ -49,6 +49,7 @@ echo "-----------"
 mkdir build
 cd build
 cmake -DWITH_DISNEY_MATERIAL=ON -DUSE_STATIC_BOOST=OFF \
+     -DWITH_STUDIO=OFF -DWITH_PYTHON2_BINDINGS=OFF \
      -DUSE_EXTERNAL_ZLIB=ON -DUSE_EXTERNAL_PNG=ON \
      -DUSE_EXTERNAL_EXR=ON -DUSE_EXTERNAL_XERCES=ON\
      -DUSE_EXTERNAL_SEEXPR=ON -DUSE_EXTERNAL_OIIO=ON \
@@ -78,9 +79,9 @@ echo "Running appleseed tests:"
 echo "------------------------"
 ../sandbox/bin/Debug/appleseed.cli --run-unit-tests --verbose-unit-tests
 
-echo "Running appleseed.python tests:"
-echo "-------------------------------"
-export PYTHONPATH=$PYTHONPATH:../sandbox/lib/Debug/python2.7
-python ../sandbox/lib/Debug/python2.7/appleseed/test/runtests.py
+#echo "Running appleseed.python tests:"
+#echo "-------------------------------"
+#export PYTHONPATH=$PYTHONPATH:../sandbox/lib/Debug/python2.7
+#python ../sandbox/lib/Debug/python2.7/appleseed/test/runtests.py
 
 set +e


### PR DESCRIPTION
- Update linux deps.
- Switch to downloading dependencies from releases.

Additionally,temporarily disable python bindings on OSX inside travis.