### PR TITLE
Add 3ds max parameter ID meta-data to each OSL shader parameter

### DIFF
--- a/src/appleseed.shaders/src/appleseed/as_anisotropy_vector_field.osl
+++ b/src/appleseed.shaders/src/appleseed/as_anisotropy_vector_field.osl
@@ -55,14 +55,16 @@ shader as_anisotropy_vector_field
         int as_maya_attribute_keyable = 1,
         int as_maya_attribute_hidden = 0,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 0
     ]],
     color in_color = color(1)
     [[
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Field Color",
-        string page = "Field"
+        string page = "Field",
+        int as_max_param_id = 1
     ]],
     int in_field_mode = 0
     [[
@@ -76,7 +78,8 @@ shader as_anisotropy_vector_field
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 3
     ]],
     float in_rotation_value = 0.0
     [[
@@ -86,7 +89,8 @@ shader as_anisotropy_vector_field
         float max = 1.0,
         string help = "Rotation value, mapping [0,1] to [0,360] degrees.",
         string label = "Rotation Value",
-        string page = "Rotation"
+        string page = "Rotation",
+        int as_max_param_id = 4
     ]],
     int in_rotation_mode = 0
     [[
@@ -101,7 +105,8 @@ shader as_anisotropy_vector_field
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 6
     ]],
     int in_normalize_output = 1
     [[
@@ -114,14 +119,16 @@ shader as_anisotropy_vector_field
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 7
     ]],
     normal in_surface_normal = N
     [[
         string as_maya_attribute_name = "normalCamera",
         string as_maya_attribute_short_name = "n",
         string label = "Surface Normal",
-        string page = "Normal"
+        string page = "Normal",
+        int as_max_param_id = 8
     ]],
     vector Tn = vector(0)
     [[
@@ -148,7 +155,8 @@ shader as_anisotropy_vector_field
     [[
         string as_maya_attribute_name = "anisotropyVector",
         string as_maya_attribute_short_name = "av",
-        string label = "Anisotropy Vector"
+        string label = "Anisotropy Vector",
+        int as_max_param_id = 9
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_asc_cdl.osl
+++ b/src/appleseed.shaders/src/appleseed/as_asc_cdl.osl
@@ -58,7 +58,8 @@ shader as_asc_cdl
         string label = "Input Color",
         string page = "Color",
         string help = "Input color.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 0
     ]],
     string in_rgb_primaries = "sRGB/Rec.709"
     [[
@@ -73,7 +74,8 @@ shader as_asc_cdl
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 2
     ]],
     float in_slope = 1.0
     [[
@@ -86,6 +88,7 @@ shader as_asc_cdl
         string label = "Slope",
         string page = "Correction",
         string help = "Slope (adjusts the highlights).",
+        int as_max_param_id = 4
     ]],
     float in_offset = 0.0
     [[
@@ -96,6 +99,7 @@ shader as_asc_cdl
         string label = "Offset",
         string page = "Correction",
         string help = "Constant offset (adjusts the overall brightness).",
+        int as_max_param_id = 6
     ]],
     float in_power = 1.0
     [[
@@ -108,6 +112,7 @@ shader as_asc_cdl
         string label = "Power",
         string page = "Correction",
         string help = "Overall exponent (adjusts the midtones).",
+        int as_max_param_id = 8
     ]],
     float in_saturation = 1.0
     [[
@@ -120,6 +125,7 @@ shader as_asc_cdl
         string label = "Saturation",
         string page = "Output",
         string help = "Overall saturation applied after input color transformations.",
+        int as_max_param_id = 10
     ]],
     int in_clamp_output = 1
     [[
@@ -135,7 +141,8 @@ shader as_asc_cdl
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 12
     ]],
     output color out_outColor = color(0)
     [[
@@ -143,7 +150,8 @@ shader as_asc_cdl
         string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string page = "Output",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 14
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_attributes.osl
+++ b/src/appleseed.shaders/src/appleseed/as_attributes.osl
@@ -46,179 +46,208 @@ shader as_attributes
     [[
         string as_maya_attribute_name = "objectInstanceId",
         string as_maya_attribute_short_name = "oid",
-        string label = "Object Instance ID"
+        string label = "Object Instance ID",
+        int as_max_param_id = 0
     ]],
     output int out_object_instance_index = 0
     [[
         string as_maya_attribute_name = "objectInstanceIndex",
         string as_maya_attribute_short_name = "odx",
-        string label = "Object Instance Index"
+        string label = "Object Instance Index",
+        int as_max_param_id = 0
     ]],
     output string out_object_instance_name = ""
     [[
         string as_maya_attribute_name = "objectInstanceName",
         string as_maya_attribute_short_name = "oin",
-        string label = "Object Instance Name"
+        string label = "Object Instance Name",
+        int as_max_param_id = 0
     ]],
     output string out_object_name = ""
     [[
         string as_maya_attribute_name = "objectName",
         string as_maya_attribute_short_name = "onn",
-        string label = "Object Name"
+        string label = "Object Name",
+        int as_max_param_id = 0
     ]],
     output int out_assembly_instance_id = 0
     [[
         string as_maya_attribute_name = "assemblyInstanceId",
         string as_maya_attribute_short_name = "aid",
-        string label = "Assembly Instance ID"
+        string label = "Assembly Instance ID",
+        int as_max_param_id = 0
     ]],
     output string out_assembly_name = ""
     [[
         string as_maya_attribute_name = "assemblyName",
         string as_maya_attribute_short_name = "asn",
-        string label = "Assembly Name"
+        string label = "Assembly Name",
+        int as_max_param_id = 0
     ]],
     output string out_assembly_instance_name = ""
     [[
         string as_maya_attribute_name = "assemblyInstanceName",
         string as_maya_attribute_short_name = "ain",
-        string label = "Assembly Instance Name"
+        string label = "Assembly Instance Name",
+        int as_max_param_id = 0
     ]],
     // A float[2], but we can't connect array elements yet.
     output int out_camera_resolution[2] = {0, 0}
     [[
         string as_maya_attribute_name = "cameraResolution",
         string as_maya_attribute_short_name = "r",
-        string label = "Camera Resolution"
+        string label = "Camera Resolution",
+        int as_max_param_id = 0
     ]],
     output int out_camera_resolution_x = 0
     [[
         string as_maya_attribute_name = "cameraResolutionX",
         string as_maya_attribute_short_name = "rx",
-        string label = "Camera Resolution X"
+        string label = "Camera Resolution X",
+        int as_max_param_id = 0
     ]],
     output int out_camera_resolution_y = 0
     [[
         string as_maya_attribute_name = "cameraResolutionY",
         string as_maya_attribute_short_name = "ry",
-        string label = "Camera Resolution Y"
+        string label = "Camera Resolution Y",
+        int as_max_param_id = 0
     ]],
     output string out_camera_projection = ""
     [[
         string as_maya_attribute_name = "cameraProjection",
         string as_maya_attribute_short_name = "pr",
-        string label = "Camera Projection"
+        string label = "Camera Projection",
+        int as_max_param_id = 0
     ]],
     output float out_camera_pixel_aspect = 1.0
     [[
         string as_maya_attribute_name = "cameraPixelAspect",
         string as_maya_attribute_short_name = "cpa",
-        string label = "Camera Pixel Aspect"
+        string label = "Camera Pixel Aspect",
+        int as_max_param_id = 0
     ]],
     // This should be a float[4], but we can't connect array elements yet.
     output int out_camera_screen_window[4] = {0, 0, 0, 0}
     [[
         string as_maya_attribute_name = "cameraScreenWindow",
         string as_maya_attribute_short_name = "sw",
-        string label = "Camera Screen Window"
+        string label = "Camera Screen Window",
+        int as_max_param_id = 0
     ]],
     output float out_camera_screen_window_xmin = 0.0
     [[
         string as_maya_attribute_name = "cameraScreenWindowXMin",
         string as_maya_attribute_short_name = "xi",
-        string label = "Screen Window X Min"
+        string label = "Screen Window X Min",
+        int as_max_param_id = 0
     ]],
     output float out_camera_screen_window_ymin = 0.0
     [[
         string as_maya_attribute_name = "cameraScreenWindowYMin",
         string as_maya_attribute_short_name = "yi",
-        string label = "Screen Window Y Min"
+        string label = "Screen Window Y Min",
+        int as_max_param_id = 0
     ]],
     output float out_camera_screen_window_xmax = 0.0
     [[
         string as_maya_attribute_name = "cameraScreenWindowXMax",
         string as_maya_attribute_short_name = "xa",
-        string label = "Screen Window X Max"
+        string label = "Screen Window X Max",
+        int as_max_param_id = 0
     ]],
     output float out_camera_screen_window_ymax = 0.0
     [[
         string as_maya_attribute_name = "cameraScreenWindowYMax",
         string as_maya_attribute_short_name = "ya",
-        string label = "Screen Window Y Max"
+        string label = "Screen Window Y Max",
+        int as_max_param_id = 0
     ]],
     output float out_camera_fov = 0.0
     [[
         string as_maya_attribute_name = "cameraFOV",
         string as_maya_attribute_short_name = "cfo",
-        string label = "Camera FOV"
+        string label = "Camera FOV",
+        int as_max_param_id = 0
     ]],
     // No array elements connections yet, but this is near and far elements.
     output float out_camera_clip[2] = {0.0, 0.0}
     [[
         string as_maya_attribute_name = "cameraClip",
         string as_maya_attribute_short_name = "li",
-        string label = "Camera Clip Range"
+        string label = "Camera Clip Range",
+        int as_max_param_id = 0
     ]],
     output float out_camera_clip_near = 0.0
     [[
         string as_maya_attribute_name = "cameraClipNear",
         string as_maya_attribute_short_name = "ne",
-        string label = "Camera Clip Near"
+        string label = "Camera Clip Near",
+        int as_max_param_id = 0
     ]],
     output float out_camera_clip_far = 0.0
     [[
         string as_maya_attribute_name = "cameraClipFar",
         string as_maya_attribute_short_name = "nf",
-        string label = "Camera Clip Far"
+        string label = "Camera Clip Far",
+        int as_max_param_id = 0
     ]],
     // No array elements connections yet, but open/close times are below.
     output float out_camera_shutter[2] = {0.0, 0.0}
     [[
         string as_maya_attribute_name = "cameraShutter",
         string as_maya_attribute_short_name = "su",
-        string label = "Camera Shutter"
+        string label = "Camera Shutter",
+        int as_max_param_id = 0
     ]],
     output float out_camera_shutter_open = 0.0
     [[
         string as_maya_attribute_name = "cameraShutterOpen",
         string as_maya_attribute_short_name = "so",
-        string label = "Shutter Open Time"
+        string label = "Shutter Open Time",
+        int as_max_param_id = 0
     ]],
     output float out_camera_shutter_close = 0.0
     [[
         string as_maya_attribute_name = "cameraShutterClose",
         string as_maya_attribute_short_name = "sc",
-        string label = "Shutter Close Time"
+        string label = "Shutter Close Time",
+        int as_max_param_id = 0
     ]],
     output int out_global_frame = 0
     [[
         string as_maya_attribute_name = "globalFrame",
         string as_maya_attribute_short_name = "gfr",
-        string label = "Global Frame Number"
+        string label = "Global Frame Number",
+        int as_max_param_id = 0
     ]],
     output int out_path_ray_depth = 0
     [[
         string as_maya_attribute_name = "pathRayDepth",
         string as_maya_attribute_short_name = "prd",
-        string label = "Ray Depth"
+        string label = "Ray Depth",
+        int as_max_param_id = 0
     ]],
     output int out_path_has_ray_differentials = 0
     [[
         string as_maya_attribute_name = "pathHasRayDifferentials",
         string as_maya_attribute_short_name = "phd",
-        string label = "Ray Differentials"
+        string label = "Ray Differentials",
+        int as_max_param_id = 0
     ]],
     output float out_path_ray_length = 0.0
     [[
         string as_maya_attribute_name = "pathRayLength",
         string as_maya_attribute_short_name = "prl",
-        string label = "Ray Length"
+        string label = "Ray Length",
+        int as_max_param_id = 0
     ]],
     output float out_path_ray_ior = 0.0
     [[
         string as_maya_attribute_name = "pathRayIOR",
         string as_maya_attribute_short_name = "pri",
-        string label = "Ray IOR"
+        string label = "Ray IOR",
+        int as_max_param_id = 0
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_blackbody.osl
+++ b/src/appleseed.shaders/src/appleseed/as_blackbody.osl
@@ -59,7 +59,8 @@ shader as_blackbody
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 0
     ]],
     color in_color = color(0)
     [[
@@ -67,7 +68,8 @@ shader as_blackbody
         string as_maya_attribute_short_name = "inc",
         string label = "Color",
         string page = "Emission",
-        string help = "Emission color, only valid in custom mode."
+        string help = "Emission color, only valid in custom mode.",
+        int as_max_param_id = 1
     ]],
     float in_incandescence_amount = 0.0
     [[
@@ -76,7 +78,8 @@ shader as_blackbody
         float min = 0.0,
         float softmax = 1.0,
         string label = "Emission Amount",
-        string page = "Emission"
+        string page = "Emission",
+        int as_max_param_id = 3
     ]],
     float in_temperature_scale = 1.0
     [[
@@ -86,7 +89,8 @@ shader as_blackbody
         float max = 1.0,
         string label = "Temperature Scale",
         string page = "Emission",
-        string help = "Temperature scaling factor."
+        string help = "Temperature scaling factor.",
+        int as_max_param_id = 5
     ]],
     int in_temperature = 4300
     [[
@@ -104,7 +108,8 @@ shader as_blackbody
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 7
     ]],
     int in_area_normalize_edf = 0
     [[
@@ -117,7 +122,8 @@ shader as_blackbody
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 8
     ]],
     int in_tonemap_edf = 1
     [[
@@ -131,7 +137,8 @@ shader as_blackbody
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 9
     ]],
     float in_specular_amount = 0.0
     [[
@@ -140,7 +147,8 @@ shader as_blackbody
         float min = 0.0,
         float max = 1.0,
         string label = "Specular Weight",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 10
     ]],
     float in_specular_roughness = 0.1
     [[
@@ -149,7 +157,8 @@ shader as_blackbody
         float min = 0.0,
         float max = 1.0,
         string label = "Specular Roughness",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 12
     ]],
     float in_ior = 1.37
     [[
@@ -165,14 +174,16 @@ shader as_blackbody
         int as_maya_attribute_keyable = 1,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 14
     ]],
     normal in_bump_normal = N
     [[
         string as_maya_attribute_name = "normalCamera",
         string as_maya_attribute_short_name = "n",
         string label = "Surface Normal",
-        string page = "Bump"
+        string page = "Bump",
+        int as_max_param_id = 15
     ]],
     int in_enable_matte = 0
     [[
@@ -186,7 +197,8 @@ shader as_blackbody
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 16
     ]],
     float in_matte_opacity = 0.0
     [[
@@ -197,7 +209,8 @@ shader as_blackbody
         string label = "Matte Opacity",
         string page = "Matte Opacity",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 17
     ]],
     color in_matte_opacity_color = color(1,0.5,0)
     [[
@@ -209,7 +222,8 @@ shader as_blackbody
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 19
     ]],
     int in_maximum_ray_depth = 100
     [[
@@ -224,25 +238,29 @@ shader as_blackbody
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 20
     ]],
     output closure color out_color = 0
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 21
     ]],
     output closure color out_matte_opacity = 0
     [[
         string as_maya_attribute_name = "outMatteOpacity",
         string as_maya_attribute_short_name = "om",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 21
     ]],
     output color out_blackbody_color = color(0)
     [[
         string as_maya_attribute_name = "outBlackbodyColor",
         string as_maya_attribute_short_name = "bbc",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 21
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_blend_color.osl
+++ b/src/appleseed.shaders/src/appleseed/as_blend_color.osl
@@ -50,7 +50,8 @@ shader as_blend_color
         string as_maya_attribute_short_name = "c",
         string label = "Source Color",
         string page = "Color",
-        string help = "Layer 0 color, or base layer color."
+        string help = "Layer 0 color, or base layer color.",
+        int as_max_param_id = 0
     ]],
     float in_weight = 1.0
     [[
@@ -60,14 +61,16 @@ shader as_blend_color
         float max = 1.0,
         string label = "Source Weight",
         string page = "Color",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     color in_color2 = color(1)
     [[
         string as_maya_attribute_name = "color2",
         string as_maya_attribute_short_name = "c2",
         string label = "Blend Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 4
     ]],
     float in_weight2 = 1.0
     [[
@@ -77,7 +80,8 @@ shader as_blend_color
         float max = 1.0,
         string label = "Blend Weight",
         string page = "Color",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 6
     ]],
     string in_blend_mode = "Overlay"
     [[
@@ -93,7 +97,8 @@ shader as_blend_color
         string label = "Blending Mode",
         string page = "Color",
         string help = "Common image blending modes. For Porter-Duff compositing, use the Composite node.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 8
     ]],
     int in_clamp_output = 0
     [[
@@ -106,7 +111,8 @@ shader as_blend_color
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "Clamp Output",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 9
     ]],
 
     output color out_color = color(0)
@@ -114,7 +120,8 @@ shader as_blend_color
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
         string widget = "null",
-        string label = "Output Color"
+        string label = "Output Color",
+        int as_max_param_id = 10
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_blend_shader.osl
+++ b/src/appleseed.shaders/src/appleseed/as_blend_shader.osl
@@ -47,7 +47,8 @@ shader as_blend_shader
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Layer 0",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 0
     ]],
     float in_weight = 1.0
     [[
@@ -56,7 +57,8 @@ shader as_blend_shader
         float min = 0.0,
         float max = 1.0,
         string label = "Layer 0 Weight",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 1
     ]],
     int in_layer_visibility = 1
     [[
@@ -70,14 +72,16 @@ shader as_blend_shader
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 3
     ]],
     closure color in_color1 = 0
     [[
         string as_maya_attribute_name = "color1",
         string as_maya_attribute_short_name = "c1",
         string label = "Layer 1",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 4
     ]],
     float in_weight1 = 1.0
     [[
@@ -86,7 +90,8 @@ shader as_blend_shader
         float min = 0.0,
         float max = 1.0,
         string label = "Layer 1 Weight",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 5
     ]],
     int in_layer_visibility1 = 0
     [[
@@ -100,14 +105,16 @@ shader as_blend_shader
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 7
     ]],
     closure color in_color2 = 0
     [[
         string as_maya_attribute_name = "color2",
         string as_maya_attribute_short_name = "c2",
         string label = "Layer 2",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 8
     ]],
     float in_weight2 = 1.0
     [[
@@ -116,7 +123,8 @@ shader as_blend_shader
         float min = 0.0,
         float max = 1.0,
         string label = "Layer 2 Weight",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 9
     ]],
     int in_layer_visibility2 = 0
     [[
@@ -130,14 +138,16 @@ shader as_blend_shader
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 11
     ]],
     closure color in_color3 = 0
     [[
         string as_maya_attribute_name = "color3",
         string as_maya_attribute_short_name = "c3",
         string label = "Layer 3",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 12
     ]],
     float in_weight3 = 1.0
     [[
@@ -146,7 +156,8 @@ shader as_blend_shader
         float min = 0.0,
         float max = 1.0,
         string label = "Layer 3 Weight",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 13
     ]],
     int in_layer_visibility3 = 0
     [[
@@ -160,14 +171,16 @@ shader as_blend_shader
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 15
     ]],
     closure color in_color4 = 0
     [[
         string as_maya_attribute_name = "color4",
         string as_maya_attribute_short_name = "c4",
         string label = "Layer 4",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 16
     ]],
     float in_weight4 = 1.0
     [[
@@ -176,7 +189,8 @@ shader as_blend_shader
         float min = 0.0,
         float max = 1.0,
         string label = "Layer 4 Weight",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 17
     ]],
     int in_layer_visibility4 = 0
     [[
@@ -190,14 +204,16 @@ shader as_blend_shader
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 19
     ]],
     closure color in_color5 = 0
     [[
         string as_maya_attribute_name = "color5",
         string as_maya_attribute_short_name = "c5",
         string label = "Layer 5",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 20
     ]],
     float in_weight5 = 1.0
     [[
@@ -206,7 +222,8 @@ shader as_blend_shader
         float min = 0.0,
         float max = 1.0,
         string label = "Layer 5 Weight",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 21
     ]],
     int in_layer_visibility5 = 0
     [[
@@ -220,14 +237,16 @@ shader as_blend_shader
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 23
     ]],
     closure color in_color6 = 0
     [[
         string as_maya_attribute_name = "color6",
         string as_maya_attribute_short_name = "c6",
         string label = "Layer 6",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 24
     ]],
     float in_weight6 = 1.0
     [[
@@ -236,7 +255,8 @@ shader as_blend_shader
         float min = 0.0,
         float max = 1.0,
         string label = "Layer 6 Weight",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 25
     ]],
     int in_layer_visibility6 = 0
     [[
@@ -250,14 +270,16 @@ shader as_blend_shader
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 27
     ]],
     closure color in_color7 = 0
     [[
         string as_maya_attribute_name = "color7",
         string as_maya_attribute_short_name = "c7",
         string label = "Layer 7",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 28
     ]],
     float in_weight7 = 1.0
     [[
@@ -266,7 +288,8 @@ shader as_blend_shader
         float min = 0.0,
         float max = 1.0,
         string label = "Layer 7 Weight",
-        string page = "Layers"
+        string page = "Layers",
+        int as_max_param_id = 29
     ]],
     int in_layer_visibility7 = 0
     [[
@@ -280,7 +303,8 @@ shader as_blend_shader
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 31
     ]],
 
     output closure color out_color = 0
@@ -288,7 +312,8 @@ shader as_blend_shader
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
         string widget = "null",
-        string label = "Layered Output"
+        string label = "Layered Output",
+        int as_max_param_id = 32
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_color_transform.osl
+++ b/src/appleseed.shaders/src/appleseed/as_color_transform.osl
@@ -51,7 +51,8 @@ shader as_color_transform
         string as_maya_attribute_short_name = "c",
         string label = "Input Color",
         string page = "Color",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 0
     ]],
     int in_inputSpace = 0
     [[
@@ -65,7 +66,8 @@ shader as_color_transform
         string widget = "mapper",
         string options = "RGB:0|HSV:1|HSL:2|XYZ:3|xyY:4|CIE 1976 L*a*b*:5|CIE 1976 L*u*v*:6|CIE 1976 LCh_ab:7|CIE 1976 LCh_uv:8",
         string label = "Input Space",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 2
     ]],
     int in_outputSpace = 0
     [[
@@ -79,7 +81,8 @@ shader as_color_transform
         string widget = "mapper",
         string options = "RGB:0|HSV:1|HSL:2|CIE XYZ:3|CIE xyY:4|CIE 1976 L*a*b*:5|CIE 1976 L*u*v*:6|CIE 1976 LCh_ab:7|CIE 1976 LCh_uv:8",
         string label = "Output Space",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 3
     ]],
 
     MAYA_COLORMANAGEMENT_PARAMETERS,
@@ -89,7 +92,8 @@ shader as_color_transform
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
         string widget = "null",
-        string label = "Output Color"
+        string label = "Output Color",
+        int as_max_param_id = 11
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_composite_color.osl
+++ b/src/appleseed.shaders/src/appleseed/as_composite_color.osl
@@ -49,7 +49,8 @@ shader as_composite_color
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Source Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 0
     ]],
     float in_alpha = 1.0
     [[
@@ -59,14 +60,16 @@ shader as_composite_color
         float max = 1.0,
         string label = "Source Alpha",
         string page = "Color",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     color in_color2 = color(1)
     [[
         string as_maya_attribute_name = "color2",
         string as_maya_attribute_short_name = "c2",
         string label = "Destination Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 4
     ]],
     float in_alpha2 = 1.0
     [[
@@ -76,7 +79,8 @@ shader as_composite_color
         float max = 1.0,
         string label = "Destination Alpha",
         string page = "Color",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 6
     ]],
     string in_composite_mode = "Matte"
     [[
@@ -92,7 +96,8 @@ shader as_composite_color
         string label = "Composite Mode",
         string page = "Color",
         string help = "Compositing modes.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 8
     ]],
     int in_clamp_output = 0
     [[
@@ -105,7 +110,8 @@ shader as_composite_color
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "Clamp Output",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 9
     ]],
 
     output color out_color = color(0)
@@ -113,14 +119,16 @@ shader as_composite_color
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
         string widget = "null",
-        string label = "Output Color"
+        string label = "Output Color",
+        int as_max_param_id = 10
     ]],
     output float out_alpha = 0.0
     [[
         string as_maya_attribute_name = "outAlpha",
         string as_maya_attribute_short_name = "oa",
         string widget = "null",
-        string label = "Output Alpha"
+        string label = "Output Alpha",
+        int as_max_param_id = 10
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_create_mask.osl
+++ b/src/appleseed.shaders/src/appleseed/as_create_mask.osl
@@ -52,7 +52,8 @@ shader as_create_mask
         string as_maya_attribute_short_name = "c",
         string label = "Color",
         string page = "Color",
-        string help = "Color value to create mask from. It expects scene-linear values."
+        string help = "Color value to create mask from. It expects scene-linear values.",
+        int as_max_param_id = 0
     ]],
     float in_alpha = 0.0
     [[
@@ -62,7 +63,8 @@ shader as_create_mask
         float max = 1.0,
         string label = "Alpha",
         string page = "Color",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     int in_threshold_channel = 0
     [[
@@ -78,7 +80,8 @@ shader as_create_mask
         int gafferNoduleLayoutVisible = 0,
         string label = "Threshold Channel",
         string page = "Color",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 4
     ]],
     float in_threshold_value = 0.5
     [[
@@ -87,7 +90,8 @@ shader as_create_mask
         float softmin = 0.0,
         float softmax = 1.0,
         string label = "Threshold Value",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 5
     ]],
     int in_threshold_function = 0
     [[
@@ -101,7 +105,8 @@ shader as_create_mask
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "Threshold Function",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 7
     ]],
     float in_threshold_contrast = 0.25
     [[
@@ -110,7 +115,8 @@ shader as_create_mask
         float min = 0.0,
         float max = 1.0,
         string label = "Threshold Contrast",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 8
     ]],
     float in_threshold_lower_bound = 0.15
     [[
@@ -119,7 +125,8 @@ shader as_create_mask
         float min = 0.0,
         float max = 1.0,
         string label = "Smoothstep Lower Bound",
-        string page = "Color.Step Bounds"
+        string page = "Color.Step Bounds",
+        int as_max_param_id = 10
     ]],
     float in_threshold_upper_bound = 0.85
     [[
@@ -128,14 +135,16 @@ shader as_create_mask
         float min = 0.0,
         float max = 1.0,
         string label = "Smoothstep Upper Bound",
-        string page = "Color.Step Bounds"
+        string page = "Color.Step Bounds",
+        int as_max_param_id = 12
     ]],
 
     output float out_result = 0.0
     [[
         string as_maya_attribute_name = "result",
         string as_maya_attribute_short_name = "res",
-        string label = "Output Value"
+        string label = "Output Value",
+        int as_max_param_id = 14
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_disney_material.osl
+++ b/src/appleseed.shaders/src/appleseed/as_disney_material.osl
@@ -49,7 +49,8 @@ shader as_disney_material
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Surface Color",
-        string page = "Common"
+        string page = "Common",
+        int as_max_param_id = 0
     ]],
     float in_subsurface_amount = 0.0
     [[
@@ -58,7 +59,8 @@ shader as_disney_material
         float min = 0.0,
         float max = 1.0,
         string label = "Subsurface Weight",
-        string page = "Common"
+        string page = "Common",
+        int as_max_param_id = 2
     ]],
     float in_specular_amount = 0.5
     [[
@@ -67,7 +69,8 @@ shader as_disney_material
         float min = 0.0,
         float max = 1.0,
         string label = "Specular Weight",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 4
     ]],
     float in_roughness = 0.5
     [[
@@ -76,7 +79,8 @@ shader as_disney_material
         float min = 0.0,
         float max = 1.0,
         string label = "Surface Roughness",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 6
     ]],
     float in_specular_tint = 0.0
     [[
@@ -85,7 +89,8 @@ shader as_disney_material
         float min = 0.0,
         float max = 1.0,
         string label = "Specular Tinting",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 8
     ]],
     float in_metallic_amount = 0.0
     [[
@@ -95,7 +100,8 @@ shader as_disney_material
         float max = 1.0,
         string label = "Metallicness",
         string page = "Specular",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 10
     ]],
     float in_anisotropy_amount = 0.0
     [[
@@ -105,6 +111,7 @@ shader as_disney_material
         float max = 1.0,
         string label = "Anisotropy Amount",
         string page = "Specular",
+        int as_max_param_id = 12
     ]],
     float in_anisotropy_angle = 0.0
     [[
@@ -114,7 +121,8 @@ shader as_disney_material
         float max = 1.0,
         string label = "Anisotropy Angle",
         string page = "Specular",
-        string help = "The [0,1] range maps to [0,360] degrees range."
+        string help = "The [0,1] range maps to [0,360] degrees range.",
+        int as_max_param_id = 14
     ]],
     color in_anisotropy_vector_map= color(0)
     [[
@@ -122,7 +130,8 @@ shader as_disney_material
         string as_maya_attribute_short_name = "vm",
         string label = "Anisotropy Vector Map",
         string page = "Specular",
-        string help = "Vector tangent field map, with XY in R,G channels."
+        string help = "Vector tangent field map, with XY in R,G channels.",
+        int as_max_param_id = 16
     ]],
     float in_sheen_amount = 0.0
     [[
@@ -132,7 +141,8 @@ shader as_disney_material
         float max = 10.0,
         float softmax = 1.0,
         string label = "Sheen Weight",
-        string page = "Sheen"
+        string page = "Sheen",
+        int as_max_param_id = 18
     ]],
     float in_sheen_tint = 0.5
     [[
@@ -141,7 +151,8 @@ shader as_disney_material
         float min = 0.0,
         float max = 1.0,
         string label = "Sheen Tint",
-        string page = "Sheen"
+        string page = "Sheen",
+        int as_max_param_id = 20
     ]],
     float in_clear_coat = 0.0
     [[
@@ -151,7 +162,8 @@ shader as_disney_material
         float max = 100.0,
         float softmax = 1.0,
         string label = "Coating Weight",
-        string page = "Clear Coat"
+        string page = "Clear Coat",
+        int as_max_param_id = 22
     ]],
     float in_clear_coat_glossyness = 1.0
     [[
@@ -160,14 +172,16 @@ shader as_disney_material
         float min = 0.0,
         float max = 1.0,
         string label = "Coating Glossiness",
-        string page = "Clear Coat"
+        string page = "Clear Coat",
+        int as_max_param_id = 24
     ]],
     normal in_bump_normal = N
     [[
         string as_maya_attribute_name = "normalCamera",
         string as_maya_attribute_short_name = "n",
         string label = "Bump Normal",
-        string page = "Bump"
+        string page = "Bump",
+        int as_max_param_id = 26
     ]],
     int in_enable_matte = 0
     [[
@@ -181,7 +195,8 @@ shader as_disney_material
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int divider = 1,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 27
     ]],
     float in_matte_opacity = 0.0
     [[
@@ -192,7 +207,8 @@ shader as_disney_material
         string label = "Matte Opacity",
         string page = "Matte Opacity",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 28
     ]],
     color in_matte_opacity_color = color(1, 0.5, 0)
     [[
@@ -201,7 +217,8 @@ shader as_disney_material
         string label = "Matte Opacity Color",
         string page = "Matte Opacity",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 30
     ]],
     int in_maximum_ray_depth = 100
     [[
@@ -216,7 +233,8 @@ shader as_disney_material
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 32
     ]],
     vector Tn = vector(0)
     [[
@@ -224,7 +242,8 @@ shader as_disney_material
         int as_maya_attribute_hidden = 1,
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 33
     ]],
     vector Bn = vector(0)
     [[
@@ -232,7 +251,8 @@ shader as_disney_material
         int as_maya_attribute_hidden = 1,
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 34
 
     ]],
 
@@ -240,13 +260,15 @@ shader as_disney_material
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 35
     ]],
     output closure color out_outTransparency = 0
     [[
         string as_maya_attribute_name = "outTransparency",
         string as_maya_attribute_short_name = "ot",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 35
     ]],
     output closure color out_outMatteOpacity = 0
     [[
@@ -254,7 +276,8 @@ shader as_disney_material
         string as_maya_attribute_short_name = "om",
         string widget = "null",
         int as_maya_attribute_hidden = 1,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 35
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_double_shade.osl
+++ b/src/appleseed.shaders/src/appleseed/as_double_shade.osl
@@ -47,21 +47,24 @@ shader as_double_shade
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Front Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 0
     ]],
     color in_color2 = color(0)
     [[
         string as_maya_attribute_name = "color2",
         string as_maya_attribute_short_name = "c2",
         string label = "Back Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 2
     ]],
 
     output color out_color = color(0)
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string label = "Output Color"
+        string label = "Output Color",
+        int as_max_param_id = 4
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_falloff_angle.osl
+++ b/src/appleseed.shaders/src/appleseed/as_falloff_angle.osl
@@ -49,7 +49,8 @@ shader as_falloff_angle
         string as_maya_attribute_name = "vector1",
         string as_maya_attribute_short_name = "v1",
         string label = "Vector 1",
-        string page = "Input"
+        string page = "Input",
+        int as_max_param_id = 0
     ]],
     int in_normalize_input_1 = 0
     [[
@@ -63,14 +64,16 @@ shader as_falloff_angle
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     vector in_vector_2 = vector(N)
     [[
         string as_maya_attribute_name = "vector2",
         string as_maya_attribute_short_name = "v2",
         string label = "Vector 2",
-        string page = "Input"
+        string page = "Input",
+        int as_max_param_id = 3
     ]],
     int in_normalize_input_2 = 0
     [[
@@ -85,6 +88,7 @@ shader as_falloff_angle
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         int divider = 1,
+        int as_max_param_id = 4
     ]],
     float in_smooth_lower_bound = 0.25
     [[
@@ -93,7 +97,8 @@ shader as_falloff_angle
         float min = 0.0,
         float max = 1.0,
         string label = "Smoothstep Lower Bound",
-        string page = "Interpolation"
+        string page = "Interpolation",
+        int as_max_param_id = 5
     ]],
     float in_smooth_upper_bound = 0.75
     [[
@@ -103,7 +108,8 @@ shader as_falloff_angle
         float max = 1.0,
         string label = "Smoothstep Upper Bound",
         string page = "Interpolation",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 7
     ]],
     int in_smooth_function = 0
     [[
@@ -117,14 +123,16 @@ shader as_falloff_angle
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 9
     ]],
 
     output float out_result = 0.0
     [[
         string as_maya_attribute_name = "result",
         string as_maya_attribute_short_name = "rel",
-        string label = "Result"
+        string label = "Result",
+        int as_max_param_id = 10
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_fresnel.osl
+++ b/src/appleseed.shaders/src/appleseed/as_fresnel.osl
@@ -60,7 +60,8 @@ shader as_fresnel
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 0
     ]],
     float in_ior = 1.37
     [[
@@ -77,7 +78,8 @@ shader as_fresnel
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int separator = 1
+        int separator = 1,
+        int as_max_param_id = 1
     ]],
     color in_face_tint = color(0.85, 0.21, 0.05)
     [[
@@ -90,7 +92,8 @@ shader as_fresnel
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 2
     ]],
     color in_edge_tint = color(1)
     [[
@@ -104,7 +107,8 @@ shader as_fresnel
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 3
     ]],
     vector in_complex_eta = vector(0.21544, 1.0066, 1.2402)
     [[
@@ -116,7 +120,8 @@ shader as_fresnel
         int as_maya_attribute_keyable = 1,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 4
     ]],
     vector in_complex_kappa = vector(3.95560, 2.5823, 2.3929)
     [[
@@ -128,7 +133,8 @@ shader as_fresnel
         int as_maya_attribute_keyable = 1,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 5
     ]],
     normal in_surface_normal = N
     [[
@@ -136,7 +142,8 @@ shader as_fresnel
         string as_maya_attribute_short_name = "n",
         string label = "Surface Normal",
         string page = "Globals",
-        string help = "The unit length world space shading normal, it can be a bumped normal."
+        string help = "The unit length world space shading normal, it can be a bumped normal.",
+        int as_max_param_id = 6
     ]],
     vector in_viewer_vector = I
     [[
@@ -144,7 +151,8 @@ shader as_fresnel
         string as_maya_attribute_short_name = "i",
         string label = "Viewer Vector",
         string page = "Globals",
-        string help = "The unit length world space vector pointing from the viewer position to the point being shaded."
+        string help = "The unit length world space vector pointing from the viewer position to the point being shaded.",
+        int as_max_param_id = 7
     ]],
 
     output color out_color = color(0)
@@ -152,14 +160,16 @@ shader as_fresnel
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 8
     ]],
     output float out_alpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
         string as_maya_attribute_short_name = "oa",
         string label = "Output Alpha",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 8
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_glass.osl
+++ b/src/appleseed.shaders/src/appleseed/as_glass.osl
@@ -47,7 +47,8 @@ shader as_glass
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Transmittance Color",
-        string page = "Transmittance"
+        string page = "Transmittance",
+        int as_max_param_id = 0
     ]],
     float in_transmittance_amount = 0.8
     [[
@@ -56,21 +57,24 @@ shader as_glass
         float min = 0.0,
         float max = 1.0,
         string label = "Transmittance Weight",
-        string page = "Transmittance"
+        string page = "Transmittance",
+        int as_max_param_id = 2
     ]],
     color in_reflection_tint = color(1)
     [[
         string as_maya_attribute_name = "reflectionTint",
         string as_maya_attribute_short_name = "rt",
         string label = "Reflection Tint",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 4
     ]],
     color in_refraction_tint = color(1)
     [[
         string as_maya_attribute_name = "refractionTint",
         string as_maya_attribute_short_name = "tt",
         string label = "Refraction Tint",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 6
     ]],
     float in_ior = 1.5
     [[
@@ -85,7 +89,8 @@ shader as_glass
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 8
     ]],
     string in_distribution = "ggx"
     [[
@@ -99,7 +104,8 @@ shader as_glass
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 9
     ]],
     float in_roughness = 0.1
     [[
@@ -108,7 +114,8 @@ shader as_glass
         float min = 0.001,
         float max = 1.0,
         string label = "Roughness",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 10
     ]],
     float in_specular_spread = 0.5
     [[
@@ -118,7 +125,8 @@ shader as_glass
         float max = 1.0,
         string label = "Specular Spread",
         string page = "Specular",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 12
     ]],
     float in_anisotropy_amount = 0.0
     [[
@@ -127,7 +135,8 @@ shader as_glass
         float min = 0.0,
         float max = 1.0,
         string label = "Anisotropy Amount",
-        string page = "Specular.Anisotropy"
+        string page = "Specular.Anisotropy",
+        int as_max_param_id = 14
     ]],
     float in_anisotropy_angle = 0.0
     [[
@@ -138,7 +147,8 @@ shader as_glass
         string label = "Anisotropy Rotation",
         string page = "Specular.Anisotropy",
         string help = "The [0,1] range maps to [0,360] degrees range.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 16
     ]],
     int in_anisotropy_mode = 0
     [[
@@ -154,7 +164,8 @@ shader as_glass
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 18
     ]],
     color in_anisotropy_map = color(0)
     [[
@@ -163,7 +174,8 @@ shader as_glass
         string label = "Anisotropy Vector Map",
         string page = "Specular.Anisotropy",
         string help = "Vector tangent field map, with XY in R,G channels.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 19
     ]],
     vector in_anisotropy_direction = vector(0)
     [[
@@ -171,14 +183,16 @@ shader as_glass
         string as_maya_attribute_short_name = "and",
         string label = "Anisotropy Vector",
         string page = "Specular.Anisotropy",
-        string help = "Explicit anisotropy vector, such as the vector output by a tangent field node."
+        string help = "Explicit anisotropy vector, such as the vector output by a tangent field node.",
+        int as_max_param_id = 21
     ]],
     color in_volume_transmittance = 1.0
     [[
         string as_maya_attribute_name = "volumeTransmittance",
         string as_maya_attribute_short_name = "vt",
         string label = "Volume Transmittance",
-        string page = "Volume"
+        string page = "Volume",
+        int as_max_param_id = 23
     ]],
     float in_volume_transmittance_distance = 0.0
     [[
@@ -188,14 +202,16 @@ shader as_glass
         float max = 1e+9,
         string label = "Transmittance Distance",
         string page = "Volume",
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 25
     ]],
     normal in_bump_normal = N
     [[
         string as_maya_attribute_name = "normalCamera",
         string as_maya_attribute_short_name = "n",
         string label = "Bump Normal",
-        string page = "Bump"
+        string page = "Bump",
+        int as_max_param_id = 27
     ]],
     int in_enable_matte = 0
     [[
@@ -209,7 +225,8 @@ shader as_glass
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 28
     ]],
     float in_matte_opacity = 0.0
     [[
@@ -220,7 +237,8 @@ shader as_glass
         string label = "Matte Opacity",
         string page = "Matte Opacity",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 29
     ]],
     color in_matte_opacity_color = color(1,0.5,0)
     [[
@@ -229,7 +247,8 @@ shader as_glass
         string label = "Matte Opacity Color",
         string page = "Matte Opacity",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 31
     ]],
     int in_maximum_ray_depth = 100
     [[
@@ -244,7 +263,8 @@ shader as_glass
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 33
     ]],
     vector Tn = vector(0)
     [[
@@ -252,7 +272,8 @@ shader as_glass
         int as_maya_attribute_hidden = 1,
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 34
     ]],
     vector Bn = vector(0)
     [[
@@ -260,20 +281,23 @@ shader as_glass
         int as_maya_attribute_hidden = 1,
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 35
     ]],
 
     output closure color out_outColor = 0
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 36
     ]],
     output closure color out_outTransparency = 0
     [[
         string as_maya_attribute_name = "outTransparency",
         string as_maya_attribute_short_name = "ot",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 36
     ]],
     output closure color out_outMatteOpacity = 0
     [[
@@ -282,7 +306,8 @@ shader as_glass
         string widget = "null",
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 36
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_globals.osl
+++ b/src/appleseed.shaders/src/appleseed/as_globals.osl
@@ -45,66 +45,76 @@ shader as_globals
     point Pref = P
     [[
         int lockgeom = 0,
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 0
     ]],
     normal Nref = N
     [[
         int lockgeom = 0,
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 1
     ]],
     output point out_world_P = P
     [[
         string as_maya_attribute_name = "worldP",
         string as_maya_attribute_short_name = "wp",
-        string label = "Surface Position"
+        string label = "Surface Position",
+        int as_max_param_id = 2
     ]],
     output point out_world_Pref = Pref
     [[
         string as_maya_attribute_name = "worldPref",
         string as_maya_attribute_short_name = "wpr",
         string label = "Reference Point",
-        string help = "World space reference point Pref."
+        string help = "World space reference point Pref.",
+        int as_max_param_id = 2
     ]],
     output point out_world_Ps = Ps
     [[
         string as_maya_attribute_name = "worldPs",
         string as_maya_attribute_short_name = "wps",
         string label = "Light Point Position",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     output normal out_world_N = N
     [[
         string as_maya_attribute_name = "worldN",
         string as_maya_attribute_short_name = "n",
-        string label = "Shading Normal"
+        string label = "Shading Normal",
+        int as_max_param_id = 2
     ]],
     output normal out_world_Nref = Nref
     [[
         string as_maya_attribute_name = "worldNref",
         string as_maya_attribute_short_name = "nre",
         string label = "Reference Normal",
-        string help = "World space reference normal Nref."
+        string help = "World space reference normal Nref.",
+        int as_max_param_id = 2
     ]],
     output normal out_world_Ng = Ng
     [[
         string as_maya_attribute_name = "worldNg",
         string as_maya_attribute_short_name = "ng",
         string label = "Geometric Normal",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     output vector out_world_I = I
     [[
         string as_maya_attribute_name = "worldI",
         string as_maya_attribute_short_name = "wri",
         string label = "Viewer Vector",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     output vector out_world_dPdu = dPdu
     [[
         string as_maya_attribute_name = "worldDPdu",
         string as_maya_attribute_short_name = "dpu",
         string label = "dP/du",
-        string help = "Partial derivative of P along the U direction."
+        string help = "Partial derivative of P along the U direction.",
+        int as_max_param_id = 2
     ]],
     output vector out_world_dPdv = dPdv
     [[
@@ -112,21 +122,24 @@ shader as_globals
         string as_maya_attribute_short_name = "dpv",
         string label = "dP/dv",
         string help = "Partial derivative of P along the V direction.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     output vector out_world_dPdx = Dx(P)
     [[
         string as_maya_attribute_name = "worldDPdx",
         string as_maya_attribute_short_name = "dpx",
         string label = "dP/dx",
-        string help = "Partial derivative of P along the X direction."
+        string help = "Partial derivative of P along the X direction.",
+        int as_max_param_id = 2
     ]],
     output vector out_world_dPdy = Dy(P)
     [[
         string as_maya_attribute_name = "worldDPdy",
         string as_maya_attribute_short_name = "dpy",
         string label = "dP/dy",
-        string help = "Partial derivative of P along the Y direction."
+        string help = "Partial derivative of P along the Y direction.",
+        int as_max_param_id = 2
     ]],
     output vector out_world_dPdz = Dz(P)
     [[
@@ -134,7 +147,8 @@ shader as_globals
         string as_maya_attribute_short_name = "dpz",
         string label = "dP/dz",
         string help = "Partial derivative of P along the Z direction.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     output normal out_world_dNdu = 0
     [[
@@ -142,7 +156,8 @@ shader as_globals
         string as_maya_attribute_name = "worldDNdu",
         string as_maya_attribute_short_name = "dnu",
         string label = "dN/du",
-        string help = "Partial derivative of N along the V direction."
+        string help = "Partial derivative of N along the V direction.",
+        int as_max_param_id = 2
     ]],
     output normal out_world_dNdv = 0
     [[
@@ -151,14 +166,16 @@ shader as_globals
         string as_maya_attribute_short_name = "dnv",
         string label = "dN/dv",
         string help = "Partial derivative of N along the U direction.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     output vector out_world_Tn = 0
     [[
         int lockgeom = 0,
         string as_maya_attribute_name = "worldTn",
         string as_maya_attribute_short_name = "tn",
-        string label = "Tangent Vector"
+        string label = "Tangent Vector",
+        int as_max_param_id = 2
     ]],
     output vector out_world_Bn = 0
     [[
@@ -166,46 +183,53 @@ shader as_globals
         string as_maya_attribute_name = "worldBn",
         string as_maya_attribute_short_name = "bn",
         string label = "Bitangent Vector",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     output float out_u_coord = u
     [[
         string as_maya_attribute_name = "outUCoord",
         string as_maya_attribute_short_name = "ouc",
-        string label = "U Coordinate"
+        string label = "U Coordinate",
+        int as_max_param_id = 2
     ]],
     output float out_v_coord = v
     [[
         string as_maya_attribute_name = "outVCoord",
         string as_maya_attribute_short_name = "ovc",
-        string label = "V Coordinate"
+        string label = "V Coordinate",
+        int as_max_param_id = 2
     ]],
     output float out_uv_coord[2] = {u, v}
     [[
         string as_maya_attribute_name = "outUV",
         string as_maya_attribute_short_name = "o",
         string label = "UV Coords",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     output float out_time = time
     [[
         string as_maya_attribute_name = "time",
         string as_maya_attribute_short_name = "tim",
-        string label = "Shutter Time"
+        string label = "Shutter Time",
+        int as_max_param_id = 2
     ]],
     output float out_dtime = dtime
     [[
         string as_maya_attribute_name = "dtime",
         string as_maya_attribute_short_name = "dti",
         string label = "Time Amount",
-        string help = "The amount of time covered by this shading sample."
+        string help = "The amount of time covered by this shading sample.",
+        int as_max_param_id = 2
     ]],
     output vector out_world_dPdtime = dPdtime
     [[
         string as_maya_attribute_name = "worldDPdtime",
         string as_maya_attribute_short_name = "dpt",
         string label = "dP/dtime",
-        string help = "Derivative of P along time, or how P changes per unit time."
+        string help = "Derivative of P along time, or how P changes per unit time.",
+        int as_max_param_id = 2
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_id_manifold.osl
+++ b/src/appleseed.shaders/src/appleseed/as_id_manifold.osl
@@ -57,7 +57,8 @@ shader as_id_manifold
         int gafferNoduleLayoutVisible = 0,
         string label = "Type",
         string page = "Manifold",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 0
     ]],
     string in_expression = ""
     [[
@@ -71,7 +72,8 @@ shader as_id_manifold
         int gafferNoduleLayoutVisible = 0,
         string label = "Expression",
         string page = "Manifold.String",
-        string help = "String expression to search in the object or object instance name."
+        string help = "String expression to search in the object or object instance name.",
+        int as_max_param_id = 1
     ]],
     int in_domain = 0
     [[
@@ -86,7 +88,8 @@ shader as_id_manifold
         int gafferNoduleLayoutVisible = 0,
         string label = "Domain",
         string page = "Manifold.String",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     int in_seed = 0xcafe
     [[
@@ -100,7 +103,8 @@ shader as_id_manifold
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 1,
         string label = "Seed",
-        string page = "Manifold.String"
+        string page = "Manifold.String",
+        int as_max_param_id = 3
     ]],
     int in_output_mode = 1
     [[
@@ -114,7 +118,8 @@ shader as_id_manifold
         int as_maya_attribute_keyable = 1,
         int as_maya_attribute_hidden = 0,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 4
     ]],
 
     output int out_outHash = 0
@@ -127,13 +132,15 @@ shader as_id_manifold
     [[
         string as_maya_attribute_name = "outID",
         string as_maya_attribute_short_name = "oid",
-        string label = "Output ID"
+        string label = "Output ID",
+        int as_max_param_id = 5
     ]],
     output float out_outGreyscale = 0.0
     [[
         string as_maya_attribute_name = "outGreyscale",
         string as_maya_attribute_short_name = "ogr",
-        string label = "Output Greyscale"
+        string label = "Output Greyscale",
+        int as_max_param_id = 5
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_invert_color.osl
+++ b/src/appleseed.shaders/src/appleseed/as_invert_color.osl
@@ -56,7 +56,8 @@ shader as_invert_color
         string label = "Input Color",
         string page = "Color",
         string help = "Color to invert.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 0
     ]],
     string in_color_model = "RGB"
     [[
@@ -71,7 +72,8 @@ shader as_invert_color
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 2
     ]],
     int in_invert_channel_x = 0
     [[
@@ -87,7 +89,9 @@ shader as_invert_color
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 4
+
     ]],
     int in_invert_channel_y = 0
     [[
@@ -103,7 +107,8 @@ shader as_invert_color
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 6
     ]],
     int in_invert_channel_z = 0
     [[
@@ -119,7 +124,8 @@ shader as_invert_color
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 8
     ]],
     output color out_outColor = color(0)
     [[
@@ -127,7 +133,8 @@ shader as_invert_color
         string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
         string page = "Output",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 10
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_luminance.osl
+++ b/src/appleseed.shaders/src/appleseed/as_luminance.osl
@@ -51,7 +51,8 @@ shader as_luminance
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Input Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 0
     ]],
     int in_deriveFromMayaCMS = 1
     [[
@@ -65,7 +66,8 @@ shader as_luminance
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 2
     ]],
     int in_inputColorSpace = 0
     [[
@@ -81,7 +83,8 @@ shader as_luminance
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 3
     ]],
     float in_chromaticityCoordsR[2] = {0.640, 0.330}
     [[
@@ -91,7 +94,8 @@ shader as_luminance
         float min = 0.0,
         float max = 1.0,
         string label = "R xy Coordinates",
-        string page = "Color Space.RGB Primaries"
+        string page = "Color Space.RGB Primaries",
+        int as_max_param_id = 5
     ]],
     float in_chromaticityCoordsG[2] = {0.300, 0.600}
     [[
@@ -101,7 +105,8 @@ shader as_luminance
         float min = 0.0,
         float max = 1.0,
         string label = "G xy Coordinates",
-        string page = "Color Space.RGB Primaries"
+        string page = "Color Space.RGB Primaries",
+        int as_max_param_id = 7
     ]],
     float in_chromaticityCoordsB[2] = {0.150, 0.060}
     [[
@@ -112,7 +117,8 @@ shader as_luminance
         float max = 1.0,
         string label = "B xy Coordinates",
         string page = "Color Space.RGB Primaries",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 9
     ]],
     int in_inputIlluminants = 0
     [[
@@ -128,7 +134,8 @@ shader as_luminance
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 10
     ]],
     int in_colorTemperature = 6504
     [[
@@ -142,7 +149,8 @@ shader as_luminance
         int as_maya_attribute_keyable = 1,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 1
+        int gafferNoduleLayoutVisible = 1,
+        int as_max_param_id = 11
     ]],
     float in_chromaticityCoordsW[2] = {0.3127, 0.329}
     [[
@@ -152,7 +160,8 @@ shader as_luminance
         float min = 0.0,
         float max = 1.0,
         string label = "W xy Coordinates",
-        string page = "Color Space.Illuminants"
+        string page = "Color Space.Illuminants",
+        int as_max_param_id = 13
     ]],
 
     MAYA_COLORMANAGEMENT_PARAMETERS,
@@ -161,7 +170,8 @@ shader as_luminance
     [[
         string as_maya_attribute_name = "result",
         string as_maya_attribute_short_name = "r",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 21
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_manifold2d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_manifold2d.osl
@@ -49,7 +49,8 @@ shader as_manifold2D
         string as_maya_attribute_name = "uvCoord",
         string label = "UV Coordinates",
         string page = "Coordinates",
-        int as_max_attribute_hidden = 1
+        int as_max_attribute_hidden = 1,
+        int as_max_param_id = 0
     ]],
     float in_uv_filter_size[2] = {
         UNDEFINED_UVFILTER, UNDEFINED_UVFILTER}
@@ -59,7 +60,8 @@ shader as_manifold2D
         string label = "UV Filter Size",
         string page = "Coordinates",
         string help = "UV coordinates filter widths",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     int in_bypass_uv = 0
     [[
@@ -73,7 +75,8 @@ shader as_manifold2D
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 3
     ]],
     int in_compute_filters = 1
     [[
@@ -88,7 +91,8 @@ shader as_manifold2D
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string help = "Compute the filter widths of the UV coordinates.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 4
     ]],
 
     //
@@ -99,7 +103,8 @@ shader as_manifold2D
         string as_maya_attribute_short_name = "sfr",
         string label = "Scale UV Frame",
         string page = "Frame",
-        string help = "Scale the UV frame."
+        string help = "Scale the UV frame.",
+        int as_max_param_id = 6
     ]],
     float in_translate_frame[2] = {0.0, 0.0}
     [[
@@ -108,7 +113,8 @@ shader as_manifold2D
         string label = "Translate UV Frame",
         string page = "Frame",
         string help = "Translate the UV frame.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 8
     ]],
     float in_rotate_frame = 0.0
     [[
@@ -118,7 +124,8 @@ shader as_manifold2D
         float softmax = 1.0,
         string label = "Rotate UV Frame",
         string page = "Frame",
-        string help = "Rotate the UV frame, where values in the unrestricted interval [0,1] map to [0,360] degrees."
+        string help = "Rotate the UV frame, where values in the unrestricted interval [0,1] map to [0,360] degrees.",
+        int as_max_param_id = 10
     ]],
     float in_frame_center[2] = {0.5, 0.5}
     [[
@@ -126,7 +133,8 @@ shader as_manifold2D
         string as_maya_attribute_short_name = "fce",
         string label = "UV Frame Center",
         string page = "Frame",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 12
     ]],
     string in_wrap_mode_u = "Periodic"
     [[
@@ -141,7 +149,8 @@ shader as_manifold2D
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Wrap mode outside the [0,1] UV square. Textures already  have their wrap modes, but you might want to use this for a procedural texture."
+        string help = "Wrap mode outside the [0,1] UV square. Textures already  have their wrap modes, but you might want to use this for a procedural texture.",
+        int as_max_param_id = 13
     ]],
     string in_wrap_mode_v = "Periodic"
     [[
@@ -157,7 +166,8 @@ shader as_manifold2D
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string help = "Wrap mode outside the [0,1] UV square. Textures already have their wrap modes, but you might want to use this for a procedural texture.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 14
     ]],
 
     //
@@ -168,7 +178,8 @@ shader as_manifold2D
         string as_maya_attribute_short_name = "uvt",
         string label = "UV Tiles",
         string page = "Transform",
-        string help = "Number of UV tiles."
+        string help = "Number of UV tiles.",
+        int as_max_param_id = 16
     ]],
     float in_offset_tiles[2] = {0.0, 0.0}
     [[
@@ -177,7 +188,8 @@ shader as_manifold2D
         string label = "Offset Tiles",
         string page = "Transform",
         string help = "Offset UV Tiles along U, V or both.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 18
     ]],
     float in_rotate_tiles = 0.0
     [[
@@ -187,7 +199,8 @@ shader as_manifold2D
         float softmax = 1.0,
         string label = "Tiles Rotation",
         string page = "Transform",
-        string help = "Rotate the UV tiles, where the unrestricted interval [0,1] maps to [0,360] degrees."
+        string help = "Rotate the UV tiles, where the unrestricted interval [0,1] maps to [0,360] degrees.",
+        int as_max_param_id = 19
     ]],
     float in_tiles_center[2] = {0.5, 0.5}
     [[
@@ -196,7 +209,8 @@ shader as_manifold2D
         string label = "Tiles Center",
         string page = "Transform",
         string help = "The center of rotation for the UV tiles.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 22
     ]],
     float in_tiles_coverage[2] = {1.0, 1.0}
     [[
@@ -204,7 +218,8 @@ shader as_manifold2D
         string as_maya_attribute_short_name = "tco",
         string label = "Tiles Coverage",
         string page = "Transform",
-        string help = "The amount of area of the UV frame to cover."
+        string help = "The amount of area of the UV frame to cover.",
+        int as_max_param_id = 24
     ]],
 
     //
@@ -221,7 +236,8 @@ shader as_manifold2D
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Mirror the UV tile along the U direction."
+        string help = "Mirror the UV tile along the U direction.",
+        int as_max_param_id = 25
     ]],
     int in_mirror_v = 0
     [[
@@ -235,7 +251,8 @@ shader as_manifold2D
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Mirror the UV tile along the V direction."
+        string help = "Mirror the UV tile along the V direction.",
+        int as_max_param_id = 26
     ]],
     int in_wrap_u = 0
     [[
@@ -249,7 +266,8 @@ shader as_manifold2D
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Wrap the UV tile along the U direction."
+        string help = "Wrap the UV tile along the U direction.",
+        int as_max_param_id = 27
     ]],
     int in_wrap_v = 0
     [[
@@ -263,7 +281,8 @@ shader as_manifold2D
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Wrap the UV tile along the V direction."
+        string help = "Wrap the UV tile along the V direction.",
+        int as_max_param_id = 28
     ]],
     int in_stagger_uv = 0
     [[
@@ -277,7 +296,8 @@ shader as_manifold2D
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Stagger each row half the tile width."
+        string help = "Stagger each row half the tile width.",
+        int as_max_param_id = 29
     ]],
     int in_swap_uv = 0
     [[
@@ -291,7 +311,8 @@ shader as_manifold2D
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Swap the U and V coordinates."
+        string help = "Swap the U and V coordinates.",
+        int as_max_param_id = 30
     ]],
 
     //
@@ -302,7 +323,8 @@ shader as_manifold2D
         string as_maya_attribute_short_name = "nuv",
         string label = "Distort UV",
         string page = "Noise",
-        string help = "Distort U, V, or UV coordinates with a signed Perlin noise function."
+        string help = "Distort U, V, or UV coordinates with a signed Perlin noise function.",
+        int as_max_param_id = 32
     ]],
 
     //
@@ -312,7 +334,8 @@ shader as_manifold2D
         string as_maya_attribute_name = "outUV",
         string as_maya_attribute_short_name = "ouv",
         string label = "UV Coords",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 33
     ]],
     output float out_uvcoord_filter[2] = {
         UNDEFINED_UVFILTER, UNDEFINED_UVFILTER}
@@ -320,7 +343,8 @@ shader as_manifold2D
         string as_maya_attribute_name = "outUVFilter",
         string as_maya_attribute_short_name = "ouf",
         string label = "UV Filter Size",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 33
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_metal.osl
+++ b/src/appleseed.shaders/src/appleseed/as_metal.osl
@@ -50,7 +50,8 @@ shader as_metal
         string as_maya_attribute_short_name = "f0",
         string label = "Face Reflectance",
         string page = "Fresnel",
-        string help = "Reflectance at normal incidence."
+        string help = "Reflectance at normal incidence.",
+        int as_max_param_id = 0
     ]],
     color in_edge_reflectance = color(1)
     [[
@@ -58,7 +59,8 @@ shader as_metal
         string as_maya_attribute_short_name = "f90",
         string label = "Edge Reflectance",
         string page = "Fresnel",
-        string help = "Reflectance at grazing incidence."
+        string help = "Reflectance at grazing incidence.",
+        int as_max_param_id = 2
     ]],
     int in_distribution = 0
     [[
@@ -73,7 +75,8 @@ shader as_metal
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 4
     ]],
     float in_roughness = 0.25
     [[
@@ -82,7 +85,8 @@ shader as_metal
         float min = 0.0,
         float max = 1.0,
         string label = "Roughness",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 5
     ]],
     float in_energy_compensation = 1.0
     [[
@@ -107,7 +111,8 @@ shader as_metal
         float min = 0.0,
         float max = 1.0,
         string label = "Anisotropy Amount",
-        string page = "Specular.Anisotropy"
+        string page = "Specular.Anisotropy",
+        int as_max_param_id = 7
     ]],
     float in_anisotropy_angle = 0.0
     [[
@@ -118,7 +123,8 @@ shader as_metal
         string label = "Anisotropy Angle",
         string page = "Specular.Anisotropy",
         string help = "Anisotropy angle in [0,1], mapping to [0,360] degrees.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 9
     ]],
     int in_anisotropy_mode = 0
     [[
@@ -134,7 +140,8 @@ shader as_metal
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 11
     ]],
     color in_anisotropy_map = color(0)
     [[
@@ -143,7 +150,8 @@ shader as_metal
         string label = "Anisotropy Vector Map",
         string page = "Specular.Anisotropy",
         string help = "Anisotropy vector map, with XY encoded in RG channels.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 12
     ]],
     vector in_anisotropy_direction = vector(0)
     [[
@@ -151,7 +159,8 @@ shader as_metal
         string as_maya_attribute_short_name = "and",
         string label = "Anisotropy Vector",
         string page = "Specular.Anisotropy",
-        string help = "Explicit anisotropy vector, such as the vector output by a tangent field node."
+        string help = "Explicit anisotropy vector, such as the vector output by a tangent field node.",
+        int as_max_param_id = 14
     ]],
 #if 0
     float in_thinfilm_thickness = 0.0
@@ -216,7 +225,8 @@ shader as_metal
         string as_maya_attribute_short_name = "n",
         string label = "Bump Normal",
         string page = "Bump",
-        string help = "The default bump normal."
+        string help = "The default bump normal.",
+        int as_max_param_id = 16
     ]],
     int in_enable_matte = 0
     [[
@@ -230,7 +240,8 @@ shader as_metal
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 17
     ]],
     float in_matte_opacity = 0.0
     [[
@@ -241,7 +252,8 @@ shader as_metal
         string label = "Matte Opacity",
         string page = "Matte Opacity",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 18
     ]],
     color in_matte_opacity_color = color(1,0.5,0)
     [[
@@ -250,7 +262,8 @@ shader as_metal
         string label = "Matte Opacity Color",
         string page = "Matte Opacity",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 20
     ]],
     int in_maximum_ray_depth = 100
     [[
@@ -265,7 +278,8 @@ shader as_metal
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 22
     ]],
     vector Tn = vector(0)
     [[
@@ -273,7 +287,8 @@ shader as_metal
         int as_maya_attribute_hidden = 1,
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 23
     ]],
     vector Bn = vector(0)
     [[
@@ -281,14 +296,16 @@ shader as_metal
         int as_maya_attribute_hidden = 1,
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 24
     ]],
 
     output closure color out_outColor = 0
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 25
     ]],
     output closure color out_outMatteOpacity = 0
     [[
@@ -297,7 +314,8 @@ shader as_metal
         string widget = "null",
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 25
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_noise2d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_noise2d.osl
@@ -53,14 +53,16 @@ shader as_noise2d
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Color 1",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 0
     ]],
     color in_color2 = color(1)
     [[
         string as_maya_attribute_name = "color2",
         string as_maya_attribute_short_name = "c2",
         string label = "Color 2",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 2
     ]],
     float in_contrast = 1.0
     [[
@@ -70,7 +72,8 @@ shader as_noise2d
         float min = 0.0,
         float max = 1.0,
         string label = "Contrast",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 4
     ]],
     int in_type = 0
     [[
@@ -85,7 +88,8 @@ shader as_noise2d
         string help = "Noise type used.",
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 6
     ]],
     float in_intensity = 1.0
     [[
@@ -96,7 +100,8 @@ shader as_noise2d
         float softmax = 1.0,
         string label = "Intensity",
         string help = "Global noise intensity.",
-        string page = "Noise"
+        string page = "Noise",
+        int as_max_param_id = 7
     ]],
     float in_frequency_x = 1.0
     [[
@@ -106,7 +111,8 @@ shader as_noise2d
         float softmax = 8.0,
         string label = "X Frequency",
         string help = "Higher values increase the noise density.",
-        string page = "Noise"
+        string page = "Noise",
+        int as_max_param_id = 9
     ]],
     float in_frequency_y = 1.0
     [[
@@ -117,7 +123,8 @@ shader as_noise2d
         string label = "Y Frequency",
         string help = "Higher values increase the noise density.",
         string page = "Noise",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 11
     ]],
     int in_ridges = 0
     [[
@@ -129,7 +136,8 @@ shader as_noise2d
         string label = "Ridges",
         string page = "Noise",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 13
     ]],
     int in_inflection = 0
     [[
@@ -142,7 +150,8 @@ shader as_noise2d
         string page = "Noise",
         string help = "Uses the absolute value of the noise.",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 14
     ]],
     int in_signed_noise = 0
     [[
@@ -155,7 +164,8 @@ shader as_noise2d
         string page = "Noise",
         string help = "Noise range in [0,1] or [-1,1].",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 15
     ]],
     // todo: remove when we're ok to break backward compatibility
     int in_animated_noise = 0
@@ -179,7 +189,8 @@ shader as_noise2d
         float softmax = 1.0,
         string label = "Frame Time",
         string page = "Noise.Motion",
-        string help = "Frame time, typically frame number."
+        string help = "Frame time, typically frame number.",
+        int as_max_param_id = 16
     ]],
     float in_time_scale = 0.0
     [[
@@ -189,7 +200,8 @@ shader as_noise2d
         float softmax = 1.0,
         string label = "Time Scale",
         string page = "Noise.Motion",
-        string help = "Global time scale, affects frame time."
+        string help = "Global time scale, affects frame time.",
+        int as_max_param_id = 18
     ]],
     int in_periodic = 0
     [[
@@ -202,7 +214,8 @@ shader as_noise2d
         string page = "Noise.Periodic",
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 20
     ]],
     float in_period_x = 4.0
     [[
@@ -211,7 +224,8 @@ shader as_noise2d
         float min = 0.0,
         float softmax = 16.0,
         string label = "X Period",
-        string page = "Noise.Periodic"
+        string page = "Noise.Periodic",
+        int as_max_param_id = 21
     ]],
     float in_period_y = 4.0
     [[
@@ -220,7 +234,8 @@ shader as_noise2d
         float min = 0.0,
         float softmax = 16.0,
         string label = "Y Period",
-        string page = "Noise.Periodic"
+        string page = "Noise.Periodic",
+        int as_max_param_id = 23
     ]],
     float in_period_time = 4.0
     [[
@@ -229,7 +244,8 @@ shader as_noise2d
         float min = 0.0,
         float softmax = 16.0,
         string label = "Time Period",
-        string page = "Noise.Periodic"
+        string page = "Noise.Periodic",
+        int as_max_param_id = 25
     ]],
     float in_smoothness = 0.0
     [[
@@ -238,7 +254,8 @@ shader as_noise2d
         float min = 0.0,
         float max = 1.0,
         string label = "Smoothness",
-        string page = "Noise.Voronoise"
+        string page = "Noise.Voronoise",
+        int as_max_param_id = 27
     ]],
     float in_jittering = 0.0
     [[
@@ -247,7 +264,8 @@ shader as_noise2d
         float min = 0.0,
         float max = 1.0,
         string label = "Jittering",
-        string page = "Noise.Voronoise"
+        string page = "Noise.Voronoise",
+        int as_max_param_id = 29
     ]],
     int in_anisotropy = 0
     [[
@@ -261,14 +279,16 @@ shader as_noise2d
         string page = "Noise.Gabor",
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 31
     ]],
     vector in_direction = vector(1,0,0)
     [[
         string as_maya_attribute_name = "direction",
         string as_maya_attribute_short_name = "dir",
         string label = "Anisotropy Vector",
-        string page = "Noise.Gabor"
+        string page = "Noise.Gabor",
+        int as_max_param_id = 32
     ]],
     float in_bandwidth = 1.0
     [[
@@ -277,7 +297,8 @@ shader as_noise2d
         float min = 0.0,
         float softmax = 1.0,
         string label = "Bandwidth",
-        string page = "Noise.Gabor"
+        string page = "Noise.Gabor",
+        int as_max_param_id = 34
     ]],
     int in_impulses = 16
     [[
@@ -291,7 +312,8 @@ shader as_noise2d
         string page = "Noise.Gabor",
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 36
     ]],
     int in_filter_noise = 1
     [[
@@ -303,7 +325,8 @@ shader as_noise2d
         string label = "Filter",
         string page = "Noise.Gabor",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 37
     ]],
     float in_amplitude = 1.0
     [[
@@ -316,7 +339,8 @@ shader as_noise2d
         int slider = 0,
         string label = "Amplitude",
         string page = "Recursion",
-        string help = "Initial amplitude before recursion."
+        string help = "Initial amplitude before recursion.",
+        int as_max_param_id = 38
     ]],
     int in_octaves = 1
     [[
@@ -333,7 +357,8 @@ shader as_noise2d
         string help = "Maximum number of iterations.",
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 40
     ]],
     int in_cascade_mode = 0
     [[
@@ -348,7 +373,8 @@ shader as_noise2d
         string help = "Add sucessive frequencies, or multiply them.",
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 41
     ]],
     float in_lacunarity = 2.17
     [[
@@ -360,7 +386,8 @@ shader as_noise2d
         float softmax = 10.0,
         string label = "Lacunarity",
         string page = "Recursion",
-        string help = "Gap between successive frequencies."
+        string help = "Gap between successive frequencies.",
+        int as_max_param_id = 42
     ]],
     float in_offset = 0.0
     [[
@@ -370,7 +397,8 @@ shader as_noise2d
         float softmax = 1.0,
         string label = "Offset",
         string page = "Recursion",
-        string help = "Controls the multifractality."
+        string help = "Controls the multifractality.",
+        int as_max_param_id = 44
     ]],
     float in_noise_gain = 1.0
     [[
@@ -382,7 +410,8 @@ shader as_noise2d
         float softmax = 3.0,
         string label = "Gain",
         string page = "Recursion",
-        string help = "Controls the contrast of the fractal."
+        string help = "Controls the contrast of the fractal.",
+        int as_max_param_id = 46
     ]],
     float in_distortion = 0.0
     [[
@@ -392,7 +421,8 @@ shader as_noise2d
         float softmax = 1.0,
         string label = "Distortion",
         string page = "Recursion",
-        string help = "Distors the domain of the coordinates for each frequency."
+        string help = "Distors the domain of the coordinates for each frequency.",
+        int as_max_param_id = 48
     ]],
 
     MAYA_UV_PARAMETERS,
@@ -401,13 +431,15 @@ shader as_noise2d
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string label = "Color"
+        string label = "Color",
+        int as_max_param_id = 53
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
         string as_maya_attribute_short_name = "oa",
-        string label = "Alpha"
+        string label = "Alpha",
+        int as_max_param_id = 53
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_noise3d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_noise3d.osl
@@ -53,14 +53,16 @@ shader as_noise3d
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Color 1",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 0
     ]],
     color in_color2 = color(1)
     [[
         string as_maya_attribute_name = "color2",
         string as_maya_attribute_short_name = "c2",
         string label = "Color 2",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 2
     ]],
     float in_contrast = 1.0
     [[
@@ -70,7 +72,8 @@ shader as_noise3d
         float min = 0.0,
         float max = 1.0,
         string label = "Contrast",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 4
     ]],
     int in_type = 0
     [[
@@ -85,7 +88,8 @@ shader as_noise3d
         string help = "Noise type used.",
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 6
     ]],
     float in_intensity = 1.0
     [[
@@ -96,7 +100,8 @@ shader as_noise3d
         float softmax = 1.0,
         string label = "Intensity",
         string help = "Global noise intensity.",
-        string page = "Noise"
+        string page = "Noise",
+        int as_max_param_id = 7
     ]],
     vector in_frequency = vector(1)
     [[
@@ -104,7 +109,8 @@ shader as_noise3d
         string as_maya_attribute_short_name = "frq",
         string label = "XYZ Frequency",
         string help = "Higher values increase the noise density.",
-        string page = "Noise"
+        string page = "Noise",
+        int as_max_param_id = 9
     ]],
     int in_ridges = 0
     [[
@@ -116,7 +122,8 @@ shader as_noise3d
         string label = "Ridges",
         string page = "Noise",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 11
     ]],
     int in_inflection = 0
     [[
@@ -129,7 +136,8 @@ shader as_noise3d
         string page = "Noise",
         string help = "Uses the absolute value of the noise.",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 12
     ]],
     int in_signed_noise = 0
     [[
@@ -142,7 +150,8 @@ shader as_noise3d
         string page = "Noise",
         string help = "Noise range in [0,1] or [-1,1].",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 13
     ]],
     // to be removed
     int in_animated_noise = 0
@@ -166,7 +175,8 @@ shader as_noise3d
         float softmax = 1.0,
         string label = "Frame Time",
         string page = "Noise.Motion",
-        string help = "Frame time, typically frame number."
+        string help = "Frame time, typically frame number.",
+        int as_max_param_id = 14
     ]],
     float in_time_scale = 0.0
     [[
@@ -176,7 +186,8 @@ shader as_noise3d
         float softmax = 1.0,
         string label = "Time Scale",
         string page = "Noise.Motion",
-        string help = "Global time scale, affects frame time."
+        string help = "Global time scale, affects frame time.",
+        int as_max_param_id = 16
     ]],
     int in_periodic = 0
     [[
@@ -189,14 +200,16 @@ shader as_noise3d
         string page = "Noise.Periodic",
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 18
     ]],
     vector in_period = vector(4)
     [[
         string as_maya_attribute_name = "period",
         string as_maya_attribute_short_name = "prd",
         string label = "Period",
-        string page = "Noise.Periodic"
+        string page = "Noise.Periodic",
+        int as_max_param_id = 19
     ]],
     float in_period_time = 4.0
     [[
@@ -205,7 +218,8 @@ shader as_noise3d
         float min = 0.0,
         float softmax = 16.0,
         string label = "Time Period",
-        string page = "Noise.Periodic"
+        string page = "Noise.Periodic",
+        int as_max_param_id = 21
     ]],
     float in_smoothness = 0.0
     [[
@@ -214,7 +228,8 @@ shader as_noise3d
         float min = 0.0,
         float max = 1.0,
         string label = "Smoothness",
-        string page = "Noise.Voronoise"
+        string page = "Noise.Voronoise",
+        int as_max_param_id = 23
     ]],
     float in_jittering = 0.0
     [[
@@ -223,7 +238,8 @@ shader as_noise3d
         float min = 0.0,
         float max = 1.0,
         string label = "Jittering",
-        string page = "Noise.Voronoise"
+        string page = "Noise.Voronoise",
+        int as_max_param_id = 25
     ]],
     int in_anisotropy = 0
     [[
@@ -237,14 +253,16 @@ shader as_noise3d
         string page = "Noise.Gabor",
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 27
     ]],
     vector in_direction = vector(1,0,0)
     [[
         string as_maya_attribute_name = "direction",
         string as_maya_attribute_short_name = "dir",
         string label = "Anisotropy Vector",
-        string page = "Noise.Gabor"
+        string page = "Noise.Gabor",
+        int as_max_param_id = 28
     ]],
     float in_bandwidth = 1.0
     [[
@@ -253,7 +271,8 @@ shader as_noise3d
         float min = 0.0,
         float softmax = 1.0,
         string label = "Bandwidth",
-        string page = "Noise.Gabor"
+        string page = "Noise.Gabor",
+        int as_max_param_id = 30
     ]],
     int in_impulses = 16
     [[
@@ -267,7 +286,8 @@ shader as_noise3d
         string page = "Noise.Gabor",
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 32
     ]],
     int in_filter_noise = 1
     [[
@@ -279,7 +299,8 @@ shader as_noise3d
         string label = "Filter",
         string page = "Noise.Gabor",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 33
     ]],
     float in_amplitude = 1.0
     [[
@@ -292,7 +313,8 @@ shader as_noise3d
         int slider = 0,
         string label = "Amplitude",
         string page = "Recursion",
-        string help = "Initial amplitude before recursion."
+        string help = "Initial amplitude before recursion.",
+        int as_max_param_id = 34
     ]],
     int in_octaves = 1
     [[
@@ -309,7 +331,8 @@ shader as_noise3d
         string help = "Maximum number of iterations.",
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 36
     ]],
     int in_cascade_mode = 0
     [[
@@ -324,7 +347,8 @@ shader as_noise3d
         string help = "Add sucessive frequencies, or multiply them.",
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 37
     ]],
     float in_lacunarity = 2.17
     [[
@@ -336,7 +360,8 @@ shader as_noise3d
         float softmax = 10.0,
         string label = "Lacunarity",
         string page = "Recursion",
-        string help = "Gap between successive frequencies."
+        string help = "Gap between successive frequencies.",
+        int as_max_param_id = 38
     ]],
     float in_offset = 0.0
     [[
@@ -346,7 +371,8 @@ shader as_noise3d
         float softmax = 1.0,
         string label = "Offset",
         string page = "Recursion",
-        string help = "Controls the multifractality."
+        string help = "Controls the multifractality.",
+        int as_max_param_id = 40
     ]],
     float in_noise_gain = 1.0
     [[
@@ -358,7 +384,8 @@ shader as_noise3d
         float softmax = 3.0,
         string label = "Gain",
         string page = "Recursion",
-        string help = "Controls the contrast of the fractal."
+        string help = "Controls the contrast of the fractal.",
+        int as_max_param_id = 42
     ]],
     float in_distortion = 0.0
     [[
@@ -368,20 +395,23 @@ shader as_noise3d
         float softmax = 1.0,
         string label = "Distortion",
         string page = "Recursion",
-        string help = "Distors the domain of the coordinates for each frequency."
+        string help = "Distors the domain of the coordinates for each frequency.",
+        int as_max_param_id = 44
     ]],
     point in_refPointCamera = P
     [[
         string as_maya_attribute_name = "refPointCamera",
         string as_maya_attribute_short_name = "rpc",
         string label = "Surface Point",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 46
     ]],
     matrix in_placementMatrix = matrix(1)
     [[
         string as_maya_attribute_name = "placementMatrix",
         string label = "Placement Matrix",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 47
     ]],
 
     MAYA_EFFECTS_3DTEX_PARAMETERS,
@@ -390,13 +420,15 @@ shader as_noise3d
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string label = "Color"
+        string label = "Color",
+        int as_max_param_id = 54
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
         string as_maya_attribute_short_name = "oa",
-        string label = "Alpha"
+        string label = "Alpha",
+        int as_max_param_id = 54
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_plastic.osl
+++ b/src/appleseed.shaders/src/appleseed/as_plastic.osl
@@ -47,7 +47,8 @@ shader as_plastic
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Diffuse Color",
-        string page = "Diffuse"
+        string page = "Diffuse",
+        int as_max_param_id = 0
     ]],
     float in_diffuse_weight = 1.0
     [[
@@ -56,7 +57,8 @@ shader as_plastic
         float min = 0.0,
         float max = 1.0,
         string label = "Diffuse Weight",
-        string page = "Diffuse"
+        string page = "Diffuse",
+        int as_max_param_id = 2
     ]],
     float in_scattering = 0.0
     [[
@@ -65,14 +67,16 @@ shader as_plastic
         float min = 0.0,
         float max = 1.0,
         string label = "Scattering",
-        string page = "Diffuse"
+        string page = "Diffuse",
+        int as_max_param_id = 4
     ]],
     color in_specular_color = color(0.5)
     [[
         string as_maya_attribute_name = "specularColor",
         string as_maya_attribute_short_name = "scc",
         string label = "Specular Color",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 6
     ]],
     float in_specular_weight = 1.0
     [[
@@ -82,7 +86,8 @@ shader as_plastic
         float max = 1.0,
         string label = "Specular Weight",
         string page = "Specular",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 8
     ]],
     float in_ior = 1.5
     [[
@@ -92,7 +97,8 @@ shader as_plastic
         float max = 2.5,
         string label = "IOR",
         string page = "Specular",
-        string help = "Index of refraction."
+        string help = "Index of refraction.",
+        int as_max_param_id = 10
     ]],
     int in_distribution = 0
     [[
@@ -107,7 +113,8 @@ shader as_plastic
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 12
     ]],
     float in_specular_roughness = 0.2
     [[
@@ -116,7 +123,8 @@ shader as_plastic
         float min = 0.0,
         float max = 1.0,
         string label = "Specular Roughness",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 13
     ]],
     float in_specular_spread = 0.25
     [[
@@ -126,21 +134,24 @@ shader as_plastic
         float max = 1.0,
         string label = "Specular Spread",
         string page = "Specular",
-        string help = "Specular highlights spread, only valid for GTR, Student's t-MDF."
+        string help = "Specular highlights spread, only valid for GTR, Student's t-MDF.",
+        int as_max_param_id = 15
     ]],
     normal in_bump_normal = N
     [[
         string as_maya_attribute_name = "normalCamera",
         string as_maya_attribute_short_name = "n",
         string label = "Bump Normal",
-        string page = "Bump"
+        string page = "Bump",
+        int as_max_param_id = 17
     ]],
     color in_transparency = color(0)
     [[
         string as_maya_attribute_name = "transparency",
         string as_maya_attribute_short_name = "it",
         string label = "Transparency Color",
-        string page = "Transparency"
+        string page = "Transparency",
+        int as_max_param_id = 18
     ]],
     int in_enable_matte = 0
     [[
@@ -154,7 +165,8 @@ shader as_plastic
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 20
     ]],
     float in_matte_opacity = 0.0
     [[
@@ -164,7 +176,8 @@ shader as_plastic
         float max = 1.0,
         string label = "Matte Opacity",
         string page = "Matte Opacity",
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 21
     ]],
     color in_matte_opacity_color = color(1,0.5,0)
     [[
@@ -172,7 +185,8 @@ shader as_plastic
         string as_maya_attribute_short_name = "mac",
         string label = "Matte Opacity Color",
         string page = "Matte Opacity",
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 23
     ]],
     int in_maximum_ray_depth = 100
     [[
@@ -187,20 +201,23 @@ shader as_plastic
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 25
     ]],
 
     output closure color out_outColor = 0
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 26
     ]],
     output closure color out_outTransparency = 0
     [[
         string as_maya_attribute_name = "outTransparency",
         string as_maya_attribute_short_name = "ot",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 26
     ]],
     output closure color out_outMatteOpacity = 0
     [[
@@ -209,7 +226,8 @@ shader as_plastic
         string widget = "null",
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 26
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_ray_switch.osl
+++ b/src/appleseed.shaders/src/appleseed/as_ray_switch.osl
@@ -47,63 +47,72 @@ shader as_ray_switch
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Camera Ray Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 0
     ]],
     color in_color_light = color(0)
     [[
         string as_maya_attribute_name = "colorLight",
         string as_maya_attribute_short_name = "cli",
         string label = "Light Ray Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 2
     ]],
     color in_color_shadow = color(0)
     [[
         string as_maya_attribute_name = "colorShadow",
         string as_maya_attribute_short_name = "csh",
         string label = "Shadow Ray Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 4
     ]],
     color in_color_transparency = color(0)
     [[
         string as_maya_attribute_name = "colorTransparency",
         string as_maya_attribute_short_name = "ctr",
         string label = "Transparency Ray Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 6
     ]],
     color in_color_diffuse = color(0)
     [[
         string as_maya_attribute_name = "colorDiffuse",
         string as_maya_attribute_short_name = "cde",
         string label = "Diffuse Ray Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 8
     ]],
     color in_color_glossy = color(0)
     [[
         string as_maya_attribute_name = "colorGlossy",
         string as_maya_attribute_short_name = "cgl",
         string label = "Glossy Ray Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 10
     ]],
     color in_color_specular = color(0)
     [[
         string as_maya_attribute_name = "colorSpecular",
         string as_maya_attribute_short_name = "csp",
         string label = "Specular Ray Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 12
     ]],
     color in_color_subsurface = color(0)
     [[
         string as_maya_attribute_name = "colorSubsurface",
         string as_maya_attribute_short_name = "csu",
         string label = "Subsurface Ray Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 14
     ]],
 
     output color out_color = color(0)
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string label = "Output Color"
+        string label = "Output Color",
+        int as_max_param_id = 16
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_sbs_pbrmaterial.osl
+++ b/src/appleseed.shaders/src/appleseed/as_sbs_pbrmaterial.osl
@@ -52,7 +52,8 @@ shader as_sbs_pbrmaterial
         float max = 1.0,
         string label = "Ambient Occlusion",
         string page = "Ambient Occlusion",
-        string help = "Ambient occlusion channel texture from Substance Painter."
+        string help = "Ambient occlusion channel texture from Substance Painter.",
+        int as_max_param_id = 0
         // Default linear-encoded by SBS
     ]],
     color in_baseColor = color(0.5)
@@ -61,7 +62,8 @@ shader as_sbs_pbrmaterial
         string as_maya_attribute_short_name = "c",
         string label = "Surface Color",
         string page = "Base Color",
-        string help = "Diffuse base color or surface color channel."
+        string help = "Diffuse base color or surface color channel.",
+        int as_max_param_id = 2
         // Default sRGB encoded by SBS
     ]],
     color in_emissiveColor = color(0)
@@ -71,6 +73,7 @@ shader as_sbs_pbrmaterial
         string label = "Emissive Color",
         string page = "Emissive",
         string help = "Emissive channel",
+        int as_max_param_id = 4
         // Default sRGB encoded by SBS
     ]],
     float in_emissiveIntensity = 1.0
@@ -82,7 +85,8 @@ shader as_sbs_pbrmaterial
         float max = 10.0,
         string label = "Emissive Intensity",
         string page = "Emissive",
-        string help = "Controls how much light is emitted from the surface."
+        string help = "Controls how much light is emitted from the surface.",
+        int as_max_param_id = 6
     ]],
     float in_height = 0.5
     [[
@@ -92,7 +96,8 @@ shader as_sbs_pbrmaterial
         float softmax = 1.0,
         string label = "Height",
         string page = "Height",
-        string help = "Height channel."
+        string help = "Height channel.",
+        int as_max_param_id = 8
         // hidden
         // linear-encoded
     ]],
@@ -104,7 +109,8 @@ shader as_sbs_pbrmaterial
         float max = 1.0,
         string label = "Scale",
         string page = "Height",
-        string help = "A scaling factor for the height bump mapping."
+        string help = "A scaling factor for the height bump mapping.",
+        int as_max_param_id = 10
         // linear encoded
     ]],
     float in_metallic = 0.0
@@ -115,7 +121,8 @@ shader as_sbs_pbrmaterial
         float max = 1.0,
         string label = "Metallic",
         string page = "Metallic",
-        string help = "Metallicness channel."
+        string help = "Metallicness channel.",
+        int as_max_param_id = 12
         // linear encoded
     ]],
     normal in_normal = N
@@ -124,7 +131,8 @@ shader as_sbs_pbrmaterial
         string as_maya_attribute_short_name = "n",
         string label = "Normal",
         string page = "Normal",
-        string help = "Normal channel"
+        string help = "Normal channel",
+        int as_max_param_id = 13
         // linear encoded
     ]],
     float in_roughness = 0.5
@@ -135,7 +143,8 @@ shader as_sbs_pbrmaterial
         float max = 1.0,
         string label = "Roughness",
         string page = "Roughness",
-        string help = "Roughness channel."
+        string help = "Roughness channel.",
+        int as_max_param_id = 15
         // linear encoded
     ]],
     float in_opacity = 1.0
@@ -146,7 +155,8 @@ shader as_sbs_pbrmaterial
         float max = 1.0,
         string label = "Opacity",
         string page = "Opacity",
-        string help = "Opacity channel"
+        string help = "Opacity channel",
+        int as_max_param_id = 17
         // linear encoded
     ]],
     float in_specularLevel = 0.5
@@ -157,7 +167,8 @@ shader as_sbs_pbrmaterial
         float max = 1.0,
         string label = "Specular Level",
         string page = "Specular",
-        string help = "Specular level channel."
+        string help = "Specular level channel.",
+        int as_max_param_id = 19
         // linear encoded
     ]],
     float in_anisotropyLevel = 0.0
@@ -168,7 +179,8 @@ shader as_sbs_pbrmaterial
         float max = 1.0,
         string label = "Anisotropy Level",
         string page = "Anisotropy",
-        string help = "Anisotropy Level channel"
+        string help = "Anisotropy Level channel",
+        int as_max_param_id = 21
         // linear encoded
     ]],
     float in_anisotropyAngle = 0.0
@@ -179,7 +191,8 @@ shader as_sbs_pbrmaterial
         float max = 1.0,
         string label = "Anisotropy Angle",
         string page = "Anisotropy",
-        string help = "Anisotropy Angle channel, where 1 = 360 degrees."
+        string help = "Anisotropy Angle channel, where 1 = 360 degrees.",
+        int as_max_param_id = 23
         // see base.mdl for reference
         // linear encoded
     ]],
@@ -192,7 +205,8 @@ shader as_sbs_pbrmaterial
         string label = "Refraction",
         string page = "Refraction",
         string help = "Refraction channel",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 25
         // linear encoded
     ]],
     float in_refractionIOR = 1.5
@@ -213,7 +227,8 @@ shader as_sbs_pbrmaterial
         string label = "IOR",
         string page = "Refraction",
         string help = "Index of Refraction",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 27
     ]],
     float in_scattering = 0.0
     [[
@@ -223,7 +238,8 @@ shader as_sbs_pbrmaterial
         float max = 0.1,
         string label = "Scattering",
         string page = "Refraction",
-        string help = "Controls how much light is scattered through the surface."
+        string help = "Controls how much light is scattered through the surface.",
+        int as_max_param_id = 28
     ]],
     float in_absorption = 0.0
     [[
@@ -233,7 +249,8 @@ shader as_sbs_pbrmaterial
         float max = 1.0,
         string label = "Absorption",
         string page = "Refraction",
-        string help = "Controls how much light is absorbed through the surface."
+        string help = "Controls how much light is absorbed through the surface.",
+        int as_max_param_id = 30
     ]],
     color in_absorptionColor = color(1)
     [[
@@ -241,7 +258,8 @@ shader as_sbs_pbrmaterial
         string as_maya_attribute_short_name = "abc",
         string label = "Absorption Color",
         string page = "Refraction",
-        string help = "Simulates shifts in color when light passes through the surface."
+        string help = "Simulates shifts in color when light passes through the surface.",
+        int as_max_param_id = 32
     ]],
     int in_enable_matte = 0
     [[
@@ -255,7 +273,8 @@ shader as_sbs_pbrmaterial
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 34
     ]],
     float in_matte_opacity = 0.0
     [[
@@ -265,7 +284,8 @@ shader as_sbs_pbrmaterial
         float max = 1.0,
         string label = "Matte Opacity",
         string page = "Matte Opacity",
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 35
     ]],
     color in_matte_opacity_color = color(1,0.5,0)
     [[
@@ -273,7 +293,8 @@ shader as_sbs_pbrmaterial
         string as_maya_attribute_short_name = "mac",
         string label = "Matte Opacity Color",
         string page = "Matte Opacity",
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 37
     ]],
     int in_maximum_ray_depth = 100
     [[
@@ -291,7 +312,8 @@ shader as_sbs_pbrmaterial
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 39
     ]],
 
     // primvars
@@ -301,7 +323,8 @@ shader as_sbs_pbrmaterial
         int as_maya_attribute_hidden = 1,
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 40
     ]],
     vector Bn = vector(0)
     [[
@@ -309,7 +332,8 @@ shader as_sbs_pbrmaterial
         int as_maya_attribute_hidden = 1,
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 41
 
     ]],
 
@@ -318,13 +342,15 @@ shader as_sbs_pbrmaterial
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 42
     ]],
     output closure color out_outTransparency = 0
     [[
         string as_maya_attribute_name = "outTransparency",
         string as_maya_attribute_short_name = "ot",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 42
     ]],
     output closure color out_outMatteOpacity = 0
     [[
@@ -333,7 +359,8 @@ shader as_sbs_pbrmaterial
         string widget = "null",
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 42
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_space_transform.osl
+++ b/src/appleseed.shaders/src/appleseed/as_space_transform.osl
@@ -47,14 +47,16 @@ shader as_space_transform
         string as_maya_attribute_name = "point",
         string as_maya_attribute_short_name = "p",
         string label = "Point to Transform",
-        string page = "Input"
+        string page = "Input",
+        int as_max_param_id = 0
     ]],
     normal in_normal = normal(0)
     [[
         string as_maya_attribute_name = "normal",
         string as_maya_attribute_short_name = "n",
         string label = "Normal to Transform",
-        string page = "Input"
+        string page = "Input",
+        int as_max_param_id = 2
     ]],
     vector in_vector = vector(0)
     [[
@@ -62,7 +64,8 @@ shader as_space_transform
         string as_maya_attribute_short_name = "ive",
         string label = "Vector to Transform",
         string page = "Input",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 4
     ]],
     string in_from_space = "common"
     [[
@@ -76,7 +79,8 @@ shader as_space_transform
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 6
     ]],
     string in_to_space = "common"
     [[
@@ -91,7 +95,8 @@ shader as_space_transform
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 7
     ]],
     int in_normalize_vectors = 0
     [[
@@ -105,32 +110,37 @@ shader as_space_transform
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 8
     ]],
 
     output point out_transformed_point = point(0)
     [[
         string as_maya_attribute_name = "outTransformedPoint",
         string as_maya_attribute_short_name = "tpo",
-        string label = "Transformed Point"
+        string label = "Transformed Point",
+        int as_max_param_id = 9
     ]],
     output normal out_transformed_normal = normal(0)
     [[
         string as_maya_attribute_name = "outTransformedNormal",
         string as_maya_attribute_short_name = "tno",
-        string label = "Transformed Normal"
+        string label = "Transformed Normal",
+        int as_max_param_id = 9
     ]],
     output vector out_transformed_vector = vector(0)
     [[
         string as_maya_attribute_name = "outTransformedVector",
         string as_maya_attribute_short_name = "tve",
-        string label = "Transformed Vector"
+        string label = "Transformed Vector",
+        int as_max_param_id = 9
     ]],
     output matrix out_transform_matrix = matrix(1)
     [[
         string as_maya_attribute_name = "outTransformMatrix",
         string as_maya_attribute_short_name = "oma",
-        string label = "Transform Matrix"
+        string label = "Transform Matrix",
+        int as_max_param_id = 9
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
@@ -52,14 +52,16 @@ shader as_standard_surface
         float min = 0.0,
         float max = 1.0,
         string label = "Diffuse Weight",
-        string page = "Diffuse"
+        string page = "Diffuse",
+        int as_max_param_id = 0
     ]],
     color in_color = color(0.5)
     [[
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Diffuse Color",
-        string page = "Diffuse"
+        string page = "Diffuse",
+        int as_max_param_id = 2
     ]],
     float in_diffuse_roughness = 0.1
     [[
@@ -68,7 +70,8 @@ shader as_standard_surface
         float min = 0.0,
         float max = 1.0,
         string label = "Diffuse Roughness",
-        string page = "Diffuse"
+        string page = "Diffuse",
+        int as_max_param_id = 4
     ]],
     float in_subsurface_weight = 0.0
     [[
@@ -78,14 +81,16 @@ shader as_standard_surface
         float max = 1.0,
         string label = "Subsurface Weight",
         string page = "Subsurface",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 6
     ]],
     color in_sss_mfp = color(0)
     [[
         string as_maya_attribute_name = "subsurfaceMfp",
         string as_maya_attribute_short_name = "mfp",
         string label = "Depth",
-        string page = "Subsurface"
+        string page = "Subsurface",
+        int as_max_param_id = 8
     ]],
     float in_sss_mfp_scale = 1.0
     [[
@@ -100,7 +105,8 @@ shader as_standard_surface
         int as_maya_attribute_keyable = 1,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 10
     ]],
     int in_subsurface_profile = 2
     [[
@@ -115,7 +121,8 @@ shader as_standard_surface
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 11
     ]],
     int in_sss_maximum_ray_depth = 2
     [[
@@ -130,7 +137,8 @@ shader as_standard_surface
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 12
     ]],
     float in_sss_threshold = 0.001
     [[
@@ -146,7 +154,8 @@ shader as_standard_surface
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 13
     ]],
     float in_translucency_weight = 0.0
     [[
@@ -155,21 +164,24 @@ shader as_standard_surface
         float min = 0.0,
         float max = 1.0,
         string label = "Translucency Weight",
-        string page = "Translucency"
+        string page = "Translucency",
+        int as_max_param_id = 14
     ]],
     color in_translucency_color = color(0.0)
     [[
         string as_maya_attribute_name = "translucencyColor",
         string as_maya_attribute_short_name = "trc",
         string label = "Translucency Color",
-        string page = "Translucency"
+        string page = "Translucency",
+        int as_max_param_id = 16
     ]],
     color in_specular_color = color(1)
     [[
         string as_maya_attribute_name = "specularColor",
         string as_maya_attribute_short_name = "spc",
         string label = "Specular Color",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 18
     ]],
     float in_specular_roughness = 0.1
     [[
@@ -178,7 +190,8 @@ shader as_standard_surface
         float min = 0.0,
         float max = 1.0,
         string label = "Specular Roughness",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 20
     ]],
     float in_specular_spread = 0.25
     [[
@@ -189,7 +202,8 @@ shader as_standard_surface
         string label = "Specular Spread",
         string page = "Specular",
         string help = "Specular spread, controls the tails of the highlights.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 22
     ]],
     int in_fresnel_type = 0
     [[
@@ -205,7 +219,8 @@ shader as_standard_surface
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 24
     ]],
     float in_ior = 1.37
     [[
@@ -221,7 +236,8 @@ shader as_standard_surface
         int as_maya_attribute_keyable = 1,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 25
     ]],
     color in_face_tint = color(0.85, 0.21, 0.05)
     [[
@@ -234,7 +250,8 @@ shader as_standard_surface
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 26
     ]],
     color in_edge_tint = color(1)
     [[
@@ -248,7 +265,8 @@ shader as_standard_surface
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 27
     ]],
     float in_anisotropy_amount = 0.0
     [[
@@ -257,7 +275,8 @@ shader as_standard_surface
         float min = 0.0,
         float max = 1.0,
         string label = "Anisotropy Amount",
-        string page = "Specular.Anisotropy"
+        string page = "Specular.Anisotropy",
+        int as_max_param_id = 28
     ]],
     float in_anisotropy_angle = 0.0
     [[
@@ -267,7 +286,8 @@ shader as_standard_surface
         float max = 1.0,
         string label = "Anisotropy Angle",
         string page = "Specular.Anisotropy",
-        string help = "Anisotropy angle in [0,1], mapping to [0,360] degrees."
+        string help = "Anisotropy angle in [0,1], mapping to [0,360] degrees.",
+        int as_max_param_id = 30
     ]],
     color in_anisotropy_map = color(0)
     [[
@@ -275,7 +295,8 @@ shader as_standard_surface
         string as_maya_attribute_short_name = "ama",
         string label = "Anisotropy Vector Map",
         string page = "Specular.Anisotropy",
-        string help = "Anisotropy vector map, with XY encoded in RG channels."
+        string help = "Anisotropy vector map, with XY encoded in RG channels.",
+        int as_max_param_id = 32
     ]],
     float in_refraction_amount = 0.0
     [[
@@ -285,7 +306,8 @@ shader as_standard_surface
         float max = 1.0,
         string label = "Refraction Weight",
         string page = "Specular.Refraction",
-        string help = "Refraction weight. Refraction inherits the IOR."
+        string help = "Refraction weight. Refraction inherits the IOR.",
+        int as_max_param_id = 34
     ]],
     color in_refraction_tint = color(1)
     [[
@@ -293,7 +315,8 @@ shader as_standard_surface
         string as_maya_attribute_short_name = "rti",
         string label = "Refraction Tint",
         string page = "Specular.Refraction",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 36
     ]],
     float in_absorption_depth = 0.0
     [[
@@ -308,14 +331,16 @@ shader as_standard_surface
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 38
     ]],
     color in_absorption_color = color(1)
     [[
         string as_maya_attribute_name = "absorptionColor",
         string as_maya_attribute_short_name = "rac",
         string label = "Absorption Color",
-        string page = "Specular.Refraction"
+        string page = "Specular.Refraction",
+        int as_max_param_id = 39
     ]],
     float in_coating_reflectivity = 0.0
     [[
@@ -325,7 +350,8 @@ shader as_standard_surface
         float max = 1.0,
         string label = "Coating Reflectivity",
         string page = "Coating",
-        string help = "Coating specular reflectivity."
+        string help = "Coating specular reflectivity.",
+        int as_max_param_id = 41
     ]],
     float in_coating_roughness = 0.0
     [[
@@ -334,7 +360,8 @@ shader as_standard_surface
         float min = 0.0,
         float max = 1.0,
         string label = "Coating Roughness",
-        string page = "Coating"
+        string page = "Coating",
+        int as_max_param_id = 43
     ]],
     float in_coating_ior = 1.42
     [[
@@ -351,7 +378,8 @@ shader as_standard_surface
         int as_maya_attribute_keyable = 1,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 45
     ]],
     float in_coating_depth = 0.0
     [[
@@ -362,14 +390,16 @@ shader as_standard_surface
         float softmax = 1.0,
         string label = "Coating Thickness",
         string page = "Coating",
-        string help = "Maps from [0,1] to [0,10] microns."
+        string help = "Maps from [0,1] to [0,10] microns.",
+        int as_max_param_id = 46
     ]],
     color in_coating_absorption = color(1)
     [[
         string as_maya_attribute_name = "coatingAbsorption",
         string as_maya_attribute_short_name = "coa",
         string label = "Coating Absorption",
-        string page = "Coating"
+        string page = "Coating",
+        int as_max_param_id = 48
     ]],
     float in_incandescence_amount = 0.0
     [[
@@ -378,7 +408,8 @@ shader as_standard_surface
         float min = 0.0,
         float softmax = 1.0,
         string label = "Emission Amount",
-        string page = "Emission"
+        string page = "Emission",
+        int as_max_param_id = 50
     ]],
     int in_incandescence_type = 0
     [[
@@ -394,7 +425,8 @@ shader as_standard_surface
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 52
     ]],
     color in_incandescence_color = color(0)
     [[
@@ -402,7 +434,8 @@ shader as_standard_surface
         string as_maya_attribute_short_name = "inc",
         string label = "Emission Color",
         string page = "Emission",
-        string help = "Emission color, only valid in constant mode."
+        string help = "Emission color, only valid in constant mode.",
+        int as_max_param_id = 53
     ]],
     int in_temperature = 4300
     [[
@@ -420,7 +453,8 @@ shader as_standard_surface
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 55
     ]],
 
     int in_area_normalize_edf = 0
@@ -434,7 +468,8 @@ shader as_standard_surface
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 56
     ]],
     int in_tonemap_edf = 1
     [[
@@ -448,14 +483,16 @@ shader as_standard_surface
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 57
     ]],
     color in_transparency = color(0)
     [[
         string as_maya_attribute_name = "transparency",
         string as_maya_attribute_short_name = "it",
         string label = "Transparency Color",
-        string page = "Transparency"
+        string page = "Transparency",
+        int as_max_param_id = 58
     ]],
     normal in_bump_normal_coating = N
     [[
@@ -463,7 +500,8 @@ shader as_standard_surface
         string as_maya_attribute_short_name = "ncn",
         string label = "Coating Normal",
         string page = "Bump",
-        string help = "The coating normal. If not set, the substrate normal is used for both layers."
+        string help = "The coating normal. If not set, the substrate normal is used for both layers.",
+        int as_max_param_id = 60
     ]],
     normal in_bump_normal_substrate = N
     [[
@@ -471,7 +509,8 @@ shader as_standard_surface
         string as_maya_attribute_short_name = "n",
         string label = "Substrate Normal",
         string page = "Bump",
-        string help = "The default bump normal."
+        string help = "The default bump normal.",
+        int as_max_param_id = 61
     ]],
     int in_enable_matte = 0
     [[
@@ -485,7 +524,8 @@ shader as_standard_surface
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 62
     ]],
     float in_matte_opacity = 0.0
     [[
@@ -496,7 +536,8 @@ shader as_standard_surface
         string label = "Matte Opacity",
         string page = "Matte Opacity",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 63
     ]],
     color in_matte_opacity_color = color(1,0.5,0)
     [[
@@ -505,7 +546,8 @@ shader as_standard_surface
         string label = "Matte Opacity Color",
         string page = "Matte Opacity",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 65
     ]],
     int in_maximum_ray_depth = 100
     [[
@@ -520,7 +562,8 @@ shader as_standard_surface
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 67
     ]],
     vector Tn = vector(0)
     [[
@@ -528,7 +571,8 @@ shader as_standard_surface
         int as_maya_attribute_hidden = 1,
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 68
     ]],
     vector Bn = vector(0)
     [[
@@ -536,19 +580,22 @@ shader as_standard_surface
         int as_maya_attribute_hidden = 1,
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 69
     ]],
     output closure color out_outColor = 0
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 70
     ]],
     output closure color out_outTransparency = 0
     [[
         string as_maya_attribute_name = "outTransparency",
         string as_maya_attribute_short_name = "ot",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 70
     ]],
     output closure color out_outMatteOpacity = 0
     [[
@@ -557,7 +604,8 @@ shader as_standard_surface
         string widget = "null",
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 70
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_subsurface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_subsurface.osl
@@ -57,14 +57,16 @@ shader as_subsurface
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 0
     ]],
     color in_color = color(0.87, 0.31, 0.12)
     [[
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Reflectance",
-        string page = "Subsurface"
+        string page = "Subsurface",
+        int as_max_param_id = 1
     ]],
     float in_sss_amount = 1.0
     [[
@@ -74,14 +76,16 @@ shader as_subsurface
         float max = 1.0,
         string label = "Subsurface Weight",
         string page = "Subsurface",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 3
     ]],
     color in_sss_mfp = color(0.13, 0.69, 0.88)
     [[
         string as_maya_attribute_name = "meanFreePath",
         string as_maya_attribute_short_name = "mfp",
         string label = "Depth",
-        string page = "Subsurface"
+        string page = "Subsurface",
+        int as_max_param_id = 5
     ]],
     float in_sss_mfp_scale = 1.0
     [[
@@ -90,7 +94,8 @@ shader as_subsurface
         float min = 0.0,
         float softmax = 1.0,
         string label = "Depth Scale",
-        string page = "Subsurface"
+        string page = "Subsurface",
+        int as_max_param_id = 7
     ]],
     int in_sss_maximum_ray_depth = 8
     [[
@@ -106,7 +111,8 @@ shader as_subsurface
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 9
     ]],
     float in_ior = 1.41
     [[
@@ -115,7 +121,8 @@ shader as_subsurface
         float min = 1.0,
         float softmax = 3.0,
         string label = "Index of Refraction",
-        string page = "Fresnel"
+        string page = "Fresnel",
+        int as_max_param_id = 10
     ]],
     float in_fresnel_weight = 1.0
     [[
@@ -125,7 +132,8 @@ shader as_subsurface
         float max = 1.0,
         string label = "Fresnel Weight",
         string page = "Fresnel.Advanced",
-        string help = "A value of 0.0 disables scaling the subsurface scattering term by the Fresnel. It should match the specular weight ideally."
+        string help = "A value of 0.0 disables scaling the subsurface scattering term by the Fresnel. It should match the specular weight ideally.",
+        int as_max_param_id = 12
     ]],
     float in_specular_weight = 1.0
     [[
@@ -134,7 +142,8 @@ shader as_subsurface
         float min = 0.0,
         float max = 1.0,
         string label = "Specular Weight",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 14
     ]],
     float in_specular_roughness = 0.3
     [[
@@ -143,7 +152,8 @@ shader as_subsurface
         float min = 0.0,
         float max = 1.0,
         string label = "Specular Roughness",
-        string page = "Specular"
+        string page = "Specular",
+        int as_max_param_id = 16
     ]],
     float in_anisotropy_amount = 0.0
     [[
@@ -152,7 +162,8 @@ shader as_subsurface
         float min = 0.0,
         float max = 1.0,
         string label = "Anisotropy Amount",
-        string page = "Specular.Anisotropy"
+        string page = "Specular.Anisotropy",
+        int as_max_param_id = 18
     ]],
     float in_anisotropy_angle = 0.0
     [[
@@ -163,7 +174,8 @@ shader as_subsurface
         string label = "Anisotropy Angle",
         string page = "Specular.Anisotropy",
         string help = "Anisotropy angle in [0,1], mapping to [0,360] degrees.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 20
     ]],
     int in_anisotropy_mode = 0
     [[
@@ -179,7 +191,8 @@ shader as_subsurface
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 22
     ]],
     color in_anisotropy_map = color(0)
     [[
@@ -188,7 +201,8 @@ shader as_subsurface
         string label = "Anisotropy Vector Map",
         string page = "Specular.Anisotropy",
         string help = "Anisotropy vector map, with XY encoded in RG channels.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 23
     ]],
     vector in_anisotropy_direction = vector(0)
     [[
@@ -196,7 +210,8 @@ shader as_subsurface
         string as_maya_attribute_short_name = "and",
         string label = "Anisotropy Vector",
         string page = "Specular.Anisotropy",
-        string help = "Explicit anisotropy vector, such as the vector output by a tangent field node."
+        string help = "Explicit anisotropy vector, such as the vector output by a tangent field node.",
+        int as_max_param_id = 25
     ]],
     normal in_bump_normal = N
     [[
@@ -204,7 +219,8 @@ shader as_subsurface
         string as_maya_attribute_short_name = "n",
         string label = "Bump Normal",
         string page = "Bump",
-        string help = "The default bump normal."
+        string help = "The default bump normal.",
+        int as_max_param_id = 27
     ]],
     int in_enable_matte = 0
     [[
@@ -218,7 +234,8 @@ shader as_subsurface
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 28
     ]],
     float in_matte_opacity = 0.0
     [[
@@ -229,7 +246,8 @@ shader as_subsurface
         string label = "Matte Opacity",
         string page = "Matte Opacity",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 29
     ]],
     color in_matte_opacity_color = color(1,0.5,0)
     [[
@@ -238,7 +256,8 @@ shader as_subsurface
         string label = "Matte Opacity Color",
         string page = "Matte Opacity",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 31
     ]],
     vector Tn = vector(0)
     [[
@@ -246,7 +265,8 @@ shader as_subsurface
         int as_maya_attribute_hidden = 1,
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 33
     ]],
     vector Bn = vector(0)
     [[
@@ -254,7 +274,8 @@ shader as_subsurface
         int as_maya_attribute_hidden = 1,
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 34
     ]],
 
     output closure color out_outColor = 0
@@ -262,7 +283,8 @@ shader as_subsurface
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
         string widget = "null",
-        string label = "Output Color"
+        string label = "Output Color",
+        int as_max_param_id = 35
     ]],
     output closure color out_outMatteOpacity = 0
     [[
@@ -272,7 +294,8 @@ shader as_subsurface
         string label = "Output Matte",
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 35
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_switch_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_switch_surface.osl
@@ -49,49 +49,56 @@ shader as_switch_surface
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Input Surface 0",
-        string page = "Surface"
+        string page = "Surface",
+        int as_max_param_id = 0
     ]],
     closure color in_color1 = 0
     [[
         string as_maya_attribute_name = "color1",
         string as_maya_attribute_short_name = "c1",
         string label = "Input Surface 1",
-        string page = "Surface"
+        string page = "Surface",
+        int as_max_param_id = 1
     ]],
     closure color in_color2 = 0
     [[
         string as_maya_attribute_name = "color2",
         string as_maya_attribute_short_name = "c2",
         string label = "Input Surface 2",
-        string page = "Surface"
+        string page = "Surface",
+        int as_max_param_id = 2
     ]],
     closure color in_color3 = 0
     [[
         string as_maya_attribute_name = "color3",
         string as_maya_attribute_short_name = "c3",
         string label = "Input Surface 3",
-        string page = "Surface"
+        string page = "Surface",
+        int as_max_param_id = 3
     ]],
     closure color in_color4 = 0
     [[
         string as_maya_attribute_name = "color4",
         string as_maya_attribute_short_name = "c4",
         string label = "Input Surface 4",
-        string page = "Surface"
+        string page = "Surface",
+        int as_max_param_id = 4
     ]],
     closure color in_color5 = 0
     [[
         string as_maya_attribute_name = "color5",
         string as_maya_attribute_short_name = "c5",
         string label = "Input Surface 5",
-        string page = "Surface"
+        string page = "Surface",
+        int as_max_param_id = 5
     ]],
     closure color in_color6 = 0
     [[
         string as_maya_attribute_name = "color6",
         string as_maya_attribute_short_name = "c6",
         string label = "Input Surface 6",
-        string page = "Surface"
+        string page = "Surface",
+        int as_max_param_id = 6
     ]],
     closure color in_color7 = 0
     [[
@@ -99,7 +106,8 @@ shader as_switch_surface
         string as_maya_attribute_short_name = "c7",
         string label = "Input Surface 7",
         string page = "Surface",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 7
     ]],
     int in_cycle_mode = 0
     [[
@@ -114,7 +122,8 @@ shader as_switch_surface
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 8
     ]],
     int in_connected_slots_only = 1
     [[
@@ -128,7 +137,8 @@ shader as_switch_surface
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "If on (default), restricts the variation to inputs which have upstream connections only. If off uses all inputs, even if they contain nothing."
+        string help = "If on (default), restricts the variation to inputs which have upstream connections only. If off uses all inputs, even if they contain nothing.",
+        int as_max_param_id = 9
     ]],
     int in_manifold_type = 0
     [[
@@ -143,7 +153,8 @@ shader as_switch_surface
         int gafferNoduleLayoutVisible = 0,
         string label = "Type",
         string page = "Manifold",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 10
     ]],
     string in_expression = ""
     [[
@@ -157,7 +168,8 @@ shader as_switch_surface
         int gafferNoduleLayoutVisible = 0,
         string label = "Expression",
         string page = "Manifold.String",
-        string help = "String expression to search in the object or object instance name."
+        string help = "String expression to search in the object or object instance name.",
+        int as_max_param_id = 11
     ]],
     int in_domain = 0
     [[
@@ -172,7 +184,8 @@ shader as_switch_surface
         int gafferNoduleLayoutVisible = 0,
         string label = "Domain",
         string page = "Manifold.String",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 12
     ]],
     int in_seed = 0xcafe
     [[
@@ -186,7 +199,8 @@ shader as_switch_surface
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 1,
         string label = "Seed",
-        string page = "Manifold.String"
+        string page = "Manifold.String",
+        int as_max_param_id = 13
     ]],
 
     output closure color out_outColor = 0
@@ -194,7 +208,8 @@ shader as_switch_surface
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
         string widget = "null",
-        string label = "Output Color"
+        string label = "Output Color",
+        int as_max_param_id = 14
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_switch_texture.osl
+++ b/src/appleseed.shaders/src/appleseed/as_switch_texture.osl
@@ -49,49 +49,56 @@ shader as_switch_texture
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Input Color 0",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 0
     ]],
     color in_color1 = color(0)
     [[
         string as_maya_attribute_name = "color1",
         string as_maya_attribute_short_name = "c1",
         string label = "Input Color 1",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 2
     ]],
     color in_color2 = color(0)
     [[
         string as_maya_attribute_name = "color2",
         string as_maya_attribute_short_name = "c2",
         string label = "Input Color 2",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 4
     ]],
     color in_color3 = color(0)
     [[
         string as_maya_attribute_name = "color3",
         string as_maya_attribute_short_name = "c3",
         string label = "Input Color 3",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 6
     ]],
     color in_color4 = color(0)
     [[
         string as_maya_attribute_name = "color4",
         string as_maya_attribute_short_name = "c4",
         string label = "Input Color 4",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 8
     ]],
     color in_color5 = color(0)
     [[
         string as_maya_attribute_name = "color5",
         string as_maya_attribute_short_name = "c5",
         string label = "Input Color 5",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 10
     ]],
     color in_color6 = color(0)
     [[
         string as_maya_attribute_name = "color6",
         string as_maya_attribute_short_name = "c6",
         string label = "Input Color 6",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 12
     ]],
     color in_color7 = color(0)
     [[
@@ -99,7 +106,8 @@ shader as_switch_texture
         string as_maya_attribute_short_name = "c7",
         string label = "Input Color 7",
         string page = "Color",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 14
     ]],
     int in_cycle_mode = 0
     [[
@@ -113,7 +121,8 @@ shader as_switch_texture
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 16
     ]],
     int in_manifold_type = 0
     [[
@@ -128,7 +137,8 @@ shader as_switch_texture
         int gafferNoduleLayoutVisible = 0,
         string label = "Type",
         string page = "Manifold",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 17
     ]],
     string in_expression = ""
     [[
@@ -142,7 +152,8 @@ shader as_switch_texture
         int gafferNoduleLayoutVisible = 0,
         string label = "Expression",
         string page = "Manifold.String",
-        string help = "String expression to search in the object or object instance name."
+        string help = "String expression to search in the object or object instance name.",
+        int as_max_param_id = 18
     ]],
     int in_domain = 0
     [[
@@ -157,7 +168,8 @@ shader as_switch_texture
         int gafferNoduleLayoutVisible = 0,
         string label = "Domain",
         string page = "Manifold.String",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 19
     ]],
     int in_seed = 0xcafe
     [[
@@ -171,7 +183,8 @@ shader as_switch_texture
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 1,
         string label = "Seed",
-        string page = "Manifold.String"
+        string page = "Manifold.String",
+        int as_max_param_id = 20
     ]],
 
     output color out_outColor = color(0)
@@ -179,7 +192,8 @@ shader as_switch_texture
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
         string widget = "null",
-        string label = "Output Color"
+        string label = "Output Color",
+        int as_max_param_id = 21
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_swizzle.osl
+++ b/src/appleseed.shaders/src/appleseed/as_swizzle.osl
@@ -47,7 +47,8 @@ shader as_swizzle
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Color",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 0
     ]],
     float in_alpha = 1.0
     [[
@@ -55,7 +56,8 @@ shader as_swizzle
         string as_maya_attribute_short_name = "a",
         string label = "Alpha Channel",
         string page = "Color",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 2
     ]],
     int in_red_channel = 0
     [[
@@ -68,7 +70,8 @@ shader as_swizzle
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0,
         string label = "Red Channel",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 4
     ]],
     int in_green_channel = 1
     [[
@@ -81,7 +84,8 @@ shader as_swizzle
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0,
         string label = "Green Channel",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 5
     ]],
     int in_blue_channel = 2
     [[
@@ -94,7 +98,8 @@ shader as_swizzle
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0,
         string label = "Blue Channel",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 6
     ]],
     int in_alpha_channel = 3
     [[
@@ -108,7 +113,8 @@ shader as_swizzle
         int gafferNoduleLayoutVisible = 0,
         string label = "Alpha Channel",
         string page = "Color",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 7
     ]],
     int in_invert_red = 0
     [[
@@ -120,7 +126,8 @@ shader as_swizzle
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0,
         string label = "Invert Red",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 8
     ]],
     int in_invert_green = 0
     [[
@@ -132,7 +139,8 @@ shader as_swizzle
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0,
         string label = "Invert Green",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 9
     ]],
     int in_invert_blue = 0
     [[
@@ -144,7 +152,8 @@ shader as_swizzle
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0,
         string label = "Invert Blue",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 10
     ]],
     int in_invert_alpha = 0
     [[
@@ -156,7 +165,8 @@ shader as_swizzle
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0,
         string label = "Invert Alpha",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 11
     ]],
     vector in_vector = vector(0)
     [[
@@ -164,7 +174,8 @@ shader as_swizzle
         string as_maya_attribute_short_name = "vec",
         string label = "Vector Type",
         string page = "Vector",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 12
     ]],
     int in_x_channel = 0
     [[
@@ -177,7 +188,8 @@ shader as_swizzle
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0,
         string label = "X Component",
-        string page = "Vector"
+        string page = "Vector",
+        int as_max_param_id = 14
     ]],
     int in_y_channel = 1
     [[
@@ -190,7 +202,8 @@ shader as_swizzle
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0,
         string label = "Y Component",
-        string page = "Vector"
+        string page = "Vector",
+        int as_max_param_id = 15
     ]],
     int in_z_channel = 2
     [[
@@ -204,7 +217,8 @@ shader as_swizzle
         int gafferNoduleLayoutVisible = 0,
         string label = "Z Component",
         string page = "Vector",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 16
     ]],
     int in_invert_x = 0
     [[
@@ -216,7 +230,8 @@ shader as_swizzle
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0,
         string label = "Invert X",
-        string page = "Vector"
+        string page = "Vector",
+        int as_max_param_id = 17
     ]],
     int in_invert_y = 0
     [[
@@ -228,7 +243,8 @@ shader as_swizzle
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0,
         string label = "Invert Y",
-        string page = "Vector"
+        string page = "Vector",
+        int as_max_param_id = 18
     ]],
     int in_invert_z = 0
     [[
@@ -240,26 +256,30 @@ shader as_swizzle
         int as_maya_attribute_hidden = 1,
         int gafferNoduleLayoutVisible = 0,
         string label = "Invert Z",
-        string page = "Vector"
+        string page = "Vector",
+        int as_max_param_id = 19
     ]],
 
     output color out_color = color(0)
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string label = "Output Color"
+        string label = "Output Color",
+        int as_max_param_id = 20
     ]],
     output float out_alpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
         string as_maya_attribute_short_name = "oa",
-        string label = "Output Alpha"
+        string label = "Output Alpha",
+        int as_max_param_id = 20
     ]],
     output vector out_vector = vector(0)
     [[
         string as_maya_attribute_name = "outVector",
         string as_maya_attribute_short_name = "ov",
-        string label = "Output Vector"
+        string label = "Output Vector",
+        int as_max_param_id = 20
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_texture.osl
+++ b/src/appleseed.shaders/src/appleseed/as_texture.osl
@@ -60,7 +60,8 @@ shader as_texture
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 0
     ]],
     int in_atlas_type = 0
     [[
@@ -76,7 +77,8 @@ shader as_texture
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 1
     ]],
     color in_color = color(0)
     [[
@@ -84,7 +86,8 @@ shader as_texture
         string as_maya_attribute_short_name = "c",
         string label = "Default Color",
         string page = "Texture",
-        string help = "Default Fill color to use if the texture lookup fails."
+        string help = "Default Fill color to use if the texture lookup fails.",
+        int as_max_param_id = 2
     ]],
     float in_alpha = 1.0
     [[
@@ -95,6 +98,7 @@ shader as_texture
         string label = "Default Alpha",
         string page = "Texture",
         string help = "Default Fill alpha value to use if the texture lookup fails.",
+        int as_max_param_id = 4
     ]],
     int in_starting_channel = 0
     [[
@@ -110,7 +114,8 @@ shader as_texture
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 6
     ]],
     float in_s_blur_amount = 0.0
     [[
@@ -120,7 +125,8 @@ shader as_texture
         float max = 1.0,
         string label = "S Blur",
         string page = "Texture.Advanced",
-        string help = "Additional blur for texture lookup, along the S direction."
+        string help = "Additional blur for texture lookup, along the S direction.",
+        int as_max_param_id = 7
     ]],
     float in_t_blur_amount = 0.0
     [[
@@ -130,7 +136,8 @@ shader as_texture
         float max = 1.0,
         string label = "T Blur",
         string page = "Texture.Advanced",
-        string help = "Additional blur for texture lookup, along the T direction."
+        string help = "Additional blur for texture lookup, along the T direction.",
+        int as_max_param_id = 9
     ]],
     float in_s_filter_width = 1.0
     [[
@@ -140,7 +147,8 @@ shader as_texture
         float softmax = 1.0,
         string label = "S Filter Width",
         string page = "Texture.Advanced",
-        string help = "Multiplier to scale the size of the filter width along the S direction."
+        string help = "Multiplier to scale the size of the filter width along the S direction.",
+        int as_max_param_id = 11
     ]],
     float in_t_filter_width = 1.0
     [[
@@ -151,7 +159,8 @@ shader as_texture
         string label = "T Filter Width",
         string page = "Texture.Advanced",
         string help = "Multiplier to scale the size of the filter width along the S direction.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 13
     ]],
     int in_s_wrap = 0
     [[
@@ -166,7 +175,8 @@ shader as_texture
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Use the wrapping mode set on the texture, or override it."
+        string help = "Use the wrapping mode set on the texture, or override it.",
+        int as_max_param_id = 15
     ]],
     int in_t_wrap = 0
     [[
@@ -182,7 +192,8 @@ shader as_texture
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string help = "Use the wrapping mode set on the texture, or override it.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 16
     ]],
     int in_interpolation_method = 0
     [[
@@ -197,7 +208,8 @@ shader as_texture
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 17
     ]],
     int in_enable_cms = 0
     [[
@@ -212,7 +224,8 @@ shader as_texture
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 18
     ]],
     int in_eotf = 1
     [[
@@ -227,7 +240,8 @@ shader as_texture
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Transfer function of the ingested material, refers to the Opto-Electronic Transfer Function required to transform the input into scene-linear values."
+        string help = "Transfer function of the ingested material, refers to the Opto-Electronic Transfer Function required to transform the input into scene-linear values.",
+        int as_max_param_id = 19
     ]],
     string in_rgb_primaries = "sRGB/Rec.709"
     [[
@@ -242,7 +256,8 @@ shader as_texture
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "RGB primaries, note that Rec.709 and sRGB share the same CIE xy chromaticity coordinates."
+        string help = "RGB primaries, note that Rec.709 and sRGB share the same CIE xy chromaticity coordinates.",
+        int as_max_param_id = 20
     ]],
     string in_workingspace_rgb_primaries = "sRGB/Rec.709"
     [[
@@ -257,21 +272,24 @@ shader as_texture
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Working or rendering space RGB primaries. Note that Rec.709 and sRGB share the same CIE xy chromaticity coordinates."
+        string help = "Working or rendering space RGB primaries. Note that Rec.709 and sRGB share the same CIE xy chromaticity coordinates.",
+        int as_max_param_id = 21
     ]],
     float in_texture_coords[2] = {u, v}
     [[
         string as_maya_attribute_name = "uvCoord",
         string as_maya_attribute_short_name = "uv",
         string label = "UV Coords",
-        string page = "Texture Coordinates"
+        string page = "Texture Coordinates",
+        int as_max_param_id = 22
     ]],
     float in_texture_coords_filter[2] = {0.0, 0.0}
     [[
         string as_maya_attribute_name = "uvFilterSize",
         string as_maya_attribute_short_name = "fs",
         string label = "UV Filter Size",
-        string page = "Texture Coordinates"
+        string page = "Texture Coordinates",
+        int as_max_param_id = 24
     ]],
 
     output color out_color = color(0)
@@ -279,21 +297,24 @@ shader as_texture
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 25
     ]],
     output float out_alpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
         string as_maya_attribute_short_name = "oa",
         string label = "Output Alpha",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 25
     ]],
     output float out_channel = 0.0
     [[
         string as_maya_attribute_name = "outChannel",
         string as_maya_attribute_short_name = "och",
         string label = "Output Single Channel",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 25
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_texture3d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_texture3d.osl
@@ -59,7 +59,8 @@ shader as_texture3d
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string help = "The 3D texture file (field3d, f3d, etc).",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 0
     ]],
     int in_starting_channel = 0
     [[
@@ -75,7 +76,8 @@ shader as_texture3d
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 1
     ]],
     color in_color = color(0)
     [[
@@ -83,7 +85,8 @@ shader as_texture3d
         string as_maya_attribute_short_name = "c",
         string label = "Default Color",
         string page = "3D Texture",
-        string help = "Default fill color to use if the texture lookup fails."
+        string help = "Default fill color to use if the texture lookup fails.",
+        int as_max_param_id = 2
     ]],
     float in_channel_fill = 0.0
     [[
@@ -94,7 +97,8 @@ shader as_texture3d
         string label = "Default Channel Fill",
         string page = "3D Texture",
         string help = "Default fill value for any channels requested but not present.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 4
     ]],
     float in_time = 0.0
     [[
@@ -103,7 +107,8 @@ shader as_texture3d
         float softmin = 0.0,
         string label = "Time",
         string page = "3D Texture",
-        string help = "Time value to use if the texture specifies a time varying local transformation."
+        string help = "Time value to use if the texture specifies a time varying local transformation.",
+        int as_max_param_id = 6
     ]],
     int in_s_wrap = 0
     [[
@@ -118,7 +123,8 @@ shader as_texture3d
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Use the wrapping mode set on the texture, or override it."
+        string help = "Use the wrapping mode set on the texture, or override it.",
+        int as_max_param_id = 8
     ]],
     int in_t_wrap = 0
     [[
@@ -133,7 +139,8 @@ shader as_texture3d
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Use the wrapping mode set on the texture, or override it."
+        string help = "Use the wrapping mode set on the texture, or override it.",
+        int as_max_param_id = 9
     ]],
     int in_r_wrap = 0
     [[
@@ -148,7 +155,8 @@ shader as_texture3d
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Use the wrapping mode set on the texture, or override it."
+        string help = "Use the wrapping mode set on the texture, or override it.",
+        int as_max_param_id = 10
     ]],
     float in_s_blur = 0.0
     [[
@@ -163,7 +171,8 @@ shader as_texture3d
         int gafferNoduleLayoutVisible = 0,
         string label = "Blur Width",
         string page = "3D Texture.Blur",
-        string help = "Blur along the s direction, or width."
+        string help = "Blur along the s direction, or width.",
+        int as_max_param_id = 11
     ]],
     float in_t_blur = 0.0
     [[
@@ -178,7 +187,8 @@ shader as_texture3d
         int gafferNoduleLayoutVisible = 0,
         string label = "Blur Height",
         string page = "3D Texture.Blur",
-        string help = "Blur along the t direction, or height."
+        string help = "Blur along the t direction, or height.",
+        int as_max_param_id = 12
     ]],
     float in_r_blur = 0.0
     [[
@@ -194,7 +204,8 @@ shader as_texture3d
         string label = "Blur Depth",
         string page = "3D Texture.Blur",
         string help = "Blur along the r direction, or depth.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 13
     ]],
     float in_s_width = 1.0
     [[
@@ -209,7 +220,8 @@ shader as_texture3d
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Scale the size of the filter defined by the partial derivatives along s or implicitly from P, with 0 disabling filtering altogether."
+        string help = "Scale the size of the filter defined by the partial derivatives along s or implicitly from P, with 0 disabling filtering altogether.",
+        int as_max_param_id = 14
     ]],
     float in_t_width = 1.0
     [[
@@ -224,7 +236,8 @@ shader as_texture3d
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Scale the size of the filter defined by the partial derivatives along t or implicitly from P, with 0 disabling filtering altogether."
+        string help = "Scale the size of the filter defined by the partial derivatives along t or implicitly from P, with 0 disabling filtering altogether.",
+        int as_max_param_id = 15
     ]],
     float in_r_width = 1.0
     [[
@@ -239,7 +252,8 @@ shader as_texture3d
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Scale the size of the filter defined by the partial derivatives along r or implicitly from P, with 0 disabling filtering altogether."
+        string help = "Scale the size of the filter defined by the partial derivatives along r or implicitly from P, with 0 disabling filtering altogether.",
+        int as_max_param_id = 16
     ]],
     point in_surface_point = P
     [[
@@ -247,7 +261,8 @@ shader as_texture3d
         string as_maya_attribute_short_name = "sp",
         string label = "Surface Point",
         string page = "Coordinates",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 17
     ]],
     int in_coordsys = 1
     [[
@@ -261,7 +276,8 @@ shader as_texture3d
         int as_maya_attribute_keyable = 1,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 18
     ]],
     matrix in_placement_matrix = matrix(1)
     [[
@@ -271,13 +287,15 @@ shader as_texture3d
         string page = "Coordinates",
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 19
     ]],
     output color out_color = color(0)
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 20
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_texture_info.osl
+++ b/src/appleseed.shaders/src/appleseed/as_texture_info.osl
@@ -52,7 +52,8 @@ shader as_texture_info
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Texture file to query information from."
+        string help = "Texture file to query information from.",
+        int as_max_param_id = 0
     ]],
 
     output color out_average_color = color(0)
@@ -60,89 +61,102 @@ shader as_texture_info
         string as_maya_attribute_name = "averageColor",
         string as_maya_attribute_short_name = "avc",
         string label = "Average Color",
-        string help = "Returns the average color of the first 3 channels of the texture file."
+        string help = "Returns the average color of the first 3 channels of the texture file.",
+        int as_max_param_id = 2
     ]],
     output float out_average_alpha = 1.0
     [[
         string as_maya_attribute_name = "averageAlpha",
         string as_maya_attribute_short_name = "ava",
         string label = "Average Alpha",
-        string help = "Returns the average alpha of the channel with the 'A' name in the texture file, if it exists."
+        string help = "Returns the average alpha of the channel with the 'A' name in the texture file, if it exists.",
+        int as_max_param_id = 2
     ]],
     output vector out_resolution = vector(0)
     [[
         string as_maya_attribute_name = "resolution",
         string as_maya_attribute_short_name = "res",
         string label = "Resolution",
-        string help = "XY resolution, XYZ resolution for 3D textures."
+        string help = "XY resolution, XYZ resolution for 3D textures.",
+        int as_max_param_id = 2
     ]],
     output int out_num_channels = 0
     [[
         string as_maya_attribute_name = "numChannels",
         string as_maya_attribute_short_name = "cha",
         string label = "Channels",
-        string help = "Number of channels in the texture."
+        string help = "Number of channels in the texture.",
+        int as_max_param_id = 2
     ]],
     output int out_num_subimages = 0
     [[
         string as_maya_attribute_name = "numSubImages",
         string as_maya_attribute_short_name = "sub",
         string label = "Subimages",
-        string help = "Number of sub-images in the texture file."
+        string help = "Number of sub-images in the texture file.",
+        int as_max_param_id = 2
     ]],
     output string out_texture_type = ""
     [[
         string as_maya_attribute_name = "textureType",
         string as_maya_attribute_short_name = "ttt",
         string label = "Texture Type",
-        string help = "Semantic type of texture, plain texture, shadow, environmnet or volume texture."
+        string help = "Semantic type of texture, plain texture, shadow, environmnet or volume texture.",
+        int as_max_param_id = 2
     ]],
     output string out_texture_format = ""
     [[
         string as_maya_attribute_name = "textureFormat",
         string as_maya_attribute_short_name = "tfo",
         string label = "Texture Format",
-        string help = "Returns the texture format, plain, shadow, cubeface, volume, cubeface or latlong environment, volume texture."
+        string help = "Returns the texture format, plain, shadow, cubeface, volume, cubeface or latlong environment, volume texture.",
+        int as_max_param_id = 2
     ]],
     output vector out_data_window_min = vector(0)
     [[
         string as_maya_attribute_name = "dataWindowMinimum",
         string as_maya_attribute_short_name = "dmi",
         string label = "Data Window Minimum",
-        string help = "Pixel data window of the 2D/3D texture, XY(Z) minimum."
+        string help = "Pixel data window of the 2D/3D texture, XY(Z) minimum.",
+        int as_max_param_id = 2
     ]],
     output vector out_data_window_max = vector(0)
     [[
         string as_maya_attribute_name = "dataWindowMaximum",
         string as_maya_attribute_short_name = "dma",
         string label = "Data Window Maximum",
-        string help = "Pixel data window of the 2D/3D texture, XY(Z) maximum."
+        string help = "Pixel data window of the 2D/3D texture, XY(Z) maximum.",
+        int as_max_param_id = 2
     ]],
     output vector out_display_window_min = vector(0)
     [[
         string as_maya_attribute_name = "displayWindowMinimum",
         string as_maya_attribute_short_name = "wmi",
         string label = "Display Window Minimum",
-        string help = "Display (full) window of the 2D/3D texture, XY(Z) minimum."
+        string help = "Display (full) window of the 2D/3D texture, XY(Z) minimum.",
+        int as_max_param_id = 2
     ]],
     output vector out_display_window_max = vector(0)
     [[
         string as_maya_attribute_name = "displayWindowMaximum",
         string as_maya_attribute_short_name = "wma",
         string label = "Display Window Maximum",
-        string help = "Display (full) window of the 2D/3D texture, XY(Z) maximum."
+        string help = "Display (full) window of the 2D/3D texture, XY(Z) maximum.",
+        int as_max_param_id = 2
     ]],
     output matrix out_world_to_camera = matrix(1)
     [[
         string as_maya_attribute_name = "worldToCameraMatrix",
         string as_maya_attribute_short_name = "wtc",
-        string label = "World To Camera Matrix"
+        string label = "World To Camera Matrix",
+        int as_max_param_id = 2
     ]],
     output matrix out_world_to_screen = matrix(1)
     [[
         string as_maya_attribute_name = "worldToScreenMatrix",
         string as_maya_attribute_short_name = "wts",
-        string label = "World To Screen Matrix"
+        string label = "World To Screen Matrix",
+        int as_max_param_id = 2
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_toon.osl
+++ b/src/appleseed.shaders/src/appleseed/as_toon.osl
@@ -69,7 +69,8 @@ shader as_toon
         string label = "Weight",
         string page = "Incandescence",
         string help = "Global incandescence term contribution.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 0
     ]],
     float in_incandescence_attenuation = 0.2
     [[
@@ -79,7 +80,8 @@ shader as_toon
         float max = 1.0,
         string label = "Attenuation",
         string page = "Incandescence",
-        string help = "Viewer based attenuation factor for the incandescence term."
+        string help = "Viewer based attenuation factor for the incandescence term.",
+        int as_max_param_id = 2
     ]],
     color in_incandescence_tint = color(1)
     [[
@@ -87,7 +89,8 @@ shader as_toon
         string as_maya_attribute_short_name = "iti",
         string label = "Incandescence Tint",
         string page = "Incandescence.Toon",
-        string help = "Global incandescence tint."
+        string help = "Global incandescence tint.",
+        int as_max_param_id = 4
     ]],
     string in_edf_blend_mode = "Multiply"
     [[
@@ -103,7 +106,8 @@ shader as_toon
         string label = "Blending Mode",
         string page = "Incandescence.Toon",
         string help = "Blending mode for the tint factor over the cel shading effect.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 6
     ]],
     color in_edf_dark_color = color(0, 0.17, 0.28)
     [[
@@ -111,7 +115,8 @@ shader as_toon
         string as_maya_attribute_short_name = "edc",
         string label = "EDF Dark Color",
         string page = "Incandescence.Toon",
-        string help = "Incandescence dark color"
+        string help = "Incandescence dark color",
+        int as_max_param_id = 7
     ]],
     float in_edf_dark_level = 0.3
     [[
@@ -122,7 +127,8 @@ shader as_toon
         string label = "EDF Dark Level",
         string page = "Incandescence.Toon",
         string help = "Incandescence dark color to mid-tones threshold",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 9
     ]],
     color in_edf_midtone_color = color(0.035, 0.31, 0.5)
     [[
@@ -130,7 +136,8 @@ shader as_toon
         string as_maya_attribute_short_name = "emc",
         string label = "EDF Midtone Color",
         string page = "Incandescence.Toon",
-        string help = "Incandescence mid-tones color."
+        string help = "Incandescence mid-tones color.",
+        int as_max_param_id = 11
     ]],
     float in_edf_midtone_level = 0.7
     [[
@@ -141,7 +148,8 @@ shader as_toon
         string label = "EDF Midtone Level",
         string page = "Incandescence.Toon",
         string help = "Incandescence midtones to bright color threshold.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 13
     ]],
     color in_edf_bright_color = color(0.43, 0.65, 0.8)
     [[
@@ -150,7 +158,8 @@ shader as_toon
         string label = "EDF Bright Color",
         string page = "Incandescence.Toon",
         string help = "Incandescence bright color.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 15
     ]],
     float in_edf_softness = 0.05
     [[
@@ -160,7 +169,8 @@ shader as_toon
         float max = 1.0,
         string label = "EDF Softness",
         string page = "Incandescence.Toon" ,
-        string help = "Softness of tonal range transition, higher values produce softner results, lower values produce sharper transitions"
+        string help = "Softness of tonal range transition, higher values produce softner results, lower values produce sharper transitions",
+        int as_max_param_id = 17
     ]],
     int in_incandescence_area_normalize = 0
     [[
@@ -174,7 +184,8 @@ shader as_toon
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Normalize incandescence term by surface area toggle."
+        string help = "Normalize incandescence term by surface area toggle.",
+        int as_max_param_id = 19
     ]],
 
     //
@@ -189,7 +200,8 @@ shader as_toon
         string label = "Diffuse Weight",
         string page = "Diffuse",
         string help = "Global diffuse term contribution to the final shading.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 20
     ]],
     color in_diffuse_tint = color(1)
     [[
@@ -197,7 +209,8 @@ shader as_toon
         string as_maya_attribute_short_name = "dti",
         string label = "Diffuse Tint",
         string page = "Diffuse.Toon",
-        string help = "Global diffuse term tint."
+        string help = "Global diffuse term tint.",
+        int as_max_param_id = 22
     ]],
     string in_diffuse_blend_mode = "Multiply"
     [[
@@ -213,7 +226,8 @@ shader as_toon
         string label = "Blending Mode",
         string page = "Diffuse.Toon",
         string help = "Blending mode for the tint factor over the cel shading effect.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 24
     ]],
     color in_shadow_color = color(0.13, 0, 0)
     [[
@@ -221,7 +235,8 @@ shader as_toon
         string as_maya_attribute_short_name = "shc",
         string label = "Shadow Color",
         string page = "Diffuse.Toon",
-        string help = "Shadows or umbra color."
+        string help = "Shadows or umbra color.",
+        int as_max_param_id = 25
     ]],
     float in_shadow_level = 0.15
     [[
@@ -232,7 +247,8 @@ shader as_toon
         string label = "Shadow Level",
         string page = "Diffuse.Toon",
         string help = "Umbra to penumbra separation threshold.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 27
     ]],
     color in_midtone_color = color(0.19, 0.09, 0.27)
     [[
@@ -240,7 +256,8 @@ shader as_toon
         string as_maya_attribute_short_name = "mtc",
         string label = "Midtone Color",
         string page = "Diffuse.Toon",
-        string help = "Mid-tones or penumbra color."
+        string help = "Mid-tones or penumbra color.",
+        int as_max_param_id = 29
     ]],
     float in_midtone_level = 0.3
     [[
@@ -251,7 +268,8 @@ shader as_toon
         string label = "Midtone Level",
         string page = "Diffuse.Toon",
         string help = "Penumbra to highlights separation threshold.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 31
     ]],
     color in_highlight_color = color(0.13, 0.28, 0.55)
     [[
@@ -260,7 +278,8 @@ shader as_toon
         string label = "Highlight Color",
         string page = "Diffuse.Toon",
         string help = "Highlights color",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 33
     ]],
     float in_diffuse_softness = 0.05
     [[
@@ -270,7 +289,8 @@ shader as_toon
         float max = 1.0,
         string label = "Diffuse Softness",
         string page = "Diffuse.Toon" ,
-        string help = "Softness of tonal range transition, higher values produce softner results, lower values produce sharper transitions"
+        string help = "Softness of tonal range transition, higher values produce softner results, lower values produce sharper transitions",
+        int as_max_param_id = 35
     ]],
     int in_diffuse_ray_depth = 100
     [[
@@ -289,7 +309,8 @@ shader as_toon
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Maximum number of diffuse path bounces."
+        string help = "Maximum number of diffuse path bounces.",
+        int as_max_param_id = 37
     ]],
 
     //
@@ -303,7 +324,8 @@ shader as_toon
         float max = 1.0,
         string label = "Specular Weight",
         string page = "Specular",
-        string help = "Global specular reflection contribution."
+        string help = "Global specular reflection contribution.",
+        int as_max_param_id = 38
     ]],
     float in_specular_roughness = 0.1
     [[
@@ -315,7 +337,8 @@ shader as_toon
         string label = "Specular Roughness",
         string page = "Specular",
         string help = "Specular roughness, lower values have sharper reflections, higher values smoother reflections.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 40
     ]],
     float in_ior = 1.5
     [[
@@ -334,7 +357,8 @@ shader as_toon
         int gafferNoduleLayoutVisible = 0,
         string label = "Index Of Refraction",
         string page = "Specular",
-        string help = "Index of refraction for reflection and transmission."
+        string help = "Index of refraction for reflection and transmission.",
+        int as_max_param_id = 42
     ]],
 
     //
@@ -348,7 +372,8 @@ shader as_toon
         float max = 1.0,
         string label = "Anisotropy Amount",
         string page = "Specular.Anisotropy",
-        string help = "Amount of anisotropy, 0 producing isotropic specular highlights, and 1 fully anisotropic highlights."
+        string help = "Amount of anisotropy, 0 producing isotropic specular highlights, and 1 fully anisotropic highlights.",
+        int as_max_param_id = 43
     ]],
     float in_anisotropy_angle = 0.0
     [[
@@ -359,7 +384,8 @@ shader as_toon
         string label = "Anisotropy Angle",
         string page = "Specular.Anisotropy",
         string help = "Anisotropy angle, mapping a value in [0,1] range to [0,360] degrees rotation.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 45
     ]],
     int in_anisotropy_mode = 0
     [[
@@ -374,7 +400,8 @@ shader as_toon
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 47
     ]],
     color in_anisotropy_map = color(0)
     [[
@@ -383,7 +410,8 @@ shader as_toon
         string label = "Anisotropy Vector Map",
         string page = "Specular.Anisotropy",
         string help = "Anisotropy vector map, with XY encoded in RG channels.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 48
     ]],
     vector in_anisotropy_direction = vector(0)
     [[
@@ -391,7 +419,8 @@ shader as_toon
         string as_maya_attribute_short_name = "and",
         string label = "Anisotropy Vector",
         string page = "Specular.Anisotropy",
-        string help = "Explicit anisotropy vector, such as the vector output by a tangent field node."
+        string help = "Explicit anisotropy vector, such as the vector output by a tangent field node.",
+        int as_max_param_id = 50
     ]],
 
     //
@@ -403,7 +432,8 @@ shader as_toon
         string as_maya_attribute_short_name = "sti",
         string label = "Specular Tint",
         string page = "Specular.Toon",
-        string help = "Global specular reflection tint."
+        string help = "Global specular reflection tint.",
+        int as_max_param_id = 52
     ]],
     string in_specular_blend_mode = "Multiply"
     [[
@@ -419,7 +449,8 @@ shader as_toon
         string label = "Blending Mode",
         string page = "Specular.Toon",
         string help = "Blending mode for the tint factor over the cel shading effect.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 54
     ]],
     color in_glossy_color = color(1.0, 0.55, 0.2)
     [[
@@ -427,7 +458,8 @@ shader as_toon
         string as_maya_attribute_short_name = "glc",
         string label = "Glossy Color",
         string page = "Specular.Toon",
-        string help = "Specular glossy color."
+        string help = "Specular glossy color.",
+        int as_max_param_id = 55
     ]],
     float in_glossy_level = 0.25
     [[
@@ -438,7 +470,8 @@ shader as_toon
         string label = "Glossy Level",
         string page = "Specular.Toon",
         string help = "Specular highlight to no highlights transition threshold.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 57
     ]],
     float in_glossy_softness = 0.05
     [[
@@ -448,7 +481,8 @@ shader as_toon
         float max = 1.0,
         string label = "Glossy Softness",
         string page = "Specular.Toon",
-        string help = "Softness of transition from specular highlight to no highlights area."
+        string help = "Softness of transition from specular highlight to no highlights area.",
+        int as_max_param_id = 59
     ]],
     float in_facing_attenuation = 0.0
     [[
@@ -458,7 +492,8 @@ shader as_toon
         float max = 1.0,
         string label = "Facing Attenuation",
         string page = "Specular.Toon",
-        string help = "Attenuate facing incidence reflection, similar to Fresnel, retaining reflection intensity at the grazing angles."
+        string help = "Attenuate facing incidence reflection, similar to Fresnel, retaining reflection intensity at the grazing angles.",
+        int as_max_param_id = 61
     ]],
     int in_specular_ray_depth = 100
     [[
@@ -477,7 +512,8 @@ shader as_toon
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Maximum number of specular reflection bounces."
+        string help = "Maximum number of specular reflection bounces.",
+        int as_max_param_id = 63
     ]],
 
     //
@@ -491,7 +527,8 @@ shader as_toon
         float max = 1.0,
         string label = "Rim Weight",
         string page = "Rim",
-        string help = "Global rim reflection contribution."
+        string help = "Global rim reflection contribution.",
+        int as_max_param_id = 64
     ]],
     color in_rim_tint = color(1)
     [[
@@ -499,7 +536,8 @@ shader as_toon
         string as_maya_attribute_short_name = "rti",
         string label = "Rim Tint",
         string page = "Rim.Toon",
-        string help = "Global rim reflection tint."
+        string help = "Global rim reflection tint.",
+        int as_max_param_id = 66
     ]],
     string in_rim_blend_mode = "Multiply"
     [[
@@ -515,7 +553,8 @@ shader as_toon
         string label = "Blending Mode",
         string page = "Rim.Toon",
         string help = "Blending mode for the tint factor over the cel shading effect.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 68
     ]],
     float in_rim_softness = 0.05
     [[
@@ -525,7 +564,8 @@ shader as_toon
         float max = 1.0,
         string label = "Rim Softness",
         string page = "Rim.Toon",
-        string help = "Softness of transition from rim highlight to no highlights area."
+        string help = "Softness of transition from rim highlight to no highlights area.",
+        int as_max_param_id = 69
     ]],
 
     //
@@ -537,7 +577,8 @@ shader as_toon
         string as_maya_attribute_short_name = "n",
         string label = "Bump Normal",
         string widget = "maya_bump",
-        string page = "Bump"
+        string page = "Bump",
+        int as_max_param_id = 71
     ]],
     normal in_specular_normal = N
     [[
@@ -546,7 +587,8 @@ shader as_toon
         string label = "Specular Normal",
         string widget = "maya_bump",
         string page = "Bump",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 72
     ]],
     string in_normal_control = "Diffuse Affects Both"
     [[
@@ -562,14 +604,16 @@ shader as_toon
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int divider = 1,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 73
     ]],
     color in_transparency = color(0)
     [[
         string as_maya_attribute_name = "transparency",
         string as_maya_attribute_short_name = "it",
         string label = "Transparency Color",
-        string page = "Transparency"
+        string page = "Transparency",
+        int as_max_param_id = 74
     ]],
 
     //
@@ -581,7 +625,8 @@ shader as_toon
         string as_maya_attribute_short_name = "ctc",
         string label = "Color",
         string page = "Contours",
-        string help = "Global contour tint."
+        string help = "Global contour tint.",
+        int as_max_param_id = 76
     ]],
     float in_contour_opacity = 1.0
     [[
@@ -592,7 +637,8 @@ shader as_toon
         string label = "Opacity",
         string page = "Contours",
         string help = "Global contour opacity",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 78
     ]],
     float in_contour_width = 1.0
     [[
@@ -603,7 +649,8 @@ shader as_toon
         string label = "Width",
         string page = "Contours",
         string help = "Global contour line width or thickness.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 80
     ]],
     int in_contour_object = 0
     [[
@@ -615,7 +662,8 @@ shader as_toon
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
-        string help = "Generate contours based on object ID."
+        string help = "Generate contours based on object ID.",
+        int as_max_param_id = 82
     ]],
     int in_contour_material = 0
     [[
@@ -627,7 +675,8 @@ shader as_toon
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
-        string help = "Generate contours based on material ID."
+        string help = "Generate contours based on material ID.",
+        int as_max_param_id = 83
     ]],
     int in_contour_occlusion = 0
     [[
@@ -639,7 +688,8 @@ shader as_toon
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
-        string help = "Generate contours based on ambient occlusion."
+        string help = "Generate contours based on ambient occlusion.",
+        int as_max_param_id = 84
     ]],
     int in_contour_creases = 0
     [[
@@ -652,7 +702,8 @@ shader as_toon
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         string help = "Generate contours based on mesh creases.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 85
     ]],
     float in_occlusion_threshold = 0.1
     [[
@@ -661,7 +712,8 @@ shader as_toon
         float min = 0.0,
         string label = "Occlusion threshold",
         string page = "Contours",
-        string help = "Occlusion threshold for contour lines."
+        string help = "Occlusion threshold for contour lines.",
+        int as_max_param_id = 86
     ]],
     float in_crease_threshold = 15
     [[
@@ -670,7 +722,8 @@ shader as_toon
         float min = 0.0,
         string label = "Crease threshold",
         string page = "Contours",
-        string help = "Creases threshold for contour lines."
+        string help = "Creases threshold for contour lines.",
+        int as_max_param_id = 88
     ]],
 
     //
@@ -688,7 +741,8 @@ shader as_toon
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int divider = 1,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 90
     ]],
     float in_matte_opacity = 0.0
     [[
@@ -699,7 +753,8 @@ shader as_toon
         string label = "Matte Opacity",
         string page = "Matte Opacity",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 91
     ]],
     color in_matte_opacity_color = color(1, 0.5, 0)
     [[
@@ -708,7 +763,8 @@ shader as_toon
         string label = "Matte Opacity Color",
         string page = "Matte Opacity",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 93
     ]],
 
     //
@@ -718,7 +774,8 @@ shader as_toon
         int as_maya_attribute_hidden = 1,
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 95
     ]],
     vector Bn = vector(0)
     [[
@@ -726,21 +783,23 @@ shader as_toon
         int as_maya_attribute_hidden = 1,
         string widget = "null",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
-
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 96
     ]],
 
     output closure color out_outColor = 0
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 97
     ]],
     output closure color out_outTransparency = 0
     [[
         string as_maya_attribute_name = "outTransparency",
         string as_maya_attribute_short_name = "ot",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 97
     ]],
     output closure color out_outMatteOpacity = 0
     [[
@@ -748,7 +807,8 @@ shader as_toon
         string as_maya_attribute_short_name = "om",
         string widget = "null",
         int as_maya_attribute_hidden = 1,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 97
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_triplanar.osl
+++ b/src/appleseed.shaders/src/appleseed/as_triplanar.osl
@@ -60,7 +60,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string help = "Blend colors, or tangent space normal maps using reoriented normal mapping.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 0
     ]],
     float in_blend_softness = 0.1
     [[
@@ -70,7 +71,8 @@ shader as_triplanar
         float max = 1.0,
         string label = "Blend Softness",
         string page = "Projection",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 1
     ]],
     point in_surface_point = P
     [[
@@ -78,7 +80,8 @@ shader as_triplanar
         string as_maya_attribute_short_name = "p",
         string label = "Surface Point",
         string page = "Projection",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 3
     ]],
     string in_space = "World Space"
     [[
@@ -92,14 +95,16 @@ shader as_triplanar
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 4
     ]],
     normal in_normal = N
     [[
         string as_maya_attribute_name = "normalCamera",
         string as_maya_attribute_short_name = "n",
         string label = "Surface Normal",
-        string page = "Bump"
+        string page = "Bump",
+        int as_max_param_id = 5
     ]],
     matrix in_placement_matrix = matrix(1)
     [[
@@ -108,7 +113,8 @@ shader as_triplanar
         string widget = "null",
         string label = "Placement Matrix",
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 6
     ]],
     int in_enable_cms = 1
     [[
@@ -123,7 +129,8 @@ shader as_triplanar
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 7
     ]],
     string in_workingspace_rgb_primaries = "sRGB/Rec.709"
     [[
@@ -138,7 +145,8 @@ shader as_triplanar
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Working or rendering space RGB primaries. Note that Rec.709 and sRGB share the same CIE xy chromaticity coordinates."
+        string help = "Working or rendering space RGB primaries. Note that Rec.709 and sRGB share the same CIE xy chromaticity coordinates.",
+        int as_max_param_id = 8
     ]],
     color in_x_axis_color = color(1,0,0)
     [[
@@ -151,7 +159,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "Solid Color",
         string page = "Projection.X Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 9
     ]],
     string in_x_axis_filename = ""
     [[
@@ -165,7 +174,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "Texture Filename",
         string page = "Projection.X Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 10
     ]],
     float in_x_axis_width = 1.0
     [[
@@ -179,7 +189,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "Horizontal Frequency",
-        string page = "Projection.X Axis"
+        string page = "Projection.X Axis",
+        int as_max_param_id = 11
     ]],
     float in_x_axis_height = 1.0
     [[
@@ -194,7 +205,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "Vertical Frequency",
         string page = "Projection.X Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 12
     ]],
     float in_x_axis_horizontal_offset = 0.0
     [[
@@ -208,7 +220,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "Horizontal Offset",
-        string page = "Projection.X Axis"
+        string page = "Projection.X Axis",
+        int as_max_param_id = 13
     ]],
     float in_x_axis_vertical_offset = 0.0
     [[
@@ -223,7 +236,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "Vertical Offset",
         string page = "Projection.X Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 14
     ]],
     float in_x_axis_rotation_angle = 0.0
     [[
@@ -239,7 +253,8 @@ shader as_triplanar
         string label = "Rotation",
         string page = "Projection.X Axis",
         string help = "Rotation angle in degrees.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 15
     ]],
     int in_x_axis_swrap = 0
     [[
@@ -253,7 +268,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "S Wrap Mode",
-        string page = "Projection.X Axis"
+        string page = "Projection.X Axis",
+        int as_max_param_id = 16
     ]],
     int in_x_axis_twrap = 0
     [[
@@ -268,7 +284,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "T Wrap Mode",
         string page = "Projection.X Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 17
     ]],
     int in_x_axis_sflip = 0
     [[
@@ -281,7 +298,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "S Flip",
-        string page = "Projection.X Axis"
+        string page = "Projection.X Axis",
+        int as_max_param_id = 18
     ]],
     int in_x_axis_tflip = 0
     [[
@@ -294,7 +312,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "T Flip",
-        string page = "Projection.X Axis"
+        string page = "Projection.X Axis",
+        int as_max_param_id = 19
     ]], 
     string in_x_tex_eotf = "sRGB"
     [[
@@ -309,7 +328,8 @@ shader as_triplanar
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Transfer function of the ingested material, refers to the Opto-Electronic Transfer Function required to transform the input into scene-linear values."
+        string help = "Transfer function of the ingested material, refers to the Opto-Electronic Transfer Function required to transform the input into scene-linear values.",
+        int as_max_param_id = 20
     ]],
     string in_x_tex_rgb_primaries = "sRGB/Rec.709"
     [[
@@ -324,7 +344,8 @@ shader as_triplanar
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Texture RGB primaries, note that Rec.709 and sRGB share the same CIE xy chromaticity coordinates."
+        string help = "Texture RGB primaries, note that Rec.709 and sRGB share the same CIE xy chromaticity coordinates.",
+        int as_max_param_id = 21
     ]],
     color in_y_axis_color = color(0,1,0)
     [[
@@ -337,7 +358,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "Solid Color",
         string page = "Projection.Y Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 22
     ]],
     string in_y_axis_filename = ""
     [[
@@ -351,7 +373,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "Texture Filename",
         string page = "Projection.Y Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 23
     ]],
     float in_y_axis_width = 1.0
     [[
@@ -365,7 +388,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "Horizontal Frequency",
-        string page = "Projection.Y Axis"
+        string page = "Projection.Y Axis",
+        int as_max_param_id = 24
     ]],
     float in_y_axis_height = 1.0
     [[
@@ -380,7 +404,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "Vertical Frequency",
         string page = "Projection.Y Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 25
     ]],
     float in_y_axis_horizontal_offset = 0.0
     [[
@@ -394,7 +419,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "Horizontal Offset",
-        string page = "Projection.Y Axis"
+        string page = "Projection.Y Axis",
+        int as_max_param_id = 26
     ]],
     float in_y_axis_vertical_offset = 0.0
     [[
@@ -409,7 +435,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "Vertical Offset",
         string page = "Projection.Y Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 27
     ]],
     float in_y_axis_rotation_angle = 0.0
     [[
@@ -425,7 +452,8 @@ shader as_triplanar
         string label = "Rotation",
         string page = "Projection.Y Axis",
         string help = "Rotation angle in degrees.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 28
     ]],
     int in_y_axis_swrap = 0
     [[
@@ -439,7 +467,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "S Wrap Mode",
-        string page = "Projection.Y Axis"
+        string page = "Projection.Y Axis",
+        int as_max_param_id = 29
     ]],
     int in_y_axis_twrap = 0
     [[
@@ -454,7 +483,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "T Wrap Mode",
         string page = "Projection.Y Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 30
     ]],
     int in_y_axis_sflip = 0
     [[
@@ -467,7 +497,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "S Flip",
-        string page = "Projection.Y Axis"
+        string page = "Projection.Y Axis",
+        int as_max_param_id = 31
     ]],
     int in_y_axis_tflip = 0
     [[
@@ -480,7 +511,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "T Flip",
-        string page = "Projection.Y Axis"
+        string page = "Projection.Y Axis",
+        int as_max_param_id = 32
     ]],
     string in_y_tex_eotf = "sRGB"
     [[
@@ -495,7 +527,8 @@ shader as_triplanar
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Transfer function of the ingested material, refers to the Opto-Electronic Transfer Function required to transform the input into scene-linear values."
+        string help = "Transfer function of the ingested material, refers to the Opto-Electronic Transfer Function required to transform the input into scene-linear values.",
+        int as_max_param_id = 33
     ]],
     string in_y_tex_rgb_primaries = "sRGB/Rec.709"
     [[
@@ -510,7 +543,8 @@ shader as_triplanar
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Texture RGB primaries, note that Rec.709 and sRGB share the same CIE xy chromaticity coordinates."
+        string help = "Texture RGB primaries, note that Rec.709 and sRGB share the same CIE xy chromaticity coordinates.",
+        int as_max_param_id = 34
     ]],
     color in_z_axis_color = color(0,0,1)
     [[
@@ -523,7 +557,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "Solid Color",
         string page = "Projection.Z Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 35
     ]],
     string in_z_axis_filename = ""
     [[
@@ -537,7 +572,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "Texture Filename",
         string page = "Projection.Z Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 36
     ]],
     float in_z_axis_width = 1.0
     [[
@@ -551,7 +587,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "Horizontal Frequency",
-        string page = "Projection.Z Axis"
+        string page = "Projection.Z Axis",
+        int as_max_param_id = 37
     ]],
     float in_z_axis_height = 1.0
     [[
@@ -566,7 +603,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "Vertical Frequency",
         string page = "Projection.Z Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 38
     ]],
     float in_z_axis_horizontal_offset = 0.0
     [[
@@ -580,7 +618,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "Horizontal Offset",
-        string page = "Projection.Z Axis"
+        string page = "Projection.Z Axis",
+        int as_max_param_id = 39
     ]],
     float in_z_axis_vertical_offset = 0.0
     [[
@@ -595,7 +634,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "Vertical Offset",
         string page = "Projection.Z Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 40
     ]],
     float in_z_axis_rotation_angle = 0.0
     [[
@@ -611,7 +651,8 @@ shader as_triplanar
         string label = "Rotation",
         string page = "Projection.Z Axis",
         string help = "Rotation angle in degrees.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 41
     ]],
     int in_z_axis_swrap = 0
     [[
@@ -625,7 +666,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "S Wrap Mode",
-        string page = "Projection.Z Axis"
+        string page = "Projection.Z Axis",
+        int as_max_param_id = 42
     ]],
     int in_z_axis_twrap = 0
     [[
@@ -640,7 +682,8 @@ shader as_triplanar
         int gafferNoduleLayoutVisible = 0,
         string label = "T Wrap Mode",
         string page = "Projection.Z Axis",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 43
     ]],
     int in_z_axis_sflip = 0
     [[
@@ -653,7 +696,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "S Flip",
-        string page = "Projection.Z Axis"
+        string page = "Projection.Z Axis",
+        int as_max_param_id = 44
     ]],
     int in_z_axis_tflip = 0
     [[
@@ -666,7 +710,8 @@ shader as_triplanar
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "T Flip",
-        string page = "Projection.Z Axis"
+        string page = "Projection.Z Axis",
+        int as_max_param_id = 45
     ]],
     string in_z_tex_eotf = "sRGB"
     [[
@@ -681,7 +726,8 @@ shader as_triplanar
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Transfer function of the ingested material, refers to the Opto-Electronic Transfer Function required to transform the input into scene-linear values."
+        string help = "Transfer function of the ingested material, refers to the Opto-Electronic Transfer Function required to transform the input into scene-linear values.",
+        int as_max_param_id = 46
     ]],
     string in_z_tex_rgb_primaries = "sRGB/Rec.709"
     [[
@@ -696,7 +742,8 @@ shader as_triplanar
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        string help = "Texture RGB primaries, note that Rec.709 and sRGB share the same CIE xy chromaticity coordinates."
+        string help = "Texture RGB primaries, note that Rec.709 and sRGB share the same CIE xy chromaticity coordinates.",
+        int as_max_param_id = 47
     ]],
     float in_randomization = 0.0
     [[
@@ -705,7 +752,8 @@ shader as_triplanar
         float min = 0.0,
         float max = 1.0,
         string label = "Randomization",
-        string page = "Projection.Randomization"
+        string page = "Projection.Randomization",
+        int as_max_param_id = 48
     ]],
     int in_manifold = 0
     [[
@@ -713,7 +761,8 @@ shader as_triplanar
         string as_maya_attribute_short_name = "man",
         string label = "Manifold",
         string page = "Projection.Randomization",
-        string help = "Connects to an idManifold integer hash output, or lacking one, builds an hash based on the assembly instance name."
+        string help = "Connects to an idManifold integer hash output, or lacking one, builds an hash based on the assembly instance name.",
+        int as_max_param_id = 50
     ]],
 
     output color out_color = color(0)
@@ -721,21 +770,24 @@ shader as_triplanar
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
         string label = "Output Color",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 52
     ]],
     output float out_alpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
         string as_maya_attribute_short_name = "oa",
         string label = "Output Alpha",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 52
     ]],
     output normal out_normal = normal(0)
     [[
         string as_maya_attribute_name = "outNormal",
         string as_maya_attribute_short_name = "on",
         string label = "Output Normal",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 52
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_vary_color.osl
+++ b/src/appleseed.shaders/src/appleseed/as_vary_color.osl
@@ -53,7 +53,8 @@ shader as_vary_color
         string label = "Input Color",
         string page = "Color",
         string help = "Scene-linear input color.",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 0
     ]],
     int in_color_mode = 0
     [[
@@ -68,7 +69,8 @@ shader as_vary_color
         int gafferNoduleLayoutVisible = 0,
         string label = "Color Mode",
         string page = "Color",
-        string help ="Add manifold generated color to input color. Or scale it, or ignore it, setting as output the manifold generated color."
+        string help ="Add manifold generated color to input color. Or scale it, or ignore it, setting as output the manifold generated color.",
+        int as_max_param_id = 2
     ]],
     int in_manifold_type = 0
     [[
@@ -83,7 +85,8 @@ shader as_vary_color
         int gafferNoduleLayoutVisible = 0,
         string label = "Type",
         string page = "Manifold",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 3
     ]],
     string in_expression = ""
     [[
@@ -97,7 +100,8 @@ shader as_vary_color
         int gafferNoduleLayoutVisible = 0,
         string label = "Expression",
         string page = "Manifold.String",
-        string help = "String expression to search in the object or object instance name."
+        string help = "String expression to search in the object or object instance name.",
+        int as_max_param_id = 4
     ]],
     int in_domain = 0
     [[
@@ -112,7 +116,8 @@ shader as_vary_color
         int gafferNoduleLayoutVisible = 0,
         string label = "Domain",
         string page = "Manifold.String",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 5
     ]],
     int in_seed = 0xcafe
     [[
@@ -126,7 +131,8 @@ shader as_vary_color
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 1,
         string label = "Seed",
-        string page = "Manifold.String"
+        string page = "Manifold.String",
+        int as_max_param_id = 6
     ]],
     int in_variation_mode = 0
     [[
@@ -140,7 +146,8 @@ shader as_vary_color
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string label = "Variation Mode",
-        string page = "Variation"
+        string page = "Variation",
+        int as_max_param_id = 7
     ]],
     float in_vary_hue = 0.0
     [[
@@ -149,7 +156,8 @@ shader as_vary_color
         float min = 0.0,
         float max = 1.0,
         string label = "Vary Hue",
-        string page = "Variation.HSV"
+        string page = "Variation.HSV",
+        int as_max_param_id = 8
     ]],
     float in_vary_saturation = 0.0
     [[
@@ -158,7 +166,8 @@ shader as_vary_color
         float min = 0.0,
         float max = 1.0,
         string label = "Vary Saturation",
-        string page = "Variation.HSV"
+        string page = "Variation.HSV",
+        int as_max_param_id = 10
     ]],
     float in_vary_value = 0.0
     [[
@@ -167,7 +176,8 @@ shader as_vary_color
         float min = 0.0,
         float max = 1.0,
         string label = "Vary Value",
-        string page = "Variation.HSV"
+        string page = "Variation.HSV",
+        int as_max_param_id = 12
     ]],
     float in_vary_red = 0.0
     [[
@@ -176,7 +186,8 @@ shader as_vary_color
         float min = 0.0,
         float max = 1.0,
         string label = "Vary Red",
-        string page = "Variation.RGB"
+        string page = "Variation.RGB",
+        int as_max_param_id = 14
     ]],
     float in_vary_green = 0.0
     [[
@@ -185,7 +196,8 @@ shader as_vary_color
         float min = 0.0,
         float max = 1.0,
         string label = "Vary Green",
-        string page = "Variation.RGB"
+        string page = "Variation.RGB",
+        int as_max_param_id = 16
     ]],
     float in_vary_blue = 0.0
     [[
@@ -194,7 +206,8 @@ shader as_vary_color
         float min = 0.0,
         float max = 1.0,
         string label = "Vary Blue",
-        string page = "Variation.RGB"
+        string page = "Variation.RGB",
+        int as_max_param_id = 18
     ]],
     float in_vary_lstar = 0.0
     [[
@@ -203,7 +216,8 @@ shader as_vary_color
         float min = 0.0,
         float max = 1.0,
         string label = "Vary L*",
-        string page = "Variation.CIE L*a*b* 1976"
+        string page = "Variation.CIE L*a*b* 1976",
+        int as_max_param_id = 20
     ]],
     float in_vary_astar = 0.0
     [[
@@ -212,7 +226,8 @@ shader as_vary_color
         float min = 0.0,
         float max = 1.0,
         string label = "Vary a*",
-        string page = "Variation.CIE L*a*b* 1976"
+        string page = "Variation.CIE L*a*b* 1976",
+        int as_max_param_id = 22
     ]],
     float in_vary_bstar = 0.0
     [[
@@ -221,31 +236,36 @@ shader as_vary_color
         float min = 0.0,
         float max = 1.0,
         string label = "Vary b*",
-        string page = "Variation.CIE L*a*b* 1976"
+        string page = "Variation.CIE L*a*b* 1976",
+        int as_max_param_id = 24
     ]],
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string label = "Output Color"
+        string label = "Output Color",
+        int as_max_param_id = 26
     ]],
     output int out_outHash = 0
     [[
         string as_maya_attribute_name = "outHash",
         string as_maya_attribute_short_name = "osh",
-        string label = "Output Hash"
+        string label = "Output Hash",
+        int as_max_param_id = 26
     ]],
     output color out_outID = color(0)
     [[
         string as_maya_attribute_name = "outID",
         string as_maya_attribute_short_name = "oid",
-        string label = "Output ID"
+        string label = "Output ID",
+        int as_max_param_id = 26
     ]],
     output float out_outGreyscale = 0.0
     [[
         string as_maya_attribute_name = "outGreyscale",
         string as_maya_attribute_short_name = "ogr",
-        string label = "Output Greyscale"
+        string label = "Output Greyscale",
+        int as_max_param_id = 26
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_voronoi2d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_voronoi2d.osl
@@ -51,13 +51,15 @@ shader as_voronoi2d
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Color 1",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 0
     ]],
     color in_color2 = color(0.1, 0.3, 0.9)
     [[
         string as_maya_attribute_name = "color2",
         string label = "Color 2",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 2
     ]],
     float in_contrast = 0.5
     [[
@@ -66,7 +68,8 @@ shader as_voronoi2d
         float min = 0.0,
         float max = 1.0,
         string label = "Contrast",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 4
     ]],
     float in_density = 1.0
     [[
@@ -77,7 +80,8 @@ shader as_voronoi2d
         float softmin = 1.0,
         float softmax = 3.0,
         string label = "Initial Density",
-        string page = "Cell"
+        string page = "Cell",
+        int as_max_param_id = 6
     ]],
     float in_jittering = 1.0
     [[
@@ -87,7 +91,8 @@ shader as_voronoi2d
         float max = 1.0,
         string label = "Jittering",
         string page = "Cell",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 8
     ]],
     int in_metric = 0
     [[
@@ -100,7 +105,8 @@ shader as_voronoi2d
         string page = "Cell",
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 10
     ]],
     float in_Minkowski_p = 5.0
     [[
@@ -111,7 +117,8 @@ shader as_voronoi2d
         float softmin = 0.1,
         float softmax = 10.0,
         string label = "Minkowski Parameter",
-        string page = "Cell"
+        string page = "Cell",
+        int as_max_param_id = 11
     ]],
     float in_coverage = 0.5
     [[
@@ -121,7 +128,8 @@ shader as_voronoi2d
         float max = 1.0,
         string label = "Akritean Coverage",
         string page = "Cell",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 13
     ]],
     int in_featuresMode = 0
     [[
@@ -134,7 +142,8 @@ shader as_voronoi2d
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 15
     ]],
     float in_amplitude = 1.0
     [[
@@ -146,7 +155,8 @@ shader as_voronoi2d
         float softmax = 1.0,
         string label = "Amplitude",
         string page = "Recursion",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 16
     ]],
     int in_octaves = 3
     [[
@@ -163,7 +173,8 @@ shader as_voronoi2d
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 18
     ]],
     float in_lacunarity = 2.217
     [[
@@ -179,7 +190,8 @@ shader as_voronoi2d
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 19
     ]],
     float in_persistence = 1.0
     [[
@@ -190,7 +202,8 @@ shader as_voronoi2d
         float softmin = 0.0,
         float softmax = 1.0,
         string label = "Persistence",
-        string page = "Recursion"
+        string page = "Recursion",
+        int as_max_param_id = 20
     ]],
 
     MAYA_UV_PARAMETERS,
@@ -198,28 +211,33 @@ shader as_voronoi2d
     output color out_outColor = color(0)
     [[
         string as_maya_attribute_name = "outColor",
-        string as_maya_attribute_short_name = "oc"
+        string as_maya_attribute_short_name = "oc",
+        int as_max_param_id = 25
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
         string as_maya_attribute_short_name = "oa",
-        string label = "Output Alpha"
+        string label = "Output Alpha",
+        int as_max_param_id = 25
     ]],
     output float out_outFeatures[4] = {0.0, 0.0, 0.0, 0.0}
     [[
         string as_maya_attribute_name = "outFeatures",
-        string label = "Output Features"
+        string label = "Output Features",
+        int as_max_param_id = 25
     ]],
     output point out_outPositions[4] = {0.0, 0.0, 0.0, 0.0}
     [[
         string as_maya_attribute_name = "outPositions",
-        string label = "Output Positions"
+        string label = "Output Positions",
+        int as_max_param_id = 25
     ]],
     output color out_outIDs[4] = {0, 0, 0, 0}
     [[
         string as_maya_attribute_name = "outIDs",
-        string label = "Output IDs"
+        string label = "Output IDs",
+        int as_max_param_id = 25
     ]]
 )
 {

--- a/src/appleseed.shaders/src/appleseed/as_voronoi3d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_voronoi3d.osl
@@ -51,13 +51,15 @@ shader as_voronoi3d
         string as_maya_attribute_name = "color",
         string as_maya_attribute_short_name = "c",
         string label = "Color 1",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 0
     ]],
     color in_color2 = color(0.1, 0.3, 0.9)
     [[
         string as_maya_attribute_name = "color2",
         string label = "Color 2",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 2
     ]],
     float in_contrast = 0.5
     [[
@@ -66,7 +68,8 @@ shader as_voronoi3d
         float min = 0.0,
         float max = 1.0,
         string label = "Contrast",
-        string page = "Color"
+        string page = "Color",
+        int as_max_param_id = 4
     ]],
     float in_density = 1.0
     [[
@@ -77,7 +80,8 @@ shader as_voronoi3d
         float softmin = 1.0,
         float softmax = 3.0,
         string label = "Initial Density",
-        string page = "Cell"
+        string page = "Cell",
+        int as_max_param_id = 6
     ]],
     float in_jittering = 1.0
     [[
@@ -87,7 +91,8 @@ shader as_voronoi3d
         float max = 1.0,
         string label = "Jittering",
         string page = "Cell",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 8
     ]],
     int in_metric = 0
     [[
@@ -101,7 +106,8 @@ shader as_voronoi3d
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 10
     ]],
     float in_Minkowski_p = 5.0
     [[
@@ -112,7 +118,8 @@ shader as_voronoi3d
         float softmin = 0.1,
         float softmax = 10.0,
         string label = "Minkowski Parameter",
-        string page = "Cell"
+        string page = "Cell",
+        int as_max_param_id = 11
     ]],
     float in_coverage = 0.5
     [[
@@ -122,7 +129,8 @@ shader as_voronoi3d
         float max = 1.0,
         string label = "Akritean Coverage",
         string page = "Cell",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 13
     ]],
     int in_featuresMode = 0
     [[
@@ -135,7 +143,8 @@ shader as_voronoi3d
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 15
     ]],
     float in_amplitude = 1.0
     [[
@@ -147,7 +156,8 @@ shader as_voronoi3d
         float softmax = 1.0,
         string label = "Amplitude",
         string page = "Recursion",
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 16
     ]],
     int in_octaves = 3
     [[
@@ -165,7 +175,8 @@ shader as_voronoi3d
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1
+        int divider = 1,
+        int as_max_param_id = 18
     ]],
     float in_lacunarity = 2.217
     [[
@@ -181,7 +192,8 @@ shader as_voronoi3d
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 19
     ]],
     float in_persistence = 1.0
     [[
@@ -192,7 +204,8 @@ shader as_voronoi3d
         float softmin = 0.0,
         float softmax = 1.0,
         string label = "Persistence",
-        string page = "Recursion"
+        string page = "Recursion",
+        int as_max_param_id = 20
     ]],
     int in_softEdges = 1
     [[
@@ -205,7 +218,8 @@ shader as_voronoi3d
         int as_maya_attribute_keyable = 0,
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 22
     ]],
     matrix in_placementMatrix = matrix(1)
     [[
@@ -214,7 +228,8 @@ shader as_voronoi3d
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
         string widget = "null",
-        string label = "Placement Matrix"
+        string label = "Placement Matrix",
+        int as_max_param_id = 23
     ]],
     point in_surfacePoint = P
     [[
@@ -223,7 +238,8 @@ shader as_voronoi3d
         string label = "Surface Point",
         string page = "Cell",
         string widget = "null",
-        int gafferNoduleLayoutVisible = 0
+        int gafferNoduleLayoutVisible = 0,
+        int as_max_param_id = 24
     ]],
 
     MAYA_EFFECTS_3DTEX_PARAMETERS,
@@ -232,29 +248,34 @@ shader as_voronoi3d
     [[
         string as_maya_attribute_name = "outColor",
         string as_maya_attribute_short_name = "oc",
-        string label = "Output Color"
+        string label = "Output Color",
+        int as_max_param_id = 31
     ]],
     output float out_outAlpha = 1.0
     [[
         string as_maya_attribute_name = "outAlpha",
         string as_maya_attribute_short_name = "oa",
         string label = "Output Alpha",
-        string widget = "null"
+        string widget = "null",
+        int as_max_param_id = 31
     ]],
     output float out_outFeatures[4] = {0.0, 0.0, 0.0, 0.0}
     [[
         string as_maya_attribute_name = "outFeatures",
-        string label = "Output Features"
+        string label = "Output Features",
+        int as_max_param_id = 31
     ]],
     output point out_outPositions[4] = {0.0, 0.0, 0.0, 0.0}
     [[
         string as_maya_attribute_name = "outPositions",
-        string label = "Output Positions"
+        string label = "Output Positions",
+        int as_max_param_id = 31
     ]],
     output color out_outIDs[4] = {0, 0, 0, 0}
     [[
         string as_maya_attribute_name = "outIDs",
-        string label = "Output IDs"
+        string label = "Output IDs",
+        int as_max_param_id = 31
     ]]
 )
 {


### PR DESCRIPTION
Hi guys,
I was holding on this PR for too long. Finally decided to publish it. It's nothing huge, just adds each OSL parameter an ID for 3ds max plugin. By using these IDs 3ds max plugin will use the same param_id-s for each parameter and adding new parameters won't break scene compatibility.

Right now numbers reflect current 3ds max param_id-s. If plugin uses these IDs right now parameters will get the same param_id-s as before, maintaining compatibility.

I have an issue with parameters in helper .h files, such as `MAYA_COLORMANAGEMENT_PARAMETERS`. They appear in different places in plugins and get different id-s. I think shaders with that parameters are not widely used and probably I could assign some high numbers to these parameters to not make conflicts to any of the plugins.

Thanks,
Sergo.