### PR TITLE
Fix standard surface handling of Oren Nayar BRDF diffuse albedo

### DIFF
--- a/sandbox/tests/test scenes/osl/_shaders/as_diffuse_surface.oso
+++ b/sandbox/tests/test scenes/osl/_shaders/as_diffuse_surface.oso
@@ -1,24 +1,31 @@
 OpenShadingLanguage 1.00
-# Compiled by oslc 1.8.10
-# options: -O2 -DNDEBUG -I/home/est/Devel/appleseedhq/appleseed/src/appleseed.shaders/include -o /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/gaffer/surface/as_diffuse_surface.oso
+# Compiled by oslc 1.9.8
+# options: 
 shader as_diffuse_surface	%meta{string,help,"Diffuse surface shader"} 
-param	vector	Normal	0 0 0		%read{1,1} %write{0,0} %initexpr
-param	float	Reflectance	0.80000001		%meta{float,min,0}  %read{2,2} %write{2147483647,-1}
-param	color	Color	1 1 1		%read{2,2} %write{2147483647,-1}
-param	float	Roughness	0		%meta{string,help,"Surface roughness."} %meta{float,min,0} %meta{float,max,1}  %read{1,1} %write{2147483647,-1}
-oparam	closure color	BRDF			%read{2147483647,-1} %write{3,3}
+param	vector	Normal	0 0 0		%read{2,2} %write{0,0} %initexpr
+param	float	Reflectance	0.80000001		%meta{float,min,0}  %read{3,3} %write{2147483647,-1}
+param	color	Color	1 1 1		%read{3,3} %write{2147483647,-1}
+param	float	Roughness	0		%meta{string,help,"Surface roughness."} %meta{float,min,0} %meta{float,max,1}  %read{2,2} %write{2147483647,-1}
+oparam	closure color	BRDF			%read{2147483647,-1} %write{4,4}
 global	normal	N	%read{0,0} %write{2147483647,-1}
-temp	closure color	$tmp1	%read{3,3} %write{1,1}
+temp	closure color	$tmp1	%read{4,4} %write{2,2}
 const	string	$const1	"oren_nayar"		%read{1,1} %write{2147483647,-1}
-temp	color	$tmp2	%read{3,3} %write{2,2}
+const	color	$const2	1 1 1		%read{2,2} %write{2147483647,-1}
+const	string	$const3	"as_oren_nayar"		%read{2,2} %write{2147483647,-1}
+temp	color	$tmp3	%read{4,4} %write{3,3}
 code Normal
-# /home/est/Devel/appleseedhq/appleseed/src/appleseed.shaders/src/gaffer/surface/as_diffuse_surface.osl:34
+# as_diffuse_surface.osl:34
 #     vector               Normal = N,
-	assign		Normal N 	%filename{"/home/est/Devel/appleseedhq/appleseed/src/appleseed.shaders/src/gaffer/surface/as_diffuse_surface.osl"} %line{34} %argrw{"wr"}
+	assign		Normal N 	%filename{"as_diffuse_surface.osl"} %line{34} %argrw{"wr"}
 code ___main___
-# /home/est/Devel/appleseedhq/appleseed/src/appleseed.shaders/src/gaffer/surface/as_diffuse_surface.osl:49
+# as_diffuse_surface.osl:49
 #     BRDF = Reflectance * Color * oren_nayar(Normal, Roughness);
-	closure		$tmp1 $const1 Normal Roughness 	%filename{"/home/est/Devel/appleseedhq/appleseed/src/appleseed.shaders/src/gaffer/surface/as_diffuse_surface.osl"} %line{49} %argrw{"wrrr"}
-	mul		$tmp2 Reflectance Color 	%argrw{"wrr"}
-	mul		BRDF $tmp1 $tmp2 	%argrw{"wrr"}
+	functioncall	$const1 3 	%filename{"as_diffuse_surface.osl"} %line{49} %argrw{"r"}
+# /hdd/packages/appleseed/2.1.0/shaders/stdosl.h:555
+#     return as_oren_nayar(color(1.0), N, sigma);
+	closure		$tmp1 $const3 $const2 Normal Roughness 	%filename{"/hdd/packages/appleseed/2.1.0/shaders/stdosl.h"} %line{555} %argrw{"wrrrr"}
+# as_diffuse_surface.osl:49
+#     BRDF = Reflectance * Color * oren_nayar(Normal, Roughness);
+	mul		$tmp3 Reflectance Color 	%filename{"as_diffuse_surface.osl"} %line{49} %argrw{"wrr"}
+	mul		BRDF $tmp1 $tmp3 	%argrw{"wrr"}
 	end

--- a/src/appleseed.shaders/as_osl_extensions.h.in
+++ b/src/appleseed.shaders/as_osl_extensions.h.in
@@ -50,6 +50,11 @@ float max(color C)  { return max(C[0], max(C[1], C[2])); }
 float min(vector V) { return min(V[0], min(V[1], V[2])); }
 float max(vector V) { return max(V[0], max(V[1], V[2])); }
 
+closure color as_oren_nayar(
+    color       reflectance,
+    normal      N,
+    float       sigma) BUILTIN;
+
 closure color as_sheen(normal N) BUILTIN;
 
 closure color as_glossy(

--- a/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
@@ -864,7 +864,7 @@ shader as_standard_surface
         if (max(diffuse_color) > 0.0)
         {
             out_outColor += transmittance * opacity *
-                diffuse_color * oren_nayar(Nn, in_diffuse_roughness);
+                as_oren_nayar(diffuse_color, Nn, in_diffuse_roughness);
         }
 
         color translucency_color = in_translucency_weight *

--- a/src/appleseed.shaders/stdosl.h
+++ b/src/appleseed.shaders/stdosl.h
@@ -550,7 +550,10 @@ string concat (string a, string b, string c, string d, string e, string f) {
 closure color emission() BUILTIN;
 closure color background() BUILTIN;
 closure color diffuse(normal N) BUILTIN;
-closure color oren_nayar (normal N, float sigma) BUILTIN;
+closure color oren_nayar(normal N, float sigma)
+{
+    return as_oren_nayar(color(1.0), N, sigma);
+}
 closure color translucent(normal N) BUILTIN;
 closure color phong(normal N, float exponent) BUILTIN;
 //closure color ward(normal N, vector T,float ax, float ay) BUILTIN;

--- a/src/appleseed/renderer/kernel/shading/closures.cpp
+++ b/src/appleseed/renderer/kernel/shading/closures.cpp
@@ -946,13 +946,14 @@ namespace
     {
         struct Params
         {
+            OSL::Color3 reflectance;
             OSL::Vec3   N;
             float       roughness;
         };
 
         static const char* name()
         {
-            return "oren_nayar";
+            return "as_oren_nayar";
         }
 
         static ClosureID id()
@@ -969,6 +970,7 @@ namespace
         {
             const OSL::ClosureParam params[] =
             {
+                CLOSURE_COLOR_PARAM(Params, reflectance),
                 CLOSURE_VECTOR_PARAM(Params, N),
                 CLOSURE_FLOAT_PARAM(Params, roughness),
                 CLOSURE_FINISH_PARAM(Params)
@@ -997,9 +999,13 @@ namespace
                     p->N,
                     arena);
 
-            values->m_reflectance.set(1.0f);
+            const Color3f reflectance = Color3f(p->reflectance);
+            values->m_reflectance.set(reflectance, g_std_lighting_conditions, Spectrum::Reflectance);
             values->m_reflectance_multiplier = 1.0f;
             values->m_roughness = max(p->roughness, 0.0f);
+
+            const float w = luminance(weight) * luminance(reflectance);
+            composite_closure.override_closure_scalar_weight(w);
         }
     };
 


### PR DESCRIPTION
This PR is based on rbrune bug investigation and proposed fix: #2305

Because our implementation or Oren Nayar includes an interreflection term, we cannot use the albedo as a closure weight like we do for other OSL closures. We need to pass it as a closure parameter.

But oren_nayar() is a standard OSL closure and to maintain source compatibility with shaders written for other renderers, we cannot modify it.

- Added an as_oren_nayar(color, ...) closure that does the right thing.
- Use as_oren_nayar in the standard surface shader.
- Keep the standard OSL oren_nayar() closure as it is, for compatibility with OSL's spec.