### PR TITLE
Change the pause/resume text based on rendering state

### DIFF
--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -1685,11 +1685,13 @@ void MainWindow::slot_apply_application_settings()
 
 void MainWindow::slot_start_interactive_rendering()
 {
+    m_ui->action_rendering_pause_resume_rendering->setText("Pause Rendering");
     start_rendering(InteractiveRendering);
 }
 
 void MainWindow::slot_start_final_rendering()
 {
+    m_ui->action_rendering_pause_resume_rendering->setText("Pause Rendering");
     start_rendering(FinalRendering);
 }
 
@@ -1710,10 +1712,12 @@ void MainWindow::slot_pause_or_resume_rendering(const bool checked)
     if (checked)
     {
         assert(!m_rendering_manager.is_rendering_paused());
+        m_ui->action_rendering_pause_resume_rendering->setText("Resume Rendering");
         m_rendering_manager.pause_rendering();
     }
     else
     {
+        m_ui->action_rendering_pause_resume_rendering->setText("Pause Rendering");
         m_rendering_manager.resume_rendering();
     }
 
@@ -1722,6 +1726,8 @@ void MainWindow::slot_pause_or_resume_rendering(const bool checked)
 
 void MainWindow::slot_rendering_end()
 {
+    m_ui->action_rendering_pause_resume_rendering->setText("Pause/Resume Rendering");
+
     apply_false_colors_settings();
 
     update_workspace();

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -641,7 +641,7 @@ void MainWindow::build_toolbar()
     connect(m_action_start_final_rendering, SIGNAL(triggered()), SLOT(slot_start_final_rendering()));
     m_ui->main_toolbar->addAction(m_action_start_final_rendering);
 
-    m_action_pause_resume_rendering = new QAction(load_icons("rendering_pause_resume"), combine_name_and_shortcut("Pause/Resume Rendering", m_ui->action_rendering_pause_resume_rendering->shortcut()), this);
+    m_action_pause_resume_rendering = new QAction(load_icons("rendering_pause_resume"), combine_name_and_shortcut("Pause Rendering", m_ui->action_rendering_pause_resume_rendering->shortcut()), this);
     m_action_pause_resume_rendering->setCheckable(true);
     connect(m_action_pause_resume_rendering, SIGNAL(toggled(bool)), SLOT(slot_pause_or_resume_rendering(const bool)));
     m_ui->main_toolbar->addAction(m_action_pause_resume_rendering);
@@ -1685,13 +1685,11 @@ void MainWindow::slot_apply_application_settings()
 
 void MainWindow::slot_start_interactive_rendering()
 {
-    m_ui->action_rendering_pause_resume_rendering->setText("Pause Rendering");
     start_rendering(InteractiveRendering);
 }
 
 void MainWindow::slot_start_final_rendering()
 {
-    m_ui->action_rendering_pause_resume_rendering->setText("Pause Rendering");
     start_rendering(FinalRendering);
 }
 
@@ -1712,12 +1710,10 @@ void MainWindow::slot_pause_or_resume_rendering(const bool checked)
     if (checked)
     {
         assert(!m_rendering_manager.is_rendering_paused());
-        m_ui->action_rendering_pause_resume_rendering->setText("Resume Rendering");
         m_rendering_manager.pause_rendering();
     }
     else
     {
-        m_ui->action_rendering_pause_resume_rendering->setText("Pause Rendering");
         m_rendering_manager.resume_rendering();
     }
 
@@ -1726,8 +1722,6 @@ void MainWindow::slot_pause_or_resume_rendering(const bool checked)
 
 void MainWindow::slot_rendering_end()
 {
-    m_ui->action_rendering_pause_resume_rendering->setText("Pause/Resume Rendering");
-
     apply_false_colors_settings();
 
     update_workspace();


### PR DESCRIPTION
When the render is rendering, the Pause/Resume menu item
can lead to confusion as it is not clear which state the renderer
is in based on a checkbox. Does the checkbox mean that the renderer
is running, or does it mean that it is paused? This change makes it
clear which state the renderer is in. If the renderer is running
the menu item will say 'Pause Rendering', likewise if the renderer
is paused the menu item will say 'Resume Rendering'. When the rendering
is canceled or finished, the menu item will revert back to
'Pause/Resume Rendering'.