### PR TITLE
Allow to merge percent statistics

### DIFF
--- a/src/appleseed/foundation/meta/tests/test_statistics.cpp
+++ b/src/appleseed/foundation/meta/tests/test_statistics.cpp
@@ -186,7 +186,7 @@ TEST_SUITE(Foundation_Utility_Statistics)
         EXPECT_EQ("  existing value                17,042", stats.to_string());
     }
 
-    TEST_CASE(Merge_GivenExistingPercentStatistic_InsertsIt)
+    TEST_CASE(Merge_GivenNewPercentStatistic_InsertsIt)
     {
         Statistics stats;
         stats.insert_percent("existing value", 5, 10, 1);

--- a/src/appleseed/foundation/meta/tests/test_statistics.cpp
+++ b/src/appleseed/foundation/meta/tests/test_statistics.cpp
@@ -185,6 +185,32 @@ TEST_SUITE(Foundation_Utility_Statistics)
 
         EXPECT_EQ("  existing value                17,042", stats.to_string());
     }
+
+    TEST_CASE(Merge_GivenExistingPercentStatistic_InsertsIt)
+    {
+        Statistics stats;
+        stats.insert_percent("existing value", 5, 10, 1);
+
+        Statistics other_stats;
+        other_stats.insert_percent("new value", 14, 20, 1);
+
+        stats.merge(other_stats);
+
+        EXPECT_EQ("  existing value                50.0%\n  new value                     70.0%", stats.to_string());
+    }
+
+    TEST_CASE(Merge_GivenExistingPercentStatistic_MergesIt)
+    {
+        Statistics stats;
+        stats.insert_percent("existing value", 68, 400, 1);
+
+        Statistics other_stats;
+        other_stats.insert_percent("existing value", 20, 50, 1);
+
+        stats.merge(other_stats);
+
+        EXPECT_EQ("  existing value                19.6%", stats.to_string());
+    }
 }
 
 TEST_SUITE(Foundation_Utility_StatisticsVector)


### PR DESCRIPTION
#2103 
When merging percent entries, numerators and denominators are simply summed. Be sure to use the same scale when adding percent values.