### PR TITLE
Move render passes metadata to top level configuration

### DIFF
--- a/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
@@ -541,14 +541,6 @@ Dictionary GenericFrameRendererFactory::get_params_metadata()
     Dictionary metadata;
 
     metadata.dictionaries().insert(
-        "passes",
-        Dictionary()
-            .insert("type", "int")
-            .insert("default", "1")
-            .insert("label", "Passes")
-            .insert("help", "Number of render passes"));
-
-    metadata.dictionaries().insert(
         "tile_ordering",
         Dictionary()
             .insert("type", "enum")

--- a/src/appleseed/renderer/modeling/project/configuration.cpp
+++ b/src/appleseed/renderer/modeling/project/configuration.cpp
@@ -153,6 +153,14 @@ Dictionary Configuration::get_metadata()
                             .insert("label", "QMC")
                             .insert("help", "Quasi Monte Carlo sampler"))));
 
+    metadata.dictionaries().insert(
+        "passes",
+        Dictionary()
+            .insert("type", "int")
+            .insert("default", "1")
+            .insert("label", "Passes")
+            .insert("help", "Number of render passes"));
+
     metadata.insert(
         "lighting_engine",
         Dictionary()


### PR DESCRIPTION
To match the new location of the param in the configuration dict.
```
x> import appleseed as asr
x> print asr.Configuration.get_metadata()['passes']
{'default': 1.0, 'type': 'int', 'help': 'Number of render passes', 'label': 'Passes'}
```