### PR TITLE
Load adaptive sampler setting to correct index

### DIFF
--- a/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
+++ b/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
@@ -611,7 +611,7 @@ namespace
 
             if (tr_value == "adaptive")
             {
-                m_image_plane_sampler_combo->setCurrentIndex(2);
+                m_image_plane_sampler_combo->setCurrentIndex(1);
                 return;
             }
 


### PR DESCRIPTION
Otherwise, loading a project with the "adaptive" sampler setting causes the combobox to be empty, since only the indinces 0 (uniform) and 1 (adaptive) are valid here.