### PR TITLE
Fix Oren Nayar diffuse model

### DIFF
--- a/src/appleseed/renderer/modeling/bsdf/orennayarbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/orennayarbrdf.cpp
@@ -150,7 +150,6 @@ namespace
                 sample.m_value.m_diffuse *= values->m_reflectance_multiplier * RcpPi<float>();
             }
             sample.m_value.m_beauty = sample.m_value.m_diffuse;
-            
             sample.m_max_roughness = 1.0f;
 
             // Compute the probability density of the sampled direction.
@@ -284,7 +283,6 @@ namespace
             r2 *=
                   0.17f
                 * square(reflectance_multiplier) * RcpPi<float>()
-                * cos_in
                 * sigma2 / (sigma2 + 0.13f)
                 * (1.0f - delta_cos_phi * square(2.0f * beta * RcpPi<float>()));
             value += r2;


### PR DESCRIPTION
The cos_in shading term seems to be a left over from a previous refactoring. It's not supposed to be there.