### PR TITLE
Set fullscreen menu item as checkable

### DIFF
--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -144,7 +144,6 @@ MainWindow::MainWindow(QWidget* parent)
     build_connections();
 
     slot_load_application_settings();
-    slot_check_fullscreen();
 
     update_project_explorer();
     update_workspace();
@@ -397,6 +396,13 @@ void MainWindow::build_menus()
     connect(m_ui->log->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
     connect(m_ui->python_console->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
     connect(fullscreen_action, SIGNAL(triggered()), SLOT(slot_fullscreen()));
+
+    if (any_of(m_minimize_buttons.cbegin(),
+               m_minimize_buttons.cend(),
+               [](MinimizeButton* button) {return button->is_on();})) {
+
+        fullscreen_action->setChecked(false);
+    }
 
     //
     // Rendering menu.

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -144,6 +144,7 @@ MainWindow::MainWindow(QWidget* parent)
     build_connections();
 
     slot_load_application_settings();
+    slot_check_fullscreen();
 
     update_project_explorer();
     update_workspace();
@@ -390,6 +391,11 @@ void MainWindow::build_menus()
     QAction* fullscreen_action = m_ui->menu_view->addAction("Fullscreen");
     fullscreen_action->setCheckable(true);
     fullscreen_action->setShortcut(Qt::Key_F11);
+    fullscreen_action->setObjectName("Fullscreen");
+    connect(m_ui->project_explorer->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
+    connect(m_ui->attribute_editor->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
+    connect(m_ui->log->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
+    connect(m_ui->python_console->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
     connect(fullscreen_action, SIGNAL(triggered()), SLOT(slot_fullscreen()));
 
     //
@@ -2137,6 +2143,24 @@ void MainWindow::slot_fullscreen()
 
     for (MinimizeButton* button : m_minimize_buttons)
         button->set_fullscreen(m_fullscreen);
+}
+
+void MainWindow::slot_check_fullscreen()
+{
+    QAction* fullscreen = m_ui->menu_view->findChild<QAction*>("Fullscreen");
+
+    if (all_of(m_minimize_buttons.cbegin(),
+               m_minimize_buttons.cend(),
+               [](MinimizeButton* button) {return button->is_on();})) {
+
+        fullscreen->setChecked(true);
+    }
+
+    else {
+        if (fullscreen->isChecked()) {
+            fullscreen->setChecked(false);
+        }
+    }
 }
 
 void MainWindow::slot_show_application_settings_window()

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -388,6 +388,7 @@ void MainWindow::build_menus()
     m_ui->menu_view->addSeparator();
 
     QAction* fullscreen_action = m_ui->menu_view->addAction("Fullscreen");
+    fullscreen_action->setCheckable(true);
     fullscreen_action->setShortcut(Qt::Key_F11);
     connect(fullscreen_action, SIGNAL(triggered()), SLOT(slot_fullscreen()));
 

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -391,7 +391,6 @@ void MainWindow::build_menus()
     m_action_fullscreen = m_ui->menu_view->addAction("Fullscreen");
     m_action_fullscreen->setCheckable(true);
     m_action_fullscreen->setShortcut(Qt::Key_F11);
-    m_action_fullscreen->setObjectName("Fullscreen");
     connect(m_ui->project_explorer->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
     connect(m_ui->attribute_editor->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
     connect(m_ui->log->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -387,15 +387,15 @@ void MainWindow::build_menus()
     m_ui->menu_view->addAction(m_ui->python_console->toggleViewAction());
     m_ui->menu_view->addSeparator();
 
-    QAction* action_fullscreen = m_ui->menu_view->addAction("Fullscreen");
-    action_fullscreen->setCheckable(true);
-    action_fullscreen->setShortcut(Qt::Key_F11);
-    action_fullscreen->setObjectName("Fullscreen");
+    m_action_fullscreen = m_ui->menu_view->addAction("Fullscreen");
+    m_action_fullscreen->setCheckable(true);
+    m_action_fullscreen->setShortcut(Qt::Key_F11);
+    m_action_fullscreen->setObjectName("Fullscreen");
     connect(m_ui->project_explorer->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
     connect(m_ui->attribute_editor->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
     connect(m_ui->log->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
     connect(m_ui->python_console->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
-    connect(action_fullscreen, SIGNAL(triggered()), SLOT(slot_fullscreen()));
+    connect(m_action_fullscreen, SIGNAL(triggered()), SLOT(slot_fullscreen()));
 
     //
     // Rendering menu.
@@ -2146,13 +2146,11 @@ void MainWindow::slot_fullscreen()
 
 void MainWindow::slot_check_fullscreen()
 {
-    QAction* fullscreen = m_ui->menu_view->findChild<QAction*>("Fullscreen");
-
     const bool is_fullscreen = all_of(m_minimize_buttons.cbegin(),
                                       m_minimize_buttons.cend(),
                                       [](MinimizeButton* button) {return button->is_on();});
 
-    fullscreen->setChecked(is_fullscreen);
+    m_action_fullscreen->setChecked(is_fullscreen);
 }
 
 void MainWindow::slot_show_application_settings_window()

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -387,21 +387,21 @@ void MainWindow::build_menus()
     m_ui->menu_view->addAction(m_ui->python_console->toggleViewAction());
     m_ui->menu_view->addSeparator();
 
-    QAction* fullscreen_action = m_ui->menu_view->addAction("Fullscreen");
-    fullscreen_action->setCheckable(true);
-    fullscreen_action->setShortcut(Qt::Key_F11);
-    fullscreen_action->setObjectName("Fullscreen");
+    QAction* action_fullscreen = m_ui->menu_view->addAction("Fullscreen");
+    action_fullscreen->setCheckable(true);
+    action_fullscreen->setShortcut(Qt::Key_F11);
+    action_fullscreen->setObjectName("Fullscreen");
     connect(m_ui->project_explorer->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
     connect(m_ui->attribute_editor->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
     connect(m_ui->log->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
     connect(m_ui->python_console->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
-    connect(fullscreen_action, SIGNAL(triggered()), SLOT(slot_fullscreen()));
+    connect(action_fullscreen, SIGNAL(triggered()), SLOT(slot_fullscreen()));
 
     if (any_of(m_minimize_buttons.cbegin(),
                m_minimize_buttons.cend(),
                [](MinimizeButton* button) {return button->is_on();})) {
 
-        fullscreen_action->setChecked(false);
+        action_fullscreen->setChecked(false);
     }
 
     //

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -397,13 +397,6 @@ void MainWindow::build_menus()
     connect(m_ui->python_console->toggleViewAction(), SIGNAL(triggered()), SLOT(slot_check_fullscreen()));
     connect(action_fullscreen, SIGNAL(triggered()), SLOT(slot_fullscreen()));
 
-    if (any_of(m_minimize_buttons.cbegin(),
-               m_minimize_buttons.cend(),
-               [](MinimizeButton* button) {return button->is_on();})) {
-
-        action_fullscreen->setChecked(false);
-    }
-
     //
     // Rendering menu.
     //
@@ -2155,18 +2148,11 @@ void MainWindow::slot_check_fullscreen()
 {
     QAction* fullscreen = m_ui->menu_view->findChild<QAction*>("Fullscreen");
 
-    if (all_of(m_minimize_buttons.cbegin(),
-               m_minimize_buttons.cend(),
-               [](MinimizeButton* button) {return button->is_on();})) {
+    const bool is_fullscreen = all_of(m_minimize_buttons.cbegin(),
+                                      m_minimize_buttons.cend(),
+                                      [](MinimizeButton* button) {return button->is_on();});
 
-        fullscreen->setChecked(true);
-    }
-
-    else {
-        if (fullscreen->isChecked()) {
-            fullscreen->setChecked(false);
-        }
-    }
+    fullscreen->setChecked(is_fullscreen);
 }
 
 void MainWindow::slot_show_application_settings_window()

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -144,6 +144,7 @@ MainWindow::MainWindow(QWidget* parent)
     build_connections();
 
     slot_load_application_settings();
+    slot_check_fullscreen();
 
     update_project_explorer();
     update_workspace();
@@ -2146,9 +2147,11 @@ void MainWindow::slot_fullscreen()
 
 void MainWindow::slot_check_fullscreen()
 {
-    const bool is_fullscreen = all_of(m_minimize_buttons.cbegin(),
-                                      m_minimize_buttons.cend(),
-                                      [](MinimizeButton* button) {return button->is_on();});
+    QList<QDockWidget*> dock_widgets = findChildren<QDockWidget*>();
+
+    const bool is_fullscreen = all_of(dock_widgets.cbegin(),
+                                      dock_widgets.cend(),
+                                      [](QDockWidget* dock) {return dock->isHidden();});
 
     m_action_fullscreen->setChecked(is_fullscreen);
 }

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -2146,7 +2146,7 @@ void MainWindow::slot_fullscreen()
 
 void MainWindow::slot_check_fullscreen()
 {
-    QList<QDockWidget*> dock_widgets = findChildren<QDockWidget*>();
+    const QList<QDockWidget*> dock_widgets = findChildren<QDockWidget*>();
 
     const bool is_fullscreen = all_of(dock_widgets.cbegin(),
                                       dock_widgets.cend(),

--- a/src/appleseed.studio/mainwindow/mainwindow.h
+++ b/src/appleseed.studio/mainwindow/mainwindow.h
@@ -301,6 +301,7 @@ class MainWindow
 
     // General UI actions.
     void slot_fullscreen();
+    void slot_check_fullscreen();
 
     // Child windows.
     void slot_show_application_settings_window();

--- a/src/appleseed.studio/mainwindow/mainwindow.h
+++ b/src/appleseed.studio/mainwindow/mainwindow.h
@@ -137,6 +137,7 @@ class MainWindow
     QAction*                                    m_action_pause_resume_rendering;
     QAction*                                    m_action_stop_rendering;
     QAction*                                    m_action_rendering_settings;
+    QAction*                                    m_action_fullscreen;
 
     std::vector<QAction*>                       m_recently_opened;
     std::vector<MinimizeButton*>                m_minimize_buttons;


### PR DESCRIPTION
fixes #2519 

I have experience with PyQt, but this is my first with Qt in C++. I believe all that was needed was to set the fullscreen QAction as checkable. If not, please let me know!