### PR TITLE
Added 'object' and 'assembly' override shaders

### DIFF
--- a/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
@@ -583,7 +583,7 @@ void DiagnosticSurfaceShader::evaluate(
       case Assemblies:
         set_shading_result(
             shading_result,
-            integer_to_color3<float>(shading_point.get_assembly_instance().find_assembly()->get_uid()));
+            integer_to_color3<float>(shading_point.get_assembly_instance().get_assembly().get_uid()));
         break;
 
       case AssemblyInstances:
@@ -595,7 +595,7 @@ void DiagnosticSurfaceShader::evaluate(
       case Objects:
         set_shading_result(
             shading_result,
-            integer_to_color3<float>(shading_point.get_object_instance().find_object()->get_uid()));
+            integer_to_color3<float>(shading_point.get_object_instance().get_object().get_uid()));
         break;
 
       case ObjectInstances:

--- a/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
@@ -105,7 +105,9 @@ const KeyValuePair<const char*, DiagnosticSurfaceShader::ShadingMode>
     { "world_space_wireframe" ,     WorldSpaceWireframe },
     { "screen_space_wireframe" ,    ScreenSpaceWireframe },
     { "ambient_occlusion",          AmbientOcclusion },
+    { "assemblies",                 Assemblies },
     { "assembly_instances",         AssemblyInstances },
+    { "objects",                    Objects },
     { "object_instances",           ObjectInstances },
     { "primitives",                 Primitives },
     { "materials",                  Materials },
@@ -132,7 +134,9 @@ const KeyValuePair<const char*, const char*> DiagnosticSurfaceShader::ShadingMod
     { "world_space_wireframe",      "World-Space Wireframe" },
     { "screen_space_wireframe",     "Screen-Space Wireframe" },
     { "ambient_occlusion",          "Ambient Occlusion" },
+    { "assemblies",                 "Assemblies" },
     { "assembly_instances",         "Assembly Instances" },
+    { "objects",                    "Objects" },
     { "object_instances",           "Object Instances" },
     { "primitives",                 "Primitives" },
     { "materials",                  "Materials" },
@@ -576,10 +580,22 @@ void DiagnosticSurfaceShader::evaluate(
         }
         break;
 
+      case Assemblies:
+        set_shading_result(
+            shading_result,
+            integer_to_color3<float>(shading_point.get_assembly_instance().find_assembly()->get_uid()));
+        break;
+
       case AssemblyInstances:
         set_shading_result(
             shading_result,
             integer_to_color3<float>(shading_point.get_assembly_instance().get_uid()));
+        break;
+      
+      case Objects:
+        set_shading_result(
+            shading_result,
+            integer_to_color3<float>(shading_point.get_object_instance().find_object()->get_uid()));
         break;
 
       case ObjectInstances:

--- a/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
@@ -583,7 +583,7 @@ void DiagnosticSurfaceShader::evaluate(
       case Assemblies:
         set_shading_result(
             shading_result,
-            integer_to_color3<float>(shading_point.get_assembly_instance().get_assembly().get_uid()));
+            integer_to_color3<float>(shading_point.get_assembly().get_uid()));
         break;
 
       case AssemblyInstances:
@@ -595,7 +595,7 @@ void DiagnosticSurfaceShader::evaluate(
       case Objects:
         set_shading_result(
             shading_result,
-            integer_to_color3<float>(shading_point.get_object_instance().get_object().get_uid()));
+            integer_to_color3<float>(shading_point.get_object().get_uid()));
         break;
 
       case ObjectInstances:

--- a/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.h
+++ b/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.h
@@ -86,7 +86,9 @@ class APPLESEED_DLLSYMBOL DiagnosticSurfaceShader
         WorldSpaceWireframe,        // world-space wireframe
         ScreenSpaceWireframe,       // screen-space wireframe
         AmbientOcclusion,           // ambient occlusion
+        Assemblies,                 // assign a unique color to each assembly
         AssemblyInstances,          // assign a unique color to each assembly instance
+        Objects,                    // assign a unique color to each object
         ObjectInstances,            // assign a unique color to each object instance
         Primitives,                 // assign a unique color to each primitive
         Materials,                  // assign a unique color to each material


### PR DESCRIPTION
Solving issue #2420 
"Objects" override shader can be easily tested by instantiating any of the objects in the cornelBox project as it's instantiated so far and large-scaled so colors can be easily compared. (is that an issue?)
but for "Assemblies" shader, instantiate the assembly with name "assembly_inst1" then run this to translate it a little bit for it to be visible.
(running the python code while interactive render is activated crashes appleseed.studio instantly on linux ubuntu 16.04, is that an issue too?)

from appleseed.studio import *
import appleseed as asr
scene = current_project().get_scene()

assembly = scene.assembly_instances().get_by_name("assembly_inst1")
matrix = asr.Matrix4d([1.0, 0.0, 0.0, 0.3,
                       0.0, 1.0, 0.0, 0.3,
                       0.0, 0.0, 1.0, 0.0,
                       0.0, 0.0, 0.0, 1.0])
assembly.transform_sequence().set_transform(0.0, asr.Transformd(matrix))