### PR TITLE
Implement and test reading and writting exr attributes

### DIFF
--- a/src/appleseed/foundation/image/exrutils.cpp
+++ b/src/appleseed/foundation/image/exrutils.cpp
@@ -67,6 +67,40 @@ namespace
                 static_cast<int>(System::get_logical_cpu_core_count()));
         }
     };
+
+    void add_attribute(Header& header, const string& attr_name, const string& attr_value)
+    {
+        // Try to guess the type of the value represented by the string.
+
+        try // Vector3
+        {
+            const Vector3d v = from_string<Vector3d>(attr_value);
+            header.insert(attr_name.c_str(), V3dAttribute(Imath::V3d(v[0], v[1], v[2])));
+            return;
+        }
+        catch (ExceptionStringConversionError&) {}
+
+        try // Vector2
+        {
+            const Vector2d v = from_string<Vector2d>(attr_value);
+            header.insert(attr_name.c_str(), V2dAttribute(Imath::V2d(v[0], v[1])));
+            return;
+        }
+        catch (ExceptionStringConversionError&) {}
+
+        try // int / double / float
+        {
+            const float f = from_string<float>(attr_value);
+            header.insert(attr_name.c_str(), FloatAttribute(f));
+            return;
+        }
+        catch (ExceptionStringConversionError&) {}
+
+        // todo: check more types here if needed...
+
+        // As a fallback, use a string.
+        header.insert(attr_name.c_str(), StringAttribute(attr_value));
+    }
 }
 
 void initialize_openexr()
@@ -124,7 +158,7 @@ void add_attributes(
             ++num_chromaticity_coordinates;
         }
         else
-            header.insert(attr_name.c_str(), StringAttribute(attr_value));
+            add_attribute(header, attr_name, attr_value);
     }
 
     // Only save chromaticities if they are complete.

--- a/src/appleseed/foundation/meta/tests/test_exrimagefilewriter.cpp
+++ b/src/appleseed/foundation/meta/tests/test_exrimagefilewriter.cpp
@@ -32,6 +32,7 @@
 #include "foundation/image/exrimagefilewriter.h"
 #include "foundation/image/genericprogressiveimagefilereader.h"
 #include "foundation/image/image.h"
+#include "foundation/image/imageattributes.h"
 #include "foundation/image/pixel.h"
 #include "foundation/image/tile.h"
 #include "foundation/utility/iostreamop.h"
@@ -54,8 +55,17 @@ TEST_SUITE(Foundation_Image_EXRImageFileWriter)
         Image image(2, 2, 32, 32, 4, PixelFormatFloat);
         image.clear(Reference);
 
+        ImageAttributes attrs;
+        attrs.insert("appleseed:test:StringAttr", "something");
+        attrs.insert("appleseed:test:StringButIntAttr", "47");
+        attrs.insert("appleseed:test:StringButFloatAttr", "47.5");
+        attrs.insert("appleseed:test:FloatAttr", 32.0f);
+        attrs.insert("appleseed:test:DoubleAttr", 32.0);
+        attrs.insert("appleseed:test:IntAttr", 32);
+        attrs.insert("appleseed:test:UnsignedIntAttr", static_cast<size_t>(32));
+
         EXRImageFileWriter writer;
-        writer.write(Filename, image);
+        writer.write(Filename, image, attrs);
     }
 
     TEST_CASE(CorrectlyWriteTestImage)
@@ -72,5 +82,16 @@ TEST_SUITE(Foundation_Image_EXRImageFileWriter)
             tile->get_pixel(i, c);
             EXPECT_EQ(Reference, c);
         }
+
+        ImageAttributes attrs;
+        reader.read_image_attributes(attrs);
+
+        EXPECT_EQ(attrs.get<string>("appleseed:test:StringAttr"), string("something"));
+        EXPECT_EQ(attrs.get<int>("appleseed:test:StringButIntAttr"), 47);
+        EXPECT_EQ(attrs.get<float>("appleseed:test:StringButFloatAttr"), 47.5f);
+        EXPECT_EQ(attrs.get<float>("appleseed:test:FloatAttr"), 32.0f);
+        EXPECT_EQ(attrs.get<double>("appleseed:test:DoubleAttr"), 32.0);
+        EXPECT_EQ(attrs.get<int>("appleseed:test:IntAttr"), 32);
+        EXPECT_EQ(attrs.get<size_t>("appleseed:test:UnsignedIntAttr"), static_cast<size_t>(32));
     }
 }


### PR DESCRIPTION
Reading is easy, you just need to know the type so that `to_string` works correctly.
For writing, the fallback is to write the attribute as a `string`, otherwise we try to convert it. And specific cases (chromatics for instance) have to be handled before.