### PR TITLE
Normalize Pixel Sample Count AOV depending on sampling settings

### DIFF
--- a/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/adaptivepixelrenderer.cpp
@@ -43,6 +43,7 @@
 #include "renderer/kernel/rendering/shadingresultframebuffer.h"
 #include "renderer/kernel/shading/shadingresult.h"
 #include "renderer/modeling/aov/aov.h"
+#include "renderer/modeling/aov/diagnosticaov.h"
 #include "renderer/modeling/frame/frame.h"
 #include "renderer/utility/settingsparsing.h"
 
@@ -94,6 +95,17 @@ namespace
         {
             m_variation_aov_index = frame.aovs().get_index("pixel_variation");
             m_sample_aov_index = frame.aovs().get_index("pixel_sample_count");
+
+            // Send sampling parameters to the sample count AOV.
+            if (m_sample_aov_index != ~size_t(0))
+            {
+                PixelSampleCountAOV* sample_aov =
+                    static_cast<PixelSampleCountAOV*>(
+                        frame.aovs().get_by_index(m_sample_aov_index));
+
+                // The AOV takes care of normalizing values depending on sampling parameters.
+                sample_aov->set_normalization_range(m_params.m_min_samples, m_params.m_max_samples);
+            }
         }
 
         void release() override

--- a/src/appleseed/renderer/kernel/rendering/final/adaptivetilerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/adaptivetilerenderer.cpp
@@ -43,6 +43,7 @@
 #include "renderer/kernel/rendering/shadingresultframebuffer.h"
 #include "renderer/kernel/shading/shadingresult.h"
 #include "renderer/modeling/aov/aov.h"
+#include "renderer/modeling/aov/diagnosticaov.h"
 #include "renderer/modeling/frame/frame.h"
 #include "renderer/utility/settingsparsing.h"
 
@@ -246,6 +247,17 @@ namespace
 
             m_sample_aov_index = frame.aovs().get_index("pixel_sample_count");
             m_variation_aov_index = frame.aovs().get_index("pixel_variation");
+
+            // Send sampling parameters to the sample count AOV.
+            if (m_sample_aov_index != ~size_t(0))
+            {
+                PixelSampleCountAOV* sample_aov =
+                    static_cast<PixelSampleCountAOV*>(
+                        frame.aovs().get_by_index(m_sample_aov_index));
+
+                // The AOV takes care of normalizing values depending on sampling parameters.
+                sample_aov->set_normalization_range(m_params.m_min_samples, m_params.m_max_samples);
+            }
         }
 
         void release() override

--- a/src/appleseed/renderer/kernel/rendering/final/uniformpixelrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/uniformpixelrenderer.cpp
@@ -33,6 +33,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
 #include "renderer/global/globaltypes.h"
+#include "renderer/kernel/aov/aovaccumulator.h"
 #include "renderer/kernel/aov/imagestack.h"
 #include "renderer/kernel/rendering/final/pixelsampler.h"
 #include "renderer/kernel/rendering/isamplerenderer.h"
@@ -40,6 +41,8 @@
 #include "renderer/kernel/rendering/pixelrendererbase.h"
 #include "renderer/kernel/rendering/shadingresultframebuffer.h"
 #include "renderer/kernel/shading/shadingresult.h"
+#include "renderer/modeling/aov/aov.h"
+#include "renderer/modeling/aov/diagnosticaov.h"
 #include "renderer/modeling/frame/frame.h"
 #include "renderer/utility/settingsparsing.h"
 
@@ -98,6 +101,19 @@ namespace
                         m_sqrt_sample_count,
                         m_sqrt_sample_count);
                 }
+            }
+
+            const size_t sample_aov_index = frame.aovs().get_index("pixel_sample_count");
+
+            // If the sample count AOV is enabled, we need to reset its normalization
+            // range in case an adaptive render was done previously.
+            if (sample_aov_index != ~size_t(0))
+            {
+                PixelSampleCountAOV* sample_aov =
+                    static_cast<PixelSampleCountAOV*>(
+                        frame.aovs().get_by_index(sample_aov_index));
+
+                sample_aov->set_normalization_range(0, 0);
             }
         }
 

--- a/src/appleseed/renderer/modeling/aov/diagnosticaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/diagnosticaov.cpp
@@ -292,7 +292,7 @@ namespace
 
 
 //
-// Diagnostic AOV class implementation.
+// DiagnosticAOV class implementation.
 //
 
 DiagnosticAOV::DiagnosticAOV(const char* name, const ParamArray& params)
@@ -312,7 +312,7 @@ size_t DiagnosticAOV::get_channel_count() const
 
 const char** DiagnosticAOV::get_channel_names() const
 {
-    static const char* ChannelNames[] = {"R", "G", "B"};
+    static const char* ChannelNames[] = { "R", "G", "B" };
     return ChannelNames;
 }
 
@@ -413,18 +413,20 @@ void PixelSampleCountAOV::post_process_image(const AABB2u& crop_window)
     static const Color3f Blue(0.0f, 0.0f, 1.0f);
     static const Color3f Red(1.0f, 0.0f, 0.0f);
 
+    //
     // At this point, the AOV is filled with real sample/pixel count values.
     //
-    // We want to normalize it so that high sample/pixel count are red and
-    // low sample/pixel count are blue.
+    // We want to normalize it so that high sample/pixel counts are red and
+    // low sample/pixel counts are blue.
     //
-    // If the renderer is uniform, the AOV should be empty
-    // and the exported AOV will be completely red.
+    // If the Uniform Pixel Renderer is used, the AOV should be empty and
+    // the exported AOV will be completely red.
     //
-    // Otherwise, if the renderer is adaptive we use
-    // the user min and max sample/pixel count to determine the final color.
-    // If the user max sample/pixel count is 0 (infinite) then we use the
-    // actual max sample/pixel count.
+    // Otherwise, if the Adaptive Tile Renderer is used, we use the user's
+    // min and max sample/pixel counts to determine the final color. If the
+    // user's max sample/pixel count is 0 (infinite) then we use the actual
+    // max sample/pixel count found in the image.
+    //
 
     const float min_spp = static_cast<float>(m_min_spp);
     const float max_spp =

--- a/src/appleseed/renderer/modeling/aov/diagnosticaov.h
+++ b/src/appleseed/renderer/modeling/aov/diagnosticaov.h
@@ -30,22 +30,81 @@
 #define APPLESEED_RENDERER_MODELING_AOV_DIAGNOSTICAOV_H
 
 // appleseed.renderer headers.
+#include "renderer/kernel/aov/aovaccumulator.h"
+#include "renderer/kernel/aov/imagestack.h"
+#include "renderer/modeling/aov/aov.h"
 #include "renderer/modeling/aov/iaovfactory.h"
 
 // appleseed.foundation headers.
+#include "foundation/math/aabb.h"
 #include "foundation/utility/autoreleaseptr.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
 
+// Standard headers.
+#include <cstddef>
+
 // Forward declarations.
 namespace foundation    { class Dictionary; }
 namespace foundation    { class DictionaryArray; }
-namespace renderer      { class AOV; }
 namespace renderer      { class ParamArray; }
 
 namespace renderer
 {
+
+//
+// Diagnostic AOV.
+//
+
+class DiagnosticAOV
+  : public AOV
+{
+  public:
+    DiagnosticAOV(const char* name, const ParamArray& params);
+
+    void release() override;
+
+    size_t get_channel_count() const override;
+
+    const char** get_channel_names() const override;
+
+    bool has_color_data() const override;
+
+    void create_image(
+        const size_t canvas_width,
+        const size_t canvas_height,
+        const size_t tile_width,
+        const size_t tile_height,
+        ImageStack&  aov_images) override;
+
+    void clear_image() override;
+
+    foundation::auto_release_ptr<AOVAccumulator> create_accumulator() const override;
+};
+
+
+//
+// Pixel Sample Count AOV.
+//
+
+class PixelSampleCountAOV
+  : public DiagnosticAOV
+{
+  public:
+    explicit PixelSampleCountAOV(const ParamArray& params);
+
+    const char* get_model() const override;
+
+    void post_process_image(const foundation::AABB2u& crop_window) override;
+
+    void set_normalization_range(const size_t min_spp, const size_t max_spp);
+
+  private:
+    size_t m_min_spp;
+    size_t m_max_spp;
+};
+
 
 //
 // A factory for invalid sample AOVs.

--- a/src/appleseed/renderer/modeling/aov/diagnosticaov.h
+++ b/src/appleseed/renderer/modeling/aov/diagnosticaov.h
@@ -31,7 +31,6 @@
 
 // appleseed.renderer headers.
 #include "renderer/kernel/aov/aovaccumulator.h"
-#include "renderer/kernel/aov/imagestack.h"
 #include "renderer/modeling/aov/aov.h"
 #include "renderer/modeling/aov/iaovfactory.h"
 
@@ -48,6 +47,7 @@
 // Forward declarations.
 namespace foundation    { class Dictionary; }
 namespace foundation    { class DictionaryArray; }
+namespace renderer      { class ImageStack; }
 namespace renderer      { class ParamArray; }
 
 namespace renderer


### PR DESCRIPTION
fix #2222 
**Edge case tested:**
What happens if you render using adaptive rendering and then render using uniform rendering ? Are AOVs recreated when settings are changed ? Is the output AOV red or not ?