### PR TITLE
Use transformc() from OSL 1.8

### DIFF
--- a/src/appleseed.shaders/stdosl.h
+++ b/src/appleseed.shaders/stdosl.h
@@ -293,22 +293,144 @@ point rotate (point p, float angle, point a, point b)
 }
 
 
-
 // Color functions
 
 float luminance (color c) BUILTIN;
 color blackbody (float temperatureK) BUILTIN;
 color wavelength_color (float wavelength_nm) BUILTIN;
-color transformc (string from, string to, color c) BUILTIN;
-color transformc (string to, color c) { return transformc ("rgb", to, c); }
 
+// transformc() was implemented as a built-in in OSL 1.9, but in previous
+// versions is implemented here.
+
+color transformc (string to, color x)
+{
+    color rgb_to_hsv (color rgb) {  // See Foley & van Dam
+        float r = rgb[0], g = rgb[1], b = rgb[2];
+        float mincomp = min (r, min (g, b));
+        float maxcomp = max (r, max (g, b));
+        float delta = maxcomp - mincomp;  // chroma
+        float h, s, v;
+        v = maxcomp;
+        if (maxcomp > 0)
+            s = delta / maxcomp;
+        else s = 0;
+        if (s <= 0)
+            h = 0;
+        else {
+            if      (r >= maxcomp) h = (g-b) / delta;
+            else if (g >= maxcomp) h = 2 + (b-r) / delta;
+            else                   h = 4 + (r-g) / delta;
+            h /= 6;
+            if (h < 0)
+                h += 1;
+        }
+        return color (h, s, v);
+    }
+
+    color rgb_to_hsl (color rgb) {  // See Foley & van Dam
+        // First convert rgb to hsv, then to hsl
+        float minval = min (rgb[0], min (rgb[1], rgb[2]));
+        color hsv = rgb_to_hsv (rgb);
+        float maxval = hsv[2];   // v == maxval
+        float h = hsv[0], s, l = (minval+maxval) / 2;
+        if (minval == maxval)
+            s = 0;  // special 'achromatic' case, hue is 0
+        else if (l <= 0.5)
+            s = (maxval - minval) / (maxval + minval);
+        else
+            s = (maxval - minval) / (2 - maxval - minval);
+        return color (h, s, l);
+    }
+
+    color r;
+    if (to == "rgb" || to == "RGB")
+        r = x;
+    else if (to == "hsv")
+        r = rgb_to_hsv (x);
+    else if (to == "hsl")
+        r = rgb_to_hsl (x);
+    else if (to == "YIQ")
+        r = color (dot (vector(0.299,  0.587,  0.114), (vector)x),
+                   dot (vector(0.596, -0.275, -0.321), (vector)x),
+                   dot (vector(0.212, -0.523,  0.311), (vector)x));
+    else if (to == "XYZ")
+        r = color (dot (vector(0.412453, 0.357580, 0.180423), (vector)x),
+                   dot (vector(0.212671, 0.715160, 0.072169), (vector)x),
+                   dot (vector(0.019334, 0.119193, 0.950227), (vector)x));
+    else {
+        error ("Unknown color space \"%s\"", to);
+        r = x;
+    }
+    return r;
+}
+
+
+color transformc (string from, string to, color x)
+{
+    color hsv_to_rgb (color c) { // Reference: Foley & van Dam
+        float h = c[0], s = c[1], v = c[2];
+        color r;
+        if (s < 0.0001) {
+            r = v;
+        } else {
+            h = 6 * (h - floor(h));  // expand to [0..6)
+            int hi = (int)h;
+            float f = h - hi;
+            float p = v * (1-s);
+            float q = v * (1-s*f);
+            float t = v * (1-s*(1-f));
+            if      (hi == 0) r = color (v, t, p);
+            else if (hi == 1) r = color (q, v, p);
+            else if (hi == 2) r = color (p, v, t);
+            else if (hi == 3) r = color (p, q, v);
+            else if (hi == 4) r = color (t, p, v);
+            else              r = color (v, p, q);
+        }
+        return r;
+    }
+
+    color hsl_to_rgb (color c) {
+        float h = c[0], s = c[1], l = c[2];
+        // Easiest to convert hsl -> hsv, then hsv -> RGB (per Foley & van Dam)
+        float v = (l <= 0.5) ? (l * (1 + s)) : (l * (1 - s) + s);
+        color r;
+        if (v <= 0) {
+            r = 0;
+        } else {
+            float min = 2 * l - v;
+            s = (v - min) / v;
+            r = hsv_to_rgb (color (h, s, v));
+        }
+        return r;
+    }
+
+    color r;
+    if (from == "rgb" || from == "RGB")
+        r = x;
+    else if (from == "hsv")
+        r = hsv_to_rgb (x);
+    else if (from == "hsl")
+        r = hsl_to_rgb (x);
+    else if (from == "YIQ")
+        r = color (dot (vector(1,  0.9557,  0.6199), (vector)x),
+                   dot (vector(1, -0.2716, -0.6469), (vector)x),
+                   dot (vector(1, -1.1082,  1.7051), (vector)x));
+    else if (from == "XYZ")
+        r = color (dot (vector( 3.240479, -1.537150, -0.498535), (vector)x),
+                   dot (vector(-0.969256,  1.875991,  0.041556), (vector)x),
+                   dot (vector( 0.055648, -0.204043,  1.057311), (vector)x));
+    else {
+        error ("Unknown color space \"%s\"", to);
+        r = x;
+    }
+    return transformc (to, r);
+}
 
 
 // Matrix functions
 
 float determinant (matrix m) BUILTIN;
 matrix transpose (matrix m) BUILTIN;
-
 
 
 // Pattern generation


### PR DESCRIPTION
OSL 1.9 implements the ability to do OCIO transforms in transformc(),
which means transformc() is now a BUILTIN, but previous versions require
transformc() to be implemented in the header.