### PR TITLE
Disable blender input socket for metal EC

### DIFF
--- a/src/appleseed.shaders/src/appleseed/as_metal.osl
+++ b/src/appleseed.shaders/src/appleseed/as_metal.osl
@@ -97,7 +97,8 @@ shader as_metal
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
-        int as_blender_input_socket = 0,
+        // Enable at a later stage since presently it breaks backwards compat.
+        // int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0
     ]],
     float in_anisotropy_amount = 0.0


### PR DESCRIPTION
This addresses https://github.com/appleseedhq/blenderseed/issues/355
EC was inadvertanly exposed in blender, but existing scenes will break
if there are any input connections to this, so the metadata token
 as_blender_input_socket must be commented out for now.
