### PR TITLE
Linux linker visibility map fixes

### DIFF
--- a/src/appleseed/libappleseed.map
+++ b/src/appleseed/libappleseed.map
@@ -1,9 +1,4 @@
 {
-global: *;
-local:
-    extern "C++"
-    {
-        OSL*;
-        boost*;
-    };
+    global: *;
+    local: TIFF*; _TIFF*; _tiff*; png*; jpeg*;
 };


### PR DESCRIPTION
Hide symbols from libtiff, libpng and libjpeg in libappleseed.so
Fixes possible errors and crashes when using libappleseed.so in host applications 
that use different versions of the above libraries. 
