### PR TITLE
Improve rendering error analysis with fixes and AOV

### DIFF
--- a/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
@@ -374,14 +374,14 @@ void RenderingManager::print_average_luminance()
         pretty_scalar(average_luminance, 6).c_str());
 }
 
-void RenderingManager::print_rmse()
+void RenderingManager::print_rms_deviation()
 {
     const double rmse = compute_rms_deviation(
         m_project->get_frame()->image(),
         m_project->get_frame()->ref_image());
 
     RENDERER_LOG_INFO(
-        "final rmse is %s.",
+        "final rms deviation is %s.",
         pretty_scalar(rmse, 6).c_str());
 }
 
@@ -462,7 +462,7 @@ void RenderingManager::slot_rendering_end()
         print_average_luminance();
 
     if (m_project->get_frame()->validate_ref_image())
-        print_rmse();
+        print_rms_deviation();
 
     if (m_params.get_optional<bool>("autosave", true))
         archive_frame_to_disk();

--- a/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
@@ -461,7 +461,7 @@ void RenderingManager::slot_rendering_end()
     if (m_params.get_optional<bool>("print_final_average_luminance", false))
         print_average_luminance();
 
-    if (m_project->get_frame()->validate_ref_image())
+    if (m_project->get_frame()->has_valid_ref_image())
         print_rms_deviation();
 
     if (m_params.get_optional<bool>("autosave", true))

--- a/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
@@ -374,6 +374,17 @@ void RenderingManager::print_average_luminance()
         pretty_scalar(average_luminance, 6).c_str());
 }
 
+void RenderingManager::print_rmse()
+{
+    const double rmse = compute_rms_deviation(
+        m_project->get_frame()->image(),
+        m_project->get_frame()->ref_image());
+
+    RENDERER_LOG_INFO(
+        "final rmse is %s.",
+        pretty_scalar(rmse, 6).c_str());
+}
+
 void RenderingManager::archive_frame_to_disk()
 {
     RENDERER_LOG_INFO("archiving frame to disk...");
@@ -449,6 +460,9 @@ void RenderingManager::slot_rendering_end()
 
     if (m_params.get_optional<bool>("print_final_average_luminance", false))
         print_average_luminance();
+
+    if (m_project->get_frame()->validate_ref_image())
+        print_rmse();
 
     if (m_params.get_optional<bool>("autosave", true))
         archive_frame_to_disk();

--- a/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
@@ -376,13 +376,16 @@ void RenderingManager::print_average_luminance()
 
 void RenderingManager::print_rms_deviation()
 {
-    const double rmse = compute_rms_deviation(
+    if (!m_project->get_frame()->has_valid_ref_image())
+        return;
+
+    const double rmsd = compute_rms_deviation(
         m_project->get_frame()->image(),
-        m_project->get_frame()->ref_image());
+        *m_project->get_frame()->ref_image());
 
     RENDERER_LOG_INFO(
         "final rms deviation is %s.",
-        pretty_scalar(rmse, 6).c_str());
+        pretty_scalar(rmsd, 6).c_str());
 }
 
 void RenderingManager::archive_frame_to_disk()
@@ -461,8 +464,7 @@ void RenderingManager::slot_rendering_end()
     if (m_params.get_optional<bool>("print_final_average_luminance", false))
         print_average_luminance();
 
-    if (m_project->get_frame()->has_valid_ref_image())
-        print_rms_deviation();
+    print_rms_deviation();
 
     if (m_params.get_optional<bool>("autosave", true))
         archive_frame_to_disk();

--- a/src/appleseed.studio/mainwindow/rendering/renderingmanager.h
+++ b/src/appleseed.studio/mainwindow/rendering/renderingmanager.h
@@ -186,6 +186,7 @@ class RenderingManager
 
     void print_final_rendering_time();
     void print_average_luminance();
+    void print_rmse();
     void archive_frame_to_disk();
 
     void run_scheduled_actions();

--- a/src/appleseed.studio/mainwindow/rendering/renderingmanager.h
+++ b/src/appleseed.studio/mainwindow/rendering/renderingmanager.h
@@ -186,7 +186,7 @@ class RenderingManager
 
     void print_final_rendering_time();
     void print_average_luminance();
-    void print_rmse();
+    void print_rms_deviation();
     void archive_frame_to_disk();
 
     void run_scheduled_actions();

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -1458,6 +1458,8 @@ set (renderer_modeling_aov_sources
     renderer/modeling/aov/normalaov.h
     renderer/modeling/aov/npraovs.cpp
     renderer/modeling/aov/npraovs.h
+    renderer/modeling/aov/pixelerroraov.cpp
+    renderer/modeling/aov/pixelerroraov.h
     renderer/modeling/aov/pixelsamplecountaov.cpp
     renderer/modeling/aov/pixelsamplecountaov.h
     renderer/modeling/aov/pixeltimeaov.cpp

--- a/src/appleseed/foundation/image/analysis.cpp
+++ b/src/appleseed/foundation/image/analysis.cpp
@@ -141,15 +141,15 @@ double compute_rms_deviation(const Image& image1, const Image& image2)
     {
         for (size_t x = 0; x < props.m_canvas_width; ++x)
         {
-            float image_color[4];
-            image1.get_pixel(x, y, image_color);
+            float color1[4];
+            image1.get_pixel(x, y, color1);
 
-            float ref_color[4];
-            image2.get_pixel(x, y, ref_color);
+            float color2[4];
+            image2.get_pixel(x, y, color2);
 
             mse += compute_error_squared(
-                Color3f::from_array(image_color),
-                Color3f::from_array(ref_color));
+                Color3f::from_array(color1),
+                Color3f::from_array(color2));
         }
     }
 

--- a/src/appleseed/foundation/image/analysis.cpp
+++ b/src/appleseed/foundation/image/analysis.cpp
@@ -128,14 +128,6 @@ bool are_images_compatible(const Image& image1, const Image& image2)
         props1.m_canvas_height == props2.m_canvas_height;
 }
 
-double compute_error_squared(const Color3f& c1, const Color3f& c2)
-{
-    return
-        square(c1.r - c2.r) +
-        square(c1.g - c2.g) +
-        square(c1.b - c2.b);
-}
-
 double compute_rms_deviation(const Image& image1, const Image& image2)
 {
     if (!are_images_compatible(image1, image2))

--- a/src/appleseed/foundation/image/analysis.h
+++ b/src/appleseed/foundation/image/analysis.h
@@ -30,6 +30,7 @@
 #pragma once
 
 // appleseed.foundation headers.
+#include "foundation/image/color.h"
 #include "foundation/core/exceptions/exception.h"
 
 // appleseed.main headers.
@@ -56,6 +57,9 @@ APPLESEED_DLLSYMBOL double compute_average_luminance(const Image& image);
 
 // Return whether two images are compatible and thus can be compared.
 APPLESEED_DLLSYMBOL bool are_images_compatible(const Image& image1, const Image& image2);
+
+// Compute the squared error between two linear rgb colors.
+double compute_error_squared(const Color3f& c1, const Color3f& c2);
 
 // Exception thrown by comparison functions when two images are incompatible.
 struct ExceptionIncompatibleImages

--- a/src/appleseed/foundation/image/analysis.h
+++ b/src/appleseed/foundation/image/analysis.h
@@ -58,9 +58,6 @@ APPLESEED_DLLSYMBOL double compute_average_luminance(const Image& image);
 // Return whether two images are compatible and thus can be compared.
 APPLESEED_DLLSYMBOL bool are_images_compatible(const Image& image1, const Image& image2);
 
-// Compute the squared error between two linear rgb colors.
-double compute_error_squared(const Color3f& c1, const Color3f& c2);
-
 // Exception thrown by comparison functions when two images are incompatible.
 struct ExceptionIncompatibleImages
   : public Exception

--- a/src/appleseed/foundation/image/analysis.h
+++ b/src/appleseed/foundation/image/analysis.h
@@ -30,8 +30,8 @@
 #pragma once
 
 // appleseed.foundation headers.
-#include "foundation/image/color.h"
 #include "foundation/core/exceptions/exception.h"
+#include "foundation/image/color.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"

--- a/src/appleseed/foundation/image/color.h
+++ b/src/appleseed/foundation/image/color.h
@@ -347,6 +347,7 @@ Color<T, 3> integer_to_color3(const Int i);
 template <typename T>
 T compute_error_squared(const Color<T, 3>& c1, const Color<T, 3>& c2);
 
+
 //
 // N-dimensional color implementation.
 //

--- a/src/appleseed/foundation/image/color.h
+++ b/src/appleseed/foundation/image/color.h
@@ -345,7 +345,7 @@ Color<T, 3> integer_to_color3(const Int i);
 
 // Compute the squared error between two linear rgb colors.
 template <typename T>
-T compute_error_squared(const Color<T, 3>& c1, const Color<T, 3>& c2);
+inline T compute_error_squared(const Color<T, 3>& c1, const Color<T, 3>& c2);
 
 
 //

--- a/src/appleseed/foundation/image/color.h
+++ b/src/appleseed/foundation/image/color.h
@@ -345,7 +345,7 @@ Color<T, 3> integer_to_color3(const Int i);
 
 // Compute the squared error between two linear rgb colors.
 template <typename T>
-inline T compute_error_squared(const Color<T, 3>& c1, const Color<T, 3>& c2);
+T compute_error_squared(const Color<T, 3>& c1, const Color<T, 3>& c2);
 
 
 //
@@ -1188,7 +1188,7 @@ Color<T, 3> integer_to_color3(const Int i)
 }
 
 template <typename T>
-T compute_error_squared(const Color<T, 3>& c1, const Color<T, 3>& c2)
+inline T compute_error_squared(const Color<T, 3>& c1, const Color<T, 3>& c2)
 {
     return
         square(c1.r - c2.r) +

--- a/src/appleseed/foundation/image/color.h
+++ b/src/appleseed/foundation/image/color.h
@@ -343,6 +343,9 @@ typedef Color<double,   4> Color4d;
 template <typename T, typename Int>
 Color<T, 3> integer_to_color3(const Int i);
 
+// Compute the squared error between two linear rgb colors.
+template <typename T>
+T compute_error_squared(const Color<T, 3>& c1, const Color<T, 3>& c2);
 
 //
 // N-dimensional color implementation.
@@ -1181,6 +1184,15 @@ Color<T, 3> integer_to_color3(const Int i)
         static_cast<T>(x) * (1.0f / 4294967295.0f),
         static_cast<T>(y) * (1.0f / 4294967295.0f),
         static_cast<T>(z) * (1.0f / 4294967295.0f));
+}
+
+template <typename T>
+T compute_error_squared(const Color<T, 3>& c1, const Color<T, 3>& c2)
+{
+    return
+        square(c1.r - c2.r) +
+        square(c1.g - c2.g) +
+        square(c1.b - c2.b);
 }
 
 }   // namespace foundation

--- a/src/appleseed/foundation/meta/tests/test_analysis.cpp
+++ b/src/appleseed/foundation/meta/tests/test_analysis.cpp
@@ -156,7 +156,6 @@ TEST_SUITE(Foundation_Image_Analysis)
 
         const double rmsd = compute_rms_deviation(image1, image2);
 
-        EXPECT_LT(0.82f, rmsd);
-        EXPECT_GT(0.81f, rmsd);
+        EXPECT_FEQ_EPS(sqrt(2.0 / 3.0), rmsd, 1.0e-6);
     }
 }

--- a/src/appleseed/foundation/meta/tests/test_analysis.cpp
+++ b/src/appleseed/foundation/meta/tests/test_analysis.cpp
@@ -119,4 +119,44 @@ TEST_SUITE(Foundation_Image_Analysis)
 
         EXPECT_FEQ(1.0, rmsd);
     }
+
+    TEST_CASE(ComputeRMSDeviation_GivenImagesOfDifferentChannelSizes_ReturnsOne)
+    {
+        Image image1(4, 4, 2, 2, 3, PixelFormatFloat);
+        Image image2(4, 4, 2, 2, 4, PixelFormatFloat);
+
+        image1.clear(Color3f(0.0f));
+        image2.clear(Color4f(1.0f));
+
+        const double rmsd = compute_rms_deviation(image1, image2);
+
+        EXPECT_FEQ(1.0, rmsd);
+    }
+
+    TEST_CASE(ComputeRMSDeviation_GivenImagesOfDifferentTileSizes_ReturnsOne)
+    {
+        Image image1(4, 4, 1, 1, 4, PixelFormatFloat);
+        Image image2(4, 4, 2, 2, 4, PixelFormatFloat);
+
+        image1.clear(Color4f(0.0f));
+        image2.clear(Color4f(1.0f));
+
+        const double rmsd = compute_rms_deviation(image1, image2);
+
+        EXPECT_FEQ(1.0, rmsd);
+    }
+
+    TEST_CASE(ComputeRMSDeviation_GivenRedImageAndBlueImage_ReturnsAlmostRootTwoThirds)
+    {
+        Image image1(4, 4, 2, 2, 4, PixelFormatFloat);
+        Image image2(4, 4, 2, 2, 4, PixelFormatFloat);
+
+        image1.clear(Color4f(1.0f, 0.0f, 0.0f, 0.0f));
+        image2.clear(Color4f(0.0f, 1.0f, 0.0f, 0.0f));
+
+        const double rmsd = compute_rms_deviation(image1, image2);
+
+        EXPECT_LT(0.82f, rmsd);
+        EXPECT_GT(0.81f, rmsd);
+    }
 }

--- a/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
@@ -147,7 +147,8 @@ namespace
             if (callback_factory)
                 m_tile_callback.reset(callback_factory->create());
 
-            if (m_project.get_frame()->validate_ref_image()) {
+            if (m_project.get_frame()->validate_ref_image())
+            {
                 m_ref_image_avg_lum = compute_average_luminance(m_project.get_frame()->ref_image());
 
                 RENDERER_LOG_DEBUG(

--- a/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
@@ -149,7 +149,7 @@ namespace
 
             if (m_project.get_frame()->has_valid_ref_image())
             {
-                m_ref_image_avg_lum = compute_average_luminance(m_project.get_frame()->ref_image());
+                m_ref_image_avg_lum = compute_average_luminance(*m_project.get_frame()->ref_image());
 
                 RENDERER_LOG_DEBUG(
                     "reference image average luminance is %s.",
@@ -253,7 +253,7 @@ namespace
                     *m_buffer.get(),
                     m_params.m_perf_stats,
                     m_params.m_luminance_stats,
-                    &m_project.get_frame()->ref_image(),
+                    m_project.get_frame()->ref_image(),
                     m_ref_image_avg_lum,
                     m_abort_switch));
             m_statistics_thread.reset(

--- a/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
@@ -147,7 +147,7 @@ namespace
             if (callback_factory)
                 m_tile_callback.reset(callback_factory->create());
 
-            if (m_project.get_frame()->validate_ref_image())
+            if (m_project.get_frame()->has_valid_ref_image())
             {
                 m_ref_image_avg_lum = compute_average_luminance(m_project.get_frame()->ref_image());
 

--- a/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
@@ -196,7 +196,7 @@ namespace
                 "  max samples                   %s\n"
                 "  max fps                       %f\n"
                 "  collect performance stats     %s\n"
-                "  collect luminance stats       %s\n",
+                "  collect luminance stats       %s",
                 get_spectrum_mode_name(m_params.m_spectrum_mode).c_str(),
                 get_sampling_context_mode_name(m_params.m_sampling_mode).c_str(),
                 pretty_uint(m_params.m_thread_count).c_str(),

--- a/src/appleseed/renderer/modeling/aov/aovfactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/aov/aovfactoryregistrar.cpp
@@ -39,6 +39,7 @@
 #include "renderer/modeling/aov/invalidsamplesaov.h"
 #include "renderer/modeling/aov/normalaov.h"
 #include "renderer/modeling/aov/npraovs.h"
+#include "renderer/modeling/aov/pixelerroraov.h"
 #include "renderer/modeling/aov/pixelsamplecountaov.h"
 #include "renderer/modeling/aov/pixeltimeaov.h"
 #include "renderer/modeling/aov/pixelvariationaov.h"
@@ -83,6 +84,7 @@ AOVFactoryRegistrar::AOVFactoryRegistrar(const SearchPaths& search_paths)
     impl->register_factory(auto_release_ptr<FactoryType>(new NormalAOVFactory()));
     impl->register_factory(auto_release_ptr<FactoryType>(new NPRContourAOVFactory()));
     impl->register_factory(auto_release_ptr<FactoryType>(new NPRShadingAOVFactory()));
+    impl->register_factory(auto_release_ptr<FactoryType>(new PixelErrorAOVFactory()));
     impl->register_factory(auto_release_ptr<FactoryType>(new PixelSampleCountAOVFactory()));
     impl->register_factory(auto_release_ptr<FactoryType>(new PixelTimeAOVFactory()));
     impl->register_factory(auto_release_ptr<FactoryType>(new PixelVariationAOVFactory()));

--- a/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
+++ b/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
@@ -98,7 +98,7 @@ namespace
                     float ref_color[4];
                     frame.ref_image().get_pixel(x, y, ref_color);
 
-                    float error = sqrt(compute_error_squared(
+                    const float error = sqrt(compute_error_squared(
                         Color3f::from_array(image_color),
                         Color3f::from_array(ref_color)));
                     max_error = max(max_error, error);

--- a/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
+++ b/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
@@ -1,0 +1,170 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2019 Luke Wilimitis, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "pixelerroraov.h"
+
+// appleseed.renderer headers.
+#include "renderer/kernel/aov/aovaccumulator.h"
+#include "renderer/modeling/aov/aov.h"
+#include "renderer/modeling/frame/frame.h"
+
+// appleseed.foundation headers.
+#include <foundation/image/analysis.h>
+#include "foundation/image/color.h"
+#include "foundation/image/image.h"
+#include "foundation/utility/api/specializedapiarrays.h"
+#include "foundation/utility/containers/dictionary.h"
+
+// Standard headers.
+#include <cstddef>
+#include <memory>
+#include <string>
+
+using namespace foundation;
+using namespace std;
+
+namespace renderer
+{
+
+namespace
+{
+    //
+    // Pixel Error AOV.
+    //
+
+    const char* PixelErrorAOVModel = "pixel_error_aov";
+
+    class PixelErrorAOV
+      : public UnfilteredAOV
+    {
+      public:
+        explicit PixelErrorAOV(const ParamArray& params)
+          : UnfilteredAOV("pixel_error", params)
+        {
+        }
+
+        const char* get_model() const override
+        {
+            return PixelErrorAOVModel;
+        }
+
+        void post_process_image(const Frame& frame) override
+        {
+            if (!frame.validate_ref_image())
+                return;
+
+            // TODO: Convert to inferno color map.
+            static const Color3f Blue(0.0f, 0.0f, 1.0f);
+            static const Color3f Red(1.0f, 0.0f, 0.0f);
+
+            const AABB2u& crop_window = frame.get_crop_window();
+
+            float max_error = 0.0f;
+
+            for (size_t y = crop_window.min.y; y <= crop_window.max.y; ++y)
+            {
+                for (size_t x = crop_window.min.x; x <= crop_window.max.x; ++x)
+                {
+                    float image_color[4];
+                    frame.image().get_pixel(x, y, image_color);
+
+                    float ref_color[4];
+                    frame.ref_image().get_pixel(x, y, ref_color);
+
+                    float error = static_cast<float>(
+                        sqrt(compute_error_squared(
+                            Color3f::from_array(image_color),
+                            Color3f::from_array(ref_color))));
+                    max_error = max(max_error, error);
+
+                    const Color3f color(error, 0, 0);
+                    m_image->set_pixel(x, y, color);
+                }
+            }
+
+            if (max_error == 0.0f)
+                return;
+
+            for (size_t y = crop_window.min.y; y <= crop_window.max.y; ++y)
+            {
+                for (size_t x = crop_window.min.x; x <= crop_window.max.x; ++x)
+                {
+                    Color3f error;
+                    m_image->get_pixel(x, y, error);
+
+                    const float color = fit(error.r, 0.0f, max_error, 0.0f, 1.0f);
+                    assert(color >= 0.0f && color <= 1.0f);
+                    m_image->set_pixel(x, y, lerp(Blue, Red, color));
+                }
+            }
+        }
+
+      private:
+        auto_release_ptr<AOVAccumulator> create_accumulator() const override
+        {
+            return auto_release_ptr<AOVAccumulator>(new AOVAccumulator());
+        }
+    };
+}
+
+
+//
+// PixelErrorAOVFactory class implementation.
+//
+
+void PixelErrorAOVFactory::release()
+{
+    delete this;
+}
+
+const char* PixelErrorAOVFactory::get_model() const
+{
+    return PixelErrorAOVModel;
+}
+
+Dictionary PixelErrorAOVFactory::get_model_metadata() const
+{
+    return
+        Dictionary()
+            .insert("name", PixelErrorAOVModel)
+            .insert("label", "Pixel Error");
+}
+
+DictionaryArray PixelErrorAOVFactory::get_input_metadata() const
+{
+    DictionaryArray metadata;
+    return metadata;
+}
+
+auto_release_ptr<AOV> PixelErrorAOVFactory::create(const ParamArray& params) const
+{
+    return auto_release_ptr<AOV>(new PixelErrorAOV(params));
+}
+
+}   // namespace renderer

--- a/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
+++ b/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
@@ -103,7 +103,7 @@ namespace
                         Color3f::from_array(ref_color)));
                     max_error = max(max_error, error);
 
-                    const Color3f color(error, 0, 0);
+                    const Color3f color(error, 0.0f, 0.0f);
                     m_image->set_pixel(x, y, color);
                 }
             }

--- a/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
+++ b/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
@@ -42,6 +42,7 @@
 #include "foundation/utility/containers/dictionary.h"
 
 // Standard headers.
+#include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <string>

--- a/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
+++ b/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
@@ -35,7 +35,7 @@
 #include "renderer/modeling/frame/frame.h"
 
 // appleseed.foundation headers.
-#include <foundation/image/analysis.h>
+#include "foundation/image/analysis.h"
 #include "foundation/image/color.h"
 #include "foundation/image/image.h"
 #include "foundation/utility/api/specializedapiarrays.h"

--- a/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
+++ b/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
@@ -97,10 +97,9 @@ namespace
                     float ref_color[4];
                     frame.ref_image().get_pixel(x, y, ref_color);
 
-                    float error = static_cast<float>(
-                        sqrt(compute_error_squared(
-                            Color3f::from_array(image_color),
-                            Color3f::from_array(ref_color))));
+                    float error = sqrt(compute_error_squared(
+                        Color3f::from_array(image_color),
+                        Color3f::from_array(ref_color)));
                     max_error = max(max_error, error);
 
                     const Color3f color(error, 0, 0);

--- a/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
+++ b/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
@@ -96,7 +96,7 @@ namespace
                     frame.image().get_pixel(x, y, image_color);
 
                     float ref_color[4];
-                    frame.ref_image().get_pixel(x, y, ref_color);
+                    frame.ref_image()->get_pixel(x, y, ref_color);
 
                     const float error = sqrt(compute_error_squared(
                         Color3f::from_array(image_color),

--- a/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
+++ b/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
@@ -76,7 +76,7 @@ namespace
 
         void post_process_image(const Frame& frame) override
         {
-            if (!frame.validate_ref_image())
+            if (!frame.has_valid_ref_image())
                 return;
 
             // TODO: Convert to inferno color map.

--- a/src/appleseed/renderer/modeling/aov/pixelerroraov.h
+++ b/src/appleseed/renderer/modeling/aov/pixelerroraov.h
@@ -41,7 +41,6 @@
 // Forward declarations.
 namespace foundation    { class Dictionary; }
 namespace foundation    { class DictionaryArray; }
-namespace renderer      { class AOV; }
 namespace renderer      { class ParamArray; }
 
 namespace renderer

--- a/src/appleseed/renderer/modeling/aov/pixelerroraov.h
+++ b/src/appleseed/renderer/modeling/aov/pixelerroraov.h
@@ -1,0 +1,74 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2019 Luke Wilimitis, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.renderer headers.
+#include "renderer/modeling/aov/aov.h"
+#include "renderer/modeling/aov/iaovfactory.h"
+
+// appleseed.foundation headers.
+#include "foundation/utility/autoreleaseptr.h"
+
+// appleseed.main headers.
+#include "main/dllsymbol.h"
+
+// Forward declarations.
+namespace foundation    { class Dictionary; }
+namespace foundation    { class DictionaryArray; }
+namespace renderer      { class AOV; }
+namespace renderer      { class ParamArray; }
+
+namespace renderer
+{
+
+//
+// A factory for pixel error AOVs.
+//
+
+class APPLESEED_DLLSYMBOL PixelErrorAOVFactory
+  : public IAOVFactory
+{
+  public:
+    // Delete this instance.
+    void release() override;
+
+    // Return a string identifying this AOV model.
+    const char* get_model() const override;
+
+    // Return metadata for this AOV model.
+    foundation::Dictionary get_model_metadata() const override;
+
+    // Return metadata for the inputs of this AOV model.
+    foundation::DictionaryArray get_input_metadata() const override;
+
+    // Create a new AOV instance.
+    foundation::auto_release_ptr<AOV> create(const ParamArray& params) const override;
+};
+
+}   // namespace renderer

--- a/src/appleseed/renderer/modeling/frame/frame.cpp
+++ b/src/appleseed/renderer/modeling/frame/frame.cpp
@@ -324,9 +324,9 @@ Image& Frame::image() const
     return *impl->m_image.get();
 }
 
-Image& Frame::ref_image() const
+Image* Frame::ref_image() const
 {
-    return *impl->m_ref_image.get();
+    return impl->m_ref_image.get();
 }
 
 bool Frame::has_valid_ref_image() const

--- a/src/appleseed/renderer/modeling/frame/frame.cpp
+++ b/src/appleseed/renderer/modeling/frame/frame.cpp
@@ -1770,10 +1770,10 @@ auto_release_ptr<Frame> FrameFactory::create(
 }
 
 auto_release_ptr<Frame> FrameFactory::create(
-        const char*         name,
-        const ParamArray&   params,
-        const AOVContainer& aovs,
-        const SearchPaths&  search_paths)
+    const char*         name,
+    const ParamArray&   params,
+    const AOVContainer& aovs,
+    const SearchPaths&  search_paths)
 {
     return
         auto_release_ptr<Frame>(

--- a/src/appleseed/renderer/modeling/frame/frame.cpp
+++ b/src/appleseed/renderer/modeling/frame/frame.cpp
@@ -186,7 +186,12 @@ Frame::Frame(
         impl->m_ref_image.reset(reader.read(
             search_paths.qualify(impl->m_ref_image_path).c_str()));
 
-        validate_ref_image();
+        if (!has_valid_ref_image())
+        {
+            RENDERER_LOG_ERROR(
+                "the reference image is not compatible with the output frame "
+                "(different dimensions, tile size or number of channels).");
+        }
     }
 
     // Create the image stack for AOVs.
@@ -325,21 +330,10 @@ Image& Frame::ref_image() const
     return *impl->m_ref_image.get();
 }
 
-bool Frame::validate_ref_image() const
+bool Frame::has_valid_ref_image() const
 {
-    if (!impl->m_ref_image)
-        return false;
-
-    bool is_compatible = are_images_compatible(*impl->m_image.get(), *impl->m_ref_image.get());
-    if (!is_compatible)
-    {
-        RENDERER_LOG_ERROR(
-            "the reference image is not compatible with the output frame "
-            "(different dimensions, tile size or number of channels).");
-
-        impl->m_ref_image.reset();
-    }
-    return is_compatible;
+    return impl->m_ref_image &&
+        are_images_compatible(*impl->m_image.get(), *impl->m_ref_image.get());
 }
 
 void Frame::clear_main_and_aov_images()

--- a/src/appleseed/renderer/modeling/frame/frame.cpp
+++ b/src/appleseed/renderer/modeling/frame/frame.cpp
@@ -189,8 +189,7 @@ Frame::Frame(
         if (!has_valid_ref_image())
         {
             RENDERER_LOG_ERROR(
-                "the reference image is not compatible with the output frame "
-                "(different dimensions, tile size or number of channels).");
+                "the reference image is not compatible with the output frame (different dimensions).");
         }
     }
 

--- a/src/appleseed/renderer/modeling/frame/frame.h
+++ b/src/appleseed/renderer/modeling/frame/frame.h
@@ -103,8 +103,8 @@ class APPLESEED_DLLSYMBOL Frame
     // Access the main underlying image.
     foundation::Image& image() const;
 
-    // Access the reference image.
-    foundation::Image& ref_image() const;
+    // Access the reference image. Returns nullptr if there is no reference image.
+    foundation::Image* ref_image() const;
 
     // Returns whether the reference image is compatible with the frame.
     bool has_valid_ref_image() const;

--- a/src/appleseed/renderer/modeling/frame/frame.h
+++ b/src/appleseed/renderer/modeling/frame/frame.h
@@ -107,7 +107,7 @@ class APPLESEED_DLLSYMBOL Frame
     foundation::Image& ref_image() const;
 
     // Returns whether the reference image is compatible with the frame.
-    bool validate_ref_image() const;
+    bool has_valid_ref_image() const;
 
     // Clear the main and AOV images to transparent black.
     void clear_main_and_aov_images();

--- a/src/appleseed/renderer/modeling/frame/frame.h
+++ b/src/appleseed/renderer/modeling/frame/frame.h
@@ -56,6 +56,7 @@ namespace foundation    { class DictionaryArray; }
 namespace foundation    { class IAbortSwitch; }
 namespace foundation    { class Image; }
 namespace foundation    { class ImageAttributes; }
+namespace foundation    { class SearchPaths; }
 namespace foundation    { class StringArray; }
 namespace foundation    { class StringDictionary; }
 namespace foundation    { class Tile; }
@@ -101,6 +102,12 @@ class APPLESEED_DLLSYMBOL Frame
 
     // Access the main underlying image.
     foundation::Image& image() const;
+
+    // Access the reference image.
+    foundation::Image& ref_image() const;
+
+    // Returns whether the reference image is compatible with the frame.
+    bool validate_ref_image() const;
 
     // Clear the main and AOV images to transparent black.
     void clear_main_and_aov_images();
@@ -222,7 +229,8 @@ class APPLESEED_DLLSYMBOL Frame
     Frame(
         const char*                                 name,
         const ParamArray&                           params,
-        const AOVContainer&                         aovs);
+        const AOVContainer&                         aovs,
+        const foundation::SearchPaths&              search_paths);
 
     // Destructor.
     ~Frame() override;
@@ -254,6 +262,13 @@ class APPLESEED_DLLSYMBOL FrameFactory
         const char*                 name,
         const ParamArray&           params,
         const AOVContainer&         aovs);
+
+    // Create a new frame.
+    static foundation::auto_release_ptr<Frame> create(
+        const char*                     name,
+        const ParamArray&               params,
+        const AOVContainer&             aovs,
+        const foundation::SearchPaths&  search_paths);
 };
 
 


### PR DESCRIPTION
Please see individual commit comments for related implementation notes.

**Pixel Error AOV**
See https://www.ci.i.u-tokyo.ac.jp/~hachisuka/mbdpt.pdf for an elaborate reference example.

Generally useful for understanding the behavior of sampling or light transport optimizations. For instance, we would expect there to be lower error near hard to reach specular spots for some bidirectional methods (sppm, bdpt, ...). An obvious next step would be to enable comparing two renders side-by-side normalized against the highest error of a single render (or allow an upper bound param), but this might be better suited as a python script.

Directly relevant to the discussion in #2465 regarding the behavior of computing tile noise in sRGB space, where we might expect to see less variance in darker areas and higher variance in lighter areas for sRGB.

Usage
```
...
<frame name="beauty">
  ...
  <parameter name="reference_image" value="ref.exr" />
  <aovs>
    <aov model="pixel_error_aov" />
  </aovs>
</frame>
```

Left to right: SPPM reference, UDPT render
![Screen Shot 2019-03-15 at 8 36 17 AM](https://user-images.githubusercontent.com/4917232/54488277-e7da7680-486d-11e9-9062-56fff4c7a851.png)

Top to bottom: Linear RGB adaptive tiling, sRGB adaptive tiling
![Untitled Diagram](https://user-images.githubusercontent.com/4917232/54488439-deeaa480-486f-11e9-8d73-08abed7e6344.png)

