### PR TITLE
Generate header file with cmake build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,7 @@ link_directories (${Boost_LIBRARY_DIRS})
 #--------------------------------------------------------------------------------------------------
 
 if (WITH_EMBREE)
+    set (APPLESEED_WITH_EMBREE ON)
     add_definitions (-DAPPLESEED_WITH_EMBREE)
     if (USE_STATIC_EMBREE)
         add_definitions (-DEMBREE_STATIC_LIB)
@@ -298,6 +299,7 @@ if (USE_FIND_PACKAGE_FOR_PNG)
 endif ()
 
 if (WITH_DISNEY_MATERIAL)
+    set (APPLESEED_WITH_DISNEY_MATERIAL ON)
     add_definitions (-DAPPLESEED_WITH_DISNEY_MATERIAL)
     if (USE_FIND_PACKAGE_FOR_SEEXPR)
         find_package (SeExpr REQUIRED)
@@ -434,6 +436,7 @@ endif ()
 # SIMD.
 if (is_x86)
     if (USE_AVX2)
+        set (APPLESEED_USE_AVX2 ON)
         set (preprocessor_definitions_common
             ${preprocessor_definitions_common}
             APPLESEED_USE_AVX2
@@ -441,6 +444,7 @@ if (is_x86)
         set (USE_AVX TRUE)
     endif ()
     if (USE_AVX)
+        set (APPLESEED_USE_AVX ON)
         set (preprocessor_definitions_common
             ${preprocessor_definitions_common}
             APPLESEED_USE_AVX
@@ -448,6 +452,7 @@ if (is_x86)
         set (USE_SSE42 TRUE)
     endif ()
     if (USE_SSE42)
+        set (APPLESEED_USE_SSE42 ON)
         set (preprocessor_definitions_common
             ${preprocessor_definitions_common}
             APPLESEED_USE_SSE42
@@ -455,6 +460,7 @@ if (is_x86)
         set (USE_SSE TRUE)
     endif ()
     if (USE_SSE)
+        set (APPLESEED_USE_SSE ON)
         set (preprocessor_definitions_common
             ${preprocessor_definitions_common}
             APPLESEED_USE_SSE
@@ -464,6 +470,7 @@ if (is_x86)
         endif ()
     endif ()
     if (USE_F16C)
+        set (APPLESEED_USE_FC16 ON)
         set (preprocessor_definitions_common
             ${preprocessor_definitions_common}
             APPLESEED_USE_F16C
@@ -536,6 +543,14 @@ macro (append_custom_preprocessor_definitions target first_definition)
         COMPILE_DEFINITIONS_PROFILE ${definitions}
     )
 endmacro ()
+
+
+#--------------------------------------------------------------------------------------------------
+# Auto-generate build options header.
+#--------------------------------------------------------------------------------------------------
+
+configure_file (${PROJECT_SOURCE_DIR}/src/appleseed/foundation/core/buildoptions.h.in
+                ${PROJECT_SOURCE_DIR}/src/appleseed/foundation/core/buildoptions.h)
 
 
 #--------------------------------------------------------------------------------------------------

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -82,6 +82,7 @@ source_group ("foundation\\core\\exceptions" FILES
 set (foundation_core_sources
     foundation/core/appleseed.cpp
     foundation/core/appleseed.h
+    foundation/core/buildoptions.h.in
     foundation/core/thirdparties.cpp
     foundation/core/thirdparties.h
     foundation/core/version.h.in
@@ -952,6 +953,7 @@ set (renderer_api_sources
     renderer/api/aov.h
     renderer/api/bsdf.h
     renderer/api/bssrdf.h
+    renderer/api/buildoptions.h
     renderer/api/camera.h
     renderer/api/color.h
     renderer/api/display.h

--- a/src/appleseed/foundation/core/.gitignore
+++ b/src/appleseed/foundation/core/.gitignore
@@ -1,2 +1,3 @@
 version.h
+buildoptions.h
 

--- a/src/appleseed/foundation/core/buildoptions.h.in
+++ b/src/appleseed/foundation/core/buildoptions.h.in
@@ -1,0 +1,42 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2019 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// SIMD options.
+
+#cmakedefine APPLESEED_USE_SSE
+#cmakedefine APPLESEED_USE_SSE42
+#cmakedefine APPLESEED_USE_AVX
+#cmakedefine APPLESEED_USE_AVX2
+#cmakedefine APPLESEED_USE_F16C
+
+// Optional components.
+
+#cmakedefine APPLESEED_WITH_DISNEY_MATERIAL
+#cmakedefine APPLESEED_WITH_EMBREE

--- a/src/appleseed/renderer/api/buildoptions.h
+++ b/src/appleseed/renderer/api/buildoptions.h
@@ -1,0 +1,32 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2019 Esteban Tovagliari, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// API headers.
+#include "foundation/core/buildoptions.h"


### PR DESCRIPTION
Use CMake's configure_file to generate a header file with the build options as part of the API.