### PR TITLE
Fix locale issues with OCIO

### DIFF
--- a/src/appleseed.studio/main/main.cpp
+++ b/src/appleseed.studio/main/main.cpp
@@ -339,9 +339,6 @@ int main(int argc, char* argv[])
     // The locale must be set after the construction of QApplication.
     QLocale::setDefault(QLocale::C);
 
-    // QApplication sets C locale to the user's locale, we need to fix this.
-    std::setlocale(LC_ALL, "C");
-
     // Qt changes the locale when loading images from disk for the very first time.
     // The problem was tracked for both `QImage` and `QPixmap`: in their `load()`
     // functions, both classes call `QImageReader::read()` which causes the locale
@@ -370,6 +367,9 @@ int main(int argc, char* argv[])
 
     // Create the application's main window.
     appleseed::studio::MainWindow window;
+
+    // QApplication and QMainWindow set C locale to the user's locale, we need to fix this.
+    std::setlocale(LC_ALL, "C");
 
     // Initialize the python interpreter and load plugins.
     PythonInterpreter::instance().set_main_window(&window);

--- a/src/appleseed.studio/mainwindow/mainwindow.ui
+++ b/src/appleseed.studio/mainwindow/mainwindow.ui
@@ -14,7 +14,7 @@
    <string>appleseed.studio</string>
   </property>
   <property name="locale">
-   <locale language="English" country="UnitedStates"/>
+   <locale language="C" country="AnyCountry"/>
   </property>
   <property name="toolButtonStyle">
    <enum>Qt::ToolButtonIconOnly</enum>


### PR DESCRIPTION
This PR fixes #2567.

The `m_ui->setupUi(this);` call in `src/appleseed.studio/mainwindow/mainwindow.cpp:136` causes the locale to be reset to the systems locale again. Therefore, I moved the `std::setlocale` call in the `main.cpp` behind the `MainWindow` initialization.

Also, I changed the language of the mainwindow.ui to C, to fit every other locale setting. This change doesn't make any difference and has only been made for consistency.

Generally, this issue should be treated by OCIO (e.g. not relying on the users locale) and/or QT (e.g. not changing the locale, or at least setting it back after initializing everything).