### PR TITLE
Remove useless `compiler.h` in camera codes

### DIFF
--- a/src/appleseed/renderer/modeling/camera/orthographiccamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/orthographiccamera.cpp
@@ -47,7 +47,6 @@
 #include "foundation/math/intersection/planesegment.h"
 #include "foundation/math/transform.h"
 #include "foundation/math/vector.h"
-#include "foundation/platform/compiler.h"
 #include "foundation/utility/api/apistring.h"
 #include "foundation/utility/api/specializedapiarrays.h"
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed/renderer/modeling/camera/orthographiccamera.h
+++ b/src/appleseed/renderer/modeling/camera/orthographiccamera.h
@@ -32,7 +32,6 @@
 #include "renderer/modeling/camera/icamerafactory.h"
 
 // appleseed.foundation headers.
-#include "foundation/platform/compiler.h"
 #include "foundation/utility/autoreleaseptr.h"
 
 // appleseed.main headers.

--- a/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
@@ -44,7 +44,6 @@
 #include "foundation/math/matrix.h"
 #include "foundation/math/transform.h"
 #include "foundation/math/vector.h"
-#include "foundation/platform/compiler.h"
 #include "foundation/utility/api/apistring.h"
 #include "foundation/utility/api/specializedapiarrays.h"
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed/renderer/modeling/camera/pinholecamera.h
+++ b/src/appleseed/renderer/modeling/camera/pinholecamera.h
@@ -33,7 +33,6 @@
 #include "renderer/modeling/camera/icamerafactory.h"
 
 // appleseed.foundation headers.
-#include "foundation/platform/compiler.h"
 #include "foundation/utility/autoreleaseptr.h"
 
 // appleseed.main headers.

--- a/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
@@ -48,7 +48,6 @@
 #include "foundation/math/scalar.h"
 #include "foundation/math/transform.h"
 #include "foundation/math/vector.h"
-#include "foundation/platform/compiler.h"
 #include "foundation/utility/api/apistring.h"
 #include "foundation/utility/api/specializedapiarrays.h"
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed/renderer/modeling/camera/sphericalcamera.h
+++ b/src/appleseed/renderer/modeling/camera/sphericalcamera.h
@@ -33,7 +33,6 @@
 #include "renderer/modeling/camera/icamerafactory.h"
 
 // appleseed.foundation headers.
-#include "foundation/platform/compiler.h"
 #include "foundation/utility/autoreleaseptr.h"
 
 // appleseed.main headers.

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -57,7 +57,6 @@
 #include "foundation/math/scalar.h"
 #include "foundation/math/transform.h"
 #include "foundation/math/vector.h"
-#include "foundation/platform/compiler.h"
 #include "foundation/platform/types.h"
 #include "foundation/utility/api/apistring.h"
 #include "foundation/utility/api/specializedapiarrays.h"

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.h
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.h
@@ -33,7 +33,6 @@
 #include "renderer/modeling/camera/icamerafactory.h"
 
 // appleseed.foundation headers.
-#include "foundation/platform/compiler.h"
 #include "foundation/utility/autoreleaseptr.h"
 
 // appleseed.main headers.


### PR DESCRIPTION
Remove useless `compiler.h` in camera codes.