### PR TITLE
Hide node input in node editor (maya, blender, gaffer)

### DIFF
--- a/src/appleseed.shaders/src/appleseed/as_blackbody.osl
+++ b/src/appleseed.shaders/src/appleseed/as_blackbody.osl
@@ -277,10 +277,9 @@ shader as_blackbody
     if (in_specular_amount > 0.0 && in_ior > 1.0)
     {
         // Dielectric coating, so the Schlick approximation suffices.
-        vector In = normalize(I);
         normal Nn = normalize(in_bump_normal);
 
-        float costheta_o = dot(-In, Nn);
+        float costheta_o = dot(-I, Nn);
 
         float R0 = sqr((in_ior - 1.0) / (in_ior + 1.0));
         float Kr = R0 + (1.0 - R0) * pow(1.0 - costheta_o, 5.0);

--- a/src/appleseed.shaders/src/appleseed/as_fresnel.osl
+++ b/src/appleseed.shaders/src/appleseed/as_fresnel.osl
@@ -172,7 +172,7 @@ shader as_fresnel
 
         if (exterior_medium_ior != 1.0)
         {
-            float costheta = dot(normalize(N), -normalize(I));
+            float costheta = dot(normalize(N), -I);
 
             Kr = dielectricDielectricFresnel(
                     exterior_medium_ior,
@@ -184,7 +184,7 @@ shader as_fresnel
             float Kt;
 
             fresnel(
-                normalize(I),
+                I,
                 normalize(N),
                 backfacing() ? in_ior : 1.0 / in_ior,
                 Kr,
@@ -208,7 +208,7 @@ shader as_fresnel
             k = color(in_complex_kappa);
         }
 
-        float costheta = dot(normalize(N), -normalize(I));
+        float costheta = dot(normalize(N), -I);
 
         for (int i = 0; i < 3; ++i)
         {

--- a/src/appleseed.shaders/src/appleseed/as_metal.osl
+++ b/src/appleseed.shaders/src/appleseed/as_metal.osl
@@ -93,7 +93,12 @@ shader as_metal
         string label = "Energy Compensation",
         string page = "Specular",
         string help = "Energy compensation, to account for energy loss with high roughness. Valid for Beckmann and GGX MDF only.",
-        string widget = "null"
+        string widget = "null",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0
     ]],
     float in_anisotropy_amount = 0.0
     [[

--- a/src/appleseed.shaders/src/appleseed/as_sbs_pbrmaterial.osl
+++ b/src/appleseed.shaders/src/appleseed/as_sbs_pbrmaterial.osl
@@ -430,7 +430,7 @@ shader as_sbs_pbrmaterial
             float F0 = in_specularLevel * 0.08; // from MDL (dielectric)
             float F90 = 1.0;
 
-            float tmp = 1.0 - max(0.0, dot(normalize(-I), Nn));
+            float tmp = 1.0 - max(0.0, dot(-I, Nn));
             float F = (tmp > 0.0) ? F0 + (F90 - F0) * pow(tmp, 5.0) : 0.0;
 
             bsdf *= 1.0 - F;

--- a/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
@@ -606,13 +606,11 @@ shader as_standard_surface
 
     if (compute_coating)
     {
-        vector In = normalize(I);
-
         normal Nn = isconnected(in_bump_normal_coating)
             ? normalize(in_bump_normal_coating)
             : normalize(in_bump_normal_substrate);
 
-        float costheta_o = dot(-In, Nn);
+        float costheta_o = dot(-I, Nn);
 
         if (in_coating_ior > 1.0)
         {
@@ -760,7 +758,7 @@ shader as_standard_surface
         if ((compute_diffuse || compute_bssrdf || compute_edf ||
             compute_translucency) && max(in_specular_color) > 0.0)
         {
-            float costheta_o = dot(-normalize(I), Nn);
+            float costheta_o = dot(-I, Nn);
 
             if (in_fresnel_type == 0)
             {

--- a/src/appleseed.shaders/src/appleseed/as_toon.osl
+++ b/src/appleseed.shaders/src/appleseed/as_toon.osl
@@ -863,7 +863,7 @@ shader as_toon
         {
             int status = getattribute("surface_shader:emission", emission_term);
 
-            float facing_ratio = dot(normalize(-I), normalize(in_bump_normal));
+            float facing_ratio = dot(-I, normalize(in_bump_normal));
             float attenuation = (in_incandescence_attenuation * 4.0) + 1.0;
 
             facing_ratio = pow(max(0.0, facing_ratio), attenuation);
@@ -967,8 +967,7 @@ shader as_toon
             float diffuse_Y = clamp(luminance(rim_term), 0.0, 1.0);
             float mixing = smoothstep(0.5, 0.9, diffuse_Y);
 
-            float facing = 1.0 - max(0.0, dot(normalize(in_bump_normal),
-                                              normalize(-I)));
+            float facing = 1.0 - max(0.0, dot(normalize(in_bump_normal), -I));
 
             float rim_factor = mixing *
                 pow(facing, max(2.0, sqrt(in_rim_softness) * 10));
@@ -1030,7 +1029,7 @@ shader as_toon
             if (in_facing_attenuation > 0.0)
             {
                 float cos_theta_o = max(0.0,
-                    dot(normalize(-I), normalize(in_bump_normal)));
+                    dot(-I, normalize(in_bump_normal)));
 
                 float tmp = 1.0 - in_facing_attenuation;
                 float F = tmp + (1.0 - tmp) * (1.0 - pow(cos_theta_o, 5));

--- a/src/appleseed.shaders/src/maya/as_maya_anisotropic.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_anisotropic.osl
@@ -259,7 +259,7 @@ shader as_maya_anisotropic
         {
             transparency = mix(
                 transparency,
-                abs(dot(-normalize(I), normalize(in_normalCamera))),
+                abs(dot(-I, normalize(in_normalCamera))),
                 in_shadowAttenuation
                 );
         }

--- a/src/appleseed.shaders/src/maya/as_maya_blinn.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_blinn.osl
@@ -211,7 +211,7 @@ shader as_maya_blinn
         {
             transparency = mix(
                 transparency,
-                abs(dot(-normalize(I), normalize(in_normalCamera))),
+                abs(dot(-I, normalize(in_normalCamera))),
                 in_shadowAttenuation
                 );
         }

--- a/src/appleseed.shaders/src/maya/as_maya_cloud.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_cloud.osl
@@ -217,7 +217,7 @@ shader as_maya_cloud
         out_outColor = mix(in_color2, color_blend, 1.0 - weight);
         out_outAlpha = weight;
 
-        float cos_wo = dot(normalize(-I), normalize(in_normalCamera));
+        float cos_wo = dot(-I, normalize(in_normalCamera));
 
         float facing_ratio = (cos_wo >= EPS)
             ? sqrt(1.0 - max(EPS, sqr(cos_wo)))

--- a/src/appleseed.shaders/src/maya/as_maya_lambert.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_lambert.osl
@@ -175,7 +175,7 @@ shader as_maya_lambert
         {
             transparency = mix(
                 transparency,
-                abs(dot(-normalize(I), normalize(in_normalCamera))),
+                abs(dot(-I, normalize(in_normalCamera))),
                 in_shadowAttenuation);
         }
 

--- a/src/appleseed.shaders/src/maya/as_maya_phong.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_phong.osl
@@ -215,7 +215,7 @@ shader as_maya_phong
         {
             transparency = mix(
                 transparency,
-                abs(dot(-normalize(I), normalize(in_normalCamera))),
+                abs(dot(-I, normalize(in_normalCamera))),
                 in_shadowAttenuation
                 );
         }

--- a/src/appleseed.shaders/src/maya/as_maya_phongE.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_phongE.osl
@@ -223,7 +223,7 @@ shader as_maya_phongE
         {
             transparency = mix(
                 transparency,
-                abs(dot(-normalize(I), normalize(in_normalCamera))),
+                abs(dot(-I, normalize(in_normalCamera))),
                 in_shadowAttenuation
                 );
         }

--- a/src/appleseed.shaders/src/maya/as_maya_samplerInfo.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_samplerInfo.osl
@@ -161,5 +161,5 @@ shader as_maya_samplerInfo
 
     out_flippedNormal = backfacing();
 
-    out_facingRatio = max(0, dot(normalize(-I), normalize(N)));
+    out_facingRatio = max(0, dot(-I, normalize(N)));
 }


### PR DESCRIPTION
Metal had a null widget for energy conservation since this was not be exposed to the user, but the node editor input socket was still visible if you expanded the attributes in Maya.
Added the token to disable and hide this input socket in Maya, Gaffer, Blender.
Max probably needs an similar metadata token to hide an existing input from the nodes in its graph editor.