### PR TITLE
Use modern OpenGL to draw light paths and scene representation

### DIFF
--- a/src/appleseed.studio/main/main.cpp
+++ b/src/appleseed.studio/main/main.cpp
@@ -52,6 +52,7 @@
 #include <QLocale>
 #include <QMessageBox>
 #include <QString>
+#include <QSurfaceFormat>
 #include <QTextStream>
 
 // Boost headers.
@@ -324,6 +325,13 @@ int main(int argc, char* argv[])
 {
     // Enable memory tracking immediately as to catch as many leaks as possible.
     start_memory_tracking();
+
+    // Set default surface format before creating application instance. This is
+    // required on macOS in order to use an OpenGL Core profile context.
+    QSurfaceFormat default_format;
+    default_format.setVersion(3, 3);
+    default_format.setProfile(QSurfaceFormat::CoreProfile);
+    QSurfaceFormat::setDefaultFormat(default_format);
 
     // Our message handler must be set before the construction of QApplication.
     g_previous_message_handler = qInstallMessageHandler(message_handler);

--- a/src/appleseed.studio/mainwindow/rendering/lightpathswidget.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathswidget.cpp
@@ -29,6 +29,9 @@
 // Interface header.
 #include "lightpathswidget.h"
 
+// appleseed.studio headers.
+#include "utility/miscellaneous.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/camera.h"
 #include "renderer/api/entity.h"
@@ -47,11 +50,13 @@
 
 // Qt headers.
 #include <QKeyEvent>
+#include <QOpenGLFunctions_3_3_Core>
+#include <QSurfaceFormat>
+#include <QString>
 
 // Standard headers.
 #include <algorithm>
 #include <cmath>
-#include <string>
 
 using namespace foundation;
 using namespace renderer;
@@ -59,6 +64,63 @@ using namespace std;
 
 namespace appleseed {
 namespace studio {
+
+namespace {
+    // Number of floats per OpenGL vertex for a piece of scene geometry
+    // Vector3 position and Vector3 normal.
+    const size_t SceneVertexFloatStride = 6;
+    // Number of bytes per OpenGL vertex for a piece of scene geometry.
+    const size_t SceneVertexByteStride = SceneVertexFloatStride * sizeof(float);
+    // Number of floats per triangle for a piece of scene geometry.
+    const size_t SceneTriangleFloatStride = SceneVertexFloatStride * 3;
+
+    // Number of floats per OpenGL vertex for a light path
+    // Vector3 position and Vector3 color.
+    const size_t LightPathVertexFloatStride = 6;
+    // Number of bytes per OpenGL vertex for a piece of scene geometry.
+    const size_t LightPathVertexByteStride = LightPathVertexFloatStride * sizeof(float);
+    // Number of floats per line for a light path.
+    const size_t LightPathVertexLineFloatStride = LightPathVertexFloatStride * 2;
+
+    // Number of floats per OpenGL transform matrix.
+    const size_t TransformFloatStride = 16;
+    // Number of bytes per OpenGL transform matrix.
+    const size_t TransformByteStride = TransformFloatStride * sizeof(float);
+
+    struct OpenGLRasterizer
+      : public ObjectRasterizer
+    {
+        vector<float>   m_buffer;
+        size_t          m_prim_count;
+
+        void begin_object(const size_t triangle_count_hint) override
+        {
+            m_buffer.clear();
+            m_buffer.reserve(triangle_count_hint * SceneTriangleFloatStride);
+            m_prim_count = 0;
+        }
+
+        void end_object() override {}
+
+        void rasterize(const Triangle& triangle) override
+        {
+            const float temp_store[SceneTriangleFloatStride] =
+            {
+                static_cast<float>(triangle.m_v0[0]), static_cast<float>(triangle.m_v0[1]), static_cast<float>(triangle.m_v0[2]),
+                static_cast<float>(triangle.m_n0[0]), static_cast<float>(triangle.m_n0[1]), static_cast<float>(triangle.m_n0[2]),
+
+                static_cast<float>(triangle.m_v1[0]), static_cast<float>(triangle.m_v1[1]), static_cast<float>(triangle.m_v1[2]),
+                static_cast<float>(triangle.m_n1[0]), static_cast<float>(triangle.m_n1[1]), static_cast<float>(triangle.m_n1[2]),
+
+                static_cast<float>(triangle.m_v2[0]), static_cast<float>(triangle.m_v2[1]), static_cast<float>(triangle.m_v2[2]),
+                static_cast<float>(triangle.m_n2[0]), static_cast<float>(triangle.m_n2[1]), static_cast<float>(triangle.m_n2[2]),
+            };
+            m_buffer.reserve(m_buffer.size() + SceneTriangleFloatStride);
+            m_buffer.insert(m_buffer.end(), temp_store, temp_store + SceneTriangleFloatStride);
+            m_prim_count++;
+        }
+    };
+}
 
 LightPathsWidget::LightPathsWidget(
     const Project&          project,
@@ -68,23 +130,26 @@ LightPathsWidget::LightPathsWidget(
   , m_camera(*m_project.get_uncached_active_camera())
   , m_backface_culling_enabled(false)
   , m_selected_light_path_index(-1)
+  , m_gl_initialized(false)
 {
     setFocusPolicy(Qt::StrongFocus);
     setFixedWidth(static_cast<int>(width));
     setFixedHeight(static_cast<int>(height));
 
     const float time = m_camera.get_shutter_middle_time();
-    m_camera_matrix = m_camera.transform_sequence().evaluate(time).get_parent_to_local();
+    set_transform(m_camera.transform_sequence().evaluate(time));
 }
 
 QImage LightPathsWidget::capture()
 {
-    return grabFrameBuffer();
+    return grabFramebuffer();
 }
 
 void LightPathsWidget::set_transform(const Transformd& transform)
 {
     m_camera_matrix = transform.get_parent_to_local();
+    m_gl_view_matrix = transpose(m_camera_matrix);
+    m_camera_position = Vector3f(m_camera_matrix.extract_translation());
 }
 
 void LightPathsWidget::set_light_paths(const LightPathArray& light_paths)
@@ -114,6 +179,7 @@ void LightPathsWidget::set_light_paths(const LightPathArray& light_paths)
 
     // Display all paths by default.
     set_selected_light_path_index(-1);
+    load_light_paths_data();
 }
 
 void LightPathsWidget::set_selected_light_path_index(const int selected_light_path_index)
@@ -159,24 +225,480 @@ void LightPathsWidget::slot_synchronize_camera()
         Transformd::from_local_to_parent(inverse(m_camera_matrix)));
 }
 
+void LightPathsWidget::load_object_instance(
+    const ObjectInstance&   object_instance,
+    const Matrix4f&         assembly_transform_matrix)
+{
+    Object* object = object_instance.find_object();
+
+    // This would already be logged in LightPathsWidget::load_scene_data
+    if (object == nullptr)
+        return;
+
+    const Transformd& transform = object_instance.get_transform();
+    const Matrix4f& object_transform_matrix(transform.get_local_to_parent());
+    const Matrix4f model_matrix = assembly_transform_matrix * object_transform_matrix;
+
+    // Object vertex buffer data has already been loaded; just add an instance
+    const string obj_name = string(object->get_name());
+    size_t buf_idx = m_scene_object_index_map.at(obj_name);
+
+    const GLuint object_instances_vbo = m_scene_object_instance_vbos[buf_idx];
+    const GLuint object_vao = m_scene_object_vaos[buf_idx];
+    const GLsizei current_instance = m_scene_object_current_instances[buf_idx];
+    m_scene_object_current_instances[buf_idx] += 1;
+
+    m_gl->glBindVertexArray(object_vao);
+    m_gl->glBindBuffer(GL_ARRAY_BUFFER, object_instances_vbo);
+    const Matrix4f gl_matrix = transpose(model_matrix);
+    m_gl->glBufferSubData(
+        GL_ARRAY_BUFFER,
+        current_instance * TransformByteStride,
+        TransformByteStride,
+        reinterpret_cast<const GLvoid*>(&gl_matrix[0]));
+}
+
+void LightPathsWidget::load_assembly_instance(
+    const AssemblyInstance& assembly_instance,
+    const float             time)
+{
+    const Assembly* assembly = assembly_instance.find_assembly();
+
+    // This would already be logged in LightPathsWidget::load_scene_data
+    if (assembly == nullptr)
+        return;
+
+    const Transformd transform = assembly_instance.transform_sequence().evaluate(time);
+
+    const Matrix4f transform_matrix(transform.get_local_to_parent());
+
+    for (const auto& object_instance : assembly->object_instances())
+        load_object_instance(object_instance, transform_matrix);
+
+    for (const auto& child_assembly_instance : assembly->assembly_instances())
+        load_assembly_instance(child_assembly_instance, time);
+}
+
+void LightPathsWidget::load_object_data(const Object& object)
+{
+    const string obj_name = string(object.get_name());
+    RENDERER_LOG_DEBUG("opengl: uploading mesh data for object: %s", obj_name.c_str());
+    if (m_scene_object_index_map.count(obj_name) == 0)
+    {
+        // Object vertex buffer data has not been loaded; load it
+        const size_t buf_idx = m_scene_object_data_vbos.size();
+        GLuint object_vao;
+        m_gl->glGenVertexArrays(1, &object_vao);
+        GLuint object_data_vbo;
+        m_gl->glGenBuffers(1, &object_data_vbo);
+        m_gl->glBindVertexArray(object_vao);
+        m_gl->glBindBuffer(GL_ARRAY_BUFFER, object_data_vbo);
+
+        m_scene_object_vaos.push_back(object_vao);
+        m_scene_object_data_vbos.push_back(object_data_vbo);
+        m_scene_object_index_map[obj_name] = buf_idx;
+
+        OpenGLRasterizer rasterizer;
+        object.rasterize(rasterizer);
+        m_scene_object_data_index_counts.push_back(static_cast<GLsizei>(rasterizer.m_prim_count * 3));
+
+        m_gl->glBufferData(
+            GL_ARRAY_BUFFER,
+            rasterizer.m_buffer.size() * sizeof(float),
+            reinterpret_cast<const GLvoid*>(&rasterizer.m_buffer[0]),
+            GL_STATIC_DRAW);
+
+        m_gl->glVertexAttribPointer(
+            0,
+            3,
+            GL_FLOAT,
+            GL_FALSE,
+            SceneVertexByteStride,
+            reinterpret_cast<const GLvoid*>(0));
+        m_gl->glVertexAttribPointer(
+            1,
+            3,
+            GL_FLOAT,
+            GL_FALSE,
+            SceneVertexByteStride,
+            reinterpret_cast<const GLvoid*>(SceneVertexByteStride / 2));
+        m_gl->glEnableVertexAttribArray(0);
+        m_gl->glEnableVertexAttribArray(1);
+    }
+}
+
+void LightPathsWidget::load_assembly_data(const Assembly& assembly)
+{
+    for (const auto& object : assembly.objects())
+        load_object_data(object);
+
+    for (const auto& child_assembly : assembly.assemblies())
+        load_assembly_data(child_assembly);
+}
+
+void LightPathsWidget::load_scene_data()
+{
+    const float time = m_camera.get_shutter_middle_time();
+
+    RENDERER_LOG_DEBUG("opengl: uploading scene data.");
+
+    // First, load all the unique object vertex buffer data into static VBOs
+    for (const auto& assembly : m_project.get_scene()->assemblies())
+        load_assembly_data(assembly);
+
+    // Create space for per-instance data
+    for (size_t i = 0; i < m_scene_object_index_map.size(); i++)
+    {
+        m_scene_object_instance_vbos.push_back(0);
+        m_scene_object_instance_counts.push_back(0);
+        m_scene_object_current_instances.push_back(0);
+    }
+
+    // Generate instance buffers for each object
+    m_gl->glGenBuffers(
+        static_cast<GLsizei>(m_scene_object_instance_vbos.size()),
+        &m_scene_object_instance_vbos[0]);
+
+    // Figure out how many instances of each mesh are required for all assembly instances
+    for (const auto& assembly_instance : m_project.get_scene()->assembly_instances())
+    {
+        const Assembly* assembly = assembly_instance.find_assembly();
+
+        if (assembly == nullptr)
+        {
+            RENDERER_LOG_ERROR(
+                "assembly instance \"%s\" has null base assembly reference",
+                assembly_instance.get_name());
+            continue;
+        }
+
+        for (const auto& object_instance : assembly->object_instances())
+        {
+            Object* object = object_instance.find_object();
+
+            if (object == nullptr)
+            {
+                RENDERER_LOG_ERROR(
+                    "object instance \"%s\" has null base object reference",
+                    object_instance.get_name());
+                continue;
+            }
+
+            const string obj_name = string(object->get_name());
+            const size_t buf_idx = m_scene_object_index_map[obj_name];
+            m_scene_object_instance_counts[buf_idx] += 1;
+        }
+    }
+
+    // Setup instance buffers by allocating a buffer big enough for the number
+    // of required instances and setting up vertex attributes
+    for (size_t i = 0; i < m_scene_object_instance_vbos.size(); i++)
+    {
+        const GLuint object_vao = m_scene_object_vaos[i];
+        const GLuint object_instance_vbo = m_scene_object_instance_vbos[i];
+        const GLsizei object_instance_count = m_scene_object_instance_counts[i];
+
+        m_gl->glBindVertexArray(object_vao);
+        m_gl->glBindBuffer(GL_ARRAY_BUFFER, object_instance_vbo);
+        m_gl->glBufferData(
+            GL_ARRAY_BUFFER,
+            object_instance_count * TransformByteStride,
+            NULL,
+            GL_DYNAMIC_DRAW);
+
+        // Attributes for a 4x4 model matrix; requires four separate attributes
+        // to be setup, one for each column of the matrix.
+        for (int i = 0; i < 4; i++)
+        {
+            m_gl->glVertexAttribPointer(
+                2 + i,
+                4,
+                GL_FLOAT,
+                GL_FALSE,
+                TransformByteStride,
+                reinterpret_cast<const GLvoid*>(sizeof(float) * 4 * i));
+            m_gl->glEnableVertexAttribArray(2 + i);
+            m_gl->glVertexAttribDivisor(2 + i, 1);
+        }
+    }
+
+    // Actually load the transform data for each instance into the allocated instance buffers
+    for (const auto& assembly_instance : m_project.get_scene()->assembly_instances())
+        load_assembly_instance(assembly_instance, time);
+}
+
+void LightPathsWidget::load_light_paths_data()
+{
+    m_light_paths_index_offsets.clear();
+    if (!m_light_paths.empty())
+    {
+        m_light_paths_index_offsets.push_back(0);
+
+        const auto& light_path_recorder = m_project.get_light_path_recorder();
+
+        const size_t total_gl_vertex_count = 2 * (light_path_recorder.get_vertex_count() - 2) + 2;
+
+        GLsizei total_index_count = 0;
+        vector<float> buffer;
+        buffer.reserve(total_gl_vertex_count * LightPathVertexFloatStride);
+        for (size_t light_path_idx = 0; light_path_idx < m_light_paths.size(); light_path_idx++)
+        {
+            const auto& path = m_light_paths[light_path_idx];
+            assert(path.m_vertex_end_index - path.m_vertex_begin_index >= 2);
+
+            LightPathVertex prev;
+            light_path_recorder.get_light_path_vertex(path.m_vertex_begin_index, prev);
+            for (size_t vertex_idx = path.m_vertex_begin_index + 1; vertex_idx < path.m_vertex_end_index; vertex_idx++)
+            {
+                LightPathVertex curr;
+                light_path_recorder.get_light_path_vertex(vertex_idx, curr);
+
+                auto piece_radiance = Color3f::from_array(curr.m_radiance);
+                piece_radiance /= sum_value(piece_radiance);
+                piece_radiance = linear_rgb_to_srgb(piece_radiance);
+
+                const float temp_store[LightPathVertexLineFloatStride] =
+                {
+                    prev.m_position[0], prev.m_position[1], prev.m_position[2],
+                    piece_radiance[0], piece_radiance[1], piece_radiance[2],
+
+                    curr.m_position[0], curr.m_position[1], curr.m_position[2],
+                    piece_radiance[0], piece_radiance[1], piece_radiance[2],
+                };
+                buffer.insert(buffer.end(), temp_store, temp_store + 12);
+
+                total_index_count += 2;
+                prev = curr;
+            }
+            m_light_paths_index_offsets.push_back(total_index_count);
+        }
+
+        m_gl->glBindBuffer(GL_ARRAY_BUFFER, m_light_paths_vbo);
+        m_gl->glBufferData(
+            GL_ARRAY_BUFFER,
+            buffer.size() * sizeof(float),
+            reinterpret_cast<const GLvoid*>(&buffer[0]),
+            GL_STATIC_DRAW);
+    }
+}
+
+namespace {
+    const string shader_kind_to_string(const GLint shader_kind)
+    {
+        switch (shader_kind) {
+            case GL_VERTEX_SHADER:
+                return "Vertex";
+            case GL_FRAGMENT_SHADER:
+                return "Fragment";
+            default:
+                return "Unknown Kind";
+        }
+    }
+
+    void compile_shader(
+        QOpenGLFunctions_3_3_Core* f,
+        const GLuint               shader,
+        const GLsizei              count,
+        const GLchar**             src_string,
+        const GLint*               length)
+    {
+        f->glShaderSource(shader, count, src_string, length);
+        f->glCompileShader(shader);
+        GLint success;
+        f->glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+
+        if (!success)
+        {
+            char info_log[1024];
+            f->glGetShaderInfoLog(shader, 1024, NULL, info_log);
+
+            GLint shader_kind;
+            f->glGetShaderiv(shader, GL_SHADER_TYPE, &shader_kind);
+            string shader_kind_string = shader_kind_to_string(shader_kind);
+
+            RENDERER_LOG_ERROR("opengl: %s shader compilation failed:\n%s", shader_kind_string.c_str(), info_log);
+        }
+    }
+
+    void link_shader_program(
+        QOpenGLFunctions_3_3_Core*  f,
+        const GLuint                program,
+        const GLuint                vert,
+        const GLuint                frag)
+    {
+        f->glAttachShader(program, vert);
+        f->glAttachShader(program, frag);
+        f->glLinkProgram(program);
+
+        GLint success;
+        f->glGetProgramiv(program, GL_LINK_STATUS, &success);
+
+        if (!success)
+        {
+            char info_log[1024];
+            f->glGetProgramInfoLog(program, 1024, NULL, info_log);
+            RENDERER_LOG_ERROR("opengl: shader program linking failed:\n%s", info_log);
+        }
+    }
+
+    void create_shader_program(
+        QOpenGLFunctions_3_3_Core*  f,
+        GLuint&                     program,
+        const QByteArray&               vert_source,
+        const QByteArray&               frag_source)
+    {
+        GLuint vert = f->glCreateShader(GL_VERTEX_SHADER);
+        GLuint frag = f->glCreateShader(GL_FRAGMENT_SHADER);
+
+        auto gl_vert_source = static_cast<const GLchar*>(vert_source.constData());
+        auto gl_vert_source_length = static_cast<const GLint>(vert_source.size());
+
+        auto gl_frag_source = static_cast<const GLchar*>(frag_source.constData());
+        auto gl_frag_source_length = static_cast<const GLint>(frag_source.size());
+
+        compile_shader(f, vert, 1, &gl_vert_source, &gl_vert_source_length);
+        compile_shader(f, frag, 1, &gl_frag_source, &gl_frag_source_length);
+
+        program = f->glCreateProgram();
+        link_shader_program(f, program, vert, frag);
+
+        f->glDeleteShader(vert);
+        f->glDeleteShader(frag);
+    }
+}
+
 void LightPathsWidget::initializeGL()
 {
+    m_gl = QOpenGLContext::currentContext()->versionFunctions<QOpenGLFunctions_3_3_Core>();
+    // If there was already previous data, clean up
+    LightPathsWidget::cleanup_gl_data();
+
+    const auto qgl_format = format();
+
+    if (!m_gl->initializeOpenGLFunctions())
+    {
+        const int major_version = qgl_format.majorVersion();
+        const int minor_version = qgl_format.minorVersion();
+        RENDERER_LOG_ERROR(
+            "opengl: could not load required gl functions. loaded version %d.%d, required version 3.3",
+            major_version,
+            minor_version);
+        m_gl_initialized = false;
+        return;
+    }
+
     glEnable(GL_DEPTH_TEST);
-    glEnable(GL_NORMALIZE);
-    glShadeModel(GL_SMOOTH);
 
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 
-    static const GLfloat LightPosition[] = { 0.0f, 0.0f, 0.0f, 1.0f };
-    static const GLfloat LightAmbient[] = { 0.0f, 0.0f, 0.0f, 1.0f };
-    static const GLfloat LightDiffuse[] = { 0.8f, 0.8f, 0.8f, 1.0f };
-    static const GLfloat LightSpecular[] = { 0.3f, 0.3f, 0.3f, 1.0f };
+    create_shader_program(
+        m_gl,
+        m_scene_shader_program,
+        load_gl_shader("scene.vert"),
+        load_gl_shader("scene.frag"));
 
-    glEnable(GL_LIGHT0);
-    glLightfv(GL_LIGHT0, GL_POSITION, LightPosition);
-    glLightfv(GL_LIGHT0, GL_AMBIENT, LightAmbient);
-    glLightfv(GL_LIGHT0, GL_DIFFUSE, LightDiffuse);
-    glLightfv(GL_LIGHT0, GL_SPECULAR, LightSpecular);
+    create_shader_program(
+        m_gl,
+        m_light_paths_shader_program,
+        load_gl_shader("lightpaths.vert"),
+        load_gl_shader("lightpaths.frag"));
+
+    m_scene_view_mat_location = m_gl->glGetUniformLocation(m_scene_shader_program, "u_view");
+    m_scene_proj_mat_location = m_gl->glGetUniformLocation(m_scene_shader_program, "u_proj");
+    m_scene_camera_pos_location = m_gl->glGetUniformLocation(m_scene_shader_program, "u_camera_pos");
+
+    m_light_paths_view_mat_location = m_gl->glGetUniformLocation(m_light_paths_shader_program, "u_view");
+    m_light_paths_proj_mat_location = m_gl->glGetUniformLocation(m_light_paths_shader_program, "u_proj");
+
+    const float z_near = 0.01f;
+    const float z_far = 1000.0f;
+
+    const auto& rc = m_camera.get_rasterization_camera();
+
+    const float fy = tan(rc.m_hfov / rc.m_aspect_ratio * 0.5) * z_near;
+    const float fx = fy * rc.m_aspect_ratio;
+
+    const float shift_x = rc.m_shift_x * 2.0 * fx;
+    const float shift_y = rc.m_shift_y * 2.0 * fy;
+
+    const float left   = -fx + shift_x;
+    const float right  =  fx + shift_x;
+    const float top    = -fy + shift_y;
+    const float bottom =  fy + shift_y;
+
+    // Top and bottom are flipped because QOpenGLWidget draws to a framebuffer object and then blits
+    // from the FBO to the default framebuffer, which flips the image.
+    m_gl_proj_matrix = transpose(Matrix4f::make_frustum(top, bottom, left, right, z_near, z_far));
+
+    GLuint temp_light_paths_vao = 0;
+    GLuint temp_light_paths_vbo = 0;
+    m_gl->glGenVertexArrays(1, &temp_light_paths_vao);
+    m_gl->glGenBuffers(1, &temp_light_paths_vbo);
+    m_light_paths_vao = temp_light_paths_vao;
+    m_light_paths_vbo = temp_light_paths_vbo;
+
+    m_gl->glBindVertexArray(m_light_paths_vao);
+    m_gl->glBindBuffer(GL_ARRAY_BUFFER, m_light_paths_vbo);
+    m_gl->glVertexAttribPointer(
+        0,
+        3,
+        GL_FLOAT,
+        GL_FALSE,
+        LightPathVertexByteStride,
+        reinterpret_cast<const GLvoid*>(0));
+    m_gl->glVertexAttribPointer(
+        1,
+        3,
+        GL_FLOAT,
+        GL_FALSE,
+        LightPathVertexByteStride,
+        reinterpret_cast<const GLvoid*>(LightPathVertexByteStride / 2));
+    m_gl->glEnableVertexAttribArray(0);
+    m_gl->glEnableVertexAttribArray(1);
+
+    m_gl->glBindVertexArray(0);
+
+    load_scene_data();
+    load_light_paths_data();
+
+    m_gl_initialized = true;
+}
+
+void LightPathsWidget::cleanup_gl_data()
+{
+    if (!m_scene_object_vaos.empty())
+    {
+        m_gl->glDeleteVertexArrays(
+            static_cast<GLsizei>(m_scene_object_vaos.size()),
+            &m_scene_object_vaos[0]);
+        m_scene_object_vaos.clear();
+    }
+    if (!m_scene_object_data_vbos.empty())
+    {
+        m_gl->glDeleteBuffers(
+            static_cast<GLsizei>(m_scene_object_data_vbos.size()),
+            &m_scene_object_data_vbos[0]);
+        m_scene_object_data_vbos.clear();
+    }
+    if (!m_scene_object_instance_vbos.empty())
+    {
+        m_gl->glDeleteBuffers(
+            static_cast<GLsizei>(m_scene_object_instance_vbos.size()),
+            &m_scene_object_instance_vbos[0]);
+        m_scene_object_instance_vbos.clear();
+    }
+    if (m_scene_shader_program != 0)
+    {
+        m_gl->glDeleteProgram(m_scene_shader_program);
+    }
+    if (m_light_paths_shader_program != 0)
+    {
+        m_gl->glDeleteProgram(m_light_paths_shader_program);
+    }
+    m_scene_object_index_map.clear();
+    m_scene_object_data_index_counts.clear();
+    m_scene_object_instance_counts.clear();
+    m_scene_object_current_instances.clear();
 }
 
 void LightPathsWidget::resizeGL(int w, int h)
@@ -184,124 +706,12 @@ void LightPathsWidget::resizeGL(int w, int h)
     glViewport(0, 0, static_cast<GLsizei>(w), static_cast<GLsizei>(h));
 }
 
-namespace
-{
-    void glMultMatrixd(const Matrix4d& m)
-    {
-        const Matrix4d mt(transpose(m));
-        ::glMultMatrixd(const_cast<GLdouble*>(&mt[0]));
-    }
-
-    void glColor(const Color3f& c)
-    {
-        glColor3f(c[0], c[1], c[2]);
-    }
-
-    struct OpenGLRasterizer
-      : public ObjectRasterizer
-    {
-        void begin_object() override
-        {
-            glBegin(GL_TRIANGLES);
-        }
-
-        void end_object() override
-        {
-            glEnd();
-        }
-
-        void rasterize(const Triangle& triangle) override
-        {
-            glNormal3d(triangle.m_n0[0], triangle.m_n0[1], triangle.m_n0[2]);
-            glVertex3d(triangle.m_v0[0], triangle.m_v0[1], triangle.m_v0[2]);
-
-            glNormal3d(triangle.m_n1[0], triangle.m_n1[1], triangle.m_n1[2]);
-            glVertex3d(triangle.m_v1[0], triangle.m_v1[1], triangle.m_v1[2]);
-
-            glNormal3d(triangle.m_n2[0], triangle.m_n2[1], triangle.m_n2[2]);
-            glVertex3d(triangle.m_v2[0], triangle.m_v2[1], triangle.m_v2[2]);
-        }
-    };
-
-    void draw(const ObjectInstance& object_instance)
-    {
-        Object* object = object_instance.find_object();
-
-        if (object == nullptr)
-            return;
-
-        static const GLfloat Ambient[] = { 0.0f, 0.0f, 0.0f, 1.0f };
-        static const GLfloat Diffuse[] = { 0.4f, 0.4f, 0.4f, 1.0f };
-        static const GLfloat Specular[] = { 0.15f, 0.15f, 0.15f, 1.0f };
-        static const GLfloat Shininess = 20.0f;
-
-        glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, Ambient);
-        glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, Diffuse);
-        glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, Specular);
-        glMaterialf(GL_FRONT_AND_BACK, GL_SHININESS, Shininess);
-
-        const Transformd& transform = object_instance.get_transform();
-
-        glPushMatrix();
-        glMultMatrixd(transform.get_local_to_parent());
-
-        OpenGLRasterizer rasterizer;
-        object->rasterize(rasterizer);
-
-        glPopMatrix();
-    }
-
-    void draw(
-        const AssemblyInstance& assembly_instance,
-        const float             time)
-    {
-        const Assembly* assembly = assembly_instance.find_assembly();
-
-        if (assembly == nullptr)
-            return;
-
-        const Transformd transform = assembly_instance.transform_sequence().evaluate(time);
-
-        glPushMatrix();
-        glMultMatrixd(transform.get_local_to_parent());
-
-        for (const auto& object_instance : assembly->object_instances())
-            draw(object_instance);
-
-        for (const auto& child_assembly_instance : assembly->assembly_instances())
-            draw(child_assembly_instance, time);
-
-        glPopMatrix();
-    }
-}
-
 void LightPathsWidget::paintGL()
 {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    const auto& rc = m_camera.get_rasterization_camera();
-
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-
-    const double ZNear = 0.01;
-    const double ZFar = 1000.0;
-
-    const double fy = tan(rc.m_hfov / rc.m_aspect_ratio * 0.5) * ZNear;
-    const double fx = fy * rc.m_aspect_ratio;
-
-    const double shift_x = rc.m_shift_x * 2.0 * fx;
-    const double shift_y = rc.m_shift_y * 2.0 * fy;
-
-    const double left   = -fx + shift_x;
-    const double right  =  fx + shift_x;
-    const double top    = -fy + shift_y;
-    const double bottom =  fy + shift_y;
-
-    glFrustum(left, right, top, bottom, ZNear, ZFar);
-
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
+    if (!m_gl_initialized)
+        return;
 
     if (m_backface_culling_enabled)
         glEnable(GL_CULL_FACE);
@@ -331,69 +741,77 @@ void LightPathsWidget::keyPressEvent(QKeyEvent* event)
         break;
 
       default:
-        QGLWidget::keyPressEvent(event);
+        QOpenGLWidget::keyPressEvent(event);
         break;
     }
 }
 
-void LightPathsWidget::render_geometry() const
+void LightPathsWidget::render_geometry()
 {
-    glEnable(GL_LIGHTING);
+    m_gl->glUseProgram(m_scene_shader_program);
+    m_gl->glUniformMatrix4fv(
+        m_scene_view_mat_location,
+        1,
+        false,
+        const_cast<const GLfloat*>(&m_gl_view_matrix[0]));
+    m_gl->glUniformMatrix4fv(
+        m_scene_proj_mat_location,
+        1,
+        false,
+        const_cast<const GLfloat*>(&m_gl_proj_matrix[0]));
+    m_gl->glUniform3fv(
+        m_scene_camera_pos_location,
+        1,
+        const_cast<const GLfloat*>(&m_camera_position[0]));
 
-    glMultMatrixd(m_camera_matrix);
+    for (size_t i = 0; i < m_scene_object_data_vbos.size(); i++)
+    {
+        GLuint vao = m_scene_object_vaos[i];
+        int index_count = m_scene_object_data_index_counts[i];
+        int instance_count = m_scene_object_instance_counts[i];
 
-    const float time = m_camera.get_shutter_middle_time();
+        m_gl->glBindVertexArray(vao);
 
-    for (const auto& assembly_instance : m_project.get_scene()->assembly_instances())
-        draw(assembly_instance, time);
+        m_gl->glDrawArraysInstanced(
+            GL_TRIANGLES,
+            0,
+            index_count,
+            instance_count);
+    }
 }
 
-void LightPathsWidget::render_light_paths() const
+void LightPathsWidget::render_light_paths()
 {
-    glDisable(GL_LIGHTING);
-
-    glBegin(GL_LINES);
-
-    assert(m_selected_light_path_index >= -1);
-
-    if (m_selected_light_path_index == -1)
+    if (m_light_paths_index_offsets.size() > 1)
     {
-        for (size_t i = 0, e = m_light_paths.size(); i < e; ++i)
-            render_light_path(i);
-    }
-    else
-    {
-        render_light_path(static_cast<size_t>(m_selected_light_path_index));
-    }
+        m_gl->glUseProgram(m_light_paths_shader_program);
+        m_gl->glUniformMatrix4fv(
+            m_light_paths_view_mat_location,
+            1,
+            false,
+            const_cast<const GLfloat*>(&m_gl_view_matrix[0]));
+        m_gl->glUniformMatrix4fv(
+            m_light_paths_proj_mat_location,
+            1,
+            false,
+            const_cast<const GLfloat*>(&m_gl_proj_matrix[0]));
 
-    glEnd();
-}
+        m_gl->glBindVertexArray(m_light_paths_vao);
 
-void LightPathsWidget::render_light_path(const size_t light_path_index) const
-{
-    const auto& path = m_light_paths[light_path_index];
-    assert(path.m_vertex_end_index - path.m_vertex_begin_index >= 2);
-
-    const auto& light_path_recorder = m_project.get_light_path_recorder();
-
-    LightPathVertex v0;
-    light_path_recorder.get_light_path_vertex(path.m_vertex_begin_index, v0);
-
-    for (size_t i = path.m_vertex_begin_index + 1; i < path.m_vertex_end_index; ++i)
-    {
-        LightPathVertex v1;
-        light_path_recorder.get_light_path_vertex(i, v1);
-
-        auto radiance = Color3f::from_array(v1.m_radiance);
-        radiance /= radiance + Color3f(1.0);
-        radiance = linear_rgb_to_srgb(radiance);
-
-        glColor(radiance);
-
-        glVertex3f(v0.m_position[0], v0.m_position[1], v0.m_position[2]);
-        glVertex3f(v1.m_position[0], v1.m_position[1], v1.m_position[2]);
-
-        v0 = v1;
+        GLint first;
+        GLsizei count;
+        assert(m_selected_light_path_index >= -1);
+        if (m_selected_light_path_index == -1)
+        {
+            first = 0;
+            count = m_light_paths_index_offsets[m_light_paths_index_offsets.size() - 1];
+        }
+        else
+        {
+            first = static_cast<GLint>(m_light_paths_index_offsets[m_selected_light_path_index]);
+            count = m_light_paths_index_offsets[m_selected_light_path_index + 1] - first;
+        }
+        glDrawArrays(GL_LINES, first, count);
     }
 }
 

--- a/src/appleseed.studio/resources/resources.qrc
+++ b/src/appleseed.studio/resources/resources.qrc
@@ -1,6 +1,10 @@
 <RCC>
     <qresource prefix="/">
         <file>images/appleseed-logo-256.png</file>
+        <file>shaders/lightpaths.frag</file>
+        <file>shaders/lightpaths.vert</file>
+        <file>shaders/scene.frag</file>
+        <file>shaders/scene.vert</file>
         <file>widgets/checkbox_checked_disabled.png</file>
         <file>widgets/checkbox_checked_enabled.png</file>
         <file>widgets/checkbox_indeterminate_disabled.png</file>

--- a/src/appleseed.studio/resources/shaders/lightpaths.frag
+++ b/src/appleseed.studio/resources/shaders/lightpaths.frag
@@ -1,11 +1,10 @@
-
 //
 // This source file is part of appleseed.
 // Visit https://appleseedhq.net/ for additional information and resources.
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2018 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2019 Gray Olson, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,36 +25,14 @@
 // THE SOFTWARE.
 //
 
-#pragma once
+#version 330
+#extension GL_ARB_separate_shader_objects : enable
 
-// appleseed.main headers.
-#include "main/dllsymbol.h"
+layout(location = 0) in vec3 v_color;
 
-// Standard headers.
-#include <cstddef>
+out vec4 Target0;
 
-namespace renderer
+void main()
 {
-
-class APPLESEED_DLLSYMBOL ObjectRasterizer
-{
-  public:
-    virtual ~ObjectRasterizer() {}
-
-    virtual void begin_object(const size_t triangle_count_hint) = 0;
-    virtual void end_object() = 0;
-
-    struct Triangle
-    {
-        double m_v0[3];
-        double m_v1[3];
-        double m_v2[3];
-        double m_n0[3];
-        double m_n1[3];
-        double m_n2[3];
-    };
-
-    virtual void rasterize(const Triangle& triangle) = 0;
-};
-
-}   // namespace renderer
+    Target0 = vec4(v_color, 1.0);
+}

--- a/src/appleseed.studio/resources/shaders/lightpaths.vert
+++ b/src/appleseed.studio/resources/shaders/lightpaths.vert
@@ -1,11 +1,10 @@
-
 //
 // This source file is part of appleseed.
 // Visit https://appleseedhq.net/ for additional information and resources.
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2018 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2019 Gray Olson, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,36 +25,19 @@
 // THE SOFTWARE.
 //
 
-#pragma once
+#version 330
+#extension GL_ARB_separate_shader_objects : enable
 
-// appleseed.main headers.
-#include "main/dllsymbol.h"
+layout(location = 0) in vec3 a_pos;
+layout(location = 1) in vec3 a_color;
 
-// Standard headers.
-#include <cstddef>
+uniform mat4 u_view;
+uniform mat4 u_proj;
 
-namespace renderer
+layout(location = 0) out vec3 v_color;
+
+void main()
 {
-
-class APPLESEED_DLLSYMBOL ObjectRasterizer
-{
-  public:
-    virtual ~ObjectRasterizer() {}
-
-    virtual void begin_object(const size_t triangle_count_hint) = 0;
-    virtual void end_object() = 0;
-
-    struct Triangle
-    {
-        double m_v0[3];
-        double m_v1[3];
-        double m_v2[3];
-        double m_n0[3];
-        double m_n1[3];
-        double m_n2[3];
-    };
-
-    virtual void rasterize(const Triangle& triangle) = 0;
-};
-
-}   // namespace renderer
+    v_color = a_color;
+    gl_Position = u_proj * u_view * vec4(a_pos, 1.0);
+}

--- a/src/appleseed.studio/resources/shaders/scene.vert
+++ b/src/appleseed.studio/resources/shaders/scene.vert
@@ -1,11 +1,10 @@
-
 //
 // This source file is part of appleseed.
 // Visit https://appleseedhq.net/ for additional information and resources.
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2018 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2019 Gray Olson, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,36 +25,23 @@
 // THE SOFTWARE.
 //
 
-#pragma once
+#version 330
+#extension GL_ARB_separate_shader_objects : enable
 
-// appleseed.main headers.
-#include "main/dllsymbol.h"
+layout(location = 0) in vec3 a_pos;
+layout(location = 1) in vec3 a_norm;
+layout(location = 2) in mat4 i_model;
 
-// Standard headers.
-#include <cstddef>
+uniform mat4 u_view;
+uniform mat4 u_proj;
 
-namespace renderer
+layout(location = 1) out vec3 v_world_pos;
+layout(location = 0) out vec3 v_norm;
+
+void main()
 {
-
-class APPLESEED_DLLSYMBOL ObjectRasterizer
-{
-  public:
-    virtual ~ObjectRasterizer() {}
-
-    virtual void begin_object(const size_t triangle_count_hint) = 0;
-    virtual void end_object() = 0;
-
-    struct Triangle
-    {
-        double m_v0[3];
-        double m_v1[3];
-        double m_v2[3];
-        double m_n0[3];
-        double m_n1[3];
-        double m_n2[3];
-    };
-
-    virtual void rasterize(const Triangle& triangle) = 0;
-};
-
-}   // namespace renderer
+    vec4 world_pos = i_model * vec4(a_pos, 1.0);
+    v_world_pos = world_pos.xyz;
+    v_norm = a_norm;
+    gl_Position = u_proj * u_view * world_pos;
+}

--- a/src/appleseed.studio/utility/miscellaneous.cpp
+++ b/src/appleseed.studio/utility/miscellaneous.cpp
@@ -50,6 +50,7 @@
 
 // Qt headers.
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
 #include <QGridLayout>
 #include <QIcon>
@@ -194,6 +195,16 @@ bool file_exists(const QString& path)
 {
     const QFileInfo info(path);
     return info.exists() && info.isFile();
+}
+
+QByteArray load_gl_shader(const QString& base_name)
+{
+    const QString resource_path(QString(":/shaders/%1").arg(base_name));
+
+    QFile file(resource_path);
+    file.open(QFile::ReadOnly);
+
+    return file.readAll();
 }
 
 QIcon load_icons(const QString& base_name)

--- a/src/appleseed.studio/utility/miscellaneous.h
+++ b/src/appleseed.studio/utility/miscellaneous.h
@@ -35,6 +35,7 @@
 
 // Forward declarations.
 namespace renderer  { class ParamArray; }
+class QByteArray;
 class QIcon;
 class QLayout;
 class QMessageBox;
@@ -78,6 +79,9 @@ QString combine_name_and_shortcut(const QString& name, const QKeySequence& short
 
 // Check whether a file exists.
 bool file_exists(const QString& path);
+
+// Load a GLSL shader from file into a QByteArray.
+QByteArray load_gl_shader(const QString& base_name);
 
 // Load an icon and its variants (hover, disabled...) from the application's icons directory.
 QIcon load_icons(const QString& base_name);

--- a/src/appleseed/foundation/math/matrix.h
+++ b/src/appleseed/foundation/math/matrix.h
@@ -453,6 +453,18 @@ class Matrix<T, 4, 4>
         const Vector<T, 3>&     target,                     // target point
         const Vector<T, 3>&     up);                        // up vector, unit-length
 
+    // Build a matrix that maps a frustum defined by the
+    // top, botom, left, and right points on the near plane and
+    // extending from z_near to z_far in the +Z axis to the axis aligned
+    // cube in the area (-1, -1, -1) to (1, 1, 1).
+    static MatrixType make_frustum(
+        const ValueType bottom,
+        const ValueType top,
+        const ValueType left,
+        const ValueType right,
+        const ValueType z_near,
+        const ValueType z_far);
+
     // Unchecked array subscripting.
     ValueType& operator[](const size_t i);
     const ValueType& operator[](const size_t i) const;
@@ -2006,6 +2018,49 @@ inline Matrix<T, 4, 4> Matrix<T, 4, 4>::make_lookat(
     mat[13] = T(0.0);
     mat[14] = T(0.0);
     mat[15] = T(1.0);
+
+    return mat;
+}
+
+template <typename T>
+Matrix<T, 4, 4> Matrix<T, 4, 4>::make_frustum(
+    const ValueType bottom,
+    const ValueType top,
+    const ValueType left,
+    const ValueType right,
+    const ValueType z_near,
+    const ValueType z_far)
+{
+    assert(left   != right);
+    assert(top    != bottom);
+    assert(z_near != z_far);
+
+    const T a = (right + left) / (right - left);
+    const T b = (top + bottom) / (top - bottom);
+    const T c = -(z_far + z_near) / (z_far - z_near);
+    const T d = T(-2.0) * (z_far * z_near) / (z_far - z_near);
+
+    MatrixType mat;
+
+    mat[ 0] = T(2.0) * z_near / (right - left);
+    mat[ 1] = T(0.0);
+    mat[ 2] = a;
+    mat[ 3] = T(0.0);
+
+    mat[ 4] = T(0.0);
+    mat[ 5] = T(2.0) * z_near / (top - bottom);
+    mat[ 6] = b;
+    mat[ 7] = T(0.0);
+
+    mat[ 8] = T(0.0);
+    mat[ 9] = T(0.0);
+    mat[10] = c;
+    mat[11] = d;
+
+    mat[12] = T(0.0);
+    mat[13] = T(0.0);
+    mat[14] = T(-1.0);
+    mat[15] = T(0.0);
 
     return mat;
 }

--- a/src/appleseed/renderer/kernel/lighting/lightpathrecorder.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lightpathrecorder.cpp
@@ -116,6 +116,14 @@ size_t LightPathRecorder::get_light_path_count() const
     return count;
 }
 
+size_t LightPathRecorder::get_vertex_count() const
+{
+    assert(impl->m_streams.size() == 1);
+    const LightPathStream* stream = impl->m_streams[0].get();
+
+    return stream->m_vertices.size();
+}
+
 LightPathStream* LightPathRecorder::create_stream()
 {
     boost::mutex::scoped_lock lock(impl->m_mutex);

--- a/src/appleseed/renderer/kernel/lighting/lightpathrecorder.h
+++ b/src/appleseed/renderer/kernel/lighting/lightpathrecorder.h
@@ -111,6 +111,9 @@ class APPLESEED_DLLSYMBOL LightPathRecorder
     // Return the number of stored light paths.
     size_t get_light_path_count() const;
 
+    // Return the total number of stored vertices in all light paths. `finalize()` must have been called.
+    size_t get_vertex_count() const;
+
     // Retrieve all light paths falling into a region of the render.
     // All bounds are inclusive. `finalize()` must have been called.
     void query(

--- a/src/appleseed/renderer/modeling/object/meshobject.cpp
+++ b/src/appleseed/renderer/modeling/object/meshobject.cpp
@@ -109,7 +109,7 @@ const StaticTriangleTess& MeshObject::get_static_triangle_tess() const
 
 void MeshObject::rasterize(ObjectRasterizer& rasterizer) const
 {
-    rasterizer.begin_object();
+    rasterizer.begin_object(impl->m_tess.m_primitives.size());
 
     for (const auto& prim : impl->m_tess.m_primitives)
     {

--- a/src/appleseed/renderer/modeling/object/object.h
+++ b/src/appleseed/renderer/modeling/object/object.h
@@ -71,6 +71,8 @@ class APPLESEED_DLLSYMBOL Object
         const ParamArray&   params);
 
     // Return a string identifying the model of this entity.
+    // Model here is synonymous with which "kind" of Object this entity is,
+    // not an identifier for its actual mesh or curve representation.
     virtual const char* get_model() const = 0;
 
     // Compute the local space bounding box of the object over the shutter interval.


### PR DESCRIPTION
Fixes #2393 

Requires #2509 in order to work

Uses OpenGL 3.3 core to draw the light paths visualization. Drastically improves performance on more complex scenes and scenes with many light paths.

* Uses instanced drawing to draw multiple instances of the same object in the same draw call
* Currently **does not update positions or other data of the scene objects based on changes in appleseed.studio after the first data load has completed.** (This is for the scene object representations only; light paths are updated dynamically based on user input). If this is a significant issue to have this merged then I can fix it first.
* Uses Qt 5 builtins to load GL and GL function pointers.
* Adds a `triangle_count_hint` to `begin_object` on `ObjectRasterizer` which allows the rasterizer to preallocate a buffer of the appropriate size.
* Adds `get_vertex_count` to `LightPathRecorder` to get the total number of vertices stored in all light paths, also for use in preallocating space for a buffer