### PR TITLE
Fix standard surface handling of Oren Nayar BRDF diffuse albedo

### DIFF
--- a/sandbox/tests/test scenes/osl/_shaders/as_diffuse_surface.osl
+++ b/sandbox/tests/test scenes/osl/_shaders/as_diffuse_surface.osl
@@ -46,5 +46,5 @@ shader as_diffuse_surface
     output closure color BRDF = 0
 )
 {
-    BRDF = Reflectance * Color * oren_nayar(Normal, Roughness);
+    BRDF = Reflectance * oren_nayar(Color, Normal, Roughness);
 }

--- a/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
@@ -864,7 +864,7 @@ shader as_standard_surface
         if (max(diffuse_color) > 0.0)
         {
             out_outColor += transmittance * opacity *
-                diffuse_color * oren_nayar(Nn, in_diffuse_roughness);
+                oren_nayar(diffuse_color, Nn, in_diffuse_roughness);
         }
 
         color translucency_color = in_translucency_weight *

--- a/src/appleseed.shaders/stdosl.h
+++ b/src/appleseed.shaders/stdosl.h
@@ -550,7 +550,7 @@ string concat (string a, string b, string c, string d, string e, string f) {
 closure color emission() BUILTIN;
 closure color background() BUILTIN;
 closure color diffuse(normal N) BUILTIN;
-closure color oren_nayar (normal N, float sigma) BUILTIN;
+closure color oren_nayar (color albedo, normal N, float sigma) BUILTIN;
 closure color translucent(normal N) BUILTIN;
 closure color phong(normal N, float exponent) BUILTIN;
 //closure color ward(normal N, vector T,float ax, float ay) BUILTIN;

--- a/src/appleseed/renderer/kernel/shading/closures.cpp
+++ b/src/appleseed/renderer/kernel/shading/closures.cpp
@@ -946,6 +946,7 @@ namespace
     {
         struct Params
         {
+            OSL::Color3 diffuse_reflectance;
             OSL::Vec3   N;
             float       roughness;
         };
@@ -969,6 +970,7 @@ namespace
         {
             const OSL::ClosureParam params[] =
             {
+                CLOSURE_COLOR_PARAM(Params, diffuse_reflectance),
                 CLOSURE_VECTOR_PARAM(Params, N),
                 CLOSURE_FLOAT_PARAM(Params, roughness),
                 CLOSURE_FINISH_PARAM(Params)
@@ -997,7 +999,7 @@ namespace
                     p->N,
                     arena);
 
-            values->m_reflectance.set(1.0f);
+            values->m_reflectance.set(Color3f(p->diffuse_reflectance), g_std_lighting_conditions, Spectrum::Reflectance);
             values->m_reflectance_multiplier = 1.0f;
             values->m_roughness = max(p->roughness, 0.0f);
         }


### PR DESCRIPTION
Since the albedo/reflectance doesn't go linearly into the Oren Nayar we have to pass it from OSL down into the model.