### PR TITLE
Rename tests related build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ option (WITH_DISNEY_MATERIAL                "Build Disney material"             
 option (WITH_EMBREE                         "Include support for Embree intersection backend"           OFF)
 option (WITH_HEADERS                        "Install header files (to build samples)"                   ON)
 option (WITH_SAMPLES                        "Install sample files (requires headers)"                   ON)
-option (WITH_TESTS                          "Install unit tests and benchmarks"                         ON)
+option (INSTALL_TESTS                       "Install unit tests and benchmarks"                         ON)
 option (WITH_DOXYGEN                        "Generate API reference with Doxygen"                       ON)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -751,7 +751,7 @@ if (WITH_SAMPLES)
     )
 endif ()
 
-if (WITH_TESTS)
+if (INSTALL_TESTS)
     install (
         DIRECTORY
             "sandbox/tests/unit benchmarks"


### PR DESCRIPTION
#2513 
Simple fix renaming `WITH_TESTS` to `INSTALL_TESTS` as suggested.