### PR TITLE
Increase default number of bounces

### DIFF
--- a/src/appleseed.shaders/src/appleseed/as_blackbody.osl
+++ b/src/appleseed.shaders/src/appleseed/as_blackbody.osl
@@ -211,13 +211,13 @@ shader as_blackbody
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0
     ]],
-    int in_maximum_ray_depth = 8
+    int in_maximum_ray_depth = 100
     [[
         string as_maya_attribute_name = "maximumRayDepth",
         string as_maya_attribute_short_name = "mrd",
         int min = 0,
         int max = 100,
-        int softmax = 8,
+        int softmax = 16,
         string label = "Ray Depth",
         string page = "Advanced",
         int as_maya_attribute_connectable = 0,

--- a/src/appleseed.shaders/src/appleseed/as_disney_material.osl
+++ b/src/appleseed.shaders/src/appleseed/as_disney_material.osl
@@ -203,13 +203,13 @@ shader as_disney_material
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0
     ]],
-    int in_maximum_ray_depth = 4
+    int in_maximum_ray_depth = 100
     [[
         string as_maya_attribute_name = "maximumRayDepth",
         string as_maya_attribute_short_name = "rd",
         int min = 0,
         int max = 100,
-        int softmax = 8,
+        int softmax = 16,
         string label = "Ray Depth",
         string page = "Advanced",
         int as_maya_attribute_connectable = 0,

--- a/src/appleseed.shaders/src/appleseed/as_glass.osl
+++ b/src/appleseed.shaders/src/appleseed/as_glass.osl
@@ -231,13 +231,13 @@ shader as_glass
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0
     ]],
-    int in_maximum_ray_depth = 4
+    int in_maximum_ray_depth = 100
     [[
         string as_maya_attribute_name = "maximumRayDepth",
         string as_maya_attribute_short_name = "mr",
         int min = 0,
         int max = 100,
-        int softmax = 8,
+        int softmax = 16,
         string label = "Ray Depth",
         string page = "Advanced",
         int as_maya_attribute_connectable = 0,

--- a/src/appleseed.shaders/src/appleseed/as_metal.osl
+++ b/src/appleseed.shaders/src/appleseed/as_metal.osl
@@ -252,13 +252,13 @@ shader as_metal
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0
     ]],
-    int in_maximum_ray_depth = 8
+    int in_maximum_ray_depth = 100
     [[
         string as_maya_attribute_name = "maximumRayDepth",
         string as_maya_attribute_short_name = "mrd",
         int min = 0,
         int max = 100,
-        int softmax = 8,
+        int softmax = 16,
         string label = "Ray Depth",
         string page = "Advanced",
         int as_maya_attribute_connectable = 0,

--- a/src/appleseed.shaders/src/appleseed/as_plastic.osl
+++ b/src/appleseed.shaders/src/appleseed/as_plastic.osl
@@ -174,13 +174,13 @@ shader as_plastic
         string page = "Matte Opacity",
         int gafferNoduleLayoutVisible = 0
     ]],
-    int in_maximum_ray_depth = 4
+    int in_maximum_ray_depth = 100
     [[
         string as_maya_attribute_name = "maximumRayDepth",
         string as_maya_attribute_short_name = "mr",
         int min = 0,
         int max = 100,
-        int softmax = 8,
+        int softmax = 16,
         string label = "Ray Depth",
         string page = "Advanced",
         int as_maya_attribute_connectable = 0,

--- a/src/appleseed.shaders/src/appleseed/as_sbs_pbrmaterial.osl
+++ b/src/appleseed.shaders/src/appleseed/as_sbs_pbrmaterial.osl
@@ -275,13 +275,13 @@ shader as_sbs_pbrmaterial
         string page = "Matte Opacity",
         int gafferNoduleLayoutVisible = 0
     ]],
-    int in_maximum_ray_depth = 4
+    int in_maximum_ray_depth = 100
     [[
         string as_maya_attribute_name = "maximumRayDepth",
         string as_maya_attribute_short_name = "mr",
         int min = 0,
         int max = 100,
-        int softmax = 8,
+        int softmax = 16,
         string widget = "slider",
         int slidermin = 0,
         int slidermax = 10,

--- a/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
@@ -507,13 +507,13 @@ shader as_standard_surface
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0
     ]],
-    int in_maximum_ray_depth = 8
+    int in_maximum_ray_depth = 100
     [[
         string as_maya_attribute_name = "maximumRayDepth",
         string as_maya_attribute_short_name = "mrd",
         int min = 0,
         int max = 100,
-        int softmax = 8,
+        int softmax = 16,
         string label = "Ray Depth",
         string page = "Advanced",
         int as_maya_attribute_connectable = 0,

--- a/src/appleseed.shaders/src/appleseed/as_subsurface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_subsurface.osl
@@ -49,7 +49,7 @@ shader as_subsurface
         string as_maya_attribute_name = "sssProfile",
         string as_maya_attribute_short_name = "ssp",
         string widget = "mapper",
-        string options = "Better Dipole:0|Directional Dipole:1|Gaussian:2|Normalized Diffusion:3|Standard Dipole:4|Random Walk:5",
+        string options = "Better Dipole:0|Directional Dipole:1|Gaussian:2|Normalized Diffusion:3|Standard Dipole:4|Diffuse Random Walk:5",
         string label = "Subsurface Profile",
         string page = "Subsurface",
         int as_maya_attribute_connectable = 0,
@@ -92,15 +92,16 @@ shader as_subsurface
         string label = "Depth Scale",
         string page = "Subsurface"
     ]],
-    int in_sss_maximum_ray_depth = 2
+    int in_sss_maximum_ray_depth = 8
     [[
         string as_maya_attribute_name = "sssMaximumRayDepth",
         string as_maya_attribute_short_name = "ssd",
         int min = 1,
-        int max = 16,
-        int softmax = 8,
+        int max = 100,
+        int softmax = 16,
         string label = "Subsurface Ray Depth",
         string page = "Subsurface.Advanced",
+        string help = "Maximum number of bounces allowed",
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
@@ -260,13 +261,15 @@ shader as_subsurface
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string widget = "null"
+        string widget = "null",
+        string label = "Output Color"
     ]],
     output closure color out_outMatteOpacity = 0
     [[
         string as_maya_attribute_name = "outMatteOpacity",
         string as_maya_attribute_short_name = "om",
         string widget = "null",
+        string label = "Output Matte",
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0
@@ -285,6 +288,18 @@ shader as_subsurface
 
         out_outColor += out_outMatteOpacity;
     }
+
+    int ray_depth;
+    int status = getattribute("path:ray_depth", ray_depth);
+
+    if (!status || ray_depth > in_sss_maximum_ray_depth)
+    {
+        return;
+    }
+
+    normal Nn = normalize(in_bump_normal);
+
+    color albedo = clamp(in_sss_amount * in_color, 0.01, 0.99);
 
     string sss_profile;
 
@@ -310,36 +325,16 @@ shader as_subsurface
     }
     else
     {
-        sss_profile = "randomwalk";
+        sss_profile = "randomwalk"; // diffuse random walk
     }
 
-    normal Nn = normalize(in_bump_normal);
-
-    if (in_sss_amount * max(in_color) > 0.0)
-    {
-        color albedo = clamp(in_sss_amount * in_color, 0.01, 0.99);
-
-        if (sss_profile == "randomwalk")
-        {
-            out_outColor += as_subsurface(
-                sss_profile,
-                Nn,
-                albedo,
-                in_sss_mfp_scale * in_sss_mfp,
-                in_ior,
-                "fresnel_weight", in_fresnel_weight);
-        }
-        else
-        {
-            out_outColor += as_subsurface(
-                sss_profile,
-                Nn,
-                albedo,
-                in_sss_mfp_scale * in_sss_mfp,
-                in_ior,
-                "fresnel_weight", in_fresnel_weight);
-        }
-    }
+    out_outColor += as_subsurface(
+        sss_profile,
+        Nn,
+        albedo,
+        in_sss_mfp_scale * in_sss_mfp,
+        in_ior,
+        "fresnel_weight", in_fresnel_weight);
 
     if (in_specular_weight > 0.0)
     {
@@ -381,7 +376,7 @@ shader as_subsurface
             vector(0),  // tangent
             in_specular_roughness,
             0.0,        // specular spread for Student's t-MDF
-            0.0,        // anisotropy amount
+            in_anisotropy_amount,
             in_ior,
             "energy_compensation", 1.0);
     }

--- a/src/appleseed.shaders/src/appleseed/as_toon.osl
+++ b/src/appleseed.shaders/src/appleseed/as_toon.osl
@@ -272,13 +272,13 @@ shader as_toon
         string page = "Diffuse.Toon" ,
         string help = "Softness of tonal range transition, higher values produce softner results, lower values produce sharper transitions"
     ]],
-    int in_diffuse_ray_depth = 2
+    int in_diffuse_ray_depth = 100
     [[
         string as_maya_attribute_name = "diffuseRayDepth",
         string as_maya_attribute_short_name = "drd",
         int min = 0,
-        int max = 16,
-        int softmax = 8,
+        int max = 100,
+        int softmax = 16,
         string widget = "slider",
         int slidermin = 0,
         int slidermax = 8,
@@ -460,13 +460,13 @@ shader as_toon
         string page = "Specular.Toon",
         string help = "Attenuate facing incidence reflection, similar to Fresnel, retaining reflection intensity at the grazing angles."
     ]],
-    int in_specular_ray_depth = 2
+    int in_specular_ray_depth = 100
     [[
         string as_maya_attribute_name = "specularRayDepth",
         string as_maya_attribute_short_name = "srd",
         int min = 0,
-        int max = 16,
-        int softmax = 8,
+        int max = 100,
+        int softmax = 16,
         string widget = "slider",
         int slidermin = 0,
         int slidermax = 8,


### PR DESCRIPTION
To address issue #2322 
64 bounces ought to be enough for anybody.... though we settled for the maximum allowed by default, which is 100. Metadata for default sliders soft maximum was increased from 8 to 16.
