### PR TITLE
propagate rename to install script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -746,7 +746,7 @@ install (
 if (WITH_SAMPLES)
     install (
         DIRECTORY
-            sandbox/samples
+            sandbox/examples
         DESTINATION .
     )
 endif ()

--- a/scripts/appleseed.package.py
+++ b/scripts/appleseed.package.py
@@ -325,7 +325,7 @@ class PackageBuilder:
         safe_delete_file("appleseed/tests/unit benchmarks/inputs/test_knn_photons.bin")
 
         # Temporarily remove Alembic assembly C++ plugin.
-        safe_delete_directory("appleseed/samples/cpp/alembicassembly")
+        safe_delete_directory("appleseed/examples/cpp/alembicassembly")
 
     def add_local_binaries_to_stage(self):
         progress("Adding local binaries to staging directory")


### PR DESCRIPTION
after renaming `samples` => `examples` install script needs some readjustment
refers: 653efbc379fd322b717a3002c64510679de80156