### PR TITLE
Fix invalid noise values in empty areas

### DIFF
--- a/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
+++ b/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
@@ -470,7 +470,7 @@ namespace
             create_direct_link("adaptive_sampler.max_samples",              "adaptive_pixel_renderer.max_samples");
             create_direct_link("adaptive_sampler.quality",                  "adaptive_pixel_renderer.quality");
 
-            create_direct_link("adaptive_tile_sampler.min_samples",         "adaptive_tile_renderer.min_samples");
+            create_direct_link("adaptive_tile_sampler.batch_size",          "adaptive_tile_renderer.batch_size");
             create_direct_link("adaptive_tile_sampler.max_samples",         "adaptive_tile_renderer.max_samples");
             create_direct_link("adaptive_tile_sampler.noise_threshold",     "adaptive_tile_renderer.noise_threshold");
             create_direct_link("adaptive_tile_sampler.adaptiveness",        "adaptive_tile_renderer.adaptiveness");
@@ -546,8 +546,12 @@ namespace
             parent->addLayout(layout);
 
             create_image_plane_sampling_uniform_sampler_settings(layout);
-            create_image_plane_sampling_adaptive_sampler_settings(layout);
-            create_image_plane_sampling_adaptive_tile_sampler_settings(layout);
+
+            QHBoxLayout* next_layout = create_horizontal_layout();
+            parent->addLayout(next_layout);
+
+            create_image_plane_sampling_adaptive_tile_sampler_settings(next_layout);
+            create_image_plane_sampling_adaptive_sampler_settings(next_layout);
         }
 
         void create_image_plane_sampling_uniform_sampler_settings(QHBoxLayout* parent)
@@ -614,9 +618,9 @@ namespace
             QFormLayout* sublayout = create_form_layout();
             layout->addLayout(sublayout);
 
-            QSpinBox* min_samples = create_integer_input("adaptive_tile_sampler.min_samples", 1, 1000000, 1);
-            min_samples->setToolTip(m_params_metadata.get_path("adaptive_tile_renderer.min_samples.help"));
-            sublayout->addRow("Min Samples:", min_samples);
+            QSpinBox* batch_size = create_integer_input("adaptive_tile_sampler.batch_size", 1, 1000000, 1);
+            batch_size->setToolTip(m_params_metadata.get_path("adaptive_tile_renderer.batch_size.help"));
+            sublayout->addRow("Batch Size:", batch_size);
 
             QSpinBox* max_samples = create_integer_input("adaptive_tile_sampler.max_samples", 1, 1000000, 1);
             max_samples->setToolTip(m_params_metadata.get_path("adaptive_tile_renderer.max_samples.help"));

--- a/src/appleseed/foundation/image/filteredtile.cpp
+++ b/src/appleseed/foundation/image/filteredtile.cpp
@@ -179,14 +179,19 @@ float FilteredTile::compute_weighted_pixel_variance(
     const float rcp_second_weight = second_weight == 0.0f ? 0.0f : 1.0f / second_weight;
 
     // Get colors and assign weights.
-    Color4f main_color(abs(main[0]), abs(main[1]), abs(main[2]), abs(main[3]));
+    Color4f main_color(main[0], main[1], main[2], main[3]);
     main_color *= rcp_main_weight;
 
-    Color4f second_color(abs(second[0]), abs(second[1]), abs(second[2]), abs(second[3]));
+    Color4f second_color(second[0], second[1], second[2], second[3]);
     second_color *= rcp_second_weight;
 
+    const float rgb = abs(main_color.r) + abs(main_color.g) + abs(main_color.b);
+
+    if (rgb == 0.0f)
+        return 0.0f;
+
     // Compute variance.
-    return fast_rcp_sqrt(main_color.r + main_color.g + main_color.b) * (
+    return fast_rcp_sqrt(rgb) * (
         abs(main_color.r - second_color.r) +
         abs(main_color.g - second_color.g) +
         abs(main_color.b - second_color.b));


### PR DESCRIPTION
- Lower the convergence warning threshold
- Adjust the convergence warning message
- Rename min_samples to batch_size
- Store block's noise into the pixel_variation AOV
- Change the rendering settings window layout
