### PR TITLE
Additions and improvements to sampling functions

### DIFF
--- a/src/appleseed/foundation/math/sampling/mappings.h
+++ b/src/appleseed/foundation/math/sampling/mappings.h
@@ -147,7 +147,7 @@ void build_regular_polygon(
     const T             tilt_angle,
     Vector<T, 2>        vertices[]);
 
-// Map a uniform sample in [0,1)^2 to a point on the surface of a regular
+// Map a uniform sample in [0,1)^3 to a point on the surface of a regular
 // N-sided polygon with a uniform probability density p(x) = 1/A.
 template <typename T>
 Vector<T, 2> sample_regular_polygon_uniform(
@@ -223,9 +223,10 @@ T equiangular_distribution_pdf(
     const T theta_b,                // end angle
     const T distance);              // distance from point to the ray
 
+
 //
-// Reciprocal distribution.
-// p(X) ~ 1 / X, where X belongs to [l,r).
+// Reciprocal distribution:
+// p(X) ~ 1 / X, where X belongs to [l, r).
 //
 
 template <typename T>
@@ -238,6 +239,7 @@ T rcp_distribution_pdf(
     const T x,
     const T l,
     const T r);
+
 
 //
 // Implementation.
@@ -499,6 +501,8 @@ Vector<T, 3> sample_spherical_triangle_uniform(
     // Compute the interior angles of the spherical triangle.
     T alpha, beta, gamma;
     compute_spherical_triangle_interior_angles(a, b, c, alpha, beta, gamma);
+    const T cos_alpha = std::cos(alpha);
+    const T sin_alpha = std::sin(alpha);
 
     // Compute the area of the spherical triangle.
     const T area = compute_spherical_triangle_area(alpha, beta, gamma);
@@ -511,22 +515,23 @@ Vector<T, 3> sample_spherical_triangle_uniform(
     const T t = std::cos(area_hat - alpha);
 
     // Compute the pair (u, v) that determines beta_hat.
-    const T u = t - std::cos(alpha);
-    const T v = s + std::sin(alpha) * std::cos(c);
+    const T u = t - cos_alpha;
+    const T v = s + sin_alpha * std::cos(c);
 
     // Let q be the cosine of the new edge length b_hat.
-    const T q_num = (v * t - u * s) * std::cos(alpha) - v;
-    const T q_den = (v * s + u * t) * std::sin(alpha);
+    const T q_num = (v * t - u * s) * cos_alpha - v;
+    const T q_den = (v * s + u * t) * sin_alpha;
     const T q = clamp(q_num / q_den, T(-1.0), T(1.0));
 
     // Compute the third vertex of the sub-triangle.
-    const Vector3d C_hat = q * A + std::sqrt(T(1.0) - q * q) * normalize(C - dot(C, A) * A);
+    const Vector<T, 3> C_hat = q * A + std::sqrt(T(1.0) - q * q) * normalize(C - dot(C, A) * A);
+    const T dot_C_hat_B = dot(C_hat, B);
 
     // Use the other random variable to select cos(theta).
-    const T z = T(1.0) - eta[1] * (T(1.0) - dot(C_hat, B));
+    const T z = T(1.0) - eta[1] * (T(1.0) - dot_C_hat_B);
 
     // Construct the corresponding point on the sphere.
-    return z * B + std::sqrt(T(1.0) - z * z) * normalize(C_hat - dot(C_hat, B) * B);
+    return z * B + std::sqrt(T(1.0) - z * z) * normalize(C_hat - dot_C_hat_B * B);
 }
 
 template <typename T>
@@ -572,7 +577,9 @@ inline T exponential_distribution_on_segment_pdf(
     const T l,
     const T r)
 {
-    assert (x >= l && x <= r);
+    assert(x >= l);
+    assert(x <= r);
+
     const T left = std::exp(a * (x - l));
     const T right = std::exp(a * (x - r));
     return a / (left - right);
@@ -602,7 +609,7 @@ inline T equiangular_distribution_pdf(
 }
 
 template <typename T>
-T sample_rcp_distribution(
+inline T sample_rcp_distribution(
     const T s,
     const T l,
     const T r)
@@ -610,24 +617,30 @@ T sample_rcp_distribution(
     assert(l > T(0.0));
     assert(r > l);
 
-    const float d = r / l;
-    if (d < T(1.01)) return l + s * (r - l);
-    return clamp(l * std::pow(d, s), l, r);
+    const T d = r / l;
+
+    return
+        d < T(1.01)
+            ? l + s * (r - l)
+            : clamp(l * std::pow(d, s), l, r);
 }
 
 template <typename T>
-T rcp_distribution_pdf(
+inline T rcp_distribution_pdf(
     const T x,
     const T l,
     const T r)
 {
-    assert(x < r);
-    assert(x >= l);
     assert(l > T(0.0));
+    assert(x >= l);
+    assert(x < r);
 
-    const float d = r / l;
-    if (d < T(1.01)) return rcp(r - l);
-    return rcp(x * (std::log(d)));
+    const T d = r / l;
+
+    return
+        d < T(1.01)
+            ? rcp(r - l)
+            : rcp(x * (std::log(d)));
 }
 
 }   // namespace foundation

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_sampling.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_sampling.cpp
@@ -121,10 +121,12 @@ BENCHMARK_SUITE(Foundation_Math_Sampling_Mappings)
     struct Fixture
     {
         Vector2d    m_samples[SampleCount];
-        Vector2d    m_dummy;
+        Vector2d    m_dummy2d;
+        Vector3d    m_dummy3d;
 
         Fixture()
-          : m_dummy(0.0)
+          : m_dummy2d(0.0)
+          , m_dummy3d(0.0)
         {
             MersenneTwister rng;
 
@@ -139,12 +141,24 @@ BENCHMARK_SUITE(Foundation_Math_Sampling_Mappings)
     BENCHMARK_CASE_F(Benchmark_SampleDiskUniform, Fixture)
     {
         for (size_t i = 0; i < SampleCount; ++i)
-            m_dummy += sample_disk_uniform(m_samples[i]);
+            m_dummy2d += sample_disk_uniform(m_samples[i]);
     }
 
     BENCHMARK_CASE_F(Benchmark_SampleDiskUniformAlt, Fixture)
     {
         for (size_t i = 0; i < SampleCount; ++i)
-            m_dummy += sample_disk_uniform_alt(m_samples[i]);
+            m_dummy2d += sample_disk_uniform_alt(m_samples[i]);
+    }
+
+    BENCHMARK_CASE_F(Benchmark_SampleTriangleUniform, Fixture)
+    {
+        for (size_t i = 0; i < SampleCount; ++i)
+            m_dummy3d += sample_triangle_uniform(m_samples[i]);
+    }
+
+    BENCHMARK_CASE_F(Benchmark_SampleTriangleUniformHeitz, Fixture)
+    {
+        for (size_t i = 0; i < SampleCount; ++i)
+            m_dummy3d += sample_triangle_uniform_heitz(m_samples[i]);
     }
 }

--- a/src/appleseed/foundation/utility/testutils.cpp
+++ b/src/appleseed/foundation/utility/testutils.cpp
@@ -96,8 +96,6 @@ bool are_images_feq(
 
     assert(channel_count <= 4);
 
-    size_t differing_pixels = 0;
-
     for (size_t y = 0; y < height; ++y)
     {
         for (size_t x = 0; x < width; ++x)
@@ -111,15 +109,12 @@ bool are_images_feq(
             for (size_t c = 0; c < channel_count; ++c)
             {
                 if (!feq(color1[c], color2[c], eps))
-                {
-                    ++differing_pixels;
-                    break;
-                }
+                    return false;
             }
         }
     }
 
-    return differing_pixels == 0;
+    return true;
 }
 
 void write_point_cloud_image(

--- a/src/appleseed/foundation/utility/testutils.cpp
+++ b/src/appleseed/foundation/utility/testutils.cpp
@@ -37,6 +37,7 @@
 #include "foundation/image/genericimagefilewriter.h"
 #include "foundation/image/image.h"
 #include "foundation/image/pixel.h"
+#include "foundation/math/aabb.h"
 #include "foundation/math/scalar.h"
 
 // Standard headers.
@@ -115,6 +116,26 @@ bool are_images_feq(
     }
 
     return true;
+}
+
+void fit_point_cloud_to_image(
+    vector<Vector2d>&           points)
+{
+    AABB2d aabb;
+    aabb.invalidate();
+
+    for (const Vector2d& p : points)
+        aabb.insert(p);
+
+    const Vector2d aabb_extent = aabb.extent();
+    const double scale = 0.8 / max_value(aabb_extent);
+
+    for (Vector2d& p : points)
+    {
+        p -= aabb.min;
+        p *= scale;
+        p += (Vector2d(1.0) - aabb_extent * scale) * 0.5;
+    }
 }
 
 void write_point_cloud_image(

--- a/src/appleseed/foundation/utility/testutils.h
+++ b/src/appleseed/foundation/utility/testutils.h
@@ -64,6 +64,10 @@ bool are_images_feq(
     const Image&                    image2,
     const float                     eps);
 
+// Rescale a 2D point cloud to fit into an image.
+void fit_point_cloud_to_image(
+    std::vector<Vector2d>&          points);
+
 // Write a 2D point cloud to an image file.
 void write_point_cloud_image(
     const std::string&              image_path,

--- a/src/appleseed/renderer/kernel/lighting/volumelightingintegrator.cpp
+++ b/src/appleseed/renderer/kernel/lighting/volumelightingintegrator.cpp
@@ -202,7 +202,7 @@ void VolumeLightingIntegrator::add_single_distance_sample_contribution(
     DirectShadingComponents&    radiance,
     const bool                  sample_phase_function) const
 {
-    assert (light_sample != nullptr);
+    assert(light_sample != nullptr);
 
     // Sample channel uniformly at random.
     sampling_context.split_in_place(1, 1);


### PR DESCRIPTION
Description from the main commit:

- Add new uniform triangle sampling function due to Eric Heitz: `foundation::sample_triangle_uniform_heitz()`
- Add variant of `foundation::sample_regular_polygon_uniform()` taking two random numbers instead of three
- Use Heitz's triangle sampling in all `foundation::sample_regular_polygon_uniform()` functions
- Improve and add unit tests
- Add unit benchmarks

`foundation::sample_triangle_uniform()`, regular grid:

![test_sampling_sample_triangle_uniform_regular](https://user-images.githubusercontent.com/321290/54259639-be1c0980-4566-11e9-9866-6bef9f4bacf7.png)

`foundation::sample_triangle_uniform()`, Hammersley sequence:

![test_sampling_sample_triangle_uniform_hammersley](https://user-images.githubusercontent.com/321290/54259658-ce33e900-4566-11e9-93aa-2c89476e12c9.png)

`foundation::sample_triangle_uniform()`, Halton sequence:

![test_sampling_sample_triangle_uniform_halton](https://user-images.githubusercontent.com/321290/54259669-dbe96e80-4566-11e9-935f-2c15f2ac4719.png)

`foundation::sample_triangle_uniform_heitz()`, regular grid:

![test_sampling_sample_triangle_uniform_heitz_regular](https://user-images.githubusercontent.com/321290/54259688-eefc3e80-4566-11e9-8d7c-027753620db2.png)

`foundation::sample_triangle_uniform_heitz()`, Hammersley sequence:

![test_sampling_sample_triangle_uniform_heitz_hammersley](https://user-images.githubusercontent.com/321290/54259695-f3285c00-4566-11e9-95de-fa30f2d25caf.png)

`foundation::sample_triangle_uniform_heitz()`, Halton sequence:

![test_sampling_sample_triangle_uniform_heitz_halton](https://user-images.githubusercontent.com/321290/54259701-f6bbe300-4566-11e9-817c-826b89b70f28.png)
