### PR TITLE
Fix 3ds max plugin UV transform

### DIFF
--- a/src/appleseed.shaders/src/max/as_max_uv_transform.osl
+++ b/src/appleseed.shaders/src/max/as_max_uv_transform.osl
@@ -61,34 +61,22 @@ shader as_max_uv_transform
 {
     float out_u = in_coordU;
     float out_v = in_coordV;
-    float u_center = 0.5;
-    float v_center = 0.5;
 
-    // Apply rotation before tiling/offset which is different from 3ds Max native bitmap transforms.
     if (in_rotateW != 0.0)
     {
         point rot = rotate(
             point(out_u, out_v, 0.0),
             radians(in_rotateW),
-            point(0.5, 0.5, 0.0),
-            point(0.5, 0.5, 1.0));
+            point(0.0, 0.0, 0.0),
+            point(0.0, 0.0, 1.0));
 
         out_u = rot[0];
         out_v = rot[1];
     }
 
-    // Don't center transforms when mirrored (3ds Max behaviour).
-    if (in_mirrorU)
-        u_center = 0.0;
-    if (in_mirrorV)
-        v_center = 0.0;
-
     // Apply tiling and offset without considering cropping
-    out_u = (out_u - u_center) * in_tilingU;
-    out_u = (out_u + u_center) - (in_offsetU * in_tilingU);
-
-    out_v = (out_v - v_center) * in_tilingV;
-    out_v = (out_v + v_center) - (in_offsetV * in_tilingV);
+    out_u = (out_u * in_tilingU) - (in_offsetU * in_tilingU);
+    out_v = (out_v * in_tilingV) - (in_offsetV * in_tilingV);
 
     // Apply mirroring.
     if (in_mirrorU)

--- a/src/appleseed.shaders/src/max/as_max_uv_transform.osl
+++ b/src/appleseed.shaders/src/max/as_max_uv_transform.osl
@@ -62,6 +62,10 @@ shader as_max_uv_transform
     float out_u = in_coordU;
     float out_v = in_coordV;
 
+    // Apply offset before rotation
+    out_u -= in_offsetU;
+    out_v -= in_offsetV;
+
     if (in_rotateW != 0.0)
     {
         point rot = rotate(
@@ -74,9 +78,9 @@ shader as_max_uv_transform
         out_v = rot[1];
     }
 
-    // Apply tiling and offset without considering cropping
-    out_u = (out_u * in_tilingU) - (in_offsetU * in_tilingU);
-    out_v = (out_v * in_tilingV) - (in_offsetV * in_tilingV);
+    // Apply tiling without considering cropping
+    out_u = (out_u * in_tilingU);
+    out_v = (out_v * in_tilingV);
 
     // Apply mirroring.
     if (in_mirrorU)


### PR DESCRIPTION
The UV transform was not replicating what 3ds max is doing (and Corona) when tiling and rotations are involved. It now does. I'm unsure what the original offset was supposed to do.
Here an image from appleseed after the fix and from the 3ds max viewport (the example is based on real world UV coordinates with real world size based tiling combined with a rotation by 90 degree).

<img width="496" alt="uv_max" src="https://user-images.githubusercontent.com/593029/54370632-3aead880-4678-11e9-8071-0a23f5c0016f.PNG">

<img width="1006" alt="uv_as" src="https://user-images.githubusercontent.com/593029/54370639-3e7e5f80-4678-11e9-8d57-16ce104ce72a.PNG">
