### PR TITLE
Array library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@
 # CMake configuration.
 #--------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
 
 cmake_policy (SET CMP0008 NEW)      # libraries linked by full-path must have a valid library file name
 
@@ -92,6 +92,26 @@ if (TARGET_ARCH MATCHES "i386|x86_64")
 else ()
     set (is_x86 FALSE)
 endif ()
+
+
+#--------------------------------------------------------------------------------------------------
+# Compiler features.
+#--------------------------------------------------------------------------------------------------
+
+include (WriteCompilerDetectionHeader)
+
+write_compiler_detection_header (
+  FILE ${PROJECT_SOURCE_DIR}/src/appleseed/foundation/platform/compilerfeatures.h
+  PREFIX APPLESEED
+  COMPILERS GNU Clang MSVC AppleClang
+  FEATURES
+    cxx_final
+    cxx_noexcept
+    cxx_constexpr
+    cxx_defaulted_functions
+    cxx_deleted_functions
+    cxx_generalized_initializers
+)
 
 
 #--------------------------------------------------------------------------------------------------

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -32,6 +32,27 @@
 # Source files.
 #--------------------------------------------------------------------------------------------------
 
+set (foundation_array_sources
+    foundation/array/algorithm.cpp
+    foundation/array/algorithm.h
+    foundation/array/applyvisitor.h
+    foundation/array/array.cpp
+    foundation/array/array.h
+    foundation/array/arrayref.h
+    foundation/array/arraytraits.h
+    foundation/array/arrayview.h
+    foundation/array/exception.cpp
+    foundation/array/exception.h
+    foundation/array/meshalgorithm.cpp
+    foundation/array/meshalgorithm.h
+)
+list (APPEND appleseed_sources
+    ${foundation_array_sources}
+)
+source_group ("foundation\\array" FILES
+    ${foundation_array_sources}
+)
+
 set (foundation_core_concepts_sources
     foundation/core/concepts/iunknown.h
     foundation/core/concepts/noncopyable.h
@@ -286,6 +307,7 @@ set (foundation_math_sources
     foundation/math/bvh.h
     foundation/math/cdf.h
     foundation/math/combination.h
+    foundation/math/compressedunitvector.h
     foundation/math/distance.h
     foundation/math/dual.h
     foundation/math/fastmath.h
@@ -410,6 +432,9 @@ source_group ("foundation\\meta\\benchmarks" FILES
 set (foundation_meta_tests_sources
     foundation/meta/tests/test_aabb.cpp
     foundation/meta/tests/test_analysis.cpp
+    foundation/meta/tests/test_array.cpp
+    foundation/meta/tests/test_arrayalgorithm.cpp
+    foundation/meta/tests/test_arrayapplyvisitor.cpp
     foundation/meta/tests/test_attributeset.cpp
     foundation/meta/tests/test_autoreleaseptr.cpp
     foundation/meta/tests/test_benchmarkaggregator.cpp
@@ -429,7 +454,9 @@ set (foundation_meta_tests_sources
     foundation/meta/tests/test_color.cpp
     foundation/meta/tests/test_colorspace.cpp
     foundation/meta/tests/test_commandlineparser.cpp
+    foundation/meta/tests/test_compressedunitvector.cpp
     foundation/meta/tests/test_concepts.cpp
+    foundation/meta/tests/test_copyonwrite.cpp
     foundation/meta/tests/test_countof.cpp
     foundation/meta/tests/test_datetime.cpp
     foundation/meta/tests/test_dictionary.cpp
@@ -827,6 +854,7 @@ set (foundation_utility_sources
     foundation/utility/casts.h
     foundation/utility/cc.h
     foundation/utility/commandlineparser.h
+    foundation/utility/copyonwrite.h
     foundation/utility/countof.h
     foundation/utility/filter.h
     foundation/utility/foreach.h

--- a/src/appleseed/foundation/array/algorithm.cpp
+++ b/src/appleseed/foundation/array/algorithm.cpp
@@ -1,0 +1,89 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// appleseed.foundation headers.
+#include "foundation/array/algorithm.h"
+#include "foundation/array/arraytraits.h"
+#include "foundation/platform/types.h"
+
+// Standard headers.
+#include <algorithm>
+
+namespace foundation
+{
+namespace
+{
+    template <typename SrcType, typename DstType>
+    void convert_array(Array& array)
+    {
+        Array tmp(ArrayTraits<DstType>::array_type());
+        tmp.reserve(array.size());
+
+        ArrayView<SrcType> src(array);
+        ArrayRef<DstType> dst(tmp);
+
+        std::copy(src.begin(), src.end(), std::back_inserter(dst));
+        array = std::move(tmp);
+    }
+}
+
+void convert_to_smallest_type(Array& array)
+{
+    if (array.empty())
+        return;
+
+    switch (array.type())
+    {
+      case UInt16Type:
+      {
+        const ArrayView<uint16> view(array);
+        const uint16 max_element = *std::max_element(view.begin(), view.end());
+
+        if (max_element <= std::numeric_limits<uint8>::max())
+            convert_array<uint16, uint8>(array);
+      }
+      break;
+
+      case UInt32Type:
+      {
+        const ArrayView<uint32> view(array);
+        const uint32 max_element = *std::max_element(view.begin(), view.end());
+
+        if (max_element <= std::numeric_limits<uint8>::max())
+            convert_array<uint32, uint8>(array);
+        else if (max_element <= std::numeric_limits<uint16>::max())
+            convert_array<uint32, uint16>(array);
+      }
+      break;
+
+      default:
+        break;
+    }
+}
+
+}       // namespace foundation

--- a/src/appleseed/foundation/array/algorithm.h
+++ b/src/appleseed/foundation/array/algorithm.h
@@ -1,0 +1,106 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/array/applyvisitor.h"
+#include "foundation/array/array.h"
+#include "foundation/array/arrayref.h"
+#include "foundation/array/arrayview.h"
+
+namespace foundation
+{
+namespace detail
+{
+
+template <typename RandomAccessIter>
+class CopyIndexedVisitor
+{
+  public:
+    CopyIndexedVisitor(
+        const Array&              src,
+        const RandomAccessIter    first_index,
+        const RandomAccessIter    last_index)
+      : m_src(src)
+      , m_first_index(first_index)
+      , m_last_index(last_index)
+    {
+    }
+
+    template <typename T>
+    void operator()(ArrayRef<T>& dst)
+    {
+        const ArrayView<T> src(m_src);
+
+        for (RandomAccessIter it = m_first_index; it != m_last_index; ++it)
+            dst.push_back(src[*it]);
+    }
+
+  private:
+    const Array&              m_src;
+    const RandomAccessIter    m_first_index;
+    const RandomAccessIter    m_last_index;
+};
+
+}       // namespace detail
+
+//
+// Return a new array, where each element is taken
+// from src as specified by a range of indices:
+// new_array[i] = src[indices[i]];
+//
+
+template <typename RandomAccessIter>
+Array copy_indexed(
+    const Array&        src,
+    RandomAccessIter    begin_index,
+    RandomAccessIter    end_index)
+{
+    Array dst(src.type());
+
+    if (begin_index == end_index)
+        return dst;
+
+    dst.reserve(end_index - begin_index);
+
+    detail::CopyIndexedVisitor<RandomAccessIter> v(src, begin_index, end_index);
+    apply_visitor(dst, v);
+
+    return dst;
+}
+
+//
+// If the array contains integers, convert the array in place
+// to the smallest type that can represent the array elements,
+// otherwise leave the array unchanged.
+//
+
+void convert_to_smallest_type(Array& array);
+
+}       // namespace foundation

--- a/src/appleseed/foundation/array/applyvisitor.h
+++ b/src/appleseed/foundation/array/applyvisitor.h
@@ -1,0 +1,107 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/array/array.h"
+#include "foundation/array/arrayref.h"
+#include "foundation/array/arrayview.h"
+#include "foundation/image/color.h"
+#include "foundation/math/compressedunitvector.h"
+#include "foundation/math/vector.h"
+#include "foundation/platform/types.h"
+#include "foundation/utility/otherwise.h"
+
+// Standard headers.
+#include <utility>
+
+namespace foundation
+{
+namespace detail
+{
+
+template <typename T, typename Visitor>
+void apply_visitor(Array& array, Visitor&& v)
+{
+    ArrayRef<T> array_ref(array);
+    v(array_ref);
+}
+
+template <typename T, typename Visitor>
+void apply_visitor(const Array& array, Visitor&& v)
+{
+    v(ArrayView<T>(array));
+}
+
+#define APPLESEED_ARRAY_APPLY_VISITOR_CASE(type_enum, type_name) \
+    case type_enum: \
+        detail::apply_visitor<type_name>(array, std::forward<Visitor>(v)); \
+        break;
+
+}       // namespace detail
+
+template <typename Visitor>
+void apply_visitor(Array& array, Visitor&& v)
+{
+    switch (array.type())
+    {
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(UInt8Type, uint8)
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(UInt16Type, uint16)
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(UInt32Type, uint32)
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(FloatType, float)
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(Vector2fType, foundation::Vector2f)
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(Vector3fType, foundation::Vector3f)
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(CompressedUnitVectorType, foundation::CompressedUnitVector)
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(Color3fType, foundation::Color3f)
+
+      assert_otherwise;
+    }
+}
+
+template <typename Visitor>
+void apply_visitor(const Array& array, Visitor&& v)
+{
+    switch (array.type())
+    {
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(UInt8Type, uint8)
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(UInt16Type, uint16)
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(UInt32Type, uint32)
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(FloatType, float)
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(Vector2fType, foundation::Vector2f)
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(Vector3fType, foundation::Vector3f)
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(CompressedUnitVectorType, foundation::CompressedUnitVector)
+      APPLESEED_ARRAY_APPLY_VISITOR_CASE(Color3fType, foundation::Color3f)
+
+      assert_otherwise;
+    }
+}
+
+#undef APPLESEED_ARRAY_APPLY_VISITOR_CASE
+
+}       // namespace foundation

--- a/src/appleseed/foundation/array/array.cpp
+++ b/src/appleseed/foundation/array/array.cpp
@@ -1,0 +1,209 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "array.h"
+
+// appleseed.foundation headers.
+#include "foundation/utility/otherwise.h"
+
+// Stamdard headers.
+#include <algorithm>
+
+using namespace std;
+
+namespace foundation
+{
+
+//
+// Array class implementation.
+//
+
+Array::Concept::~Concept()
+{
+}
+
+Array::Array(const ArrayType type, const size_t size)
+{
+#define ARRAY_INIT_CASE(type_enum, type_name) \
+    case type_enum: \
+        m_self = new Model<type_name>(); \
+        break;
+
+    switch (type)
+    {
+      ARRAY_INIT_CASE(UInt8Type, uint8)
+      ARRAY_INIT_CASE(UInt16Type, uint16)
+      ARRAY_INIT_CASE(UInt32Type, uint32)
+      ARRAY_INIT_CASE(FloatType, float)
+      ARRAY_INIT_CASE(Vector2fType, Vector2f)
+      ARRAY_INIT_CASE(Vector3fType, Vector3f)
+      ARRAY_INIT_CASE(CompressedUnitVectorType, CompressedUnitVector)
+      ARRAY_INIT_CASE(Color3fType, Color3f)
+
+      assert_otherwise;
+    }
+
+#undef ARRAY_INIT_CASE
+
+    if (size != 0)
+        resize(size);
+}
+
+Array::~Array()
+{
+    delete m_self;
+}
+
+Array::Array(const Array& other)
+{
+    m_self = other.m_self->copy();
+}
+
+Array::Array(Array&& other) APPLESEED_NOEXCEPT
+{
+    m_self = other.m_self;
+    other.m_self = nullptr;
+}
+
+Array& Array::operator=(const Array& other)
+{
+    Concept* tmp(other.m_self->copy());
+
+    delete m_self;
+    m_self = tmp;
+
+    return *this;
+}
+
+Array& Array::operator=(Array&& other) APPLESEED_NOEXCEPT
+{
+    swap(m_self, other.m_self);
+    return *this;
+}
+
+ArrayType Array::type() const
+{
+    assert(!is_moved());
+    return m_self->type();
+}
+
+bool Array::empty() const
+{
+    assert(!is_moved());
+    return m_self->empty();
+}
+
+size_t Array::size() const
+{
+    assert(!is_moved());
+    return m_self->size();
+}
+
+size_t Array::capacity() const
+{
+    assert(!is_moved());
+    return m_self->capacity();
+}
+
+void Array::clear()
+{
+    assert(!is_moved());
+    m_self->clear();
+}
+
+void Array::resize(const size_t n)
+{
+    assert(!is_moved());
+    m_self->resize(n);
+}
+
+void Array::reserve(const size_t n)
+{
+    assert(!is_moved());
+    m_self->reserve(n);
+}
+
+void Array::shrink_to_fit()
+{
+    assert(!is_moved());
+    m_self->shrink_to_fit();
+}
+
+void Array::push_back(const void* p)
+{
+    assert(!is_moved());
+    m_self->push_back(p);
+}
+
+const void* Array::begin() const
+{
+    assert(!is_moved());
+    return m_self->begin();
+}
+
+const void* Array::end() const
+{
+    assert(!is_moved());
+    return m_self->end();
+}
+
+void* Array::begin()
+{
+    assert(!is_moved());
+    return m_self->begin();
+}
+
+void* Array::end()
+{
+    assert(!is_moved());
+    return m_self->end();
+}
+
+bool Array::operator==(const Array& rhs) const
+{
+    assert(!is_moved());
+    assert(!rhs.is_moved());
+
+    return type() == rhs.type() && m_self->equals(rhs.m_self);
+}
+
+bool Array::operator!=(const Array& rhs) const
+{
+    assert(!is_moved());
+    assert(!rhs.is_moved());
+
+    return type() != rhs.type() || !m_self->equals(rhs.m_self);
+}
+
+bool Array::is_moved() const
+{
+    return m_self == nullptr;
+}
+
+}   // namespace foundation

--- a/src/appleseed/foundation/array/array.h
+++ b/src/appleseed/foundation/array/array.h
@@ -1,0 +1,256 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/array/arraytraits.h"
+#include "foundation/platform/compiler.h"
+#include "foundation/utility/alignedallocator.h"
+#include "foundation/utility/test.h"
+
+// appleseed.main headers.
+#include "main/dllsymbol.h"
+
+// Standard headers.
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+DECLARE_TEST_CASE(Foundation_Array_Array, MoveConstruct);
+
+namespace foundation
+{
+
+//
+// An array that can hold items of a predetermined set of types.
+//
+
+class APPLESEED_DLLSYMBOL Array
+{
+  public:
+    // Constructor.
+    explicit Array(const ArrayType type, const size_t size = 0);
+
+    // Destructor.
+    ~Array();
+
+    // Copy constructor
+    Array(const Array& other);
+
+    // Move constructor.
+    Array(Array&& other) APPLESEED_NOEXCEPT;
+
+    // Assignment.
+    Array& operator=(const Array& other);
+
+    // Move assignment.
+    Array& operator=(Array&& other) APPLESEED_NOEXCEPT;
+
+    // Return the type of the array elements.
+    ArrayType type() const;
+
+    // Return true if the array is empty.
+    bool empty() const;
+
+    // Return the number of items in the array.
+    size_t size() const;
+
+    // Return the capacity of the array.
+    size_t capacity() const;
+
+    // Remove all items from the array.
+    void clear();
+
+    // Reserve memory for n items.
+    void reserve(const size_t n);
+
+    // Resize the array to n items.
+    void resize(const size_t n);
+
+    // Remove excess capacity from the array.
+    void shrink_to_fit();
+
+    // Equality and inequality tests.
+    bool operator==(const Array& rhs) const;
+    bool operator!=(const Array& rhs) const;
+
+  private:
+    template <typename T>
+    friend class ArrayRef;
+
+    template <typename T>
+    friend class ArrayView;
+
+    GRANT_ACCESS_TO_TEST_CASE(Foundation_Array_Array, MoveConstruct);
+
+    bool is_moved() const;
+
+    const void* begin() const;
+    const void* end() const;
+
+    void* begin();
+    void* end();
+
+    void push_back(const void* p);
+
+    struct Concept
+    {
+        virtual ~Concept();
+        virtual Concept* copy() const = 0;
+
+        virtual ArrayType type() const = 0;
+
+        virtual size_t item_size() const = 0;
+
+        virtual bool empty() const = 0;
+        virtual size_t size() const = 0;
+        virtual size_t capacity() const = 0;
+
+        virtual void clear() = 0;
+
+        virtual void reserve(const size_t n) = 0;
+        virtual void resize(const size_t n) = 0;
+        virtual void shrink_to_fit() = 0;
+
+        virtual void push_back(const void* p) = 0;
+
+        virtual const void* begin() const = 0;
+        virtual const void* end() const = 0;
+
+        virtual void* begin() = 0;
+        virtual void* end() = 0;
+
+        virtual bool equals(const Concept* rhs) const = 0;
+    };
+
+    template <typename T>
+    struct Model
+      : public Concept
+    {
+        Model()
+        {
+        }
+
+        Model(const Model& other)
+          : m_items(other.m_items)
+        {
+        }
+
+        Concept* copy() const override
+        {
+            return new Model(*this);
+        }
+
+        ArrayType type() const override
+        {
+            return ArrayTraits<T>::array_type();
+        }
+
+        size_t item_size() const override
+        {
+            return sizeof(T);
+        }
+
+        bool empty() const override
+        {
+            return m_items.empty();
+        }
+
+        size_t size() const override
+        {
+            return m_items.size();
+        }
+
+        size_t capacity() const override
+        {
+            return m_items.capacity();
+        }
+
+        void clear() override
+        {
+            m_items.clear();
+        }
+
+        void reserve(const size_t n) override
+        {
+            m_items.reserve(n);
+        }
+
+        void resize(const size_t n) override
+        {
+            m_items.resize(n);
+        }
+
+        void shrink_to_fit() override
+        {
+            m_items.shrink_to_fit();
+        }
+
+        void push_back(const void* p) override
+        {
+            m_items.push_back(*reinterpret_cast<const T*>(p));
+        }
+
+        const void* begin() const override
+        {
+            return m_items.data();
+        }
+
+        const void* end() const override
+        {
+            return
+                reinterpret_cast<const int8*>(m_items.data())
+                + sizeof(T) * m_items.size();
+        }
+
+        void* begin() override
+        {
+            return m_items.data();
+        }
+
+        void* end() override
+        {
+            return
+                reinterpret_cast<int8*>(m_items.data())
+                + sizeof(T) * m_items.size();
+        }
+
+        bool equals(const Concept* rhs) const override
+        {
+            const Model* m = reinterpret_cast<const Model*>(rhs);
+            return m_items == m->m_items;
+        }
+
+        std::vector<T, AlignedAllocator<T>> m_items;
+    };
+
+    Concept* m_self;
+};
+
+}       // namespace foundation

--- a/src/appleseed/foundation/array/arrayref.h
+++ b/src/appleseed/foundation/array/arrayref.h
@@ -1,0 +1,176 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/array/array.h"
+#include "foundation/array/arrayview.h"
+#include "foundation/platform/compiler.h"
+
+// Standard headers.
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#if APPLESEED_COMPILER_CXX_GENERALIZED_INITIALIZERS
+#include <initializer_list>
+#endif
+
+namespace foundation
+{
+
+//
+// Typed non-const reference to an array.
+//
+
+template <typename T>
+class ArrayRef
+{
+  public:
+    typedef T value_type;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+    typedef size_t size_type;
+
+    // Constructor.
+    explicit ArrayRef(Array& array)
+      : m_array(const_cast<Array&>(array))
+    {
+    }
+
+    // Implicit conversion to ArrayView.
+    operator const ArrayView<T>() const
+    {
+        return ArrayView<T>(m_array);
+    }
+
+    // Return true if the array is empty.
+    bool empty() const
+    {
+        return m_array.empty();
+    }
+
+    // Return the number of items in the array.
+    size_t size() const
+    {
+        return m_array.size();
+    }
+
+    // Return a pointer to the beginning of the array.
+    const T* begin() const
+    {
+        return reinterpret_cast<const T*>(m_array.begin());
+    }
+
+    // Return a pointer to the end of the array.
+    const T* end() const
+    {
+        return reinterpret_cast<const T*>(m_array.end());
+    }
+
+    // Return a pointer to the beginning of the array.
+    T* begin()
+    {
+        return reinterpret_cast<T*>(m_array.begin());
+    }
+
+    // Return a pointer to the end of the array.
+    T* end()
+    {
+        return reinterpret_cast<T*>(m_array.end());
+    }
+
+    // Array element access.
+    const T& operator[](const size_t i) const
+    {
+        assert(i < size());
+        return begin()[i];
+    }
+
+    T& operator[](const size_t i)
+    {
+        assert(i < size());
+        return begin()[i];
+    }
+
+    // Remove all items from the array.
+    void clear()
+    {
+        m_array.clear();
+    }
+
+    // Return the capacity of the array.
+    size_t capacity() const
+    {
+        return m_array.capacity();
+    }
+
+    // Reserve memory for n items.
+    void reserve(const size_t n)
+    {
+        m_array.reserve(n);
+    }
+
+    // Resize the array to n items.
+    void resize(const size_t n)
+    {
+        m_array.resize(n);
+    }
+
+    // Remove excess capacity from the array.
+    void shrink_to_fit()
+    {
+        m_array.shrink_to_fit();
+    }
+
+    // Add new items to the array.
+    void push_back(const T& x)
+    {
+        m_array.push_back(&x);
+    }
+
+    template <typename Iterator>
+    void assign(Iterator first, Iterator last)
+    {
+        m_array.clear();
+        m_array.reserve(std::distance(first, last));
+        std::copy(first, last, std::back_inserter(*this));
+    }
+
+#if APPLESEED_COMPILER_CXX_GENERALIZED_INITIALIZERS
+    void assign(std::initializer_list<T> l)
+    {
+        assign(l.begin(), l.end());
+    }
+#endif
+
+  private:
+    Array& m_array;
+};
+
+}       // namespace foundation

--- a/src/appleseed/foundation/array/arraytraits.h
+++ b/src/appleseed/foundation/array/arraytraits.h
@@ -1,0 +1,76 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/image/color.h"
+#include "foundation/math/compressedunitvector.h"
+#include "foundation/math/vector.h"
+#include "foundation/platform/types.h"
+
+namespace foundation
+{
+
+enum ArrayType
+{
+    UInt8Type = 0,
+    UInt16Type,
+    UInt32Type,
+    FloatType,
+    Vector2fType,
+    Vector3fType,
+    CompressedUnitVectorType,
+    Color3fType,
+    ArrayTypeCount
+};
+
+template <typename T>
+struct ArrayTraits
+{
+};
+
+#define APPLESEED_ARRAY_TYPE_TRAITS_SPECIALIZATION(type_enum, type_name) \
+    template <> \
+    struct ArrayTraits<type_name> \
+    { \
+        static ArrayType array_type() {return type_enum;} \
+    }
+
+APPLESEED_ARRAY_TYPE_TRAITS_SPECIALIZATION(UInt8Type, uint8);
+APPLESEED_ARRAY_TYPE_TRAITS_SPECIALIZATION(UInt16Type, uint16);
+APPLESEED_ARRAY_TYPE_TRAITS_SPECIALIZATION(UInt32Type, uint32);
+APPLESEED_ARRAY_TYPE_TRAITS_SPECIALIZATION(FloatType, float);
+APPLESEED_ARRAY_TYPE_TRAITS_SPECIALIZATION(Vector2fType, Vector2f);
+APPLESEED_ARRAY_TYPE_TRAITS_SPECIALIZATION(Vector3fType, Vector3f);
+APPLESEED_ARRAY_TYPE_TRAITS_SPECIALIZATION(CompressedUnitVectorType, CompressedUnitVector);
+APPLESEED_ARRAY_TYPE_TRAITS_SPECIALIZATION(Color3fType, Color3f);
+
+#undef APPLESEED_ARRAY_TYPE_TRAITS_SPECIALIZATION
+
+}       // namespace foundation

--- a/src/appleseed/foundation/array/arrayview.h
+++ b/src/appleseed/foundation/array/arrayview.h
@@ -1,0 +1,95 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/array/array.h"
+
+// Standard headers.
+#include <cassert>
+#include <cstddef>
+
+namespace foundation
+{
+
+//
+// Typed const view of an array contents.
+//
+
+template <typename T>
+class ArrayView
+{
+  public:
+    typedef T value_type;
+
+    // Constructor.
+    explicit ArrayView(const Array& array)
+      : m_begin(reinterpret_cast<const T*>(array.begin()))
+      , m_end  (reinterpret_cast<const T*>(array.end()))
+    {
+        assert(array.type() == ArrayTraits<T>::array_type());
+    }
+
+    // Return true if the array is empty.
+    bool empty() const
+    {
+        return m_begin == m_end;
+    }
+
+    // Return the number of items in the array.
+    size_t size() const
+    {
+        return m_end - m_begin;
+    }
+
+    // Return a pointer to the beginning of the array.
+    const T* begin() const
+    {
+        return m_begin;
+    }
+
+    // Return a pointer to the end of the array.
+    const T* end() const
+    {
+        return m_end;
+    }
+
+    // Array element access.
+    const T& operator[](const size_t i) const
+    {
+        assert(i < size());
+        return begin()[i];
+    }
+
+  protected:
+    const T*    m_begin;
+    const T*    m_end;
+};
+
+}       // namespace foundation

--- a/src/appleseed/foundation/array/exception.cpp
+++ b/src/appleseed/foundation/array/exception.cpp
@@ -1,0 +1,48 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "exception.h"
+
+namespace foundation
+{
+
+//
+// BadArrayTypeException class implementation.
+//
+
+BadArrayTypeException::BadArrayTypeException()
+{
+}
+
+BadArrayTypeException::BadArrayTypeException(const char* what)
+  : Exception(what)
+{
+}
+
+}   // namespace foundation

--- a/src/appleseed/foundation/array/exception.h
+++ b/src/appleseed/foundation/array/exception.h
@@ -1,0 +1,46 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/core/exceptions/exception.h"
+
+namespace foundation
+{
+
+class BadArrayTypeException
+  : public Exception
+{
+  public:
+    // Constructors.
+    BadArrayTypeException();
+    explicit BadArrayTypeException(const char* what);
+};
+
+}       // namespace foundation

--- a/src/appleseed/foundation/array/meshalgorithm.cpp
+++ b/src/appleseed/foundation/array/meshalgorithm.cpp
@@ -1,0 +1,145 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// appleseed.foundation headers.
+#include "foundation/array/applyvisitor.h"
+#include "foundation/array/array.h"
+#include "foundation/array/arrayview.h"
+#include "foundation/array/exception.h"
+#include "foundation/array/meshalgorithm.h"
+
+// Standard headers.
+#include <algorithm>
+
+using namespace std;
+
+namespace foundation
+{
+namespace
+{
+    struct ComputeBBoxVisitor
+    {
+        AABB3f m_bbox;
+
+        ComputeBBoxVisitor()
+        {
+            m_bbox.invalidate();
+        }
+
+        explicit ComputeBBoxVisitor(const AABB3f& bbox)
+        : m_bbox(bbox)
+        {
+        }
+
+        void operator()(const ArrayView<Vector3f>& view)
+        {
+            for (const Vector3f& p : view)
+                m_bbox.insert(p);
+        }
+
+        template <typename T>
+        void operator()(const ArrayView<T>& view)
+        {
+            throw BadArrayTypeException();
+        }
+    };
+
+    class FaceSidesInfoVisitor
+    {
+    public:
+        explicit FaceSidesInfoVisitor(FaceSidesInfo& stats)
+        : m_stats(stats)
+        {
+        }
+
+        void operator()(const ArrayView<uint8>& view)
+        {
+            collect_stats(view);
+        }
+
+        void operator()(const ArrayView<uint16>& view)
+        {
+            collect_stats(view);
+        }
+
+        void operator()(const ArrayView<uint32>& view)
+        {
+            collect_stats(view);
+        }
+
+        template <typename T>
+        void operator()(const ArrayView<T>& view)
+        {
+            throw BadArrayTypeException();
+        }
+
+    private:
+        FaceSidesInfo& m_stats;
+
+        template <typename T>
+        void collect_stats(const ArrayView<T>& view)
+        {
+            for (const T n : view)
+            {
+                m_stats.m_face_count++;
+
+                    if (n <  3) m_stats.m_invalid_count++;
+                else if (n == 3) m_stats.m_triangle_count++;
+                else if (n == 4) m_stats.m_quad_count++;
+                else             m_stats.m_ngon_count++;
+
+                m_stats.m_max_face_sides = max(
+                    m_stats.m_max_face_sides,
+                    static_cast<size_t>(n));
+            }
+        }
+    };
+}
+
+AABB3f compute_bounding_box(const Array& vertices)
+{
+    ComputeBBoxVisitor v;
+    apply_visitor(vertices, v);
+    return v.m_bbox;
+}
+
+AABB3f compute_bounding_box(const Array& vertices, const AABB3f& initial_bbox)
+{
+    ComputeBBoxVisitor v(initial_bbox);
+    apply_visitor(vertices, v);
+    return v.m_bbox;
+}
+
+FaceSidesInfo get_face_sides_info(const Array& verts_per_face)
+{
+    FaceSidesInfo info;
+    apply_visitor(verts_per_face, FaceSidesInfoVisitor(info));
+    return info;
+}
+
+}       // namespace foundation

--- a/src/appleseed/foundation/array/meshalgorithm.h
+++ b/src/appleseed/foundation/array/meshalgorithm.h
@@ -1,0 +1,68 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/math/aabb.h"
+
+// Standard headers.
+#include <cstddef>
+
+// Forward declarations.
+namespace foundation { class Array; }
+
+namespace foundation
+{
+
+AABB3f compute_bounding_box(const Array& vertices);
+AABB3f compute_bounding_box(const Array& vertices, const AABB3f& initial_bbox);
+
+struct FaceSidesInfo
+{
+    FaceSidesInfo()
+      : m_face_count(0)
+      , m_triangle_count(0)
+      , m_quad_count(0)
+      , m_ngon_count(0)
+      , m_invalid_count(0)
+      , m_max_face_sides(0)
+    {
+    }
+
+    size_t m_face_count;
+    size_t m_triangle_count;
+    size_t m_quad_count;
+    size_t m_ngon_count;
+    size_t m_invalid_count;
+    size_t m_max_face_sides;
+};
+
+FaceSidesInfo get_face_sides_info(const Array& verts_per_face);
+
+}       // namespace foundation

--- a/src/appleseed/foundation/image/color.h
+++ b/src/appleseed/foundation/image/color.h
@@ -66,7 +66,7 @@ class Color
     static const size_t Components = N;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Color() = default;                          // leave all components uninitialized
 #else
     Color() {}                                  // leave all components uninitialized
@@ -194,7 +194,7 @@ class Color<T, 3>
     ValueType r, g, b;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Color() = default;                          // leave all components uninitialized
 #else
     Color() {}                                  // leave all components uninitialized
@@ -259,7 +259,7 @@ class Color<T, 4>
     ValueType r, g, b, a;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Color() = default;                          // leave all components uninitialized
 #else
     Color() {}                                  // leave all components uninitialized

--- a/src/appleseed/foundation/image/regularspectrum.h
+++ b/src/appleseed/foundation/image/regularspectrum.h
@@ -65,7 +65,7 @@ class RegularSpectrum
 #ifdef APPLESEED_USE_SSE
     RegularSpectrum();
 #else
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     RegularSpectrum() = default;                            // leave all components uninitialized
 #else
     RegularSpectrum() {}                                    // leave all components uninitialized

--- a/src/appleseed/foundation/math/aabb.h
+++ b/src/appleseed/foundation/math/aabb.h
@@ -72,7 +72,7 @@ class AABBBase
     VectorType min, max;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     AABBBase() = default;               // leave all components uninitialized
 #else
     AABBBase() {}                       // leave all components uninitialized
@@ -172,7 +172,7 @@ class AABB
     typedef AABB<T, N> AABBType;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     AABB() = default;                   // leave all components uninitialized
 #else
     AABB() {}                           // leave all components uninitialized

--- a/src/appleseed/foundation/math/basis.h
+++ b/src/appleseed/foundation/math/basis.h
@@ -56,7 +56,7 @@ class Basis3
     typedef Basis3<T> BasisType;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Basis3() = default;                             // leave all components uninitialized
 #else
     Basis3() {}                                     // leave all components uninitialized
@@ -186,7 +186,7 @@ inline void Basis3<T>::build(const VectorType& normal)
 
     m_n = normal;
 
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     const T sign = std::copysign(T(1.0), m_n[2]);
 #else
     const T sign = m_n[2] < T(0.0) ? T(-1.0) : T(1.0);

--- a/src/appleseed/foundation/math/compressedunitvector.h
+++ b/src/appleseed/foundation/math/compressedunitvector.h
@@ -1,0 +1,179 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/math/scalar.h"
+#include "foundation/math/vector.h"
+#include "foundation/platform/compiler.h"
+#include "foundation/platform/types.h"
+
+// Standard headers.
+#include <cmath>
+
+namespace foundation
+{
+
+//
+// The CompressedUnitVector class stores unit vectors
+// encoded as 32-bit octahedral unit vectors.
+//
+// Reference:
+//
+//   A Survey of Efficient Representations for Independent Unit Vectors.
+//   http://jcgt.org/published/0003/02/01/paper-lowres.pdf
+//
+
+class CompressedUnitVector
+{
+  public:
+    // Constructors.
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
+    CompressedUnitVector() = default;     // leave uninitialized
+#else
+    CompressedUnitVector() {}             // leave uninitialized
+#endif
+
+    explicit CompressedUnitVector(const Vector3f& vec);
+
+    operator Vector3f() const;
+
+    bool operator==(const CompressedUnitVector& rhs) const;
+    bool operator!=(const CompressedUnitVector& rhs) const;
+
+  private:
+    static float sign_not_zero(const float v);
+    static int16 round16(const float f);
+    static int16 floor16(const float f);
+    static Vector3f oct_decode(const int16 bits[2]);
+
+    int16 m_bits[2];
+};
+
+
+//
+// CompressedUnitVector class implementation.
+//
+
+inline CompressedUnitVector::CompressedUnitVector(const Vector3f& vec)
+{
+    int16 projected[2];
+
+    const float inv_l1_norm = 1.0f / (std::abs(vec[0]) + std::abs(vec[1]) + std::abs(vec[2]));
+
+    if (vec[2] <= 0.0f)
+    {
+        projected[0] = floor16((1.0f - std::abs(vec[1] * inv_l1_norm)) * sign_not_zero(vec[0]));
+        projected[1] = floor16((1.0f - std::abs(vec[0] * inv_l1_norm)) * sign_not_zero(vec[1]));
+    }
+    else
+    {
+        projected[0] = floor16(vec[0] * inv_l1_norm);
+        projected[1] = floor16(vec[1] * inv_l1_norm);
+    }
+
+    int16 best_projected[2] = {0, 0};
+    float error = 0.0f;
+
+    unsigned int bits_x = static_cast<unsigned int>(projected[0]);
+    unsigned int bits_y = static_cast<unsigned int>(projected[1]);
+
+    for (unsigned int i = 0; i < 2; ++i)
+    {
+        for (unsigned int j = 0; j < 2; ++j)
+        {
+            projected[0] = static_cast<foundation::int16>(bits_x + i);
+            projected[1] = static_cast<foundation::int16>(bits_y + j);
+
+            const Vector3f decoded = oct_decode(projected);
+
+            const float alt_error = std::abs(dot(vec, decoded));
+            if (alt_error > error)
+            {
+                error = alt_error;
+                best_projected[0] = projected[0];
+                best_projected[1] = projected[1];
+            }
+        }
+    }
+
+    m_bits[0] = best_projected[0];
+    m_bits[1] = best_projected[1];
+}
+
+inline CompressedUnitVector::operator Vector3f() const
+{
+    return oct_decode(m_bits);
+}
+
+inline bool CompressedUnitVector::operator==(const CompressedUnitVector& rhs) const
+{
+    return m_bits[0] == rhs.m_bits[0] && m_bits[1] == rhs.m_bits[1];
+}
+
+inline bool CompressedUnitVector::operator!=(const CompressedUnitVector& rhs) const
+{
+    return !(*this == rhs);
+}
+
+inline float CompressedUnitVector::sign_not_zero(const float v)
+{
+    return v < 0.0f ? -1.0f : 1.0f;
+}
+
+inline int16 CompressedUnitVector::round16(const float f)
+{
+    return round<int16>(clamp(f, -1.0f, 1.0f) * 32767.0f);
+}
+
+inline int16 CompressedUnitVector::floor16(const float f)
+{
+    return static_cast<int16>(std::floor(clamp(f, -1.0f, 1.0f) * 32767.0f));
+}
+
+inline Vector3f CompressedUnitVector::oct_decode(const int16 bits[2])
+{
+    Vector3f vec;
+
+    const float Rcp32767 = 1.0f / 32767.0f;
+    vec[0] = clamp(bits[0] * Rcp32767, -1.0f, 1.0f);
+    vec[1] = clamp(bits[1] * Rcp32767, -1.0f, 1.0f);
+    vec[2] = 1.0f - (std::abs(vec[0]) + std::abs(vec[1]));
+
+    if (vec[2] < 0.0f)
+    {
+        const float tmp = vec[0];
+        vec[0] = (1.0f - std::abs(vec[1])) * sign_not_zero(tmp);
+        vec[1] = (1.0f - std::abs(tmp)) * sign_not_zero(vec[1]);
+    }
+
+    return normalize(vec);
+}
+
+}       // namespace foundation

--- a/src/appleseed/foundation/math/dual.h
+++ b/src/appleseed/foundation/math/dual.h
@@ -49,7 +49,7 @@ class Dual
     typedef T ValueType;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Dual() = default;                         // leave all components uninitialized
 #else
     Dual() {}                                 // leave all components uninitialized

--- a/src/appleseed/foundation/math/matrix.h
+++ b/src/appleseed/foundation/math/matrix.h
@@ -83,7 +83,7 @@ class Matrix
     static const size_t Components = M * N;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Matrix() = default;                                     // leave all components uninitialized
 #else
     Matrix() {}                                             // leave all components uninitialized
@@ -182,7 +182,7 @@ class Matrix<T, N, N>
     static const size_t Components = N * N;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Matrix() = default;                                     // leave all components uninitialized
 #else
     Matrix() {}                                             // leave all components uninitialized
@@ -254,7 +254,7 @@ class Matrix<T, 3, 3>
     static const size_t Components = 3 * 3;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Matrix() = default;                                     // leave all components uninitialized
 #else
     Matrix() {}                                             // leave all components uninitialized
@@ -379,7 +379,7 @@ class Matrix<T, 4, 4>
     static const size_t Components = 4 * 4;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Matrix() = default;                                     // leave all components uninitialized
 #else
     Matrix() {}                                             // leave all components uninitialized

--- a/src/appleseed/foundation/math/quaternion.h
+++ b/src/appleseed/foundation/math/quaternion.h
@@ -66,7 +66,7 @@ class Quaternion
     VectorType  v;                                          // vector part
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Quaternion() = default;                                 // leave all components uninitialized
 #else
     Quaternion() {}                                         // leave all components uninitialized

--- a/src/appleseed/foundation/math/ray.h
+++ b/src/appleseed/foundation/math/ray.h
@@ -71,7 +71,7 @@ class Ray
     ValueType   m_tmax;                     // end of the ray interval (exclusive)
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Ray() = default;                        // leave all fields uninitialized
 #else
     Ray() {}                                // leave all fields uninitialized
@@ -89,7 +89,7 @@ class Ray
     // Return true if the ray has finite length.
     bool is_finite() const;
 
-    // Get length of the ray interval, assuming that m_tmax is finite. 
+    // Get length of the ray interval, assuming that m_tmax is finite.
     ValueType get_length() const;
 
     // Return the point of the ray at abscissa t, t >= 0.
@@ -151,7 +151,7 @@ class RayInfo
     Vector<uint32, N> m_sgn_dir;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     RayInfo() = default;                    // leave all fields uninitialized
 #else
     RayInfo() {}                            // leave all fields uninitialized
@@ -187,7 +187,7 @@ class RayInfo<double, 3>
     APPLESEED_SIMD4_ALIGN Vector<uint32, 4> m_sgn_dir;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     RayInfo() = default;                    // leave all fields uninitialized
 #else
     RayInfo() {}                            // leave all fields uninitialized

--- a/src/appleseed/foundation/math/transform.h
+++ b/src/appleseed/foundation/math/transform.h
@@ -64,7 +64,7 @@ class Transform
     typedef Transform<T> TransformType;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Transform() = default;                      // leave the transformation uninitialized
 #else
     Transform() {}                              // leave the transformation uninitialized
@@ -178,7 +178,7 @@ class TransformInterpolator
     typedef Transform<T> TransformType;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     TransformInterpolator() = default;          // leave the interpolator uninitialized
 #else
     TransformInterpolator() {}                  // leave the interpolator uninitialized

--- a/src/appleseed/foundation/math/vector.h
+++ b/src/appleseed/foundation/math/vector.h
@@ -65,7 +65,7 @@ class Vector
     static const size_t Dimension = N;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Vector() = default;                         // leave all components uninitialized
 #else
     Vector() {}                                 // leave all components uninitialized
@@ -252,7 +252,7 @@ class Vector<T, 2>
     ValueType x, y;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Vector() = default;                         // leave all components uninitialized
 #else
     Vector() {}                                 // leave all components uninitialized
@@ -308,7 +308,7 @@ class Vector<T, 3>
     ValueType x, y, z;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Vector() = default;                         // leave all components uninitialized
 #else
     Vector() {}                                 // leave all components uninitialized
@@ -375,7 +375,7 @@ class Vector<T, 4>
     ValueType x, y, z, w;
 
     // Constructors.
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if APPLESEED_COMPILER_CXX_DEFAULTED_FUNCTIONS
     Vector() = default;                         // leave all components uninitialized
 #else
     Vector() {}                                 // leave all components uninitialized

--- a/src/appleseed/foundation/meta/tests/test_array.cpp
+++ b/src/appleseed/foundation/meta/tests/test_array.cpp
@@ -1,0 +1,87 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// appleseed.foundation headers.
+#include "foundation/array/array.h"
+#include "foundation/array/arrayref.h"
+#include "foundation/utility/countof.h"
+#include "foundation/utility/test.h"
+
+// Standard headers.
+#include <utility>
+
+using namespace foundation;
+using namespace std;
+
+TEST_SUITE(Foundation_Array_Array)
+{
+    TEST_CASE(Construct)
+    {
+        Array x(FloatType);
+        EXPECT_TRUE(x.empty());
+        EXPECT_EQ(FloatType, x.type());
+
+        Array y(UInt32Type, 100);
+        EXPECT_FALSE(y.empty());
+        EXPECT_EQ(UInt32Type, y.type());
+        EXPECT_EQ(100, y.size());
+    }
+
+    TEST_CASE(CopyConstruct)
+    {
+        Array x(FloatType);
+        ArrayRef<float> xref(x);
+
+        const float items[] = {1.0f, 5.0f, 7.0f, 11.0f};
+        xref.assign(items, items + countof(items));
+
+        Array y(x);
+        EXPECT_TRUE(x == y);
+
+        ArrayRef<float> yref(y);
+        EXPECT_EQ(yref[2], 7.0f);
+    }
+
+    TEST_CASE(MoveConstruct)
+    {
+        Array x(UInt32Type);
+        ArrayRef<uint32> xref(x);
+
+        const uint32 items[] = {1, 5, 7, 11};
+        xref.assign(items, items + countof(items));
+
+        Array y(x);
+        Array z(move(y));
+
+        EXPECT_TRUE(y.is_moved());
+        EXPECT_TRUE(x == z);
+
+        ArrayRef<uint32> zref(z);
+        EXPECT_EQ(zref[2], 7);
+    }
+}

--- a/src/appleseed/foundation/meta/tests/test_arrayalgorithm.cpp
+++ b/src/appleseed/foundation/meta/tests/test_arrayalgorithm.cpp
@@ -1,0 +1,134 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// appleseed.foundation headers.
+#include "foundation/array/algorithm.h"
+
+// Standard headers.
+#include <vector>
+
+using namespace foundation;
+using namespace std;
+
+TEST_SUITE(Foundation_Array_Algorithm)
+{
+    TEST_CASE(CopyIndexed)
+    {
+        Array src(ArrayType::UInt32Type);
+        ArrayRef<uint32> src_ref(src);
+
+        const uint32 items[] = {1, 2, 3, 4, 5, 6, 7};
+        src_ref.assign(items, items + countof(items));
+
+        const size_t indices[] = {6, 2, 3, 1, 1, 4, 3, 1, 2};
+
+        Array dst(
+            copy_indexed(
+                src, indices, indices + countof(indices)));
+
+        EXPECT_EQ(dst.size(), countof(indices));
+
+        const ArrayView<uint32> dst_ref(dst);
+
+        for (size_t i = 0, e = countof(indices); i < e; ++i)
+        {
+            size_t src_index = indices[i];
+            EXPECT_LT(src_ref.size(), src_index);
+
+            EXPECT_EQ(dst_ref[i], src_ref[src_index]);
+        }
+    }
+
+    TEST_CASE(ConvertToSmallestType16to8)
+    {
+        Array src(ArrayType::UInt16Type);
+        ArrayRef<uint16> src_ref(src);
+        const uint32 items[] = {1, 2, 132, 4, 255, 6, 77};
+        src_ref.assign(items, items + countof(items));
+
+        Array array(src);
+        convert_to_smallest_type(array);
+        EXPECT_EQ(array.type(), ArrayType::UInt8Type);
+
+        const ArrayView<uint16> src_view(src);
+        const ArrayView<uint8> dst_view(array);
+
+        EXPECT_TRUE(equal(src_view.begin(), src_view.end(), dst_view.begin()));
+    }
+
+    TEST_CASE(ConvertToSmallestType32to8)
+    {
+        Array src(ArrayType::UInt32Type);
+        ArrayRef<uint32> src_ref(src);
+        const uint32 items[] = {1, 2, 132, 4, 255, 6, 77};
+        src_ref.assign(items, items + countof(items));
+
+        Array array(src);
+        convert_to_smallest_type(array);
+        EXPECT_EQ(array.type(), ArrayType::UInt8Type);
+
+        const ArrayView<uint32> src_view(src);
+        const ArrayView<uint8> dst_view(array);
+
+        EXPECT_TRUE(equal(src_view.begin(), src_view.end(), dst_view.begin()));
+    }
+
+    TEST_CASE(ConvertToSmallestType32to16)
+    {
+        Array src(ArrayType::UInt32Type);
+        ArrayRef<uint32> src_ref(src);
+        const uint32 items[] = {1, 2156, 132, 4, 65535, 6, 77};
+        src_ref.assign(items, items + countof(items));
+
+        Array array(src);
+        convert_to_smallest_type(array);
+        EXPECT_EQ(array.type(), ArrayType::UInt16Type);
+
+        const ArrayView<uint32> src_view(src);
+        const ArrayView<uint16> dst_view(array);
+
+        EXPECT_TRUE(equal(src_view.begin(), src_view.end(), dst_view.begin()));
+    }
+
+    TEST_CASE(ConvertToSmallestType32NoOp)
+    {
+        Array src(ArrayType::UInt32Type);
+        ArrayRef<uint32> src_ref(src);
+        const uint32 items[] = {1, 2156, 132, 4, 65537, 6, 77};
+        src_ref.assign(items, items + countof(items));
+
+        Array array(src);
+        convert_to_smallest_type(array);
+        EXPECT_EQ(array.type(), ArrayType::UInt32Type);
+
+        const ArrayView<uint32> src_view(src);
+        const ArrayView<uint32> dst_view(array);
+
+        EXPECT_TRUE(equal(src_view.begin(), src_view.end(), dst_view.begin()));
+    }
+}

--- a/src/appleseed/foundation/meta/tests/test_arrayapplyvisitor.cpp
+++ b/src/appleseed/foundation/meta/tests/test_arrayapplyvisitor.cpp
@@ -1,0 +1,97 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// appleseed.foundation headers.
+#include "foundation/array/applyvisitor.h"
+#include "foundation/array/array.h"
+#include "foundation/utility/test.h"
+
+// Standard headers.
+#include <algorithm>
+#include <vector>
+
+using namespace foundation;
+using namespace std;
+
+TEST_SUITE(Foundation_Array_ApplyVisitor)
+{
+    class CountAppliesVisitor
+    {
+      public:
+        CountAppliesVisitor()
+          : m_applies(ArrayType::ArrayTypeCount, 0)
+        {
+        }
+
+        template <typename ArrayRefType>
+        void operator()(ArrayRefType ref)
+        {
+            typedef typename ArrayRefType::value_type T;
+
+            const size_t type_index = static_cast<size_t>(ArrayTraits<T>::array_type());
+            m_applies[type_index]++;
+        }
+
+        bool all_types_applied() const
+        {
+            return std::all_of(
+                m_applies.begin(),
+                m_applies.end(),
+                [](size_t x) { return x == 1; });
+        }
+
+      private:
+        vector<size_t> m_applies;
+    };
+
+    TEST_CASE(ApplyConst)
+    {
+        CountAppliesVisitor v;
+
+        for (int i = 0; i < ArrayType::ArrayTypeCount; ++i)
+        {
+            const Array array(static_cast<ArrayType>(i));
+            apply_visitor(array, v);
+        }
+
+        EXPECT_TRUE(v.all_types_applied());
+    }
+
+    TEST_CASE(ApplyNonConst)
+    {
+        CountAppliesVisitor v;
+
+        for (int i = 0; i < ArrayType::ArrayTypeCount; ++i)
+        {
+            Array array(static_cast<ArrayType>(i));
+            apply_visitor(array, v);
+        }
+
+        EXPECT_TRUE(v.all_types_applied());
+    }
+}

--- a/src/appleseed/foundation/meta/tests/test_compressedunitvector.cpp
+++ b/src/appleseed/foundation/meta/tests/test_compressedunitvector.cpp
@@ -1,0 +1,62 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// appleseed.foundation headers.
+#include "foundation/math/compressedunitvector.h"
+#include "foundation/math/vector.h"
+#include "foundation/math/rng/distribution.h"
+#include "foundation/math/rng/xoroshiro128plus.h"
+#include "foundation/math/sampling/mappings.h"
+#include "foundation/utility/iostreamop.h"
+#include "foundation/utility/test.h"
+
+// Standard headers.
+#include <cstddef>
+
+using namespace foundation;
+
+TEST_SUITE(Foundation_Math_CompressedUnitVector)
+{
+    TEST_CASE(RoundTrip)
+    {
+        const size_t N = 2048;
+        Xoroshiro128plus rng(349, 684658);
+
+        for (size_t i = 0; i < N; ++i)
+        {
+            const Vector2f s(rand_float1(rng), rand_float1(rng));
+            const Vector3f v = sample_sphere_uniform(s);
+
+            const CompressedUnitVector compressed_v(v);
+            const Vector3f uncompressed_v(compressed_v);
+
+            const float cos_vv = dot(v, uncompressed_v);
+            EXPECT_FEQ_EPS(1.0f, cos_vv, 1.0e-6f);
+        }
+    }
+}

--- a/src/appleseed/foundation/meta/tests/test_copyonwrite.cpp
+++ b/src/appleseed/foundation/meta/tests/test_copyonwrite.cpp
@@ -1,0 +1,134 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// appleseed.foundation headers.
+#include "foundation/utility/copyonwrite.h"
+#include "foundation/utility/test.h"
+
+// Standard headers.
+#include <utility>
+#include <vector>
+
+using namespace foundation;
+using namespace std;
+
+TEST_SUITE(Foundation_Utility_CopyOnWrite)
+{
+    TEST_CASE(ConstructWithCopyableType)
+    {
+        CopyOnWrite<int> cow(7);
+        EXPECT_TRUE(cow.unique());
+        EXPECT_EQ(7, cow.read());
+    }
+
+    TEST_CASE(ConstructWithMovableType)
+    {
+        vector<int> x(1, 11);
+        CopyOnWrite<vector<int>> cow(move(x));
+        EXPECT_TRUE(cow.unique());
+        EXPECT_EQ(11, cow.read()[0]);
+    }
+
+    TEST_CASE(CopyConstruct)
+    {
+        CopyOnWrite<int> a(7);
+        EXPECT_TRUE(a.unique());
+
+        {
+            CopyOnWrite<int> b(a);
+            EXPECT_EQ(7, b.read());
+
+            EXPECT_FALSE(a.unique());
+            EXPECT_FALSE(b.unique());
+        }
+
+        EXPECT_TRUE(a.unique());
+    }
+
+    TEST_CASE(MoveConstruct)
+    {
+        CopyOnWrite<int> a(11);
+        EXPECT_TRUE(a.unique());
+
+        CopyOnWrite<int> b(move(a));
+        EXPECT_TRUE(a.empty());
+        EXPECT_TRUE(b.unique());
+
+        EXPECT_EQ(11, b.read());
+    }
+
+    TEST_CASE(CopyAssign)
+    {
+        CopyOnWrite<int> a(7);
+        EXPECT_TRUE(a.unique());
+
+        {
+            CopyOnWrite<int> b;
+            b = a;
+            EXPECT_EQ(7, b.read());
+
+            EXPECT_FALSE(a.unique());
+            EXPECT_FALSE(b.unique());
+        }
+
+        EXPECT_TRUE(a.unique());
+    }
+
+    TEST_CASE(MoveAssign)
+    {
+        CopyOnWrite<int> a(11);
+        EXPECT_TRUE(a.unique());
+
+        CopyOnWrite<int> b;
+        b = move(a);
+        EXPECT_TRUE(a.empty());
+        EXPECT_TRUE(b.unique());
+
+        EXPECT_EQ(11, b.read());
+    }
+
+    TEST_CASE(Write)
+    {
+        CopyOnWrite<int> a(7);
+        CopyOnWrite<int> b(a);
+
+        EXPECT_FALSE(a.unique());
+        EXPECT_FALSE(b.unique());
+
+        EXPECT_EQ(7, a.read());
+        EXPECT_EQ(7, b.read());
+
+        a.write() = 11;
+
+        EXPECT_TRUE(a.unique());
+        EXPECT_TRUE(b.unique());
+
+        EXPECT_EQ(11, a.read());
+        EXPECT_EQ(7, b.read());
+    }
+}

--- a/src/appleseed/foundation/platform/.gitignore
+++ b/src/appleseed/foundation/platform/.gitignore
@@ -1,0 +1,1 @@
+compilerfeatures.h

--- a/src/appleseed/foundation/platform/compiler.h
+++ b/src/appleseed/foundation/platform/compiler.h
@@ -44,6 +44,7 @@
 
 // appleseed.foundation headers.
 #include "foundation/core/concepts/noncopyable.h"
+#include "foundation/platform/compilerfeatures.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"
@@ -219,20 +220,6 @@ namespace foundation
 // Other compilers: ignore.
 #else
     #define APPLESEED_UNUSED
-#endif
-
-
-//
-//  noexcept support.
-//
-
-// Visual C++ 2012 and earlier: ignore.
-#if defined _MSC_VER && _MSC_VER < 1800
-    #define APPLESEED_NOEXCEPT
-
-// Other compilers.
-#else
-    #define APPLESEED_NOEXCEPT noexcept
 #endif
 
 

--- a/src/appleseed/foundation/utility/alignedvector.h
+++ b/src/appleseed/foundation/utility/alignedvector.h
@@ -53,7 +53,7 @@ namespace foundation
 //   std::vector of Aligned Elements
 //   http://thetweaker.wordpress.com/2010/05/05/stdvector-of-aligned-elements/
 //
-//   std::vector of Aligned Elements – Revisited
+//   std::vector of Aligned Elements Revisited
 //   http://thetweaker.wordpress.com/2010/08/15/stdvector-of-aligned-elements-revisited/
 //
 //   StackOverflow: Self-contained, STL-compatible implementation of std::vector

--- a/src/appleseed/foundation/utility/copyonwrite.h
+++ b/src/appleseed/foundation/utility/copyonwrite.h
@@ -1,0 +1,166 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/platform/compiler.h"
+
+// Standard headers.
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <utility>
+
+namespace foundation
+{
+
+//
+// A copy-on-write wrapper for any type that models RegularType.
+// This class is based on stlab's copy-on-write class:
+// https://github.com/stlab/libraries
+//
+
+template <typename T> // T models RegularType.
+class CopyOnWrite
+{
+  public:
+    // Constructors.
+    CopyOnWrite() APPLESEED_NOEXCEPT
+      : m_model(nullptr)
+    {
+    }
+
+    explicit CopyOnWrite(const T& x)
+      : m_model(new Model(x))
+    {
+    }
+
+    explicit CopyOnWrite(T&& x)
+      : m_model(new Model(std::forward<T>(x)))
+    {
+    }
+
+    // Destructor.
+    ~CopyOnWrite()
+    {
+        if (m_model)
+        {
+            assert(m_model->m_count > 0);
+
+            if (--m_model->m_count == 0)
+                delete m_model;
+        }
+    }
+
+    // Copy constructor.
+    CopyOnWrite(const CopyOnWrite& other)
+      : m_model(other.m_model)
+    {
+        assert(m_model);
+        m_model->m_count++;
+    }
+
+    // Move constructor.
+    CopyOnWrite(CopyOnWrite&& other) APPLESEED_NOEXCEPT
+    {
+        m_model = other.m_model;
+        other.m_model = nullptr;
+    }
+
+    // Copy assignment.
+    CopyOnWrite& operator=(const CopyOnWrite& other)
+    {
+        CopyOnWrite tmp(other);
+        std::swap(this->m_model, tmp.m_model);
+        return *this;
+    }
+
+    // Move assignment.
+    CopyOnWrite& operator=(CopyOnWrite&& other) APPLESEED_NOEXCEPT
+    {
+        std::swap(m_model, other.m_model);
+        return *this;
+    }
+
+    // Return true if the wrapper is empty.
+    bool empty() const APPLESEED_NOEXCEPT
+    {
+        return m_model == nullptr;
+    }
+
+    // Return true if the wrapped object is not shared
+    // by other copy on write wrappers.
+    bool unique() const APPLESEED_NOEXCEPT
+    {
+        assert(m_model);
+        return m_model->m_count == 1;
+    }
+
+    // Return a const reference to the wrapped object.
+    const T& read() const APPLESEED_NOEXCEPT
+    {
+        assert(m_model);
+        return m_model->m_value;
+    }
+
+    // Return a non const reference to the wrapped object.
+    // If the object is shared, this method will make a copy of it.
+    T& write()
+    {
+        assert(m_model);
+
+        if (!unique())
+            *this = CopyOnWrite(read());
+
+        return m_model->m_value;
+    }
+
+  private:
+    struct Model
+    {
+        T                        m_value;
+        std::atomic<std::size_t> m_count;
+
+        explicit Model(const T& value)
+          : m_value(value)
+          , m_count(1)
+        {
+        }
+
+        explicit Model(T&& value)
+          : m_value(value)
+          , m_count(1)
+        {
+        }
+    };
+
+    Model* m_model;
+};
+
+}       // namespace foundation


### PR DESCRIPTION
- Use CMake to detect C++ compiler features. This change requires CMake 3.1 or later.
- Added CopyOnWrite wrapper.
- Added oct32 compressed unit vectors for normals and tangents.
- Added an Array class that can hold elements of some predefined types.
- Added some simple array related algorithms.

Issue #2341