### PR TITLE
Added functionality for closing Search Path Editor dialogue Box (#2277)

### DIFF
--- a/src/appleseed.studio/mainwindow/project/searchpathswindow.cpp
+++ b/src/appleseed.studio/mainwindow/project/searchpathswindow.cpp
@@ -101,7 +101,9 @@ SearchPathsWindow::SearchPathsWindow(
     connect(new QShortcut(QKeySequence(Qt::Key_Delete), this), SIGNAL(activated()), SLOT(slot_remove()));
     connect(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Up), this), SIGNAL(activated()), SLOT(slot_move_up()));
     connect(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Down), this), SIGNAL(activated()), SLOT(slot_move_down()));
-
+    connect(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Return), this), SIGNAL(activated()), SLOT(accept()));
+    connect(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Enter), this), SIGNAL(activated()), SLOT(accept()));
+    
     WindowBase::load_settings();
 
     // Project root path.


### PR DESCRIPTION
this fixes #2277. `CTRL + Enter`  or `CTRL + Return` now closes Search Path Editor dialogue box. @dictoon 