### PR TITLE
Allow the camera controller to use the project's camera or a given one

### DIFF
--- a/src/appleseed.studio/mainwindow/rendering/cameracontroller.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/cameracontroller.cpp
@@ -75,10 +75,22 @@ namespace studio {
 //     controller target if the user wishes so (by pressing 'f').
 //
 
+CameraController::CameraController(QWidget* widget, Project& project)
+  : m_widget(widget)
+  , m_project(project)
+  , m_custom_camera(nullptr)
+  , m_custom_camera_enabled(false)
+  , m_enabled(true)
+{
+    configure_controller();
+    m_widget->installEventFilter(this);
+}
+
 CameraController::CameraController(QWidget* widget, Project& project, Camera* camera)
   : m_widget(widget)
   , m_project(project)
-  , m_camera(camera)
+  , m_custom_camera(camera)
+  , m_custom_camera_enabled(true)
   , m_enabled(true)
 {
     configure_controller();
@@ -102,20 +114,22 @@ Transformd CameraController::get_transform() const
 
 void CameraController::update_camera_transform()
 {
-    if (m_camera != nullptr)
+    if (Camera* camera = fetch_camera())
     {
         // Moving the camera kills camera motion blur.
-        m_camera->transform_sequence().clear();
+        camera->transform_sequence().clear();
 
         // Set the scene camera orientation and position based on the controller.
-        m_camera->transform_sequence().set_transform(0.0f, get_transform());
+        camera->transform_sequence().set_transform(0.0f, get_transform());
     }
 }
 
 void CameraController::save_camera_target()
 {
-    if (m_camera != nullptr)
-        m_camera->get_parameters().insert("controller_target", m_controller.get_target());
+    if (Camera* camera = fetch_camera())
+    {
+        camera->get_parameters().insert("controller_target", m_controller.get_target());
+    }
 }
 
 void CameraController::slot_entity_picked(ScenePicker::PickingResult result)
@@ -170,17 +184,27 @@ bool CameraController::eventFilter(QObject* object, QEvent* event)
     return QObject::eventFilter(object, event);
 }
 
+Camera* CameraController::fetch_camera()
+{
+    if (m_custom_camera_enabled)
+        return m_custom_camera;
+    else
+        return m_project.get_uncached_active_camera();
+}
+
 void CameraController::configure_controller()
 {
     // By default, the pivot point is the scene's center.
     m_pivot = Vector3d(m_project.get_scene()->compute_bbox().center());
 
+    Camera* camera = fetch_camera();
+
     // Set the controller orientation and position.
-    if (m_camera != nullptr)
+    if (camera != nullptr)
     {
         // Use the scene's camera.
         m_controller.set_transform(
-            m_camera->transform_sequence().get_earliest_transform().get_local_to_parent());
+            camera->transform_sequence().get_earliest_transform().get_local_to_parent());
     }
     else
     {
@@ -194,8 +218,8 @@ void CameraController::configure_controller()
 
     // Check whether the camera has a controller target.
     const bool has_target =
-        m_camera != nullptr &&
-        m_camera->get_parameters().strings().exist("controller_target");
+        camera != nullptr &&
+        camera->get_parameters().strings().exist("controller_target");
 
     // Retrieve the controller target from the camera.
     Vector3d controller_target;
@@ -203,7 +227,7 @@ void CameraController::configure_controller()
     {
         // The scene's camera has a controller target, retrieve it.
         controller_target =
-            m_camera->get_parameters().get<Vector3d>("controller_target");
+            camera->get_parameters().get<Vector3d>("controller_target");
     }
     else
     {

--- a/src/appleseed.studio/mainwindow/rendering/cameracontroller.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/cameracontroller.cpp
@@ -79,7 +79,6 @@ CameraController::CameraController(QWidget* widget, Project& project)
   : m_widget(widget)
   , m_project(project)
   , m_custom_camera(nullptr)
-  , m_custom_camera_enabled(false)
   , m_enabled(true)
 {
     configure_controller();
@@ -90,7 +89,6 @@ CameraController::CameraController(QWidget* widget, Project& project, Camera* ca
   : m_widget(widget)
   , m_project(project)
   , m_custom_camera(camera)
-  , m_custom_camera_enabled(true)
   , m_enabled(true)
 {
     configure_controller();
@@ -163,17 +161,17 @@ bool CameraController::eventFilter(QObject* object, QEvent* event)
             if (handle_mouse_button_press_event(static_cast<QMouseEvent*>(event)))
                 return true;
             break;
-    
+
           case QEvent::MouseButtonRelease:
             if (handle_mouse_button_release_event(static_cast<QMouseEvent*>(event)))
                 return true;
             break;
-    
+
           case QEvent::MouseMove:
             if (handle_mouse_move_event(static_cast<QMouseEvent*>(event)))
                 return true;
             break;
-    
+
           case QEvent::KeyPress:
             if (handle_key_press_event(static_cast<QKeyEvent*>(event)))
                 return true;
@@ -186,7 +184,7 @@ bool CameraController::eventFilter(QObject* object, QEvent* event)
 
 Camera* CameraController::fetch_camera()
 {
-    if (m_custom_camera_enabled)
+    if (m_custom_camera != nullptr)
         return m_custom_camera;
     else
         return m_project.get_uncached_active_camera();

--- a/src/appleseed.studio/mainwindow/rendering/cameracontroller.h
+++ b/src/appleseed.studio/mainwindow/rendering/cameracontroller.h
@@ -61,6 +61,14 @@ class CameraController
   public:
     // Constructor.
     // The camera controller is disabled by default.
+    // The camera controller controls the project's camera.
+    CameraController(
+        QWidget*            widget,
+        renderer::Project&  project);
+
+    // Constructor.
+    // The camera controller is disabled by default.
+    // The camera controller controls the given camera.
     CameraController(
         QWidget*            widget,
         renderer::Project&  project,
@@ -91,7 +99,8 @@ class CameraController
 
     QWidget*                m_widget;
     renderer::Project&      m_project;
-    renderer::Camera*       m_camera;
+    renderer::Camera*       m_custom_camera;
+    const bool              m_custom_camera_enabled;
     bool                    m_enabled;
 
     ControllerType          m_controller;
@@ -100,6 +109,8 @@ class CameraController
     void configure_controller();
 
     bool eventFilter(QObject* object, QEvent* event) override;
+
+    renderer::Camera* fetch_camera();
 
     bool handle_mouse_button_press_event(const QMouseEvent* event);
     bool handle_mouse_button_release_event(const QMouseEvent* event);

--- a/src/appleseed.studio/mainwindow/rendering/cameracontroller.h
+++ b/src/appleseed.studio/mainwindow/rendering/cameracontroller.h
@@ -100,7 +100,6 @@ class CameraController
     QWidget*                m_widget;
     renderer::Project&      m_project;
     renderer::Camera*       m_custom_camera;
-    const bool              m_custom_camera_enabled;
     bool                    m_enabled;
 
     ControllerType          m_controller;

--- a/src/appleseed.studio/mainwindow/rendering/rendertab.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/rendertab.cpp
@@ -438,8 +438,7 @@ void RenderTab::recreate_handlers()
     m_camera_controller.reset(
         new CameraController(
             m_render_widget,
-            m_project,
-            m_project.get_uncached_active_camera()));
+            m_project));
     connect(
         m_camera_controller.get(), SIGNAL(signal_camera_change_begin()),
         SIGNAL(signal_camera_change_begin()));


### PR DESCRIPTION
This fixes crashes occurring in interactive mode while editing the
camera.