### PR TITLE
Expose checkpoint option and save/restore renders in cli

### DIFF
--- a/src/appleseed.cli/commandlinehandler.cpp
+++ b/src/appleseed.cli/commandlinehandler.cpp
@@ -151,6 +151,22 @@ CommandLineHandler::CommandLineHandler()
 #endif
 
     parser().add_option_handler(
+        &m_checkpoint_create
+            .add_name("--checkpoint-create")
+            .set_description("write a rendering checkpoint after each pass")
+            .set_syntax("filename")
+            .set_min_value_count(0)
+            .set_max_value_count(1));
+
+    parser().add_option_handler(
+        &m_checkpoint_resume
+            .add_name("--checkpoint-resume")
+            .set_description("resume rendering from a checkpoint")
+            .set_syntax("filename")
+            .set_min_value_count(0)
+            .set_max_value_count(1));
+
+    parser().add_option_handler(
         &m_send_to_stdout
             .add_name("--to-stdout")
             .set_description("send render to standard output"));

--- a/src/appleseed.cli/commandlinehandler.h
+++ b/src/appleseed.cli/commandlinehandler.h
@@ -76,6 +76,8 @@ class CommandLineHandler
 #if defined __APPLE__ || defined _WIN32
     foundation::FlagOptionHandler                       m_display_output;
 #endif
+    foundation::ValueOptionHandler<std::string>         m_checkpoint_create;
+    foundation::ValueOptionHandler<std::string>         m_checkpoint_resume;
     foundation::FlagOptionHandler                       m_send_to_stdout;
     foundation::FlagOptionHandler                       m_disable_autosave;
     foundation::ValueOptionHandler<std::string>         m_save_light_paths;

--- a/src/appleseed.cli/main.cpp
+++ b/src/appleseed.cli/main.cpp
@@ -339,7 +339,10 @@ namespace
 
             if (g_cl.m_checkpoint_create.values().empty() && !g_cl.m_output.is_set())
             {
-                LOG_ERROR(g_logger, "output path must be specified if no path is given for --checkpoint-create");
+                LOG_ERROR(
+                    g_logger,
+                    "output path must be specified if no path is given for %s",
+                    g_cl.m_checkpoint_create.get_name().c_str());
                 return false;
             }
 
@@ -356,7 +359,10 @@ namespace
 
             if (g_cl.m_checkpoint_resume.values().empty() && !g_cl.m_output.is_set())
             {
-                LOG_ERROR(g_logger, "output path must be specified if no path is given for --checkpoint-resume");
+                LOG_ERROR(
+                    g_logger,
+                    "output path must be specified if no path is given for %s",
+                    g_cl.m_checkpoint_resume.get_name().c_str());
                 return false;
             }
 

--- a/src/appleseed.cli/main.cpp
+++ b/src/appleseed.cli/main.cpp
@@ -335,44 +335,40 @@ namespace
 
         if (g_cl.m_checkpoint_create.is_set())
         {
-            params.insert("checkpoint_create", "on");
+            params.insert("checkpoint_create", true);
 
             if (g_cl.m_checkpoint_create.values().empty() && !g_cl.m_output.is_set())
             {
-                LOG_ERROR(g_logger, "ouput path must be specified if no path is given for --checkpoint-create");
+                LOG_ERROR(g_logger, "output path must be specified if no path is given for --checkpoint-create");
                 return false;
             }
 
             params.insert(
                 "checkpoint_create_path",
                 !g_cl.m_checkpoint_create.values().empty()
-                    ? g_cl.m_checkpoint_create.value().c_str()
+                    ? g_cl.m_checkpoint_create.value()
                     : "");
         }
 
         if (g_cl.m_checkpoint_resume.is_set())
         {
-            params.insert("checkpoint_resume", "on");
+            params.insert("checkpoint_resume", true);
 
             if (g_cl.m_checkpoint_resume.values().empty() && !g_cl.m_output.is_set())
             {
-                LOG_ERROR(g_logger, "ouput path must be specified if no path is given for --checkpoint-resume");
+                LOG_ERROR(g_logger, "output path must be specified if no path is given for --checkpoint-resume");
                 return false;
             }
 
             params.insert(
                 "checkpoint_resume_path",
                 !g_cl.m_checkpoint_resume.values().empty()
-                    ? g_cl.m_checkpoint_resume.value().c_str()
+                    ? g_cl.m_checkpoint_resume.value()
                     : "");
         }
 
         if (g_cl.m_passes.is_set())
-        {
-            params.insert_path(
-                "passes",
-                g_cl.m_passes.values()[0]);
-        }
+            params.insert_path("passes", g_cl.m_passes.values()[0]);
 
         auto_release_ptr<Frame> new_frame(
             FrameFactory::create(
@@ -430,7 +426,8 @@ namespace
         apply_custom_parameter_command_line_options(params);
 
         // Apply command line options that alter the project.
-        if (!apply_frame_command_line_options(project)) return false;
+        if (!apply_frame_command_line_options(project))
+            return false;
         apply_visibility_command_line_options(project);
 
         return true;
@@ -763,4 +760,3 @@ int main(int argc, char* argv[])
 
     return success ? 0 : 1;
 }
-

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -2043,6 +2043,8 @@ set (renderer_utility_sources
     renderer/utility/autodeskmax.h
     renderer/utility/bbox.h
     renderer/utility/dynamicspectrum.h
+    renderer/utility/filesystem.cpp
+    renderer/utility/filesystem.h
     renderer/utility/iostreamop.h
     renderer/utility/messagecontext.cpp
     renderer/utility/messagecontext.h

--- a/src/appleseed/foundation/image/genericimagefilewriter.cpp
+++ b/src/appleseed/foundation/image/genericimagefilewriter.cpp
@@ -331,7 +331,6 @@ void GenericImageFileWriter::write_tiles(const size_t image_index)
     // Retrieve image spec.
     assert(image_index < impl->m_spec.size());
     const OIIO::ImageSpec& spec = impl->m_spec[image_index];
-
     assert(spec.nchannels == spec.channelnames.size());
     assert(spec.nchannels == props.m_channel_count);
 

--- a/src/appleseed/foundation/image/genericimagefilewriter.cpp
+++ b/src/appleseed/foundation/image/genericimagefilewriter.cpp
@@ -144,6 +144,7 @@ void GenericImageFileWriter::set_image_channels(
     OIIO::ImageSpec& spec = impl->m_spec.back();
 
     spec.nchannels = static_cast<int>(channel_count);
+    spec.channelnames.clear();
 
     for (size_t i = 0; i < channel_count; i++)
     {
@@ -192,8 +193,12 @@ void GenericImageFileWriter::set_image_spec()
     }
 
     // Channel names.
-    const char* channel_names[] = { "R", "G", "B", "A" };
-    set_image_channels(props.m_channel_count, channel_names);
+    // Needs to be manually set if the number of channels is higher than 4.
+    if (props.m_channel_count <= 4)
+    {
+        const char* channel_names[] = { "R", "G", "B", "A" };
+        set_image_channels(props.m_channel_count, channel_names);
+    }
 
     // Format of the pixel data.
     const boost::filesystem::path filepath(impl->m_filename);
@@ -327,6 +332,9 @@ void GenericImageFileWriter::write_tiles(const size_t image_index)
     assert(image_index < impl->m_spec.size());
     const OIIO::ImageSpec& spec = impl->m_spec[image_index];
 
+    assert(spec.nchannels == spec.channelnames.size());
+    assert(spec.nchannels == props.m_channel_count);
+
     // Compute the tiles' xstride offset in bytes.
     size_t xstride = props.m_pixel_size;
 
@@ -343,7 +351,7 @@ void GenericImageFileWriter::write_tiles(const size_t image_index)
             assert(tile_offset_y <= props.m_canvas_height);
 
             // Compute the tile's ystride offset in bytes.
-            const size_t ystride = xstride * std::min(static_cast<size_t>(spec.width + spec.x - tile_offset_x), 
+            const size_t ystride = xstride * std::min(static_cast<size_t>(spec.width + spec.x - tile_offset_x),
                                                       static_cast<size_t>(spec.tile_width));
 
             // Retrieve the (tile_x, tile_y) tile.
@@ -417,9 +425,9 @@ void GenericImageFileWriter::write_scanlines(const size_t image_index)
 
         // Write scanline into the file.
         if (!impl->m_writer->write_scanlines(
-                static_cast<int>(y_begin), 
-                static_cast<int>(y_end), 
-                0, 
+                static_cast<int>(y_begin),
+                static_cast<int>(y_end),
+                0,
                 convert_pixel_format(props.m_pixel_format),
                 buffer_ptr))
         {
@@ -465,7 +473,7 @@ void GenericImageFileWriter::write_multi_images()
         const std::string msg = impl->m_writer->geterror();
         throw ExceptionIOError(msg.c_str());
     }
-    
+
     for (size_t i = 0, e = get_image_count(); i < e; ++i)
     {
         if (i > 0)
@@ -480,7 +488,7 @@ void GenericImageFileWriter::write_multi_images()
 
         write(i);
     }
-    
+
     close_file();
 }
 

--- a/src/appleseed/foundation/image/genericprogressiveimagefilereader.cpp
+++ b/src/appleseed/foundation/image/genericprogressiveimagefilereader.cpp
@@ -314,9 +314,9 @@ void GenericProgressiveImageFileReader::read_tile(
         const size_t tile_width = min(impl->m_props.m_tile_width, impl->m_props.m_canvas_width - origin_x);
         const size_t tile_height = min(impl->m_props.m_tile_height, impl->m_props.m_canvas_height - origin_y);
 
-        // The tile fits perfectly into the canvas.
         if (tile_width == impl->m_props.m_tile_width && tile_height == impl->m_props.m_tile_height)
         {
+            // The tile fits perfectly into the canvas.
             assert(output_tile->get_width() == impl->m_props.m_tile_width);
             assert(output_tile->get_height() == impl->m_props.m_tile_height);
 

--- a/src/appleseed/foundation/image/genericprogressiveimagefilereader.h
+++ b/src/appleseed/foundation/image/genericprogressiveimagefilereader.h
@@ -79,10 +79,19 @@ class APPLESEED_DLLSYMBOL GenericProgressiveImageFileReader
     void read_image_attributes(
         ImageAttributes&    attrs) override;
 
+    // Choose the layer in the image file if available.
+    bool choose_subimage(const size_t subimage) const;
+
     // Read an image tile. Returns a newly allocated tile.
     Tile* read_tile(
         const size_t        tile_x,
         const size_t        tile_y) override;
+
+    // Read an image tile. Outputs the content in the given tile.
+    void read_tile(
+        const size_t        tile_x,
+        const size_t        tile_y,
+        Tile*               output_tile);
 
   private:
     struct Impl;

--- a/src/appleseed/foundation/utility/commandlineparser/optionhandler.h
+++ b/src/appleseed/foundation/utility/commandlineparser/optionhandler.h
@@ -34,6 +34,7 @@
 #include "foundation/utility/foreach.h"
 
 // Standard headers.
+#include <cassert>
 #include <cstddef>
 #include <string>
 #include <vector>
@@ -73,6 +74,9 @@ class OptionHandler
 
     // Add a name for this option.
     OptionHandler& add_name(const std::string& name);
+
+    // Return the first name of the option.
+    const std::string& get_name() const;
 
     // Set a description of this option.
     OptionHandler& set_description(const std::string& description);
@@ -130,6 +134,12 @@ inline OptionHandler& OptionHandler::add_name(const std::string& name)
 {
     m_names.push_back(name);
     return *this;
+}
+
+inline const std::string& OptionHandler::get_name() const
+{
+    assert(!m_names.empty());
+    return m_names[0];
 }
 
 inline OptionHandler& OptionHandler::set_description(const std::string& description)

--- a/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
@@ -38,9 +38,9 @@
 #include "renderer/kernel/rendering/iframerenderer.h"
 #include "renderer/kernel/rendering/ipasscallback.h"
 #include "renderer/kernel/rendering/ishadingresultframebufferfactory.h"
-#include "renderer/kernel/rendering/permanentshadingresultframebufferfactory.h"
 #include "renderer/kernel/rendering/itilecallback.h"
 #include "renderer/kernel/rendering/itilerenderer.h"
+#include "renderer/kernel/rendering/permanentshadingresultframebufferfactory.h"
 #include "renderer/modeling/frame/frame.h"
 #include "renderer/utility/settingsparsing.h"
 
@@ -73,7 +73,6 @@ namespace renderer
 
 namespace
 {
-
     //
     // Generic frame renderer.
     //

--- a/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
@@ -83,8 +83,8 @@ namespace
       public:
         GenericFrameRenderer(
             const Frame&                        frame,
-            ITileRendererFactory*               tile_renderer_factory,
             IShadingResultFrameBufferFactory*   framebuffer_factory,
+            ITileRendererFactory*               tile_renderer_factory,
             ITileCallbackFactory*               tile_callback_factory,
             IPassCallback*                      pass_callback,
             const ParamArray&                   params)
@@ -192,8 +192,8 @@ namespace
                     m_params.m_pass_count,
                     m_params.m_spectrum_mode,
                     m_tile_renderers,
-                    m_framebuffer_factory,
                     m_tile_callbacks,
+                    m_framebuffer_factory,
                     m_pass_callback,
                     m_job_queue,
                     m_params.m_thread_count,
@@ -297,8 +297,8 @@ namespace
                 const size_t                        pass_count,
                 const Spectrum::Mode                spectrum_mode,
                 vector<ITileRenderer*>&             tile_renderers,
-                IShadingResultFrameBufferFactory*   framebuffer_factory,
                 vector<ITileCallback*>&             tile_callbacks,
+                IShadingResultFrameBufferFactory*   framebuffer_factory,
                 IPassCallback*                      pass_callback,
                 JobQueue&                           job_queue,
                 const size_t                        thread_count,
@@ -307,8 +307,8 @@ namespace
               : m_frame(frame)
               , m_tile_ordering(tile_ordering)
               , m_tile_renderers(tile_renderers)
-              , m_framebuffer_factory(framebuffer_factory)
               , m_tile_callbacks(tile_callbacks)
+              , m_framebuffer_factory(framebuffer_factory)
               , m_pass_callback(pass_callback)
               , m_pass_count(pass_count)
               , m_spectrum_mode(spectrum_mode)
@@ -424,8 +424,8 @@ namespace
             const Frame&                            m_frame;
             const TileJobFactory::TileOrdering      m_tile_ordering;
             vector<ITileRenderer*>&                 m_tile_renderers;
-            IShadingResultFrameBufferFactory*       m_framebuffer_factory;
             vector<ITileCallback*>&                 m_tile_callbacks;
+            IShadingResultFrameBufferFactory*       m_framebuffer_factory;
             IPassCallback*                          m_pass_callback;
             const size_t                            m_pass_count;
             const Spectrum::Mode                    m_spectrum_mode;
@@ -505,14 +505,14 @@ namespace
 
 GenericFrameRendererFactory::GenericFrameRendererFactory(
     const Frame&                        frame,
-    ITileRendererFactory*               tile_renderer_factory,
     IShadingResultFrameBufferFactory*   framebuffer_factory,
+    ITileRendererFactory*               tile_renderer_factory,
     ITileCallbackFactory*               tile_callback_factory,
     IPassCallback*                      pass_callback,
     const ParamArray&                   params)
   : m_frame(frame)
-  , m_tile_renderer_factory(tile_renderer_factory)
   , m_framebuffer_factory(framebuffer_factory)
+  , m_tile_renderer_factory(tile_renderer_factory)
   , m_tile_callback_factory(tile_callback_factory)
   , m_pass_callback(pass_callback)
   , m_params(params)
@@ -529,8 +529,8 @@ IFrameRenderer* GenericFrameRendererFactory::create()
     return
         new GenericFrameRenderer(
             m_frame,
-            m_tile_renderer_factory,
             m_framebuffer_factory,
+            m_tile_renderer_factory,
             m_tile_callback_factory,
             m_pass_callback,
             m_params);
@@ -538,8 +538,8 @@ IFrameRenderer* GenericFrameRendererFactory::create()
 
 IFrameRenderer* GenericFrameRendererFactory::create(
     const Frame&                        frame,
-    ITileRendererFactory*               tile_renderer_factory,
     IShadingResultFrameBufferFactory*   framebuffer_factory,
+    ITileRendererFactory*               tile_renderer_factory,
     ITileCallbackFactory*               tile_callback_factory,
     IPassCallback*                      pass_callback,
     const ParamArray&                   params)
@@ -547,8 +547,8 @@ IFrameRenderer* GenericFrameRendererFactory::create(
     return
         new GenericFrameRenderer(
             frame,
-            tile_renderer_factory,
             framebuffer_factory,
+            tile_renderer_factory,
             tile_callback_factory,
             pass_callback,
             params);

--- a/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
@@ -325,10 +325,6 @@ namespace
 
                 const size_t start_pass = m_frame.get_initial_pass();
 
-                PermanentShadingResultFrameBufferFactory* buffer_factory =
-                    static_cast<PermanentShadingResultFrameBufferFactory*>(
-                        m_framebuffer_factory);
-
                 //
                 // Rendering passes.
                 //
@@ -389,7 +385,7 @@ namespace
                         assert(!m_job_queue.has_scheduled_or_running_jobs());
                     }
 
-                    m_frame.save_checkpoint(buffer_factory, pass);
+                    m_frame.save_checkpoint(m_framebuffer_factory, pass);
                 }
 
                 // Check abort flag.

--- a/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.h
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.h
@@ -40,6 +40,7 @@
 namespace foundation    { class Dictionary; }
 namespace renderer      { class Frame; }
 namespace renderer      { class IPassCallback; }
+namespace renderer      { class IShadingResultFrameBufferFactory; }
 namespace renderer      { class ITileCallbackFactory; }
 namespace renderer      { class ITileRendererFactory; }
 
@@ -56,11 +57,12 @@ class GenericFrameRendererFactory
   public:
     // Constructor.
     GenericFrameRendererFactory(
-        const Frame&            frame,
-        ITileRendererFactory*   tile_renderer_factory,
-        ITileCallbackFactory*   tile_callback_factory,      // may be 0
-        IPassCallback*          pass_callback,              // may be 0
-        const ParamArray&       params);
+        const Frame&                        frame,
+        ITileRendererFactory*               tile_renderer_factory,
+        IShadingResultFrameBufferFactory*   framebuffer_factory,
+        ITileCallbackFactory*               tile_callback_factory,      // may be nullptr
+        IPassCallback*                      pass_callback,              // may be nullptr
+        const ParamArray&                   params);
 
     // Delete this instance.
     void release() override;
@@ -70,21 +72,23 @@ class GenericFrameRendererFactory
 
     // Return a new generic frame renderer instance.
     static IFrameRenderer* create(
-        const Frame&            frame,
-        ITileRendererFactory*   tile_renderer_factory,
-        ITileCallbackFactory*   tile_callback_factory,      // may be 0
-        IPassCallback*          pass_callback,              // may be 0
-        const ParamArray&       params);
+        const Frame&                        frame,
+        ITileRendererFactory*               tile_renderer_factory,
+        IShadingResultFrameBufferFactory*   framebuffer_factory,
+        ITileCallbackFactory*               tile_callback_factory,      // may be 0
+        IPassCallback*                      pass_callback,              // may be 0
+        const ParamArray&                   params);
 
     // Return the metadata of the generic frame renderer parameters.
     static foundation::Dictionary get_params_metadata();
 
   private:
-    const Frame&                m_frame;
-    ITileRendererFactory*       m_tile_renderer_factory;
-    ITileCallbackFactory*       m_tile_callback_factory;    // may be 0
-    IPassCallback*              m_pass_callback;            // may be 0
-    const ParamArray            m_params;
+    const Frame&                            m_frame;
+    ITileRendererFactory*                   m_tile_renderer_factory;
+    IShadingResultFrameBufferFactory*       m_framebuffer_factory;
+    ITileCallbackFactory*                   m_tile_callback_factory;    // may be 0
+    IPassCallback*                          m_pass_callback;            // may be 0
+    const ParamArray                        m_params;
 };
 
 }   // namespace renderer

--- a/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.h
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.h
@@ -58,8 +58,8 @@ class GenericFrameRendererFactory
     // Constructor.
     GenericFrameRendererFactory(
         const Frame&                        frame,
-        ITileRendererFactory*               tile_renderer_factory,
         IShadingResultFrameBufferFactory*   framebuffer_factory,
+        ITileRendererFactory*               tile_renderer_factory,
         ITileCallbackFactory*               tile_callback_factory,      // may be nullptr
         IPassCallback*                      pass_callback,              // may be nullptr
         const ParamArray&                   params);
@@ -73,10 +73,10 @@ class GenericFrameRendererFactory
     // Return a new generic frame renderer instance.
     static IFrameRenderer* create(
         const Frame&                        frame,
-        ITileRendererFactory*               tile_renderer_factory,
         IShadingResultFrameBufferFactory*   framebuffer_factory,
-        ITileCallbackFactory*               tile_callback_factory,      // may be 0
-        IPassCallback*                      pass_callback,              // may be 0
+        ITileRendererFactory*               tile_renderer_factory,
+        ITileCallbackFactory*               tile_callback_factory,      // may be nullptr
+        IPassCallback*                      pass_callback,              // may be nullptr
         const ParamArray&                   params);
 
     // Return the metadata of the generic frame renderer parameters.
@@ -84,10 +84,10 @@ class GenericFrameRendererFactory
 
   private:
     const Frame&                            m_frame;
-    ITileRendererFactory*                   m_tile_renderer_factory;
     IShadingResultFrameBufferFactory*       m_framebuffer_factory;
-    ITileCallbackFactory*                   m_tile_callback_factory;    // may be 0
-    IPassCallback*                          m_pass_callback;            // may be 0
+    ITileRendererFactory*                   m_tile_renderer_factory;
+    ITileCallbackFactory*                   m_tile_callback_factory;    // may be nullptr
+    IPassCallback*                          m_pass_callback;            // may be nullptr
     const ParamArray                        m_params;
 };
 

--- a/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
@@ -490,7 +490,6 @@ struct MasterRenderer::Impl
         recorder.on_render_end(m_project);
 
         const CanvasProperties& props = m_project.get_frame()->image().properties();
-
         m_project.get_light_path_recorder().finalize(
             props.m_canvas_width,
             props.m_canvas_height);

--- a/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
@@ -36,7 +36,6 @@
 #include "renderer/kernel/rendering/iframerenderer.h"
 #include "renderer/kernel/rendering/itilecallback.h"
 #include "renderer/kernel/rendering/oiioerrorhandler.h"
-#include "renderer/kernel/rendering/permanentshadingresultframebufferfactory.h"
 #include "renderer/kernel/rendering/renderercomponents.h"
 #include "renderer/kernel/rendering/rendererservices.h"
 #include "renderer/kernel/rendering/serialrenderercontroller.h"
@@ -466,10 +465,7 @@ struct MasterRenderer::Impl
 
         // Load the checkpoint if any.
         Frame& frame = *m_project.get_frame();
-        PermanentShadingResultFrameBufferFactory* buffer_factory =
-            static_cast<PermanentShadingResultFrameBufferFactory*>(
-                &(components.get_shading_result_framebuffer_factory()));
-        if (!frame.load_checkpoint(buffer_factory))
+        if (!frame.load_checkpoint(&(components.get_shading_result_framebuffer_factory())))
             return IRendererController::AbortRendering;
 
         // Print renderer component settings.

--- a/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
@@ -466,11 +466,9 @@ struct MasterRenderer::Impl
 
         // Load the checkpoint if any.
         Frame& frame = *m_project.get_frame();
-
         PermanentShadingResultFrameBufferFactory* buffer_factory =
             static_cast<PermanentShadingResultFrameBufferFactory*>(
                 &(components.get_shading_result_framebuffer_factory()));
-
         if (!frame.load_checkpoint(buffer_factory))
             return IRendererController::AbortRendering;
 

--- a/src/appleseed/renderer/kernel/rendering/renderercomponents.cpp
+++ b/src/appleseed/renderer/kernel/rendering/renderercomponents.cpp
@@ -485,6 +485,12 @@ bool RendererComponents::create_frame_renderer_factory()
     }
     else if (name == "generic")
     {
+        if (m_shading_result_framebuffer_factory.get() == nullptr)
+        {
+            RENDERER_LOG_ERROR("cannot use the generic frame renderer without a shading result framebuffer.");
+            return false;
+        }
+
         if (m_tile_renderer_factory.get() == nullptr)
         {
             RENDERER_LOG_ERROR("cannot use the generic frame renderer without a tile renderer.");
@@ -495,6 +501,7 @@ bool RendererComponents::create_frame_renderer_factory()
             GenericFrameRendererFactory::create(
                 m_frame,
                 m_tile_renderer_factory.get(),
+                m_shading_result_framebuffer_factory.get(),
                 m_tile_callback_factory,
                 m_pass_callback.get(),
                 get_child_and_inherit_globals(m_params, "generic_frame_renderer")));

--- a/src/appleseed/renderer/kernel/rendering/renderercomponents.cpp
+++ b/src/appleseed/renderer/kernel/rendering/renderercomponents.cpp
@@ -500,8 +500,8 @@ bool RendererComponents::create_frame_renderer_factory()
         m_frame_renderer.reset(
             GenericFrameRendererFactory::create(
                 m_frame,
-                m_tile_renderer_factory.get(),
                 m_shading_result_framebuffer_factory.get(),
+                m_tile_renderer_factory.get(),
                 m_tile_callback_factory,
                 m_pass_callback.get(),
                 get_child_and_inherit_globals(m_params, "generic_frame_renderer")));

--- a/src/appleseed/renderer/kernel/rendering/renderercomponents.h
+++ b/src/appleseed/renderer/kernel/rendering/renderercomponents.h
@@ -86,28 +86,30 @@ class RendererComponents
 
     IFrameRenderer& get_frame_renderer();
 
-  private:
-    const Project&                                      m_project;
-    const ParamArray&                                   m_params;
-    ITileCallbackFactory*                               m_tile_callback_factory;
-    const Scene&                                        m_scene;
-    const Frame&                                        m_frame;
-    const TraceContext&                                 m_trace_context;
-    std::unique_ptr<ForwardLightSampler>                m_forward_light_sampler;
-    std::unique_ptr<BackwardLightSampler>               m_backward_light_sampler;
-    ShadingEngine                                       m_shading_engine;
-    TextureStore&                                       m_texture_store;
-    OIIOTextureSystem&                                  m_texture_system;
-    OSLShadingSystem&                                   m_shading_system;
+    IShadingResultFrameBufferFactory& get_shading_result_framebuffer_factory();
 
-    std::unique_ptr<ILightingEngineFactory>             m_lighting_engine_factory;
-    std::unique_ptr<ISampleRendererFactory>             m_sample_renderer_factory;
-    std::unique_ptr<ISampleGeneratorFactory>            m_sample_generator_factory;
-    std::unique_ptr<IPixelRendererFactory>              m_pixel_renderer_factory;
-    std::unique_ptr<IShadingResultFrameBufferFactory>   m_shading_result_framebuffer_factory;
-    std::unique_ptr<ITileRendererFactory>               m_tile_renderer_factory;
-    std::unique_ptr<IPassCallback>                      m_pass_callback;
-    foundation::auto_release_ptr<IFrameRenderer>        m_frame_renderer;
+  private:
+    const Project&                                                  m_project;
+    const ParamArray&                                               m_params;
+    ITileCallbackFactory*                                           m_tile_callback_factory;
+    const Scene&                                                    m_scene;
+    const Frame&                                                    m_frame;
+    const TraceContext&                                             m_trace_context;
+    std::unique_ptr<ForwardLightSampler>                            m_forward_light_sampler;
+    std::unique_ptr<BackwardLightSampler>                           m_backward_light_sampler;
+    ShadingEngine                                                   m_shading_engine;
+    TextureStore&                                                   m_texture_store;
+    OIIOTextureSystem&                                              m_texture_system;
+    OSLShadingSystem&                                               m_shading_system;
+
+    std::unique_ptr<ILightingEngineFactory>                         m_lighting_engine_factory;
+    std::unique_ptr<ISampleRendererFactory>                         m_sample_renderer_factory;
+    std::unique_ptr<ISampleGeneratorFactory>                        m_sample_generator_factory;
+    std::unique_ptr<IPixelRendererFactory>                          m_pixel_renderer_factory;
+    foundation::auto_release_ptr<IShadingResultFrameBufferFactory>  m_shading_result_framebuffer_factory;
+    std::unique_ptr<ITileRendererFactory>                           m_tile_renderer_factory;
+    std::unique_ptr<IPassCallback>                                  m_pass_callback;
+    foundation::auto_release_ptr<IFrameRenderer>                    m_frame_renderer;
 
     bool create_lighting_engine_factory();
     bool create_sample_renderer_factory();
@@ -133,4 +135,9 @@ inline IFrameRenderer& RendererComponents::get_frame_renderer()
     return *m_frame_renderer.get();
 }
 
-}   // namespace renderer
+inline IShadingResultFrameBufferFactory& RendererComponents::get_shading_result_framebuffer_factory()
+{
+    return *m_shading_result_framebuffer_factory.get();
+}
+
+}       // namespace renderer

--- a/src/appleseed/renderer/kernel/rendering/renderercomponents.h
+++ b/src/appleseed/renderer/kernel/rendering/renderercomponents.h
@@ -106,7 +106,7 @@ class RendererComponents
     std::unique_ptr<ISampleRendererFactory>                         m_sample_renderer_factory;
     std::unique_ptr<ISampleGeneratorFactory>                        m_sample_generator_factory;
     std::unique_ptr<IPixelRendererFactory>                          m_pixel_renderer_factory;
-    foundation::auto_release_ptr<IShadingResultFrameBufferFactory>  m_shading_result_framebuffer_factory;
+    std::unique_ptr<IShadingResultFrameBufferFactory>               m_shading_result_framebuffer_factory;
     std::unique_ptr<ITileRendererFactory>                           m_tile_renderer_factory;
     std::unique_ptr<IPassCallback>                                  m_pass_callback;
     foundation::auto_release_ptr<IFrameRenderer>                    m_frame_renderer;

--- a/src/appleseed/renderer/kernel/rendering/shadingresultframebuffer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/shadingresultframebuffer.cpp
@@ -48,15 +48,6 @@ using namespace std;
 namespace renderer
 {
 
-namespace
-{
-    inline size_t get_total_channel_count(const size_t aov_count)
-    {
-        // The main image plus a number of AOVs, all RGBA.
-        return (1 + aov_count) * 4;
-    }
-}
-
 ShadingResultFrameBuffer::ShadingResultFrameBuffer(
     const size_t                    width,
     const size_t                    height,

--- a/src/appleseed/renderer/kernel/rendering/shadingresultframebuffer.h
+++ b/src/appleseed/renderer/kernel/rendering/shadingresultframebuffer.h
@@ -80,9 +80,17 @@ class ShadingResultFrameBuffer
         foundation::Tile&               tile,
         TileStack&                      aov_tiles) const;
 
+    static inline size_t get_total_channel_count(const size_t aov_count);
+
   private:
     const size_t                        m_aov_count;
     std::vector<float>                  m_scratch;
 };
+
+size_t ShadingResultFrameBuffer::get_total_channel_count(const size_t aov_count)
+{
+    // The main image plus a number of AOVs, all RGBA.
+    return (1 + aov_count) * 4;
+}
 
 }   // namespace renderer

--- a/src/appleseed/renderer/kernel/rendering/shadingresultframebuffer.h
+++ b/src/appleseed/renderer/kernel/rendering/shadingresultframebuffer.h
@@ -63,6 +63,8 @@ class ShadingResultFrameBuffer
         const foundation::AABB2u&       crop_window,
         const foundation::Filter2f&     filter);
 
+    static size_t get_total_channel_count(const size_t aov_count);
+
     void add(
         const float                     x,
         const float                     y,
@@ -80,14 +82,12 @@ class ShadingResultFrameBuffer
         foundation::Tile&               tile,
         TileStack&                      aov_tiles) const;
 
-    static inline size_t get_total_channel_count(const size_t aov_count);
-
   private:
     const size_t                        m_aov_count;
     std::vector<float>                  m_scratch;
 };
 
-size_t ShadingResultFrameBuffer::get_total_channel_count(const size_t aov_count)
+inline size_t ShadingResultFrameBuffer::get_total_channel_count(const size_t aov_count)
 {
     // The main image plus a number of AOVs, all RGBA.
     return (1 + aov_count) * 4;

--- a/src/appleseed/renderer/modeling/aov/aov.cpp
+++ b/src/appleseed/renderer/modeling/aov/aov.cpp
@@ -96,11 +96,15 @@ void AOV::create_image(
     const size_t            tile_height,
     ImageStack&             aov_images)
 {
-    m_image_index =
-        aov_images.append(
+    m_image_index = aov_images.get_index(get_name());
+
+    if (m_image_index == ~size_t(0))
+    {
+        m_image_index = aov_images.append(
             get_name(),
             get_channel_count(),
             PixelFormatFloat);
+    }
 
     m_image = &aov_images.get_image(m_image_index);
 }

--- a/src/appleseed/renderer/modeling/aov/denoiseraov.cpp
+++ b/src/appleseed/renderer/modeling/aov/denoiseraov.cpp
@@ -280,7 +280,6 @@ struct DenoiserAOV::Impl
     Deepimf m_covariance_accum;
 
     Deepimf m_histograms;
-    Deepimf m_covariances;
 };
 
 DenoiserAOV::DenoiserAOV(
@@ -378,6 +377,26 @@ const Deepimf& DenoiserAOV::histograms_image() const
 Deepimf& DenoiserAOV::histograms_image()
 {
     return impl->m_histograms;
+}
+
+const Deepimf& DenoiserAOV::covariance_image() const
+{
+    return impl->m_covariance_accum;
+}
+
+Deepimf& DenoiserAOV::covariance_image()
+{
+    return impl->m_covariance_accum;
+}
+
+const Deepimf& DenoiserAOV::sum_image() const
+{
+    return impl->m_sum_accum;
+}
+
+Deepimf& DenoiserAOV::sum_image()
+{
+    return impl->m_sum_accum;
 }
 
 void DenoiserAOV::extract_num_samples_image(bcd::Deepimf& num_samples_image) const

--- a/src/appleseed/renderer/modeling/aov/denoiseraov.h
+++ b/src/appleseed/renderer/modeling/aov/denoiseraov.h
@@ -80,6 +80,12 @@ class DenoiserAOV
     const bcd::Deepimf& histograms_image() const;
     bcd::Deepimf& histograms_image();
 
+    const bcd::Deepimf& covariance_image() const;
+    bcd::Deepimf& covariance_image();
+
+    const bcd::Deepimf& sum_image() const;
+    bcd::Deepimf& sum_image();
+
     void extract_num_samples_image(bcd::Deepimf& num_samples_image) const;
     void compute_covariances_image(bcd::Deepimf& covariances_image) const;
 

--- a/src/appleseed/renderer/modeling/frame/frame.cpp
+++ b/src/appleseed/renderer/modeling/frame/frame.cpp
@@ -494,7 +494,7 @@ namespace
 {
     inline size_t get_checkpoint_total_channel_count(const size_t aov_count)
     {
-        // The beauty image plus the shadding result framebuffer.
+        // The beauty image plus the shading result framebuffer.
         return ShadingResultFrameBuffer::get_total_channel_count(aov_count) + 1;
     }
 
@@ -1430,7 +1430,8 @@ void Frame::extract_parameters()
         {
             string path = m_params.get_optional<string>("checkpoint_create_path", "");
             const bool use_default_path = path.empty();
-            if (use_default_path) path = m_params.get_required<string>("output_path");
+            if (use_default_path)
+                path = m_params.get_required<string>("output_path");
 
             bf::path bf_path(path.c_str());
 
@@ -1439,7 +1440,7 @@ void Frame::extract_parameters()
             if (extension != ".exr")
             {
                 // Only .exr files are allowed.
-                RENDERER_LOG_ERROR("checkpoint file must be an \".exr\" file, disabling checkpoint creation");
+                RENDERER_LOG_ERROR("checkpoint file must be an \".exr\" file, disabling checkpoint creation.");
                 impl->m_checkpoint_create = false;
             }
             else
@@ -1465,7 +1466,8 @@ void Frame::extract_parameters()
         {
             string path = m_params.get_optional<string>("checkpoint_resume_path", "");
             const bool use_default_path = path == "";
-            if (use_default_path) path = m_params.get_required<string>("output_path");
+            if (use_default_path)
+                path = m_params.get_required<string>("output_path");
 
             bf::path bf_path(path.c_str());
 
@@ -1474,7 +1476,7 @@ void Frame::extract_parameters()
             if (extension != ".exr")
             {
                 // Only .exr files are allowed.
-                RENDERER_LOG_ERROR("checkpoint file must be an \".exr\" file, disabling checkpoint resuming");
+                RENDERER_LOG_ERROR("checkpoint file must be an \".exr\" file, disabling checkpoint resuming.");
                 impl->m_checkpoint_resume = false;
             }
             else

--- a/src/appleseed/renderer/modeling/frame/frame.h
+++ b/src/appleseed/renderer/modeling/frame/frame.h
@@ -62,9 +62,9 @@ namespace foundation    { class Tile; }
 namespace renderer      { class BaseGroup; }
 namespace renderer      { class DenoiserAOV; }
 namespace renderer      { class ImageStack; }
+namespace renderer      { class IShadingResultFrameBufferFactory; }
 namespace renderer      { class OnFrameBeginRecorder; }
 namespace renderer      { class ParamArray; }
-namespace renderer      { class PermanentShadingResultFrameBufferFactory; }
 namespace renderer      { class Project; }
 
 namespace renderer
@@ -179,12 +179,11 @@ class APPLESEED_DLLSYMBOL Frame
     // Open the checkpoint if checkpoint is enabled and the file located
     // at checkpoint_path exists and is valid.
     // Returns true if successful or if checkpoint is disabled, false otherwise.
-    bool load_checkpoint(
-        PermanentShadingResultFrameBufferFactory*   buffer_factory);
+    bool load_checkpoint(IShadingResultFrameBufferFactory*   buffer_factory);
 
     // Create a checkpoint file for the resuming the render at the current pass.
     void save_checkpoint(
-        PermanentShadingResultFrameBufferFactory*   buffer_factory,
+        IShadingResultFrameBufferFactory*           buffer_factory,
         const size_t                                pass) const;
 
     // Write the main image to disk.

--- a/src/appleseed/renderer/modeling/frame/frame.h
+++ b/src/appleseed/renderer/modeling/frame/frame.h
@@ -176,10 +176,9 @@ class APPLESEED_DLLSYMBOL Frame
         const size_t                                thread_count,
         foundation::IAbortSwitch*                   abort_switch) const;
 
-    // Open the checkpoint if checkpoint is enabled and the file located
-    // at checkpoint_path exists and is valid.
-    // Returns true if successful or if checkpoint is disabled, false otherwise.
-    bool load_checkpoint(IShadingResultFrameBufferFactory*   buffer_factory);
+    // Open the checkpoint if the chekpoint resume option is enabled.
+    // Returns true if successful, false otherwise.
+    bool load_checkpoint(IShadingResultFrameBufferFactory*  buffer_factory);
 
     // Create a checkpoint file for the resuming the render at the current pass.
     void save_checkpoint(

--- a/src/appleseed/renderer/modeling/frame/frame.h
+++ b/src/appleseed/renderer/modeling/frame/frame.h
@@ -62,9 +62,9 @@ namespace foundation    { class Tile; }
 namespace renderer      { class BaseGroup; }
 namespace renderer      { class DenoiserAOV; }
 namespace renderer      { class ImageStack; }
-namespace renderer      { class PermanentShadingResultFrameBufferFactory; }
 namespace renderer      { class OnFrameBeginRecorder; }
 namespace renderer      { class ParamArray; }
+namespace renderer      { class PermanentShadingResultFrameBufferFactory; }
 namespace renderer      { class Project; }
 
 namespace renderer

--- a/src/appleseed/renderer/modeling/input/texturesource.cpp
+++ b/src/appleseed/renderer/modeling/input/texturesource.cpp
@@ -36,7 +36,6 @@
 #include "renderer/modeling/texture/texture.h"
 
 // appleseed.foundation headers.
-#include "foundation/image/color.h"
 #include "foundation/image/tile.h"
 #include "foundation/math/hash.h"
 #include "foundation/math/scalar.h"

--- a/src/appleseed/renderer/modeling/project/configuration.cpp
+++ b/src/appleseed/renderer/modeling/project/configuration.cpp
@@ -300,8 +300,6 @@ auto_release_ptr<Configuration> BaseConfigurationFactory::create_base_interactiv
     parameters.insert("spectrum_mode", "rgb");
     parameters.insert("sampling_mode", "qmc");
 
-    parameters.insert("passes", 1);
-
     parameters.insert("frame_renderer", "progressive");
     parameters.insert("sample_generator", "generic");
     parameters.insert("sample_renderer", "generic");

--- a/src/appleseed/renderer/utility/filesystem.cpp
+++ b/src/appleseed/renderer/utility/filesystem.cpp
@@ -1,0 +1,64 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Kevin Masson, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "filesystem.h"
+
+// appleseed.renderer headers.
+#include "renderer/global/globallogger.h"
+
+namespace bf = boost::filesystem;
+namespace bsys = boost::system;
+
+namespace renderer
+{
+
+void create_parent_directories(const bf::path& file_path)
+{
+    const bf::path parent_path = file_path.parent_path();
+
+    if (!parent_path.empty() && !bf::exists(parent_path))
+    {
+        bsys::error_code ec;
+        if (!bf::create_directories(parent_path, ec))
+        {
+            RENDERER_LOG_ERROR(
+                "could not create directory %s: %s",
+                parent_path.c_str(),
+                ec.message().c_str());
+        }
+    }
+}
+
+void create_parent_directories(const char* file_path)
+{
+    create_parent_directories(bf::path(file_path));
+}
+
+}       // namespace renderer
+

--- a/src/appleseed/renderer/utility/filesystem.cpp
+++ b/src/appleseed/renderer/utility/filesystem.cpp
@@ -61,4 +61,3 @@ void create_parent_directories(const char* file_path)
 }
 
 }       // namespace renderer
-

--- a/src/appleseed/renderer/utility/filesystem.h
+++ b/src/appleseed/renderer/utility/filesystem.h
@@ -1,0 +1,44 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Kevin Masson, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef APPLESEED_RENDERER_UTILITY_FILESYSTEM_H
+#define APPLESEED_RENDERER_UTILITY_FILESYSTEM_H
+
+// Boost headers.
+#include "boost/filesystem.hpp"
+
+namespace renderer
+{
+
+void create_parent_directories(const boost::filesystem::path& file_path);
+
+void create_parent_directories(const char* file_path);
+
+}       // namespace renderer
+
+#endif  // !APPLESEED_RENDERER_UTILITY_FILESYSTEM_H


### PR DESCRIPTION
- [x] Correctly write buffer weights in the checkpoint EXR
- [x] Correctly load weights from the checkpoint
- [x] Correctly save filtered AOVs
- [x] Correctly save un-filtered AOVs
- [x] Correctly load filtered AOVs
- [x] Correctly load un-filtered AOVs
- [x] Allow only `.exr` files for checkpoints
- [x] Add custom message when a checkpoint is invalid
- [x] Compatibility: Check for layer count 
- [x] Color AOVs: don't recreate the same image multiple times
- [x] Support for denoiser AOV
- [x] Reading: use a map containing for each subimage the layer name
- [x] After render finished, rename previously created checkpoint file to not override it
- [x] Restore and save from the frame 

#### Future Work
- Expose option in studio
- Save denoiser checkpoint in the same exr file
- Allow to resume progressive rendering
- Suggested by @est77 : Add checkpoint paths in the project file
- Handle interruption happening while writing a checkpoint file (a solution could be to stop Ctrl-C during that moment). 

#2355 