### PR TITLE
Make AOV::write_image() virtual

### DIFF
--- a/src/appleseed/renderer/modeling/aov/aov.cpp
+++ b/src/appleseed/renderer/modeling/aov/aov.cpp
@@ -37,6 +37,7 @@
 #include "foundation/image/color.h"
 #include "foundation/image/genericimagefilewriter.h"
 #include "foundation/image/image.h"
+#include "foundation/image/imageattributes.h"
 
 // Standard headers.
 #include <exception>
@@ -107,7 +108,7 @@ bool AOV::write_images(const char* file_path) const
 
         writer.append_image(&get_image());
 
-        if(has_color_data())
+        if (has_color_data())
             writer.set_image_output_format(PixelFormatHalf);
 
         writer.set_image_channels(get_channel_count(), get_channel_names());

--- a/src/appleseed/renderer/modeling/aov/aov.cpp
+++ b/src/appleseed/renderer/modeling/aov/aov.cpp
@@ -30,11 +30,16 @@
 #include "aov.h"
 
 // appleseed.renderer headers.
+#include "renderer/global/globallogger.h"
 #include "renderer/kernel/aov/imagestack.h"
 
 // appleseed.foundation headers.
 #include "foundation/image/color.h"
+#include "foundation/image/genericimagefilewriter.h"
 #include "foundation/image/image.h"
+
+// Standard headers.
+#include <exception>
 
 using namespace foundation;
 
@@ -94,6 +99,37 @@ void AOV::create_image(
     m_image = &aov_images.get_image(m_image_index);
 }
 
+bool AOV::write_images(const char* file_path) const
+{
+    try
+    {
+        GenericImageFileWriter writer(file_path);
+
+        writer.append_image(&get_image());
+
+        if(has_color_data())
+            writer.set_image_output_format(PixelFormatHalf);
+
+        writer.set_image_channels(get_channel_count(), get_channel_names());
+
+        ImageAttributes image_attributes = ImageAttributes::create_default_attributes();
+        image_attributes.insert("color_space", "linear");
+        writer.set_image_attributes(image_attributes);
+
+        writer.write();
+    }
+    catch (const std::exception& e)
+    {
+        RENDERER_LOG_ERROR(
+            "failed to write image file %s: %s.",
+            file_path,
+            e.what());
+
+        return false;
+    }
+
+    return true;
+}
 
 //
 // ColorAOV class implementation.

--- a/src/appleseed/renderer/modeling/aov/aov.h
+++ b/src/appleseed/renderer/modeling/aov/aov.h
@@ -92,7 +92,7 @@ class APPLESEED_DLLSYMBOL AOV
     // Apply any post-processing needed to the AOV image.
     virtual void post_process_image(const Frame& frame);
 
-    // Write image to EXR file.
+    // Write image to OpenEXR file.
     virtual bool write_images(const char* file_path) const;
 
   protected:

--- a/src/appleseed/renderer/modeling/aov/aov.h
+++ b/src/appleseed/renderer/modeling/aov/aov.h
@@ -92,6 +92,9 @@ class APPLESEED_DLLSYMBOL AOV
     // Apply any post-processing needed to the AOV image.
     virtual void post_process_image(const Frame& frame);
 
+    // Write image to EXR file.
+    virtual bool write_images(const char* file_path) const;
+
   protected:
     friend class AOVAccumulatorContainer;
     friend class Frame;

--- a/src/appleseed/renderer/modeling/aov/denoiseraov.h
+++ b/src/appleseed/renderer/modeling/aov/denoiseraov.h
@@ -82,7 +82,7 @@ class DenoiserAOV
     void extract_num_samples_image(bcd::Deepimf& num_samples) const;
     void compute_covariances_image(bcd::Deepimf& covariances) const;
 
-    bool write_images(const char* file_path) const;
+    bool write_images(const char* file_path) const override;
 
   protected:
     foundation::auto_release_ptr<AOVAccumulator> create_accumulator() const override;

--- a/src/appleseed/renderer/modeling/frame/frame.cpp
+++ b/src/appleseed/renderer/modeling/frame/frame.cpp
@@ -706,7 +706,7 @@ bool Frame::write_aov_images(const char* file_path) const
 
         // Write AOV image.
         if (!aov->write_images(aov_file_path.c_str()))
-            return false;
+            success = false;
     }
 
     return success;
@@ -753,7 +753,7 @@ bool Frame::write_main_and_aov_images() const
 
             // Write AOV image.
             if (!aov->write_images(filepath.string().c_str()))
-                return false;
+                success = false;
         }
     }
 

--- a/src/appleseed/renderer/modeling/frame/frame.cpp
+++ b/src/appleseed/renderer/modeling/frame/frame.cpp
@@ -496,8 +496,7 @@ namespace
     void write_exr_image(
         const bf::path&         file_path,
         const Image&            image,
-        ImageAttributes&        image_attributes,
-        const AOV*              aov)
+        ImageAttributes&        image_attributes)
     {
         create_parent_directories(file_path);
 
@@ -506,15 +505,6 @@ namespace
         GenericImageFileWriter writer(filename.c_str());
 
         writer.append_image(&image);
-
-        if (aov)
-        {
-            // If the AOV has color data, assume we can save it as half floats.
-            if (aov->has_color_data())
-                writer.set_image_output_format(PixelFormatHalf);
-
-            writer.set_image_channels(aov->get_channel_count(), aov->get_channel_names());
-        }
 
         image_attributes.insert("color_space", "linear");
         writer.set_image_attributes(image_attributes);
@@ -589,8 +579,7 @@ namespace
 
     bool write_image(
         const char*             file_path,
-        const Image&            image,
-        const AOV*              aov = nullptr)
+        const Image&            image)
     {
         assert(file_path);
 
@@ -616,8 +605,7 @@ namespace
                 write_exr_image(
                     bf_file_path,
                     image,
-                    image_attributes,
-                    aov);
+                    image_attributes);
             }
             else if (extension == ".png")
             {
@@ -717,8 +705,8 @@ bool Frame::write_aov_images(const char* file_path) const
         const string aov_file_path = (directory / aov_file_name).string();
 
         // Write AOV image.
-        if (!write_image(aov_file_path.c_str(), aov->get_image(), aov))
-            success = false;
+        if (!aov->write_images(aov_file_path.c_str()))
+            return false;
     }
 
     return success;
@@ -763,8 +751,9 @@ bool Frame::write_main_and_aov_images() const
                 filepath = new_filepath;
             }
 
-            if (!write_image(filepath.string().c_str(), aov->get_image(), aov))
-                success = false;
+            // Write AOV image.
+            if (!aov->write_images(filepath.string().c_str()))
+                return false;
         }
     }
 


### PR DESCRIPTION
Hi @est77,
This is quick version of the change that you've suggested me to do. I just moved some writing functionality from frame.cpp into AOV class and made the function virtual.
I tested it on max scene and it worked.
If I understand correctly this change will not reduce cryptomatte's write_image code because of restriction of `GenericImageFileWriter` to 4 channels. Cryptomatte will still need its own FileWriter.