### PR TITLE
Add Transparency Alpha AOV

### DIFF
--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -1365,6 +1365,8 @@ source_group ("renderer\\meta\\tests" FILES
 set (renderer_modeling_aov_sources
     renderer/modeling/aov/albedoaov.cpp
     renderer/modeling/aov/albedoaov.h
+    renderer/modeling/aov/alphatransparency.cpp
+    renderer/modeling/aov/alphatransparency.h
     renderer/modeling/aov/aov.cpp
     renderer/modeling/aov/aov.h
     renderer/modeling/aov/aovcontainer.h

--- a/src/appleseed/renderer/kernel/aov/aovcomponents.cpp
+++ b/src/appleseed/renderer/kernel/aov/aovcomponents.cpp
@@ -38,6 +38,7 @@ namespace renderer
 
 AOVComponents::AOVComponents()
   : m_albedo(0.0f)
+  , m_refraction_value(0.0f)
 {
 }
 

--- a/src/appleseed/renderer/kernel/aov/aovcomponents.h
+++ b/src/appleseed/renderer/kernel/aov/aovcomponents.h
@@ -38,8 +38,8 @@ namespace renderer
 class AOVComponents
 {
   public:
-      Spectrum  m_albedo;
-      Spectrum  m_refraction_value;
+    Spectrum  m_albedo;
+    Spectrum  m_refraction_value;
 
     // Constructor. Clears all components to 0.
     AOVComponents();

--- a/src/appleseed/renderer/kernel/lighting/bdpt/bdptlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/bdpt/bdptlightingengine.cpp
@@ -675,6 +675,10 @@ namespace
             {
             }
 
+            void store_aov_components(const PathVertex& vertex)
+            {
+            }
+
             bool accept_scattering(
                 const ScatteringMode::Mode  prev_mode,
                 const ScatteringMode::Mode  next_mode) const

--- a/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
@@ -306,6 +306,10 @@ namespace
             {
             }
 
+            void store_aov_components(const PathVertex& vertex)
+            {
+            }
+
             size_t get_sample_count() const
             {
                 return m_sample_count;

--- a/src/appleseed/renderer/kernel/lighting/pathtracer.h
+++ b/src/appleseed/renderer/kernel/lighting/pathtracer.h
@@ -285,7 +285,7 @@ size_t PathTracer<PathVisitor, VolumeVisitor, Adjoint>::trace(
 
             if (!vertex.m_has_non_refraction_sample)
             {
-                vertex.m_refraction_alpha_value = Spectrum(1.0f) - saturate(vertex.m_sample_refraction_value);
+                vertex.m_refraction_alpha_value = Spectrum(1.0f) - foundation::saturate(vertex.m_sample_refraction_value);
                 m_path_visitor.store_aov_components(vertex);
             }
 

--- a/src/appleseed/renderer/kernel/lighting/pathvertex.h
+++ b/src/appleseed/renderer/kernel/lighting/pathvertex.h
@@ -93,6 +93,9 @@ class PathVertex
     ScatteringMode::Mode        m_aov_mode;
     Spectrum                    m_albedo;
     bool                        m_albedo_saved;
+    Spectrum                    m_sample_refraction_value;
+    Spectrum                    m_refraction_alpha_value;
+    bool                        m_has_non_refraction_sample;
 
     // Constructor.
     explicit PathVertex(SamplingContext& sampling_context);
@@ -127,6 +130,9 @@ class PathVertex
 inline PathVertex::PathVertex(SamplingContext& sampling_context)
   : m_sampling_context(sampling_context)
   , m_albedo_saved(false)
+  , m_has_non_refraction_sample(false)
+  , m_sample_refraction_value(1.0f)
+  , m_refraction_alpha_value(1.0f)
 {
 }
 

--- a/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.cpp
@@ -352,6 +352,11 @@ namespace
                 m_aov_components.m_albedo = vertex.m_albedo;
             }
 
+            void store_aov_components(const PathVertex& vertex)
+            {
+                m_aov_components.m_refraction_value = vertex.m_refraction_alpha_value;
+            }
+
             bool accept_scattering(
                 const ScatteringMode::Mode  prev_mode,
                 const ScatteringMode::Mode  next_mode)

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmlightingengine.cpp
@@ -254,6 +254,10 @@ namespace
             {
             }
 
+            void store_aov_components(const PathVertex& vertex)
+            {
+            }
+
             bool accept_scattering(
                 const ScatteringMode::Mode  prev_mode,
                 const ScatteringMode::Mode  next_mode) const

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmphotontracer.cpp
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmphotontracer.cpp
@@ -123,6 +123,10 @@ namespace
         {
         }
 
+        void store_aov_components(const PathVertex& vertex)
+        {
+        }
+
         bool accept_scattering(
             const ScatteringMode::Mode  prev_mode,
             const ScatteringMode::Mode  next_mode) const

--- a/src/appleseed/renderer/modeling/aov/alphatransparency.cpp
+++ b/src/appleseed/renderer/modeling/aov/alphatransparency.cpp
@@ -1,0 +1,155 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017-2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "alphatransparency.h"
+
+// appleseed.renderer headers.
+#include "renderer/kernel/aov/aovaccumulator.h"
+#include "renderer/kernel/aov/aovcomponents.h"
+#include "renderer/kernel/shading/shadingcomponents.h"
+#include "renderer/kernel/shading/shadingresult.h"
+#include "renderer/modeling/aov/aov.h"
+#include "renderer/modeling/color/colorspace.h"
+
+// appleseed.foundation headers.
+#include "foundation/image/color.h"
+#include "foundation/utility/api/apistring.h"
+#include "foundation/utility/api/specializedapiarrays.h"
+#include "foundation/utility/containers/dictionary.h"
+
+// Standard headers.
+#include <cstddef>
+
+using namespace foundation;
+using namespace std;
+
+namespace renderer
+{
+
+namespace
+{
+    //
+    // AlphaTransparency AOV accumulator.
+    //
+
+    class AlphaTransparencyAOVAccumulator
+      : public AOVAccumulator
+    {
+      public:
+        explicit AlphaTransparencyAOVAccumulator(const size_t index)
+          : m_index(index)
+        {
+        }
+
+        void write(
+            const PixelContext&         pixel_context,
+            const ShadingPoint&         shading_point,
+            const ShadingComponents&    shading_components,
+            const AOVComponents&        aov_components,
+            ShadingResult&              shading_result) override
+        {
+            shading_result.m_aovs[m_index].set(luminance(aov_components.m_refraction_value.to_rgb(g_std_lighting_conditions)));
+            shading_result.m_aovs[m_index].a = shading_result.m_main.a;
+        }
+
+      private:
+        const size_t m_index;
+    };
+
+
+    //
+    // AlphaTransparency AOV.
+    //
+
+    const char* AlphaTransparency = "alphatransparency_aov";
+
+    class AlphaTransparencyAOV
+      : public ColorAOV
+    {
+      public:
+        explicit AlphaTransparencyAOV(const ParamArray& params)
+          : ColorAOV("alphatransparency", params)
+        {
+        }
+
+        void release() override
+        {
+            delete this;
+        }
+
+        const char* get_model() const override
+        {
+            return AlphaTransparency;
+        }
+
+        auto_release_ptr<AOVAccumulator> create_accumulator() const override
+        {
+            return auto_release_ptr<AOVAccumulator>(
+                new AlphaTransparencyAOVAccumulator(m_image_index));
+        }
+    };
+}
+
+
+//
+// AlphaTransparencyAOVFactory class implementation.
+//
+
+void AlphaTransparencyAOVFactory::release()
+{
+    delete this;
+}
+
+const char* AlphaTransparencyAOVFactory::get_model() const
+{
+    return AlphaTransparency;
+}
+
+Dictionary AlphaTransparencyAOVFactory::get_model_metadata() const
+{
+    return
+        Dictionary()
+            .insert("name", get_model())
+            .insert("label", "Alpha Transparency")
+            .insert("default_model", "false");
+}
+
+DictionaryArray AlphaTransparencyAOVFactory::get_input_metadata() const
+{
+    DictionaryArray metadata;
+    return metadata;
+}
+
+auto_release_ptr<AOV> AlphaTransparencyAOVFactory::create(
+    const ParamArray&   params) const
+{
+    return auto_release_ptr<AOV>(new AlphaTransparencyAOV(params));
+}
+
+}   // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/alphatransparency.h
+++ b/src/appleseed/renderer/modeling/aov/alphatransparency.h
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2018 Sergo Pogosyan, The appleseedhq Organization
+// Copyright (c) 2017-2018 Esteban Tovagliari, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,25 +26,52 @@
 // THE SOFTWARE.
 //
 
-#ifndef APPLESEED_RENDERER_KERNEL_SHADING_AOVCOMPONENTS_H
-#define APPLESEED_RENDERER_KERNEL_SHADING_AOVCOMPONENTS_H
+#ifndef APPLESEED_RENDERER_MODELING_AOV_ALPHATRANSPARENCY_H
+#define APPLESEED_RENDERER_MODELING_AOV_ALPHATRANSPARENCY_H
 
 // appleseed.renderer headers.
-#include "renderer/global/globaltypes.h"
+#include "renderer/modeling/aov/iaovfactory.h"
+
+// appleseed.foundation headers.
+#include "foundation/utility/autoreleaseptr.h"
+
+// appleseed.main headers.
+#include "main/dllsymbol.h"
+
+// Forward declarations.
+namespace foundation    { class Dictionary; }
+namespace foundation    { class DictionaryArray; }
+namespace renderer      { class AOV; }
+namespace renderer      { class ParamArray; }
 
 namespace renderer
 {
 
-class AOVComponents
+//
+// A factory for AlphaTransparency AOVs.
+//
+
+class APPLESEED_DLLSYMBOL AlphaTransparencyAOVFactory
+  : public IAOVFactory
 {
   public:
-      Spectrum  m_albedo;
-      Spectrum  m_refraction_value;
+    // Delete this instance.
+    void release() override;
 
-    // Constructor. Clears all components to 0.
-    AOVComponents();
+    // Return a string identifying this AOV model.
+    const char* get_model() const override;
+
+    // Return metadata for this AOV model.
+    foundation::Dictionary get_model_metadata() const override;
+
+    // Return metadata for the inputs of this AOV model.
+    foundation::DictionaryArray get_input_metadata() const override;
+
+    // Create a new AOV instance.
+    foundation::auto_release_ptr<AOV> create(
+        const ParamArray&   params) const override;
 };
 
 }       // namespace renderer
 
-#endif  // !APPLESEED_RENDERER_KERNEL_SHADING_AOVCOMPONENTS_H
+#endif  // !APPLESEED_RENDERER_MODELING_AOV_ALPHATRANSPARENCY_H

--- a/src/appleseed/renderer/modeling/aov/aovfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/aov/aovfactoryregistrar.cpp
@@ -32,6 +32,7 @@
 // appleseed.renderer headers.
 #include "renderer/modeling/aov/aovtraits.h"
 #include "renderer/modeling/aov/albedoaov.h"
+#include "renderer/modeling/aov/alphatransparency.h"
 #include "renderer/modeling/aov/depthaov.h"
 #include "renderer/modeling/aov/diffuseaov.h"
 #include "renderer/modeling/aov/emissionaov.h"
@@ -93,6 +94,7 @@ void AOVFactoryRegistrar::reinitialize(const SearchPaths& search_paths)
     register_factory(auto_release_ptr<FactoryType>(new PixelTimeAOVFactory()));
     register_factory(auto_release_ptr<FactoryType>(new UVAOVFactory()));
     register_factory(auto_release_ptr<FactoryType>(new AlbedoAOVFactory()));
+    register_factory(auto_release_ptr<FactoryType>(new AlphaTransparencyAOVFactory()));
 
     // Register factories defined in plugins.
     register_factories_from_plugins<AOV>(

--- a/src/appleseed/renderer/modeling/bsdf/bsdfsample.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfsample.h
@@ -61,6 +61,8 @@ class BSDFSample
     // Roughness.
     float                           m_max_roughness;        // BSDF roughness
 
+    bool                            m_is_refraction_sample;
+
     // Outputs.
     ScatteringMode::Mode            m_mode;                 // scattering mode
     foundation::Dual3f              m_incoming;             // world space incoming direction, unit-length, defined only if m_mode != None
@@ -99,6 +101,7 @@ inline BSDFSample::BSDFSample(
   , m_shading_basis(shading_point->get_shading_basis())
   , m_outgoing(outgoing)
   , m_mode(ScatteringMode::None)
+  , m_is_refraction_sample(false)
 {
 }
 

--- a/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
@@ -384,6 +384,8 @@ namespace
 
             sample.m_incoming = Dual3f(basis.transform_to_parent(wi));
 
+            sample.m_is_refraction_sample = is_refraction;
+
             if (is_refraction)
                 sample.compute_transmitted_differentials(1.0f / eta);
             else sample.compute_reflected_differentials();


### PR DESCRIPTION
Hi,
This is an attempt to implement "transparency affects alpha" feature using separate AOV.

Basic principle is that AOV is filled with white samples and on `on_miss()` function call it's changed to whatever glossy level was in the last sample.
