### PR TITLE
Add an alpha channel to the DepthAOV

### DIFF
--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -94,8 +94,7 @@ namespace
             if (shading_point.hit_surface())
             {
                 shading_result.m_aovs[0].a = 1.0f;
-                const float depth = static_cast<float>(shading_point.get_distance());
-                *out = depth;
+                *out = static_cast<float>(shading_point.get_distance());
             }
             else
             {
@@ -144,7 +143,7 @@ namespace
 
         void clear_image() override
         {
-            m_image->clear(Color<float, 1>(numeric_limits<float>::max()));
+            m_image->clear(Color<float, 1>(0.0f));
         }
 
       protected:

--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -91,12 +91,17 @@ namespace
                         pi.x - m_tile_origin_x,
                         pi.y - m_tile_origin_y));
 
-            const float depth =
-                shading_point.hit_surface()
-                    ? static_cast<float>(shading_point.get_distance())
-                    : numeric_limits<float>::max();
-
-            *out = depth;
+            if (shading_point.hit_surface())
+            {
+                shading_result.m_aovs[0].a = 1.0f;
+                const float depth = static_cast<float>(shading_point.get_distance());
+                *out = depth;
+            }
+            else
+            {
+                shading_result.m_aovs[0].a = 0.0f;
+                *out = 0.0f;
+            }
         }
     };
 
@@ -128,12 +133,12 @@ namespace
 
         size_t get_channel_count() const override
         {
-            return 1;
+            return 2;
         }
 
         const char** get_channel_names() const override
         {
-            static const char* ChannelNames[] = { "Z" };
+            static const char* ChannelNames[] = { "Z", "A" };
             return ChannelNames;
         }
 

--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -143,7 +143,7 @@ namespace
 
         void clear_image() override
         {
-            m_image->clear(Color<float, 1>(0.0f));
+            m_image->clear(Color<float, 2>(0.0f));
         }
 
       protected:


### PR DESCRIPTION
When we don't hit an object, we set the depth to 0 and alpha to 0. This allows us to use depth = 0 instead of numeric_limits::max() which some applications don't like.