### PR TITLE
Add mode selection input and handling of non physical UV coordinates to 3ds Max UV transform

### DIFF
--- a/src/appleseed.shaders/src/max/as_max_uv_transform.osl
+++ b/src/appleseed.shaders/src/max/as_max_uv_transform.osl
@@ -39,6 +39,8 @@ shader as_max_uv_transform
 
     float in_rotateW = 0.0,
 
+    int in_real_world_mode = 1,
+
     int in_mirrorU = 0,
     int in_mirrorV = 0,
 
@@ -62,9 +64,15 @@ shader as_max_uv_transform
     float out_u = in_coordU;
     float out_v = in_coordV;
 
-    // Apply offset before rotation
     out_u -= in_offsetU;
     out_v -= in_offsetV;
+
+    // Max applies an offset when non real world sizes are used
+    if (!in_real_world_mode)
+    {
+        out_u -= 0.5;
+        out_v -= 0.5;
+    }
 
     if (in_rotateW != 0.0)
     {
@@ -78,9 +86,16 @@ shader as_max_uv_transform
         out_v = rot[1];
     }
 
-    // Apply tiling without considering cropping
+    // Apply tiling and offset without considering cropping
     out_u = (out_u * in_tilingU);
     out_v = (out_v * in_tilingV);
+
+    // undo the non real world size offset
+    if (!in_real_world_mode)
+    {
+        out_u += 0.5;
+        out_v += 0.5;
+    }
 
     // Apply mirroring.
     if (in_mirrorU)

--- a/src/appleseed.shaders/src/max/as_max_uv_transform.osl
+++ b/src/appleseed.shaders/src/max/as_max_uv_transform.osl
@@ -67,7 +67,7 @@ shader as_max_uv_transform
     out_u -= in_offsetU;
     out_v -= in_offsetV;
 
-    // Max applies an offset when non real world sizes are used
+    // Max applies an offset when non real world sizes are used.
     if (!in_real_world_mode)
     {
         out_u -= 0.5;
@@ -86,11 +86,11 @@ shader as_max_uv_transform
         out_v = rot[1];
     }
 
-    // Apply tiling and offset without considering cropping
+    // Apply tiling and offset without considering cropping.
     out_u = (out_u * in_tilingU);
     out_v = (out_v * in_tilingV);
 
-    // undo the non real world size offset
+    // Undo the non real world size offset.
     if (!in_real_world_mode)
     {
         out_u += 0.5;
@@ -119,7 +119,7 @@ shader as_max_uv_transform
     out_u = fmod(out_u, 1.0);
     out_v = fmod(out_v, 1.0);
 
-    // Avoid negative values
+    // Avoid negative values.
     if (out_u < 0)
         out_u = 1 + out_u;
     if (out_v < 0)
@@ -133,7 +133,7 @@ shader as_max_uv_transform
 
         out_v *= in_cropH;
         out_v -= in_cropV;
-        out_v = out_v + (1 - in_cropH); // Looks like V=0 is bottom left corner, so had to move it to the top to match 3ds max coords
+        out_v = out_v + (1 - in_cropH); // Looks like V=0 is bottom left corner, so had to move it to the top to match 3ds max coords.
     }
 
     out_outUvFilterSize[0] = filterwidth(out_u);


### PR DESCRIPTION
Since 3ds max handles non real world UV transformations with an additional offset a new mode selecting input is required. I tested rotations, tiling and mirroring for both physical and non physical UVs and they are replicating 3ds Max behavior. After we merge this we need appleseed-max to pass the state of the 'Use Real-World Scale' checkbox as input to the 'in_real_world_mode' parameter.