### PR TITLE
Fix basic sample MasterRenderer initializations

### DIFF
--- a/sandbox/samples/cpp/basic/basic.cpp
+++ b/sandbox/samples/cpp/basic/basic.cpp
@@ -294,10 +294,12 @@ int main()
 
     // Create the master renderer.
     asr::DefaultRendererController renderer_controller;
+    asf::SearchPaths resource_search_paths;
     std::unique_ptr<asr::MasterRenderer> renderer(
         new asr::MasterRenderer(
             project.ref(),
             project->configurations().get_by_name("final")->get_inherited_parameters(),
+            resource_search_paths,
             &renderer_controller));
 
     // Render the frame.

--- a/sandbox/samples/python/basic/basic.py
+++ b/sandbox/samples/python/basic/basic.py
@@ -282,9 +282,11 @@ def main():
     # Catch Control-C.
     signal.signal(signal.SIGINT, lambda signal, frame: renderer_controller.abort_rendering())
 
+    resource_search_paths = []
     tile_callback = TileCallback()
     renderer = asr.MasterRenderer(project,
                                   project.configurations()['final'].get_inherited_parameters(),
+                                  resource_search_paths,
                                   renderer_controller,
                                   tile_callback)
 


### PR DESCRIPTION
Causes the sample scripts to succeed given that the `MasterRenderer` constructor signature was changed via https://github.com/appleseedhq/appleseed/commit/af8a398085e2454b4efde9fa1392af4b37956482#diff-91f91057d3a3b27762aa59e1725a5bd7L58.

Considerations
- `SearchPaths` doesn't have `py` bindings, maybe that's okay for now.
- Should we add reference output for the `basic.py` sample?

`basic.cpp` (visually verified against the reference output)
![test](https://user-images.githubusercontent.com/4917232/54069279-4a9f9280-421c-11e9-8eef-f4af6aee6d4f.png)

`basic.py`
![test](https://user-images.githubusercontent.com/4917232/54069286-5ee38f80-421c-11e9-9dca-5542dab722f5.png)
