### PR TITLE
Do not store zero weight in `Foundation::cdf`

### DIFF
--- a/src/appleseed/foundation/math/cdf.h
+++ b/src/appleseed/foundation/math/cdf.h
@@ -181,7 +181,8 @@ template <typename Item, typename Weight>
 inline void CDF<Item, Weight>::insert(const Item& item, const Weight weight)
 {
     assert(weight >= Weight(0.0));
-    if(weight > Weight(0.0)){
+    if (weight > Weight(0.0))
+    {
         m_items.push_back(std::make_pair(item, weight));
         m_weight_sum += weight;
     }

--- a/src/appleseed/foundation/math/cdf.h
+++ b/src/appleseed/foundation/math/cdf.h
@@ -181,8 +181,10 @@ template <typename Item, typename Weight>
 inline void CDF<Item, Weight>::insert(const Item& item, const Weight weight)
 {
     assert(weight >= Weight(0.0));
-    m_items.push_back(std::make_pair(item, weight));
-    m_weight_sum += weight;
+    if(weight > Weight(0.0)){
+        m_items.push_back(std::make_pair(item, weight));
+        m_weight_sum += weight;
+    }
 }
 
 template <typename Item, typename Weight>


### PR DESCRIPTION
#1993 
> Should this be done by users of `foundation::CDF`?

I thought it may force to make pair `if clause(if weight > 0)` with `cdf::insert()` in future usage. It doesn't seem good to me, so I chose to change `cdf::insert()` rather than change _users_ of `cdf`. 

Feedback appreciated :)
