### PR TITLE
Revert "Don't store zero weight items in foundation::CDF"

### DIFF
--- a/src/appleseed/foundation/math/cdf.h
+++ b/src/appleseed/foundation/math/cdf.h
@@ -181,11 +181,8 @@ template <typename Item, typename Weight>
 inline void CDF<Item, Weight>::insert(const Item& item, const Weight weight)
 {
     assert(weight >= Weight(0.0));
-    if (weight > Weight(0.0))
-    {
-        m_items.push_back(std::make_pair(item, weight));
-        m_weight_sum += weight;
-    }
+    m_items.push_back(std::make_pair(item, weight));
+    m_weight_sum += weight;
 }
 
 template <typename Item, typename Weight>


### PR DESCRIPTION
This reverts commit f4c3657c5f06c1c225b5178c7e7a4847be72be02.