### PR TITLE
Normalized the computed pixel variation in Pixel Variation AOV by the user's noise threshold 

### DIFF
--- a/src/appleseed/renderer/modeling/aov/pixelvariationaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/pixelvariationaov.cpp
@@ -94,6 +94,7 @@ namespace
             // Normalize if a maximum was found.
             if (max_variation != 0.0f)
             {
+                max_variation = max_variation / m_params.get_required<float>("noise_threshold", 1.0f);
                 for (size_t y = crop_window.min.y; y <= crop_window.max.y; ++y)
                 {
                     for (size_t x = crop_window.min.x; x <= crop_window.max.x; ++x)


### PR DESCRIPTION
Divided max_variation by noise threshold to fix #2404 
- The noise threshold can have a min value of 0.0001 and so did not check for non-zero value. 