### PR TITLE
Misc work

### DIFF
--- a/src/appleseed.python/bindassembly.cpp
+++ b/src/appleseed.python/bindassembly.cpp
@@ -136,7 +136,8 @@ void bind_assembly()
         .def("texture_instances", &BaseGroup::texture_instances, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("shader_groups", &BaseGroup::shader_groups, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("assemblies", &BaseGroup::assemblies, bpy::return_value_policy<bpy::reference_existing_object>())
-        .def("assembly_instances", &BaseGroup::assembly_instances, bpy::return_value_policy<bpy::reference_existing_object>());
+        .def("assembly_instances", &BaseGroup::assembly_instances, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("clear", &BaseGroup::clear);
 
     bpy::class_<Assembly, auto_release_ptr<Assembly>, bpy::bases<Entity, BaseGroup>, boost::noncopyable>("Assembly", bpy::no_init)
         .def("__init__", bpy::make_constructor(create_assembly))
@@ -151,6 +152,7 @@ void bind_assembly()
         .def("objects", &Assembly::objects, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("object_instances", &Assembly::object_instances, bpy::return_value_policy<bpy::reference_existing_object>())
         .def("volumes", &Assembly::volumes, bpy::return_value_policy<bpy::reference_existing_object>())
+        .def("clear", &Assembly::clear)
         .def("compute_local_bbox", &Assembly::compute_local_bbox)
         .def("compute_non_hierarchical_local_bbox", &Assembly::compute_non_hierarchical_local_bbox);
 

--- a/src/appleseed/renderer/kernel/intersection/assemblytree.h
+++ b/src/appleseed/renderer/kernel/intersection/assemblytree.h
@@ -32,7 +32,9 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/intersection/curvetree.h"
+#ifdef APPLESEED_WITH_EMBREE
 #include "renderer/kernel/intersection/embreescene.h"
+#endif
 #include "renderer/kernel/intersection/probevisitorbase.h"
 #include "renderer/kernel/intersection/regiontree.h"
 #include "renderer/kernel/intersection/treerepository.h"

--- a/src/appleseed/renderer/kernel/intersection/embreescene.h
+++ b/src/appleseed/renderer/kernel/intersection/embreescene.h
@@ -29,7 +29,6 @@
 #ifndef APPLESEED_RENDERER_KERNEL_INTERSECTION_EMBREESCENE_H
 #define APPLESEED_RENDERER_KERNEL_INTERSECTION_EMBREESCENE_H
 
-#ifdef APPLESEED_WITH_EMBREE
 
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
@@ -38,9 +37,13 @@
 #include "renderer/modeling/scene/objectinstance.h"
 
 // appleseed.foundation headers.
+#include "foundation/core/concepts/noncopyable.h"
 #include "foundation/utility/lazy.h"
 #include "foundation/utility/poolallocator.h"
 #include "foundation/utility/uid.h"
+
+// Embree headers.
+#include <embree3/rtcore.h>
 
 // Standard headers.
 #include <map>
@@ -55,9 +58,14 @@ namespace renderer { class ShadingRay; }
 namespace renderer
 {
 
+class EmbreeGeometryData;
+
+typedef std::vector<std::unique_ptr<EmbreeGeometryData>>  EmbreeGeometryDataContainer;
+
 class EmbreeScene;
 
 class EmbreeDevice
+  : public foundation::NonCopyable
 {
   public:
     EmbreeDevice();
@@ -66,11 +74,11 @@ class EmbreeDevice
   private:
     friend class EmbreeScene;
 
-    struct Impl;
-    Impl* impl;
+    RTCDevice m_device;
 };
 
 class EmbreeScene
+  : public foundation::NonCopyable
 {
   public:
     struct Arguments
@@ -94,8 +102,9 @@ class EmbreeScene
     bool occlude(const ShadingRay& shading_ray) const;
 
   private:
-    struct Impl;
-    Impl* impl;
+    RTCDevice                   m_device;
+    RTCScene                    m_scene;
+    EmbreeGeometryDataContainer m_geometry_container;
 };
 
 typedef std::map<
@@ -134,5 +143,4 @@ class EmbreeSceneFactory
 
 }       // namespace renderer
 
-#endif  // APPLESEED_WITH_EMBREE
 #endif  // !APPLESEED_RENDERER_KERNEL_INTERSECTION_EMBREESCENE_H

--- a/src/appleseed/renderer/kernel/intersection/intersector.h
+++ b/src/appleseed/renderer/kernel/intersection/intersector.h
@@ -32,7 +32,9 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/intersection/curvetree.h"
+#ifdef APPLESEED_WITH_EMBREE
 #include "renderer/kernel/intersection/embreescene.h"
+#endif
 #include "renderer/kernel/intersection/intersectionsettings.h"
 #include "renderer/kernel/intersection/regiontree.h"
 #include "renderer/kernel/intersection/triangletree.h"

--- a/src/appleseed/renderer/modeling/scene/assembly.cpp
+++ b/src/appleseed/renderer/modeling/scene/assembly.cpp
@@ -178,6 +178,21 @@ VolumeContainer& Assembly::volumes() const
     return impl->m_volumes;
 }
 
+void Assembly::clear()
+{
+    BaseGroup::clear();
+
+    impl->m_bsdfs.clear();
+    impl->m_bssrdfs.clear();
+    impl->m_edfs.clear();
+    impl->m_surface_shaders.clear();
+    impl->m_materials.clear();
+    impl->m_lights.clear();
+    impl->m_objects.clear();
+    impl->m_object_instances.clear();
+    impl->m_volumes.clear();
+}
+
 GAABB3 Assembly::compute_local_bbox() const
 {
     GAABB3 bbox = compute_non_hierarchical_local_bbox();

--- a/src/appleseed/renderer/modeling/scene/assembly.h
+++ b/src/appleseed/renderer/modeling/scene/assembly.h
@@ -117,6 +117,9 @@ class APPLESEED_DLLSYMBOL Assembly
     // Access the volumes.
     VolumeContainer& volumes() const;
 
+    // Clear the assembly contents.
+    void clear();
+
     // Return true if this assembly is tagged as flushable.
     bool is_flushable() const;
 

--- a/src/appleseed/renderer/modeling/scene/basegroup.cpp
+++ b/src/appleseed/renderer/modeling/scene/basegroup.cpp
@@ -98,6 +98,16 @@ ShaderGroupContainer& BaseGroup::shader_groups() const
     return impl->m_shader_groups;
 }
 
+void BaseGroup::clear()
+{
+    impl->m_colors.clear();
+    impl->m_textures.clear();
+    impl->m_texture_instances.clear();
+    impl->m_shader_groups.clear();
+    impl->m_assemblies.clear();
+    impl->m_assembly_instances.clear();
+}
+
 bool BaseGroup::create_optimized_osl_shader_groups(
     OSLShadingSystem&           shading_system,
     IAbortSwitch*               abort_switch)

--- a/src/appleseed/renderer/modeling/scene/basegroup.h
+++ b/src/appleseed/renderer/modeling/scene/basegroup.h
@@ -74,6 +74,9 @@ class APPLESEED_DLLSYMBOL BaseGroup
     // Access the OSL shader groups.
     ShaderGroupContainer& shader_groups() const;
 
+    // Clear the base group contents.
+    void clear();
+
     // Create OSL shader groups and optimize them.
     bool create_optimized_osl_shader_groups(
         OSLShadingSystem&           shading_system,

--- a/src/appleseed/renderer/modeling/scene/scene.cpp
+++ b/src/appleseed/renderer/modeling/scene/scene.cpp
@@ -31,7 +31,9 @@
 #include "scene.h"
 
 // appleseed.renderer headers.
+#ifdef APPLESEED_WITH_EMBREE
 #include "renderer/kernel/intersection/embreescene.h"
+#endif
 #include "renderer/modeling/camera/camera.h"
 #include "renderer/modeling/color/colorentity.h"
 #include "renderer/modeling/environmentedf/environmentedf.h"


### PR DESCRIPTION
Added BaseGroup and Assembly clear method: 
- Useful to implement interactive updates of instancers in plugins.

Embree cleanups:
- Remove extra ray origin and dir copy.
- Remove unnecesary impl classes and levels of indirection to access some member variables.
- Move APPLESEED_WITH_EMBREE checks where they are needed, like other optional features.
