### PR TITLE
Add HINTS and versioned NAMES for OpenEXR, ILMBase 2.2, 2.3

### DIFF
--- a/cmake/modules/FindImath.cmake
+++ b/cmake/modules/FindImath.cmake
@@ -30,6 +30,12 @@
 #
 # Find Imath headers and libraries.
 #
+# This module can take the following variables to define
+# custom search locations:
+#
+#   ILMBASE_ROOT
+#   ILMBASE_LOCATION
+#
 # This module defines the following variables:
 #
 #   IMATH_FOUND         True if Imath was found
@@ -39,11 +45,35 @@
 
 include (FindPackageHandleStandardArgs)
 
-find_path (IMATH_INCLUDE_DIR NAMES OpenEXR/ImathVec.h)
+find_path (IMATH_INCLUDE_DIR NAMES ImathVec.h
+           PATH_SUFFIXES OpenEXR
+           HINTS ${ILMBASE_ROOT}
+                 ${ILMBASE_LOCATION}
+                 /usr/local/include
+                 /usr/include
+)
 
-find_library (IMATH_HALF_LIBRARY NAMES Half)
-find_library (IMATH_IEX_LIBRARY NAMES Iex)
-find_library (IMATH_MATH_LIBRARY NAMES Imath)
+find_library (IMATH_HALF_LIBRARY NAMES Half-2_3 Half-2_2 Half
+              PATH_SUFFIXES lib64 lib
+              HINTS ${ILMBASE_ROOT}
+                    ${ILMBASE_LOCATION}
+                    /usr/local
+                    /usr
+)
+find_library (IMATH_IEX_LIBRARY NAMES Iex-2_3 Iex-2_2 Iex
+              PATH_SUFFIXES lib64 lib
+              HINTS ${ILMBASE_ROOT}
+                    ${ILMBASE_LOCATION}
+                    /usr/local
+                    /usr
+)
+find_library (IMATH_MATH_LIBRARY NAMES Imath-2_3 Imath-2_2 Imath
+              PATH_SUFFIXES lib64 lib
+              HINTS ${ILMBASE_ROOT}
+                    ${ILMBASE_LOCATION}
+                    /usr/local
+                    /usr
+)
 
 # Handle the QUIETLY and REQUIRED arguments and set IMATH_FOUND.
 find_package_handle_standard_args (IMATH DEFAULT_MSG

--- a/cmake/modules/FindOpenEXR.cmake
+++ b/cmake/modules/FindOpenEXR.cmake
@@ -30,6 +30,12 @@
 #
 # Find OpenEXR headers and libraries.
 #
+# This module can take the following variables to define
+# custom search locations:
+#
+#   OPENEXR_ROOT
+#   OPENEXR_LOCATION
+
 # This module defines the following variables:
 #
 #   OPENEXR_FOUND           True if OpenEXR was found
@@ -39,10 +45,30 @@
 
 include (FindPackageHandleStandardArgs)
 
-find_path (OPENEXR_INCLUDE_DIR NAMES OpenEXR/ImfHeader.h)
+find_path (OPENEXR_INCLUDE_DIR NAMES ImfHeader.h
+           PATH_SUFFIXES OpenEXR
+           HINTS ${OPENEXR_ROOT}/include
+                 ${OPENEXR_LOCATION}/include
+                 /usr/local/include
+                 /usr/include
+)
 
-find_library (OPENEXR_IMF_LIBRARY NAMES IlmImf)
-find_library (OPENEXR_THREADS_LIBRARY NAMES IlmThread)
+find_library (OPENEXR_IMF_LIBRARY NAMES IlmImf-2_3 IlmImf-2_2 IlmImf
+              PATH_SUFFIXES lib64 lib
+              HINTS ${OPENEXR_ROOT}
+                    ${OPENEXR_LOCATION}
+                    /usr/local
+                    /usr
+)
+
+find_library (OPENEXR_THREADS_LIBRARY
+              NAMES IlmThread-2_3 IlmThread-2_2 IlmThread
+              PATH_SUFFIXES lib64 lib
+              HINTS ${OPENEXR_ROOT}
+                    ${OPENEXR_LOCATION}
+                    /usr/local
+                    /usr
+)
 
 # Handle the QUIETLY and REQUIRED arguments and set OPENEXR_FOUND.
 find_package_handle_standard_args (OPENEXR DEFAULT_MSG


### PR DESCRIPTION
This should have no impact in default system search paths, it merely provided hints starting from */usr/local*, to */usr*, and to whatever is the system search path in the platform of choice. It will guarantee that a custom installation of OpenEXR (2.3 for instance), installed in */usr/local* will be found and used, before your distro's default installation in */usr*.
