### PR TITLE
Extend GCC compiler optimization for Linux.

### DIFF
--- a/cmake/config/linux-gcc-clang.txt
+++ b/cmake/config/linux-gcc-clang.txt
@@ -167,7 +167,11 @@ endif ()
 # Release configuration.
 set (c_compiler_flags_release
     -O3                                                 # optimization level
-    -funroll-loops                                      # not included in O3
+    -funroll-loops                                      # Unrolls loops
+    -fgcse-las                                          # Eliminates stores followed by a load to the same positions.
+    -fgcse-sm                                           # Moves load/save instructions out of loops, if possible.
+    -fgcse-after-reload                                 # Cleans different fgcse passes up.
+    -ftree-loop-ivcanon                                 # Supports unrolling loops by determining iteration numbers of complex loops.
 )
 
 

--- a/cmake/config/linux-gcc-clang.txt
+++ b/cmake/config/linux-gcc-clang.txt
@@ -167,6 +167,7 @@ endif ()
 # Release configuration.
 set (c_compiler_flags_release
     -O3                                                 # optimization level
+    -funroll-loops                                      # not included in O3
 )
 
 

--- a/cmake/config/linux-gcc-clang.txt
+++ b/cmake/config/linux-gcc-clang.txt
@@ -170,7 +170,6 @@ set (c_compiler_flags_release
     -funroll-loops                                      # Unrolls loops
     -fgcse-las                                          # Eliminates stores followed by a load to the same positions.
     -fgcse-sm                                           # Moves load/save instructions out of loops, if possible.
-    -fgcse-after-reload                                 # Cleans different fgcse passes up.
     -ftree-loop-ivcanon                                 # Supports unrolling loops by determining iteration numbers of complex loops.
 )
 

--- a/cmake/config/linux-gcc-clang.txt
+++ b/cmake/config/linux-gcc-clang.txt
@@ -167,10 +167,8 @@ endif ()
 # Release configuration.
 set (c_compiler_flags_release
     -O3                                                 # optimization level
-    -funroll-loops                                      # Unrolls loops
     -fgcse-las                                          # Eliminates stores followed by a load to the same positions.
     -fgcse-sm                                           # Moves load/save instructions out of loops, if possible.
-    -ftree-loop-ivcanon                                 # Supports unrolling loops by determining iteration numbers of complex loops.
 )
 
 


### PR DESCRIPTION
Partly fixes #1098. 
Only covers Linux GCC (4.8.5) optimizations. Due to the lack of Mac devices, I can't verify the compilerflags for Mac.
In addition to the desired loop-unroll, some more loop optimizations have been added, which are trying to optimize loops. Generally, optimization flags have been chosen to increase runtime-speed, while maintaining precision (that's why e.g. -fast-math is not included) and sacrificing compile-speed and filesize.
Flags chosen from [GNU Optimization Options](https://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/Optimize-Options.html).
GCC 4.8.5 has been chosen, since it's the latest 4.8 version available.

Code compiles and is still able to render simple scenes (i.e. the cornell box) with these flags.