### PR TITLE
Prevent usage of negative costheta in Fresnel when normal mapping is used

### DIFF
--- a/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
@@ -610,7 +610,7 @@ shader as_standard_surface
             ? normalize(in_bump_normal_coating)
             : normalize(in_bump_normal_substrate);
 
-        float costheta_o = dot(-I, Nn);
+        float costheta_o = max(0.0, dot(-I, Nn));
 
         if (in_coating_ior > 1.0)
         {
@@ -758,7 +758,7 @@ shader as_standard_surface
         if ((compute_diffuse || compute_bssrdf || compute_edf ||
             compute_translucency) && max(in_specular_color) > 0.0)
         {
-            float costheta_o = dot(-I, Nn);
+            float costheta_o = max(0.0, dot(-I, Nn));
 
             if (in_fresnel_type == 0)
             {


### PR DESCRIPTION
The dot product of -I and Nn can be negative since Nn is based on the normal map. This causes the Fresnel term to be wrong. In appleseed internal BRDFs this issue is covered by a call to saturate(), let's do the same as as_sbs_pbrmaterial and use max(0.0, X).