### PR TITLE
Add new shaders, Maya matte support, fixes

### DIFF
--- a/src/appleseed.shaders/CMakeLists.txt
+++ b/src/appleseed.shaders/CMakeLists.txt
@@ -267,6 +267,7 @@ set (src_appleseed_sources
      src/appleseed/as_attributes.osl
      src/appleseed/as_blackbody.osl
      src/appleseed/as_blend_color.osl
+     src/appleseed/as_blend_normal.osl
      src/appleseed/as_blend_shader.osl
      src/appleseed/as_bump.osl
      src/appleseed/as_closure2surface.osl
@@ -290,10 +291,12 @@ set (src_appleseed_sources
      src/appleseed/as_noise3d.osl
      src/appleseed/as_plastic.osl
      src/appleseed/as_ray_switch.osl
+     src/appleseed/as_ray_switch_surface.osl
      src/appleseed/as_sbs_pbrmaterial.osl
      src/appleseed/as_space_transform.osl
      src/appleseed/as_standard_surface.osl
      src/appleseed/as_subsurface.osl
+     src/appleseed/as_surface_luminance.osl
      src/appleseed/as_switch_surface.osl
      src/appleseed/as_switch_texture.osl
      src/appleseed/as_swizzle.osl

--- a/src/appleseed.shaders/include/appleseed/math/as_math_helpers.h
+++ b/src/appleseed.shaders/include/appleseed/math/as_math_helpers.h
@@ -81,48 +81,14 @@ float fast_gain(float value, float g)
 //
 // Reference:
 //
-//      Lehmer linear congruential generator (Park-Miller)
-//
-//      Random Number Generators: Good Ones Are Hard To Find,
-//      Stephen K.Park and Keith W.Miller
-//
-//      http://www.firstpr.com.au/dsp/rand31/p1192-park.pdf
-//      https://en.wikipedia.org/wiki/Lehmer_random_number_generator
+//  https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/divmodnote-letter.pdf
 //
 
-int rand_int(int seed)
+int remainder(int x, int y)
 {
-    int a = 16807;
-    int q = 127773;
-    int r = 2836;
-    int m = 2147483647;
-
-    int hi = seed / q;
-    int lo = seed % q;
-    int x = a * lo - r * hi;
-
-    return x > 0 ? x : x + m;
-}
-
-int rand_float(int seed, output float result)
-{
-    int x = rand_int(seed);
-    result = x / 2147483647;
-
-    return x;
-}
-
-float random(float x, float s, float t)
-{
-    vector A = vector(s, t, 0); // s=u, t=v usually
-    vector B = vector(4.213536, 8.34621351, 0);
-
-    return mod(sin(dot(A, B)) * 917853.4917593, 1.0);
-}
-
-float random(float x)
-{
-    return random(x, u, v);
+    int rem = x % y;
+    if ((rem > 0 && y < 0) || (rem < 0 && y > 0)) rem += y;
+    return rem;
 }
 
 float fract(float x)

--- a/src/appleseed.shaders/src/appleseed/as_anisotropy_vector_field.osl
+++ b/src/appleseed.shaders/src/appleseed/as_anisotropy_vector_field.osl
@@ -30,7 +30,7 @@ shader as_anisotropy_vector_field
 [[
     string help = "Creates an anisotropy field vector from an input color.",
     string icon = "asAnisotropyVectorField.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_anisotropy_vector_field.html#label-as-anisotropy-vector-field",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_anisotropy_vector_field.html",
 
     string as_node_name = "asAnisotropyVectorField",
     string as_category = "utility",

--- a/src/appleseed.shaders/src/appleseed/as_asc_cdl.osl
+++ b/src/appleseed.shaders/src/appleseed/as_asc_cdl.osl
@@ -39,7 +39,7 @@ shader as_asc_cdl
 [[
     string icon = "asAscCdl.png",
     string help = "Slope/Offset/Power Color Decision List utility shader according to the American Society of Cinematographers",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_asc_cdl.html#label-as-asc-cdl",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_asc_cdl.html",
     
     string as_node_name = "asAscCdl",
     string as_category = "utility",
@@ -154,7 +154,7 @@ shader as_asc_cdl
 
     color unclamped = mix(luma, transformed_color, in_saturation);
 
-    out_outColor = (in_clamp_output)
+    out_outColor = in_clamp_output
         ? clamp(unclamped, color(0), color(1))
         : unclamped;
 }

--- a/src/appleseed.shaders/src/appleseed/as_attributes.osl
+++ b/src/appleseed.shaders/src/appleseed/as_attributes.osl
@@ -30,7 +30,7 @@ shader as_attributes
 [[
     string help = "OSL and appleseed attributes.",
     string icon = "asAttributes.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_attributes.html#label-as-attributes",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_attributes.html",
 
     string as_node_name = "asAttributes",
     string as_category = "utility",

--- a/src/appleseed.shaders/src/appleseed/as_blackbody.osl
+++ b/src/appleseed.shaders/src/appleseed/as_blackbody.osl
@@ -33,7 +33,7 @@ shader as_blackbody
 [[
     string help = "Emission shader with black-body radiation.",
     string icon = "asBlackbody.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_blackbody.html#label-as-blackbody",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_blackbody.html",
 
     string as_node_name = "asBlackbody",
     string as_category = "shader",

--- a/src/appleseed.shaders/src/appleseed/as_blend_color.osl
+++ b/src/appleseed.shaders/src/appleseed/as_blend_color.osl
@@ -32,7 +32,7 @@ shader as_blend_color
 [[
     string help = "Color blend utility node.",
     string icon = "asBlendColor.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_blend_color.html#label-as-blend-color",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_blend_color.html",
 
     string as_node_name = "asBlendColor",
     string as_category = "color",

--- a/src/appleseed.shaders/src/appleseed/as_blend_normal.osl
+++ b/src/appleseed.shaders/src/appleseed/as_blend_normal.osl
@@ -1,0 +1,253 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2019 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "appleseed/math/as_math_helpers.h"
+
+shader as_blend_normal
+[[
+    string help = "Tangent space normal blend utility node.",
+    string icon = "asBlendNormal.png",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_blend_normal.html",
+
+    string as_node_name = "asBlendNormal",
+    string as_category = "utility",
+
+    string as_max_class_id = "1585865021 797245718",
+    string as_max_plugin_type = "texture",
+
+    int as_maya_type_id = 0x00127a09,
+    string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility"
+]]
+(
+    normal in_base_normal = normal(0)
+    [[
+        string as_maya_attribute_name = "baseNormal",
+        string as_maya_attribute_short_name = "bnr",
+        string label = "Base Normal",
+        string page = "Base Normal",
+        string help = "The base tangent space normal map.",
+        int divider = 1
+    ]],
+    string in_base_normal_mode = "Unsigned"
+    [[
+        string as_maya_attribute_name = "baseNormalMode",
+        string as_maya_attribute_short_name = "brm",
+        string widget = "popup",
+        string options = "Unsigned|Signed",
+        string label = "Normal Map Mode",
+        string page = "Base Normal",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        int divider = 1
+    ]],
+    int in_base_normal_flip_r = 0
+    [[
+        string as_maya_attribute_name = "baseNormalFlipR",
+        string as_maya_attribute_short_name = "bfr",
+        string widget = "checkBox",
+        string label = "Flip R",
+        string page = "Base Normal",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    int in_base_normal_flip_g = 0
+    [[
+        string as_maya_attribute_name = "baseNormalFlipG",
+        string as_maya_attribute_short_name = "bfg",
+        string widget = "checkBox",
+        string label = "Flip G",
+        string page = "Base Normal",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    int in_base_normal_swap_rg = 0
+    [[
+        string as_maya_attribute_name = "baseNormalSwapRG",
+        string as_maya_attribute_short_name = "bsw",
+        string widget = "checkBox",
+        string label = "Swap RG",
+        string page = "Base Normal",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        int divider = 1
+    ]],
+
+    normal in_detail_normal = normal(0)
+    [[
+        string as_maya_attribute_name = "detailNormal",
+        string as_maya_attribute_short_name = "dno",
+        string label = "Detail Normal",
+        string page = "Detail Normal",
+        string help = "The detail tangent space normal to blend over the base.",
+        int divider = 1
+    ]],
+    string in_detail_normal_mode = "Unsigned"
+    [[
+        string as_maya_attribute_name = "detailNormalMode",
+        string as_maya_attribute_short_name = "dnm",
+        string widget = "popup",
+        string options = "Unsigned|Signed",
+        string label = "Normal Map Mode",
+        string page = "Detail Normal",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        int divider = 1
+    ]],
+    int in_detail_normal_flip_r = 0
+    [[
+        string as_maya_attribute_name = "detailNormalFlipR",
+        string as_maya_attribute_short_name = "dfr",
+        string widget = "checkBox",
+        string label = "Flip R",
+        string page = "Detail Normal",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    int in_detail_normal_flip_g = 0
+    [[
+        string as_maya_attribute_name = "detailNormalFlipG",
+        string as_maya_attribute_short_name = "dfg",
+        string widget = "checkBox",
+        string label = "Flip G",
+        string page = "Detail Normal",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    int in_detail_normal_swap_rg = 0
+    [[
+        string as_maya_attribute_name = "detailNormalSwapRG",
+        string as_maya_attribute_short_name = "dsw",
+        string widget = "checkBox",
+        string label = "Swap RG",
+        string page = "Detail Normal",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        int divider = 1
+    ]],
+    float in_detail_normal_weight = 1.0
+    [[
+        string as_maya_attribute_name = "detailNormalWeight",
+        string as_maya_attribute_short_name = "dwe",
+        float min = 0.0,
+        float max = 1.0,
+        string label = "Blending Weight",
+        string page = "Blending",
+        string help = "Detail normal blending weight.",
+        int divider = 1
+    ]],
+    vector Tn = vector(0)
+    [[
+        int lockgeom = 0,
+        string widget = "null",
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0
+    ]],
+    vector Bn = vector(0)
+    [[
+        int lockgeom = 0,
+        string widget = "null",
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0
+    ]], 
+
+    output normal out_normal = color(0)
+    [[
+        string as_maya_attribute_name = "outNormal",
+        string as_maya_attribute_short_name = "on",
+        string widget = "null",
+        string label = "Output Normal",
+        string help = "Output unsigned tangent space normal map"
+    ]]
+)
+{
+    normal baseN = (in_base_normal_mode == "Unsigned")
+        ? in_base_normal * normal(2) - normal(1)
+        : in_base_normal;
+
+    if (in_base_normal_flip_r) baseN[0] *= -1;
+    if (in_base_normal_flip_g) baseN[1] *= -1;
+
+    if (in_base_normal_swap_rg)
+    {
+        float tmp = baseN[0];
+        baseN[0] = baseN[1];
+        baseN[1] = tmp;
+    }
+
+    normal detailN = (in_detail_normal_mode == "Unsigned")
+        ? in_detail_normal * normal(2) - normal(1)
+        : in_detail_normal;
+
+    if (in_detail_normal_flip_r) detailN[0] *= -1;
+    if (in_detail_normal_flip_g) detailN[1] *= -1;
+
+    if (in_detail_normal_swap_rg)
+    {
+        float tmp = detailN[0];
+        detailN[0] = detailN[1];
+        detailN[1] = tmp;
+    }
+
+    baseN = normalize(baseN);
+    detailN = normalize(detailN);
+
+    baseN[2] += 1;
+    detailN[0] *= -in_detail_normal_weight;
+    detailN[1] *= -in_detail_normal_weight;
+
+    normal O = baseN * dot(baseN, detailN) / baseN[2] - detailN;
+
+    out_normal = normalize(O);
+    out_normal = out_normal * normal(0.5) + normal(0.5);
+}

--- a/src/appleseed.shaders/src/appleseed/as_blend_shader.osl
+++ b/src/appleseed.shaders/src/appleseed/as_blend_shader.osl
@@ -30,7 +30,7 @@ shader as_blend_shader
 [[
     string help = "Shader blending or mixing node.",
     string icon = "asBlendShader.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_blend_shader.html#label-as-blend-shader",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_blend_shader.html",
 
     string as_node_name = "asBlendShader",
     string as_category = "shader",

--- a/src/appleseed.shaders/src/appleseed/as_bump.osl
+++ b/src/appleseed.shaders/src/appleseed/as_bump.osl
@@ -32,7 +32,7 @@ shader as_bump
 [[
     string help = "Bump and normal mapping node.",
     string icon = "asBump.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_bump.html#label-as-bump",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_bump.html",
 
     string as_node_name = "asBump",
     string as_category = "utility",

--- a/src/appleseed.shaders/src/appleseed/as_color_transform.osl
+++ b/src/appleseed.shaders/src/appleseed/as_color_transform.osl
@@ -33,7 +33,7 @@ shader as_color_transform
 [[
     string help = "Transforms a color from one color model to another color model.",
     string icon = "asColorTransform.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_color_transform.html#label-as-color-transform",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_color_transform.html",
 
     string as_node_name = "asColorTransform",
     string as_category = "color",

--- a/src/appleseed.shaders/src/appleseed/as_composite_color.osl
+++ b/src/appleseed.shaders/src/appleseed/as_composite_color.osl
@@ -32,7 +32,7 @@ shader as_composite_color
 [[
     string help = "Porter-Duff Compositing operators node.",
     string icon = "asCompositeColor.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_composite_color.html#label-as-composite-color",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_composite_color.html",
 
     string as_node_name = "asCompositeColor",
     string as_category = "color",

--- a/src/appleseed.shaders/src/appleseed/as_create_mask.osl
+++ b/src/appleseed.shaders/src/appleseed/as_create_mask.osl
@@ -34,7 +34,7 @@ shader as_create_mask
 [[
     string help = "Creates a greyscale mask from an input color or grey value.",
     string icon = "asCreateMask.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_create_mask.html#label-as-create-mask",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_create_mask.html",
 
     string as_node_name = "asCreateMask",
     string as_category = "utility",

--- a/src/appleseed.shaders/src/appleseed/as_disney_material.osl
+++ b/src/appleseed.shaders/src/appleseed/as_disney_material.osl
@@ -32,7 +32,7 @@ shader as_disney_material
 [[
     string help = "Disney material.",
     string icon = "asDisneyMaterial.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_disney_material.html#label-as-disney-material",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_disney_material.html",
 
     string as_node_name = "asDisneyMaterial",
     string as_category = "shader",

--- a/src/appleseed.shaders/src/appleseed/as_double_shade.osl
+++ b/src/appleseed.shaders/src/appleseed/as_double_shade.osl
@@ -30,7 +30,7 @@ shader as_double_shade
 [[
     string help = "Shades a different color on front or back faces.",
     string icon = "asDoubleShade.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_double_shade.html#label-as-double-shade",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_double_shade.html",
 
     string as_node_name = "asDoubleShade",
     string as_category = "utility",

--- a/src/appleseed.shaders/src/appleseed/as_falloff_angle.osl
+++ b/src/appleseed.shaders/src/appleseed/as_falloff_angle.osl
@@ -32,7 +32,7 @@ shader as_falloff_angle
 [[
     string help = "Creates a ramp from the angle between two input vectors.",
     string icon = "asFalloffAngle.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_falloff_angle.html#label-as-falloff-angle",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_falloff_angle.html",
 
     string as_node_name = "asFalloffAngle",
     string as_category = "utility",

--- a/src/appleseed.shaders/src/appleseed/as_fresnel.osl
+++ b/src/appleseed.shaders/src/appleseed/as_fresnel.osl
@@ -34,7 +34,7 @@ shader as_fresnel
 [[
     string help = "A viewer Fresnel term.",
     string icon = "asFresnel.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_fresnel.html#label-as-fresnel",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_fresnel.html",
 
     string as_node_name = "asFresnel",
     string as_category = "utility",
@@ -208,7 +208,7 @@ shader as_fresnel
             k = color(in_complex_kappa);
         }
 
-        float costheta = dot(normalize(N), -I);
+        float costheta = max(0.0, dot(normalize(N), -I));
 
         for (int i = 0; i < 3; ++i)
         {

--- a/src/appleseed.shaders/src/appleseed/as_glass.osl
+++ b/src/appleseed.shaders/src/appleseed/as_glass.osl
@@ -30,7 +30,7 @@ shader as_glass
 [[
     string help = "Glass material with absorption.",
     string icon = "asGlass.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_glass.html#label-as-glass",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_glass.html",
 
     string as_node_name = "asGlass",
     string as_category = "shader",

--- a/src/appleseed.shaders/src/appleseed/as_globals.osl
+++ b/src/appleseed.shaders/src/appleseed/as_globals.osl
@@ -30,7 +30,7 @@ shader as_globals
 [[
     string help = "OSL global variables.",
     string icon = "asGlobals.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_globals.html#label-as-globals",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_globals.html",
 
     string as_node_name = "asGlobals",
     string as_category = "utility",
@@ -150,18 +150,38 @@ shader as_globals
         int divider = 1,
         int as_max_param_id = 2
     ]],
-    output normal out_world_dNdu = 0
+    normal dNdu = 0
     [[
         int lockgeom = 0,
+        string widget = "null",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string widget = "null"
+    ]],
+    normal dNdv = 0
+    [[
+        int lockgeom = 0,
+        string widget = "null",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string widget = "null"
+    ]],
+    output normal out_world_dNdu = dNdu
+    [[
         string as_maya_attribute_name = "worldDNdu",
         string as_maya_attribute_short_name = "dnu",
         string label = "dN/du",
         string help = "Partial derivative of N along the V direction.",
         int as_max_param_id = 2
     ]],
-    output normal out_world_dNdv = 0
+    output normal out_world_dNdv = dNdv
     [[
-        int lockgeom = 0,
         string as_maya_attribute_name = "worldDNdv",
         string as_maya_attribute_short_name = "dnv",
         string label = "dN/dv",
@@ -169,17 +189,37 @@ shader as_globals
         int divider = 1,
         int as_max_param_id = 2
     ]],
-    output vector out_world_Tn = 0
+    normal Tn = 0
     [[
         int lockgeom = 0,
+        string widget = "null",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string widget = "null"
+    ]],
+    normal Bn = 0
+    [[
+        int lockgeom = 0,
+        string widget = "null",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string widget = "null"
+    ]],
+    output vector out_world_Tn = Tn
+    [[
         string as_maya_attribute_name = "worldTn",
         string as_maya_attribute_short_name = "tn",
         string label = "Tangent Vector",
         int as_max_param_id = 2
     ]],
-    output vector out_world_Bn = 0
+    output vector out_world_Bn = Bn
     [[
-        int lockgeom = 0,
         string as_maya_attribute_name = "worldBn",
         string as_maya_attribute_short_name = "bn",
         string label = "Bitangent Vector",
@@ -207,6 +247,23 @@ shader as_globals
         string label = "UV Coords",
         int divider = 1,
         int as_max_param_id = 2
+    ]],
+    color vertex_color = color(1)
+    [[
+        int lockgeom = 0,
+        string widget = "null",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string widget = "null"
+    ]],
+    output color out_vertex_color = vertex_color
+    [[
+        string as_maya_attribute_name = "vertexColor",
+        string as_maya_attribute_short_name = "vrc",
+        string label = "Vertex Color"
     ]],
     output float out_time = time
     [[

--- a/src/appleseed.shaders/src/appleseed/as_hair_material.osl
+++ b/src/appleseed.shaders/src/appleseed/as_hair_material.osl
@@ -30,7 +30,7 @@ shader as_hair_material
 [[
     string help = "Hair Material.",
     string icon = "asHair.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_hair.html#label-as-hair",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_hair.html",
 
     string as_node_name = "asHair",
     string as_category = "shader",

--- a/src/appleseed.shaders/src/appleseed/as_id_manifold.osl
+++ b/src/appleseed.shaders/src/appleseed/as_id_manifold.osl
@@ -32,7 +32,7 @@ shader as_id_manifold
 [[
     string help = "ID manifold utility shader.",
     string icon = "asIdManifold.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_id_manifold.html#label-as-id-manifold",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_id_manifold.html",
 
     string as_node_name = "asIdManifold",
     string as_category = "utility",

--- a/src/appleseed.shaders/src/appleseed/as_invert_color.osl
+++ b/src/appleseed.shaders/src/appleseed/as_invert_color.osl
@@ -37,7 +37,7 @@ shader as_invert_color
 [[
     string icon = "asInvertColor.png",
     string help = "Inverts one or more individual color channels of the input color in the respective color model. The output is a RGB color.",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_invert_color.html#label-as-invert-color",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_invert_color.html",
     
     string as_node_name = "asInvertColor",
     string as_category = "utility",

--- a/src/appleseed.shaders/src/appleseed/as_manifold2d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_manifold2d.osl
@@ -32,7 +32,7 @@ shader as_manifold2D
 [[
     string icon = "asManifold2D.png",
     string help = "Node to place and transform UV coordinates.",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_manifold2d.html#label-as-manifold2d",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_manifold2d.html",
 
     string as_node_name = "asManifold2D",
     string as_category = "utility",

--- a/src/appleseed.shaders/src/appleseed/as_matte.osl
+++ b/src/appleseed.shaders/src/appleseed/as_matte.osl
@@ -30,7 +30,7 @@ shader as_matte
 [[
     string help = "Matte Material",
     string icon = "asMatte.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_matte_surface.html#label-as-matte-surface",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_matte_surface.html",
 
     string as_node_name = "asMatte",
     string as_category = "shader",

--- a/src/appleseed.shaders/src/appleseed/as_metal.osl
+++ b/src/appleseed.shaders/src/appleseed/as_metal.osl
@@ -32,7 +32,7 @@ shader as_metal
 [[
     string icon = "asMetal.png",
     string help = "A metal material shader.",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_metal.html#label-as-metal",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_metal.html",
 
     string as_node_name = "asMetal",
     string as_category = "shader",

--- a/src/appleseed.shaders/src/appleseed/as_noise2d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_noise2d.osl
@@ -36,7 +36,7 @@ shader as_noise2d
 [[
     string icon = "asNoise2D.png",
     string help = "Recursive 2D fractal noise.",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_noise2d.html#label-as-noise2d",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_noise2d.html",
 
     string as_node_name = "asNoise2D",
     string as_category = "texture2d",

--- a/src/appleseed.shaders/src/appleseed/as_noise3d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_noise3d.osl
@@ -36,7 +36,7 @@ shader as_noise3d
 [[
     string icon = "asNoise3D.png",
     string help = "Recursive 3D fractal noise.",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_noise3d.html#label-as-noise3d",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_noise3d.html",
 
     string as_node_name = "asNoise3D",
     string as_category = "texture3d",

--- a/src/appleseed.shaders/src/appleseed/as_plastic.osl
+++ b/src/appleseed.shaders/src/appleseed/as_plastic.osl
@@ -30,7 +30,7 @@ shader as_plastic
 [[
     string icon = "asPlastic.png",
     string help = "A plastic material, layering a diffuse and specular terms.",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_plastic.html#label-as-plastic",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_plastic.html",
 
     string as_node_name = "asPlastic",
     string as_category = "shader",

--- a/src/appleseed.shaders/src/appleseed/as_ray_switch.osl
+++ b/src/appleseed.shaders/src/appleseed/as_ray_switch.osl
@@ -30,7 +30,7 @@ shader as_ray_switch
 [[
     string help = "Ray switch utility node.",
     string icon = "asRaySwitch.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_ray_switch.html#label-as-ray-switch",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_ray_switch.html",
 
     string as_node_name = "asRaySwitch",
     string as_category = "utility",

--- a/src/appleseed.shaders/src/appleseed/as_ray_switch_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_ray_switch_surface.osl
@@ -1,0 +1,153 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2019 Luis Barrancos, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+shader as_ray_switch_surface
+[[
+    string help = "Ray switch surface shadear.",
+    string icon = "asRaySwitchSurface.png",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_ray_switch_surface.html",
+
+    string as_node_name = "asRaySwitchSurface",
+    string as_category = "shader",
+
+    string as_max_class_id = "553479896 1617499966",
+    string as_max_plugin_type = "material",
+
+    int as_maya_type_id = 0x00127a0b,
+    string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch"
+]]
+(
+    closure color in_material_camera = 0
+    [[
+        string as_maya_attribute_name = "materialCamera",
+        string as_maya_attribute_short_name = "mca",
+        string label = "Camera Ray Material",
+        string page = "Material"
+    ]],
+    closure color in_material_light = 0
+    [[
+        string as_maya_attribute_name = "materialLight",
+        string as_maya_attribute_short_name = "mli",
+        string label = "Light Ray Material",
+        string page = "Material"
+    ]],
+    closure color in_material_shadow = 0
+    [[
+        string as_maya_attribute_name = "materialShadow",
+        string as_maya_attribute_short_name = "msh",
+        string label = "Shadow Ray Material",
+        string page = "Material"
+    ]],
+    closure color in_material_transparency = 0
+    [[
+        string as_maya_attribute_name = "materialTransparency",
+        string as_maya_attribute_short_name = "mtr",
+        string label = "Transparency Ray Material",
+        string page = "Material"
+    ]],
+    closure color in_material_diffuse = 0
+    [[
+        string as_maya_attribute_name = "materialDiffuse",
+        string as_maya_attribute_short_name = "mdi",
+        string label = "Diffuse Ray Material",
+        string page = "Material"
+    ]],
+    closure color in_material_glossy = 0
+    [[
+        string as_maya_attribute_name = "materialGlossy",
+        string as_maya_attribute_short_name = "cgl",
+        string label = "Glossy Ray Material",
+        string page = "Material"
+    ]],
+    closure color in_material_specular = 0
+    [[
+        string as_maya_attribute_name = "materialSpecular",
+        string as_maya_attribute_short_name = "msp",
+        string label = "Specular Ray Material",
+        string page = "Material"
+    ]],
+    closure color in_material_subsurface = 0
+    [[
+        string as_maya_attribute_name = "materialSubsurface",
+        string as_maya_attribute_short_name = "msu",
+        string label = "Subsurface Ray Material",
+        string page = "Material"
+    ]],
+
+    output closure color out_color = 0
+    [[
+        string as_maya_attribute_name = "outColor",
+        string as_maya_attribute_short_name = "oc",
+        string label = "Output Material",
+        string page = "Output",
+        string widget = "null"
+    ]]
+)
+{
+    if (raytype("camera"))
+    {
+        out_color = in_material_camera;
+    }
+    else if (raytype("light"))
+    {
+        out_color = in_material_light;
+    }
+    else if (raytype("shadow"))
+    {
+        out_color = in_material_shadow;
+    }
+    else if (raytype("transparency"))
+    {
+        out_color = in_material_transparency;
+    }
+    else if (raytype("diffuse"))
+    {
+        out_color = in_material_diffuse;
+    }
+    else if (raytype("glossy"))
+    {
+        out_color = in_material_glossy;
+    }
+    else if (raytype("specular"))
+    {
+        out_color = in_material_specular;
+    }
+    else if (raytype("subsurface"))
+    {
+        out_color = in_material_subsurface;
+    }
+    else
+    {
+#ifdef DEBUG
+        string shadername = "";
+        getattribute("shader:shadername", shadername);
+        warning("[WARNING]: Unknown Ray Type in %s, %s:%d\n",
+                shadername, __FILE__, __LINE__);
+#endif
+    }
+}

--- a/src/appleseed.shaders/src/appleseed/as_sbs_pbrmaterial.osl
+++ b/src/appleseed.shaders/src/appleseed/as_sbs_pbrmaterial.osl
@@ -32,7 +32,7 @@ shader as_sbs_pbrmaterial
 [[
     string help = "Substance Painter PBR material.",
     string icon = "asSbsPbrMaterial.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_sbs_pbrmaterial.html#label-as-sbs-pbrmaterial",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_sbs_pbrmaterial.html",
 
     string as_node_name = "asSbsPbrMaterial",
     string as_category = "shader",

--- a/src/appleseed.shaders/src/appleseed/as_space_transform.osl
+++ b/src/appleseed.shaders/src/appleseed/as_space_transform.osl
@@ -30,7 +30,7 @@ shader as_space_transform
 [[
     string help = "Coordinate system transform node.",
     string icon = "asSpaceTransform.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_space_transform.html#label-as-space-transform",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_space_transform.html",
 
     string as_node_name = "asSpaceTransform",
     string as_category = "utility",

--- a/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
@@ -33,7 +33,7 @@ shader as_standard_surface
 [[
     string help = "appleseed's standard material shader.",
     string icon = "asStandardSurface.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_standard_surface.html#label-as-standard-surface",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_standard_surface.html",
 
     string as_node_name = "asStandardSurface",
     string as_category = "shader",

--- a/src/appleseed.shaders/src/appleseed/as_subsurface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_subsurface.osl
@@ -32,7 +32,7 @@ shader as_subsurface
 [[
     string help = "SubSurface Scattering material.",
     string icon = "asSubsurface.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_subsurface.html#label-as-subsurface",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_subsurface.html",
 
     string as_node_name = "asSubsurface",
     string as_category = "shader",
@@ -49,7 +49,7 @@ shader as_subsurface
         string as_maya_attribute_name = "sssProfile",
         string as_maya_attribute_short_name = "ssp",
         string widget = "mapper",
-        string options = "Better Dipole:0|Directional Dipole:1|Gaussian:2|Normalized Diffusion:3|Standard Dipole:4|Diffuse Random Walk:5",
+        string options = "Better Dipole:0|Directional Dipole:1|Gaussian:2|Normalized Diffusion:3|Standard Dipole:4|Diffuse Random Walk:5|Glassy Random Walk:6",
         string label = "Subsurface Profile",
         string page = "Subsurface",
         int as_maya_attribute_connectable = 0,
@@ -96,6 +96,24 @@ shader as_subsurface
         string label = "Depth Scale",
         string page = "Subsurface",
         int as_max_param_id = 7
+    ]],
+    float in_volume_anisotropy = 0.0
+    [[
+        string as_maya_attribute_name = "volumeAnisotropy",
+        string as_maya_attribute_short_name = "sva",
+        string widget = "slider",
+        float min = -1.0,
+        float max = 1.0,
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Volume Anisotropy",
+        string page = "Subsurface",
+        int as_max_param_id = 36,
+        string help = "Scattering anisotropy, with negative values producing back scattering, 0 producing isotropic scattering, and positive values producing forward scattering",
+        int divider = 1
     ]],
     int in_sss_maximum_ray_depth = 8
     [[
@@ -327,40 +345,54 @@ shader as_subsurface
 
     color albedo = clamp(in_sss_amount * in_color, 0.01, 0.99);
 
-    string sss_profile;
-
-    if (in_sss_profile == 0)
+    if (in_sss_profile == 6) // glass random walk
     {
-        sss_profile = "better_dipole";
-    }
-    else if (in_sss_profile == 1)
-    {
-        sss_profile = "directional_dipole";
-    }
-    else if (in_sss_profile == 2)
-    {
-        sss_profile = "gaussian";
-    }
-    else if (in_sss_profile == 3)
-    {
-        sss_profile = "normalized_diffusion";
-    }
-    else if (in_sss_profile == 4)
-    {
-        sss_profile = "standard_dipole";
+        out_outColor += as_randomwalk_glass(
+            Nn,
+            albedo,
+            in_sss_mfp_scale * in_sss_mfp,
+            in_ior,
+            in_specular_roughness,
+            "fresnel_weight", 1.0,
+            "volume_anisotropy", in_volume_anisotropy);
     }
     else
     {
-        sss_profile = "randomwalk"; // diffuse random walk
-    }
+        string sss_profile;
 
-    out_outColor += as_subsurface(
-        sss_profile,
-        Nn,
-        albedo,
-        in_sss_mfp_scale * in_sss_mfp,
-        in_ior,
-        "fresnel_weight", in_fresnel_weight);
+        if (in_sss_profile == 0)
+        {
+            sss_profile = "better_dipole";
+        }
+        else if (in_sss_profile == 1)
+        {
+            sss_profile = "directional_dipole";
+        }
+        else if (in_sss_profile == 2)
+        {
+            sss_profile = "gaussian";
+        }
+        else if (in_sss_profile == 3)
+        {
+            sss_profile = "normalized_diffusion";
+        }
+        else if (in_sss_profile == 4)
+        {
+            sss_profile = "standard_dipole";
+        }
+        else
+        {
+            sss_profile = "randomwalk"; // diffuse random walk
+        }
+
+        out_outColor += as_subsurface(
+            sss_profile,
+            Nn,
+            albedo,
+            in_sss_mfp_scale * in_sss_mfp,
+            in_ior,
+            "fresnel_weight", in_fresnel_weight);
+    }
 
     if (in_specular_weight > 0.0)
     {

--- a/src/appleseed.shaders/src/appleseed/as_surface_luminance.osl
+++ b/src/appleseed.shaders/src/appleseed/as_surface_luminance.osl
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2017-2018 Luis Barrancos, The appleseedhq Organization
+// Copyright (c) 2019 Luis Barrancos, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -30,28 +30,74 @@
 #include "appleseed/color/as_colorimetry.h"
 #include "appleseed/maya/as_maya_helpers.h"
 
-shader as_luminance
+shader as_surface_luminance
 [[
-    string icon = "asLuminance.png",
-    string help = "A node that outputs the (color space-aware) relative luminance of a color.",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_luminance.html",
+    string icon = "asSurfaceLuminance.png",
+    string help = "Node that gets the relative luminance of an input closure.",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_surface_luminance.html",
 
-    string as_node_name = "asLuminance",
-    string as_category = "color",
+    string as_node_name = "asSurfaceLuminance",
+    string as_category = "shader",
 
-    string as_max_class_id = "1648771987 792674094",
-    string as_max_plugin_type = "texture",
+    string as_max_class_id = "1813865764 1568361250",
+    string as_max_plugin_type = "material",
 
-    int as_maya_type_id = 0x001279cd,
-    string as_maya_classification = "drawdb/shader:rendernode/appleseed/utility"
+    int as_maya_type_id = 0x00127a0a,
+    string as_maya_classification = "drawdb/shader/surface:rendernode/appleseed/surface:shader/surface:swatch/AppleseedRenderSwatch"
 ]]
 (
-    color in_color = color(0.5)
+    closure color in_color = 0
     [[
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
-        string label = "Input Color",
-        string page = "Color"
+        string label = "Surface shader",
+        string page = "Surface",
+        string help = "The input material shader.",
+        int divider = 1
+    ]],
+    string in_evaluation_mode = "diffuse+specular"
+    [[
+        string as_maya_attribute_name = "evaluationMode",
+        string as_maya_attribute_short_name = "evm",
+        string widget = "popup",
+        string options = "emission|diffuse|specular|emission+diffuse|emission+specular|diffuse+specular|all",
+        string label = "Evaluation Mode",
+        string page = "Surface",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string help = "The choice of closure BxDF to consider for evaluation",
+        int divider = 1
+    ]],
+    int in_clamp_input = 0
+    [[
+        string as_maya_attribute_name = "clampInput",
+        string as_maya_attribute_short_name = "cin",
+        string widget = "checkBox",
+        string label = "Clamp Input",
+        string page = "Surface",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string help = "Clamp input to [0,1] range."
+    ]],
+    int in_clamp_output = 0
+    [[
+        string as_maya_attribute_name = "clampOutput",
+        string as_maya_attribute_short_name = "cou",
+        string widget = "checkBox",
+        string label = "Clamp Output",
+        string page = "Surface",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string help = "Clamp output to [0,1] range."
     ]],
     int in_deriveFromMayaCMS = 1
     [[
@@ -157,23 +203,72 @@ shader as_luminance
 
     MAYA_COLORMANAGEMENT_PARAMETERS,
 
-    output float out_result = 0.0
+    output float out_result = 0
     [[
         string as_maya_attribute_name = "result",
         string as_maya_attribute_short_name = "r",
+        string label = "Luminance Scalar"
+    ]],
+    output closure color out_color = 0
+    [[
+        string as_maya_attribute_name = "outColor",
+        string as_maya_attribute_short_name = "oc",
+        string label = "Surface Luminance",
         string widget = "null"
     ]]
 )
 {
-    if (in_color != 0)
+    if (!isconnected(in_color))
     {
+        return;
+    }
+
+    if (!raytype("npr"))
+    {
+        out_color = in_color;
+    }
+    else
+    {
+        color emis = color(0), diff = color(0), spec = color(0);
+
+        if (in_evaluation_mode == "emission" ||
+            in_evaluation_mode == "emission+diffuse" ||
+            in_evaluation_mode == "emission+specular" ||
+            in_evaluation_mode == "all")
+        {
+            getattribute("surface_shader:emission", emis);
+        }
+
+        if (in_evaluation_mode == "diffuse" ||
+            in_evaluation_mode == "emission+diffuse" ||
+            in_evaluation_mode == "diffuse+specular" ||
+            in_evaluation_mode == "all")
+        {
+            getattribute("surface_shader:diffuse", diff);
+        }
+
+        if (in_evaluation_mode == "specular" ||
+            in_evaluation_mode == "emission+specular" ||
+            in_evaluation_mode == "diffuse+specular" ||
+            in_evaluation_mode == "all")
+        {
+            getattribute("surface_shader:glossy", spec);
+        }
+
+        if (max(emis) < EPS && max(diff) < EPS && max(spec) < EPS)
+        {
+            return;
+        }
+                                                      
+        // Derive the rendering/working space from Maya.
+
         color coeffs;
 
         if (in_deriveFromMayaCMS)
         {
             if (!in_colorManagementEnabled)
             {
-                // CMS is off, default to Rec.709 fallback.
+                // CMS off, default to sRGB/Rec.709 RGB primaries and white.
                 coeffs = color(REC709_D65_LUMINANCE_COEFFS);
             }
             else
@@ -212,9 +307,12 @@ shader as_luminance
         }
         else
         {
+            // Explicitly set the working space, starting with custom RGBW
+            // primaries and choice of white points.
+
             if (in_inputColorSpace == 5)
             {
-                color RGBW[4]; // explicit R,G,B,W chromaticity coordinates
+                color RGBW[4];
 
                 RGBW[0] = transform_CIExyY_to_CIEXYZ(
                     color(in_chromaticityCoordsR[0],
@@ -328,6 +426,8 @@ shader as_luminance
             }
             else
             {
+                // Provide common RGBW chromaticity coordinates.
+
                 if (in_inputColorSpace == 0)
                 {
                     coeffs = color(ACES_D60_LUMINANCE_COEFFS);
@@ -354,12 +454,23 @@ shader as_luminance
                 }
             }
         }
-        out_result = coeffs[0] * in_color[0] +
-                     coeffs[1] * in_color[1] +
-                     coeffs[2] * in_color[2];
-    }
-    else
-    {
-        out_result = 0.0;
+
+        if (in_clamp_input)
+        {
+            emis = clamp(emis, 0, 1);
+            diff = clamp(diff, 0, 1);
+            spec = clamp(spec, 0, 1);
+        }
+
+        color input_color = (in_clamp_output)
+            ? clamp(emis + diff + spec, 0, 1)
+            : emis + diff + spec;
+
+        float relative_Y = coeffs[0] * input_color[0] +
+                           coeffs[1] * input_color[1] +
+                           coeffs[2] * input_color[2];
+
+        out_color = relative_Y * as_npr_shading();
+        out_result = relative_Y;
     }
 }

--- a/src/appleseed.shaders/src/appleseed/as_switch_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_switch_surface.osl
@@ -26,13 +26,14 @@
 // THE SOFTWARE.
 //
 
+#include "appleseed/math/as_math_helpers.h"
 #include "appleseed/transform/as_transform_helpers.h"
 
 shader as_switch_surface
 [[
     string help = "Material variation utility shader.",
     string icon = "asSwitchSurface.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_switch_surface.html#label-as-switch-surface",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_switch_surface.html",
 
     string as_node_name = "asSwitchSurface",
     string as_category = "utility",
@@ -276,7 +277,7 @@ shader as_switch_surface
             in_color, in_color1, in_color2, in_color3,
             in_color4, in_color5, in_color6, in_color7};
 
-        int len = arraylength(surfaces) - 1;
+        int len = arraylength(surfaces);
 
         compute_id_manifold(
             in_manifold_type,
@@ -288,8 +289,8 @@ shader as_switch_surface
             grey_id);
 
         int index = (in_cycle_mode == 0)
-            ? (int) mod(hash_id, len)
-            : (int) clamp(grey_id * len, 0, len);
+            ? (int) remainder(hash_id, len)
+            : (int) clamp(grey_id * (len - 1), 0, len - 1);
 
         out_outColor = surfaces[index];
     }

--- a/src/appleseed.shaders/src/appleseed/as_switch_texture.osl
+++ b/src/appleseed.shaders/src/appleseed/as_switch_texture.osl
@@ -26,13 +26,18 @@
 // THE SOFTWARE.
 //
 
+#include "appleseed/math/as_math_helpers.h"
 #include "appleseed/transform/as_transform_helpers.h"
+
+#ifndef AS_SWITCH_NUM_IMAGES
+#define AS_SWITCH_NUM_IMAGES    8
+#endif
 
 shader as_switch_texture
 [[
     string help = "Texture variation utility shader.",
     string icon = "asSwitchTexture.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_switch_texture.html#label-as-switch-texture",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_switch_texture.html",
 
     string as_node_name = "asSwitchTexture",
     string as_category = "utility",
@@ -183,12 +188,11 @@ shader as_switch_texture
     ]]
 )
 {
-    color textures[8] = {
+    color textures[AS_SWITCH_NUM_IMAGES] = {
             in_color, in_color1, in_color2, in_color3,
             in_color4, in_color5, in_color6, in_color7};
 
-    int len = arraylength(textures) - 1, hash_id = 0;
-
+    int hash_id = 0, index;
     float grey_id = 0.0;
     color cell_id = color(0);
 
@@ -201,9 +205,15 @@ shader as_switch_texture
         cell_id,
         grey_id);
 
-    int index = (in_cycle_mode == 0)
-        ? (int) mod(hash_id, len)
-        : (int) clamp(grey_id * len, 0, len);
+    if (in_cycle_mode == 0)
+    {
+        index = remainder(hash_id, AS_SWITCH_NUM_IMAGES);
+    }
+    else
+    {
+        int upper_bound = AS_SWITCH_NUM_IMAGES - 1;
+        index = (int) clamp(grey_id * upper_bound, 0, upper_bound);
+    }
 
     out_outColor = textures[index];
 }

--- a/src/appleseed.shaders/src/appleseed/as_swizzle.osl
+++ b/src/appleseed.shaders/src/appleseed/as_swizzle.osl
@@ -30,7 +30,7 @@ shader as_swizzle
 [[
     string help = "RGBA or vector swizzle node.",
     string icon = "asSwizzle.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_swizzle.html#label-as-swizzle",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_swizzle.html",
 
     string as_node_name = "asSwizzle",
     string as_category = "utility",

--- a/src/appleseed.shaders/src/appleseed/as_texture.osl
+++ b/src/appleseed.shaders/src/appleseed/as_texture.osl
@@ -36,7 +36,7 @@ shader as_texture
 [[
     string help = "Texture lookup node.",
     string icon = "asTexture.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_texture.html#label-as-texture",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_texture.html",
 
     string as_node_name = "asTexture",
     string as_category = "texture2d",

--- a/src/appleseed.shaders/src/appleseed/as_texture3d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_texture3d.osl
@@ -34,7 +34,7 @@ shader as_texture3d
 [[
     string help = "A field3d format 3D texture lookup node.",
     string icon = "asTexture3D.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_texture3d.html#label-as-texture3d",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_texture3d.html",
 
     string as_node_name = "asTexture3D",
     string as_category = "texture3d",

--- a/src/appleseed.shaders/src/appleseed/as_texture_info.osl
+++ b/src/appleseed.shaders/src/appleseed/as_texture_info.osl
@@ -30,7 +30,7 @@ shader as_texture_info
 [[
     string help = "Texture Information node.",
     string icon = "asTextureInfo.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_texture_info.html#label-as-texture-info",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_texture_info.html",
 
     string as_node_name = "asTextureInfo",
     string as_category = "texture2d",

--- a/src/appleseed.shaders/src/appleseed/as_toon.osl
+++ b/src/appleseed.shaders/src/appleseed/as_toon.osl
@@ -44,7 +44,7 @@ shader as_toon
 [[
     string help = "Non-Photo-Realistic (NPR) Toon material node",
     string icon = "asToon.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_toon.html#label-as-toon",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/material/as_toon.html",
 
     string as_node_name = "asToon",
     string as_category = "shader",

--- a/src/appleseed.shaders/src/appleseed/as_triplanar.osl
+++ b/src/appleseed.shaders/src/appleseed/as_triplanar.osl
@@ -34,7 +34,7 @@ shader as_triplanar
 [[
     string help = "Tri-planar projection node.",
     string icon = "asTriPlanar.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_triplanar.html#label-as-triplanar",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_triplanar.html",
 
     string as_node_name = "asTriPlanar",
     string as_category = "texture3d",
@@ -314,7 +314,52 @@ shader as_triplanar
         string label = "T Flip",
         string page = "Projection.X Axis",
         int as_max_param_id = 19
-    ]], 
+    ]],
+    int in_x_axis_flip_r = 0
+    [[
+        string as_maya_attribute_name = "xAxisFlipR",
+        string as_maya_attribute_short_name = "xfr",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Flip R",
+        string page = "Projection.X Axis.Normal",
+        string help = "Flip the red channel of the texture lookup",
+	int as_max_param_id = 53
+    ]],
+    int in_x_axis_flip_g = 0
+    [[
+        string as_maya_attribute_name = "xAxisFlipG",
+        string as_maya_attribute_short_name = "xfg",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Flip G",
+        string page = "Projection.X Axis.Normal",
+        string help = "Flip the green channel of the texture lookup",,
+	int as_max_param_id = 54
+    ]],
+    int in_x_axis_swap_rg = 0
+    [[
+        string as_maya_attribute_name = "xAxisSwapRG",
+        string as_maya_attribute_short_name = "xsp",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Swap RG",
+        string page = "Projection.X Axis.Normal",
+        string help = "Swap the red and green channels of the texture lookup",
+	int as_max_param_id = 55
+    ]],
     string in_x_tex_eotf = "sRGB"
     [[
         string as_maya_attribute_name = "xTextureEOTF",
@@ -513,6 +558,51 @@ shader as_triplanar
         string label = "T Flip",
         string page = "Projection.Y Axis",
         int as_max_param_id = 32
+    ]],
+    int in_y_axis_flip_r = 0
+    [[
+        string as_maya_attribute_name = "yAxisFlipR",
+        string as_maya_attribute_short_name = "yfr",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Flip R",
+        string page = "Projection.Y Axis.Normal",
+        string help = "Flip the red channel of the texture lookup",
+        int as_max_param_id = 56
+    ]],
+    int in_y_axis_flip_g = 0
+    [[
+        string as_maya_attribute_name = "yAxisFlipG",
+        string as_maya_attribute_short_name = "yfg",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Flip G",
+        string page = "Projection.Y Axis.Normal",
+        string help = "Flip the green channel of the texture lookup",
+        int as_max_param_id = 57
+    ]],
+    int in_y_axis_swap_rg = 0
+    [[
+        string as_maya_attribute_name = "yAxisSwapRG",
+        string as_maya_attribute_short_name = "ysp",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Swap RG",
+        string page = "Projection.Y Axis.Normal",
+        string help = "Swap the red and green channels of the texture lookup",
+        int as_max_param_id = 58
     ]],
     string in_y_tex_eotf = "sRGB"
     [[
@@ -713,6 +803,51 @@ shader as_triplanar
         string page = "Projection.Z Axis",
         int as_max_param_id = 45
     ]],
+    int in_z_axis_flip_r = 0
+    [[
+        string as_maya_attribute_name = "zAxisFlipR",
+        string as_maya_attribute_short_name = "zfr",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Flip R",
+        string page = "Projection.Z Axis.Normal",
+        string help = "Flip the red channel of the texture lookup",
+        int as_max_param_id = 59
+    ]],
+    int in_z_axis_flip_g = 0
+    [[
+        string as_maya_attribute_name = "zAxisFlipG",
+        string as_maya_attribute_short_name = "zfg",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Flip G",
+        string page = "Projection.Z Axis.Normal",
+        string help = "Flip the green channel of the texture lookup",
+        int as_max_param_id = 60
+    ]],
+    int in_z_axis_swap_rg = 0
+    [[
+        string as_maya_attribute_name = "zAxisSwapRG",
+        string as_maya_attribute_short_name = "zsp",
+        string widget = "checkBox",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        string label = "Swap RG",
+        string page = "Projection.Z Axis.Normal",
+        string help = "Swap the red and green channels of the texture lookup",
+        int as_max_param_id = 61
+    ]],
     string in_z_tex_eotf = "sRGB"
     [[
         string as_maya_attribute_name = "zTextureEOTF",
@@ -762,7 +897,7 @@ shader as_triplanar
         string label = "Manifold",
         string page = "Projection.Randomization",
         string help = "Connects to an idManifold integer hash output, or lacking one, builds an hash based on the assembly instance name.",
-        int as_max_param_id = 50
+        int as_max_param_id = 57
     ]],
 
     output color out_color = color(0)
@@ -813,7 +948,6 @@ shader as_triplanar
         if (in_placement_matrix != matrix(1))
         {
             matrix xform = matrix("common", "object") *
-
                 inverse(in_placement_matrix);
             Nn = transform(xform, Nn);
             Pp = transform(xform, Pp);
@@ -910,6 +1044,17 @@ shader as_triplanar
             if (in_blend_mode == "Tangent Normal")
             {
                 normal tmp = clamp(x_axis * 2.0 - 1.0, -1.0, 1.0);
+
+                if (in_x_axis_flip_r) tmp[0] *= -1;
+                if (in_x_axis_flip_g) tmp[1] *= -1;
+
+                if (in_x_axis_swap_rg)
+                {
+                    float x = tmp[0];
+                    tmp[0] = tmp[1];
+                    tmp[1] = x;
+                }
+
                 tmp[0] *= normal_sign[0]; // account for flipped UVs
 
                 normal X = rnm_blend(
@@ -976,6 +1121,17 @@ shader as_triplanar
             if (in_blend_mode == "Tangent Normal")
             {
                 normal tmp = clamp(y_axis * 2.0 - 1.0, -1.0, 1.0);
+
+                if (in_y_axis_flip_r) tmp[0] *= -1;
+                if (in_y_axis_flip_g) tmp[1] *= -1;
+
+                if (in_y_axis_swap_rg)
+                {
+                    float x = tmp[0];
+                    tmp[0] = tmp[1];
+                    tmp[1] = x;
+                }
+
                 tmp[0] *= normal_sign[1];
                 
                 normal Y = rnm_blend(
@@ -1038,6 +1194,17 @@ shader as_triplanar
             if (in_blend_mode == "Tangent Normal")
             {
                 normal tmp = clamp(z_axis * 2.0 - 1.0, -1.0, 1.0);
+
+                if (in_z_axis_flip_r) tmp[0] *= -1;
+                if (in_z_axis_flip_g) tmp[1] *= -1;
+
+                if (in_z_axis_swap_rg)
+                {
+                    float x = tmp[0];
+                    tmp[0] = tmp[1];
+                    tmp[1] = x;
+                }
+
                 tmp[0] *= -normal_sign[2];
 
                 normal Z = rnm_blend(
@@ -1073,3 +1240,4 @@ shader as_triplanar
 
     if (dot(out_normal, N) < 0.0) out_normal *= normal(-1);
 }
+

--- a/src/appleseed.shaders/src/appleseed/as_triplanar.osl
+++ b/src/appleseed.shaders/src/appleseed/as_triplanar.osl
@@ -328,7 +328,7 @@ shader as_triplanar
         string label = "Flip R",
         string page = "Projection.X Axis.Normal",
         string help = "Flip the red channel of the texture lookup",
-	int as_max_param_id = 53
+        int as_max_param_id = 53
     ]],
     int in_x_axis_flip_g = 0
     [[
@@ -343,7 +343,7 @@ shader as_triplanar
         string label = "Flip G",
         string page = "Projection.X Axis.Normal",
         string help = "Flip the green channel of the texture lookup",,
-	int as_max_param_id = 54
+        int as_max_param_id = 54
     ]],
     int in_x_axis_swap_rg = 0
     [[
@@ -358,7 +358,7 @@ shader as_triplanar
         string label = "Swap RG",
         string page = "Projection.X Axis.Normal",
         string help = "Swap the red and green channels of the texture lookup",
-	int as_max_param_id = 55
+        int as_max_param_id = 55
     ]],
     string in_x_tex_eotf = "sRGB"
     [[

--- a/src/appleseed.shaders/src/appleseed/as_vary_color.osl
+++ b/src/appleseed.shaders/src/appleseed/as_vary_color.osl
@@ -34,7 +34,7 @@ shader as_vary_color
 [[
     string help = "Color variation utility shader.",
     string icon = "asVaryColor.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_vary_color.html#label-as-vary-color",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/utilities/as_vary_color.html",
 
     string as_node_name = "asVaryColor",
     string as_category = "color",

--- a/src/appleseed.shaders/src/appleseed/as_voronoi2d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_voronoi2d.osl
@@ -34,7 +34,7 @@
 shader as_voronoi2d
 [[
     string icon = "asVoronoi2D.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_voronoi2d.html#label-as-voronoi2d",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_voronoi2d.html",
 
     string as_node_name = "asVoronoi2D",
     string as_category = "texture2d",

--- a/src/appleseed.shaders/src/appleseed/as_voronoi3d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_voronoi3d.osl
@@ -34,7 +34,7 @@
 shader as_voronoi3d
 [[
     string icon = "asVoronoi3D.png",
-    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_voronoi3d.html#label-as-voronoi3d",
+    string URL = "https://appleseed.readthedocs.io/projects/appleseed-maya/en/latest/shaders/texture/as_voronoi3d.html",
 
     string as_node_name = "asVoronoi3D",
     string as_category = "texture3d",

--- a/src/appleseed.shaders/src/maya/as_maya_anisotropic.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_anisotropic.osl
@@ -250,63 +250,71 @@ shader as_maya_anisotropic
     ]]
 )
 {
-    if (raytype("shadow") || raytype("transparency"))
-    {
-        color transparency = in_transparency;
+    int is_transparent = max(in_transparency) > 0.0 ? 1 : 0;
 
-        // Shadow attenuation: 0=constant, 1=fake caustics.
-        if (in_refractions && max(in_transparency) > 0.0)
+    if (raytype("transparency"))
+    {
+        if (is_transparent)
         {
-            transparency = mix(
-                transparency,
-                abs(dot(-I, normalize(in_normalCamera))),
-                in_shadowAttenuation
-                );
+            out_outTransparency = in_transparency * transparent();
+            out_outColor = out_outTransparency;
         }
 
-        if (max(transparency) > 0.0)
+        // We only support Maya's mode 0. For everything else, there's
+        // as_matte() and its shader pass-through.
+        if (in_matteOpacityMode == 0)
         {
-            out_outTransparency = transparency * transparent();
-            out_outColor = out_outTransparency;
+            out_outMatteOpacity = as_matte(color(0), 0.0);
+            out_outColor += out_outMatteOpacity;
+        }
+        return;
+    }
+
+    if (raytype("shadow"))
+    {
+        // Shadow attenuation, 0=constant, 1=fake caustics.
+        if (in_refractions && is_transparent)
+        {
+            out_outColor = mix(
+                in_transparency,
+                abs(dot(I, normalize(in_normalCamera))),
+                in_shadowAttenuation) * transparent();
         }
         return;
     }
 
     color opacity = 1.0 - in_transparency;
 
-    if (raytype("light") && max(in_incandescence) > 0.0)
+    if (raytype("light") && max(in_incandescence) > 0.0 && opacity != 0)
     {
         out_outColor += opacity * in_incandescence * emission();
+        return;
     }
 
     normal Nn = normalize(in_normalCamera);
 
-    if (max(in_color) > 0.0)
+    if (max(in_color) > 0.0 && opacity != 0)
     {
         out_outColor += opacity * in_diffuse * in_color * diffuse(Nn);
         out_outColor += opacity * in_translucence * in_color *
                         translucent(Nn);
     }
 
-    if (in_refractions)
+    if (in_refractions && is_transparent)
     {
+        // Maya associates the BTDF with transparency.
+
         int ray_depth = 0;
         int status = getattribute("path:ray_depth", ray_depth);
 
         if (status && ray_depth <= in_refractionLimit)
         {
-            // Maya associates transparency with the BTDF
             out_outColor += in_transparency *
                 refraction(Nn, in_refractiveIndex);
         }
     }
-    else if (max(in_transparency) > 0.0)
-    {
-        out_outTransparency = in_transparency * transparent();
-        out_outColor += out_outTransparency;
-    }
 
-    if (max(in_specularColor) > 0.0)
+    if (max(in_specularColor) > 0.0 && opacity != 0)
     {
         vector tangent = (in_spreadX != in_spreadY)
             ? rotate(Tn, radians(in_angle), point(0), point(Nn))
@@ -324,16 +332,5 @@ shader as_maya_anisotropic
                 alpha_y,
                 in_fresnelRefractiveIndex,
                 0);
-    }
-
-    if (in_matteOpacityMode == 1)
-    {
-        out_outMatteOpacity = holdout();
-        out_outColor += out_outMatteOpacity;
-    }
-    else
-    {
-        out_outMatteOpacity = in_matteOpacity * holdout();
-        out_outColor += out_outMatteOpacity;
     }
 }

--- a/src/appleseed.shaders/src/maya/as_maya_blinn.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_blinn.osl
@@ -202,63 +202,71 @@ shader as_maya_blinn
     ]]
 )
 {
-    if (raytype("shadow") || raytype("transparency"))
-    {
-        color transparency = in_transparency;
+    int is_transparent = max(in_transparency) > 0.0 ? 1 : 0;
 
-        // Shadow attenuation: 0=constant, 1=fake caustics.
-        if (in_refractions && max(in_transparency) > 0.0)
+    if (raytype("transparency"))
+    {
+        if (is_transparent)
         {
-            transparency = mix(
-                transparency,
-                abs(dot(-I, normalize(in_normalCamera))),
-                in_shadowAttenuation
-                );
+            out_outTransparency = in_transparency * transparent();
+            out_outColor = out_outTransparency;
         }
 
-        if (max(transparency) > 0.0)
+        // We only support Maya's mode 0. For everything else, there's
+        // as_matte() and its shader pass-through.
+        if (in_matteOpacityMode == 0)
         {
-            out_outTransparency = transparency * transparent();
-            out_outColor = out_outTransparency;
+            out_outMatteOpacity = as_matte(color(0), 0.0);
+            out_outColor += out_outMatteOpacity;
+        }
+        return;
+    }
+
+    if (raytype("shadow"))
+    {
+        // Shadow attenuation, 0=constant, 1=fake caustics.
+        if (in_refractions && is_transparent)
+        {
+            out_outColor = mix(
+                in_transparency,
+                abs(dot(I, normalize(in_normalCamera))),
+                in_shadowAttenuation) * transparent();
         }
         return;
     }
 
     color opacity = 1.0 - in_transparency;
 
-    if (raytype("light") && max(in_incandescence) > 0.0)
+    if (raytype("light") && max(in_incandescence) > 0.0 && opacity != 0)
     {
         out_outColor += opacity * in_incandescence * emission();
+        return;
     }
 
     normal Nn = normalize(in_normalCamera);
 
-    if (max(in_color) > 0.0)
+    if (max(in_color) > 0.0 && opacity != 0)
     {
         out_outColor += opacity * in_diffuse * in_color * diffuse(Nn);
         out_outColor += opacity * in_translucence * in_color *
                         translucent(Nn);
     }
 
-    if (in_refractions)
+    if (in_refractions && is_transparent)
     {
+        // Maya associates the BTDF with transparency.
+
         int ray_depth = 0;
         int status = getattribute("path:ray_depth", ray_depth);
 
         if (status && ray_depth <= in_refractionLimit)
         {
-            // Maya associates transparency with the BTDF
             out_outColor += in_transparency *
                 refraction(Nn, in_refractiveIndex);
         }
     }
-    else if (max(in_transparency) > 0.0)
-    {
-        out_outTransparency = in_transparency * transparent();
-        out_outColor += out_outTransparency;
-    }
 
-    if (max(in_specularColor) > 0.0)
+    if (max(in_specularColor) > 0.0 && opacity != 0)
     {
         // Specular rolloff seems to be a simple Fresnel term, get eta, solve
         // f0=(eta-1)^2/(eta+1)^2 for eta.
@@ -269,16 +277,5 @@ shader as_maya_blinn
         float m = pow(1.0 / max(EPS, in_eccentricity), 8.0);
 
         out_outColor += opacity * in_specularColor * as_blinn(Nn, m, eta);
-    }
-
-    if (in_matteOpacityMode == 1)
-    {
-        out_outMatteOpacity = holdout();
-        out_outColor += out_outMatteOpacity;
-    }
-    else
-    {
-        out_outMatteOpacity = in_matteOpacity * holdout();
-        out_outColor += out_outMatteOpacity;
     }
 }

--- a/src/appleseed.shaders/src/maya/as_maya_lambert.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_lambert.osl
@@ -89,19 +89,6 @@ shader as_maya_lambert
         string label = "Translucence Focus",
         string page = "Common Material Attributes"
     ]],
-    int in_hideSource = 0
-    [[
-        string as_maya_attribute_name = "hideSource",
-        string label = "Hide Glow Source",
-        string widget = "checkBox",
-        string page = "Special Effects"
-    ]],
-    float in_glowIntensity = 0.0
-    [[
-        string as_maya_attribute_name = "glowIntensity",
-        string label = "Glow Intensity",
-        string page = "Special Effects"
-    ]],
     int in_matteOpacityMode = 2
     [[
         string as_maya_attribute_name = "matteOpacityMode",
@@ -128,6 +115,8 @@ shader as_maya_lambert
         string as_maya_attribute_name = "refractiveIndex",
         string label = "Refractive Index",
         float min = 0.010,
+        float max = 3.0,
+        float softmin = 0.010,
         float softmax = 3.0,
         string page = "Raytrace Options"
     ]],
@@ -135,8 +124,11 @@ shader as_maya_lambert
     [[
         string as_maya_attribute_name = "refractionLimit",
         string label = "Refraction Limit",
+        string widget = "intslider",
         int min = 0,
         int max = 10,
+        int softmin = 0,
+        int softmax = 10,
         string page = "Raytrace Options"
     ]],
     float in_shadowAttenuation = 0.5
@@ -166,69 +158,67 @@ shader as_maya_lambert
     ]]
 )
 {
-    if (raytype("shadow") || raytype("transparency"))
-    {
-        color transparency = in_transparency;
+    int is_transparent = max(in_transparency) > 0.0 ? 1 : 0;
 
-        // Shadow attenuation: 0=constant, 1=fake caustics.
-        if (in_refractions && max(in_transparency) > 0.0)
+    if (raytype("transparency"))
+    {
+        if (is_transparent)
         {
-            transparency = mix(
-                transparency,
-                abs(dot(-I, normalize(in_normalCamera))),
-                in_shadowAttenuation);
+            out_outTransparency = in_transparency * transparent();
+            out_outColor = out_outTransparency;
         }
 
-        if (max(transparency) > 0.0)
+        // We only support Maya's mode 0. For everything else, there's
+        // as_matte() and its shader pass-through.
+        if (in_matteOpacityMode == 0)
         {
-            out_outTransparency = transparency * transparent();
-            out_outColor = out_outTransparency;
+            out_outMatteOpacity = as_matte(color(0), 0.0);
+            out_outColor += out_outMatteOpacity;
+        }
+        return;
+    }
+
+    if (raytype("shadow"))
+    {
+        // Shadow attenuation, 0=constant, 1=fake caustics.
+        if (in_refractions && is_transparent)
+        {
+            out_outColor = mix(
+                in_transparency,
+                abs(dot(I, normalize(in_normalCamera))),
+                in_shadowAttenuation) * transparent();
         }
         return;
     }
 
     color opacity = 1.0 - in_transparency;
 
-    if (raytype("light") && max(in_incandescence) > 0.0)
+    if (raytype("light") && max(in_incandescence) > 0.0 && opacity != 0)
     {
         out_outColor += opacity * in_incandescence * emission();
+        return;
     }
 
     normal Nn = normalize(in_normalCamera);
 
-    if (max(in_color) > 0.0)
+    if (max(in_color) > 0.0 && opacity != 0)
     {
         out_outColor += opacity * in_diffuse * in_color * diffuse(Nn);
         out_outColor += opacity * in_translucence * in_color *
                         translucent(Nn);
     }
 
-    if (in_refractions)
+    if (in_refractions && is_transparent)
     {
+        // Maya associates the BTDF with transparency.
+
         int ray_depth = 0;
         int status = getattribute("path:ray_depth", ray_depth);
 
         if (status && ray_depth <= in_refractionLimit)
         {
-            // Maya associates transparency with the BTDF
             out_outColor += in_transparency *
                 refraction(Nn, in_refractiveIndex);
         }
-    }
-    else if (max(in_transparency) > 0.0)
-    {
-        out_outTransparency = in_transparency * transparent();
-        out_outColor += out_outTransparency;
-    }
-
-    if (in_matteOpacityMode == 1)
-    {
-        out_outMatteOpacity = holdout();
-        out_outColor += out_outMatteOpacity;
-    }
-    else
-    {
-        out_outMatteOpacity = in_matteOpacity * holdout();
-        out_outColor += out_outMatteOpacity;
     }
 }

--- a/src/appleseed.shaders/src/maya/as_maya_phong.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_phong.osl
@@ -206,76 +206,73 @@ shader as_maya_phong
     ]]
 )
 {
-    if (raytype("shadow") || raytype("transparency"))
-    {
-        color transparency = in_transparency;
+    int is_transparent = max(in_transparency) > 0.0 ? 1 : 0;
 
-        // Shadow attenuation: 0=constant, 1=fake caustics.
-        if (in_refractions && max(in_transparency) > 0.0)
+    if (raytype("transparency"))
+    {
+        if (is_transparent)
         {
-            transparency = mix(
-                transparency,
-                abs(dot(-I, normalize(in_normalCamera))),
-                in_shadowAttenuation
-                );
+            out_outTransparency = in_transparency * transparent();
+            out_outColor = out_outTransparency;
         }
 
-        if (max(transparency) > 0.0)
+        // We only support Maya's mode 0. For everything else, there's
+        // as_matte() and its shader pass-through.
+        if (in_matteOpacityMode == 0)
         {
-            out_outTransparency = transparency * transparent();
-            out_outColor = out_outTransparency;
+            out_outMatteOpacity = as_matte(color(0), 0.0);
+            out_outColor += out_outMatteOpacity;
+        }
+        return;
+    }
+
+    if (raytype("shadow"))
+    {
+        // Shadow attenuation, 0=constant, 1=fake caustics.
+        if (in_refractions && is_transparent)
+        {
+            out_outColor = mix(
+                in_transparency,
+                abs(dot(I, normalize(in_normalCamera))),
+                in_shadowAttenuation) * transparent();
         }
         return;
     }
 
     color opacity = 1.0 - in_transparency;
 
-    if (raytype("light") && max(in_incandescence) > 0.0)
+    if (raytype("light") && max(in_incandescence) > 0.0 && opacity != 0)
     {
         out_outColor += opacity * in_incandescence * emission();
+        return;
     }
 
     normal Nn = normalize(in_normalCamera);
 
-    if (max(in_color) > 0.0)
+    if (max(in_color) > 0.0 && opacity != 0)
     {
         out_outColor += opacity * in_diffuse * in_color * diffuse(Nn);
         out_outColor += opacity * in_translucence * in_color *
                         translucent(Nn);
     }
 
-    if (in_refractions)
+    if (in_refractions && is_transparent)
     {
+        // Maya associates the BTDF with transparency.
+
         int ray_depth = 0;
         int status = getattribute("path:ray_depth", ray_depth);
 
         if (status && ray_depth <= in_refractionLimit)
         {
-            // Maya associates transparency with the BTDF
             out_outColor += in_transparency *
                 refraction(Nn, in_refractiveIndex);
         }
     }
-    else if (max(in_transparency) > 0.0)
-    {
-        out_outTransparency = in_transparency * transparent();
-        out_outColor += out_outTransparency;
-    }
 
-    if (max(in_specularColor) > 0.0)
+    if (max(in_specularColor) > 0.0 && opacity != 0)
     {
         out_outColor += opacity * in_specularColor *
             phong(Nn, in_cosinePower * 10.0);
-    }
-
-    if (in_matteOpacityMode == 1)
-    {
-        out_outMatteOpacity = holdout();
-        out_outColor += out_outMatteOpacity;
-    }
-    else
-    {
-        out_outMatteOpacity = in_matteOpacity * holdout();
-        out_outColor += out_outMatteOpacity;
     }
 }

--- a/src/appleseed.shaders/src/maya/as_maya_phongE.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_phongE.osl
@@ -214,45 +214,57 @@ shader as_maya_phongE
     ]]
 )
 {
-    if (raytype("shadow") || raytype("transparency"))
-    {
-        color transparency = in_transparency;
+    int is_transparent = max(in_transparency) > 0.0 ? 1 : 0;
 
-        // Shadow attenuation: 0=constant, 1=fake caustics.
-        if (in_refractions && max(in_transparency) > 0.0)
+    if (raytype("transparency"))
+    {
+        if (is_transparent)
         {
-            transparency = mix(
-                transparency,
-                abs(dot(-I, normalize(in_normalCamera))),
-                in_shadowAttenuation
-                );
+            out_outTransparency = in_transparency * transparent();
+            out_outColor = out_outTransparency;
         }
 
-        if (max(transparency) > 0.0)
+        // We only support Maya's mode 0. For everything else, there's
+        // as_matte() and its shader pass-through.
+        if (in_matteOpacityMode == 0)
         {
-            out_outTransparency = transparency * transparent();
-            out_outColor = out_outTransparency;
+            out_outMatteOpacity = as_matte(color(0), 0.0);
+            out_outColor += out_outMatteOpacity;
+        }
+        return;
+    }
+
+    if (raytype("shadow"))
+    {
+        // Shadow attenuation, 0=constant, 1=fake caustics.
+        if (in_refractions && is_transparent)
+        {
+            out_outColor = mix(
+                in_transparency,
+                abs(dot(I, normalize(in_normalCamera))),
+                in_shadowAttenuation) * transparent();
         }
         return;
     }
 
     color opacity = 1.0 - in_transparency;
 
-    if (raytype("light") && max(in_incandescence) > 0.0)
+    if (raytype("light") && max(in_incandescence) > 0.0 && opacity != 0)
     {
         out_outColor += opacity * in_incandescence * emission();
+        return;
     }
 
     normal Nn = normalize(in_normalCamera);
 
-    if (max(in_color) > 0.0)
+    if (max(in_color) > 0.0 && opacity != 0)
     {
         out_outColor += opacity * in_diffuse * in_color * diffuse(Nn);
         out_outColor += opacity * in_translucence * in_color *
                         translucent(Nn);
     }
 
-    if (in_refractions)
+    if (in_refractions && is_transparent)
     {
         int ray_depth = 0;
         int status = getattribute("path:ray_depth", ray_depth);
@@ -264,13 +276,8 @@ shader as_maya_phongE
                 refraction(Nn, in_refractiveIndex);
         }
     }
-    else if (max(in_transparency) > 0.0)
-    {
-        out_outTransparency = in_transparency * transparent();
-        out_outColor += out_outTransparency;
-    }
 
-    if (max(in_specularColor) > 0.0)
+    if (max(in_specularColor) > 0.0 && opacity != 0)
     {
         color specular_color = in_specularColor *
             mix(in_color, color(1), in_whiteness);


### PR DESCRIPTION
- Added raySwitch surface shader, for closures. We have one for textures.
- Added blendNormals node to blend **tangent space normal maps** via reoriented normal mapping.
- Added surface luminance node via NPR rays, color space aware.
- Added support for matte opacity in the Maya shaders, but restricted only to matte opacity mode 0 (*Black Hole*). For the rest, piping the output to the [as_matte](https://github.com/appleseedhq/appleseed/blob/master/src/appleseed.shaders/src/appleseed/as_matte.osl) shader via shader passthrough provides equivalent functionality.
- Added minor performance optimizations to the Maya nodes, mostly related to opacity tests and *shadow* and *transparency* rays.
- Added orientation check to *as_fresnel*, to ensure the normal is forward facing.
- Added access to appleseed exclusive global primvars dNdu, dNdv, and others.
- Added access to *vertex_color*, currently a placeholder attribute.
- Chromaticity coordinates can be negative, so ensure the UI metadata reflects this in *as_luminance* node.
- Added the *glass random walk* profile to *as_subsurface*.
- Added flip/switch XY/RG components of the texture sections of the triplanar node, required to blend correctly tangent space normal maps if they follow different conventions (OpenGL vs DX)
- Minor fixes and cleanups.