### PR TITLE
Increase precision of floating point values in text files

### DIFF
--- a/src/appleseed/foundation/mesh/objmeshfilewriter.cpp
+++ b/src/appleseed/foundation/mesh/objmeshfilewriter.cpp
@@ -275,7 +275,7 @@ void OBJMeshFileWriter::write_faces_vn_vt(const IMeshWalker& walker) const
 }
 
 // Formatting string for all floating-point values.
-#define FP_FORMAT "%.15f"
+#define FP_FORMAT "%.17f"
 
 void OBJMeshFileWriter::write_vector(const char* prefix, const Vector2d& v) const
 {

--- a/src/appleseed/foundation/meta/tests/test_qmc.cpp
+++ b/src/appleseed/foundation/meta/tests/test_qmc.cpp
@@ -50,6 +50,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdio>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -549,8 +550,9 @@ TEST_SUITE(Foundation_Math_QMC)
             for (size_t d = 0; d < Dimension; ++d)
             {
                 const double s = radical_inverse<double>(Primes[d], i);
-
-                fprintf(file, "%.17f", s);
+                
+                std::string fmt = "%." + std::to_string(std::numeric_limits<double>::max_digits10) + "f";
+                fprintf(file, fmt.c_str(), s);
 
                 if (d < Dimension - 1)
                     fprintf(file, ", ");

--- a/src/appleseed/foundation/meta/tests/test_qmc.cpp
+++ b/src/appleseed/foundation/meta/tests/test_qmc.cpp
@@ -549,7 +549,7 @@ TEST_SUITE(Foundation_Math_QMC)
             for (size_t d = 0; d < Dimension; ++d)
             {
                 const double s = radical_inverse<double>(Primes[d], i);
-                
+
                 fprintf(file, "%.17f", s);
 
                 if (d < Dimension - 1)

--- a/src/appleseed/foundation/meta/tests/test_qmc.cpp
+++ b/src/appleseed/foundation/meta/tests/test_qmc.cpp
@@ -550,8 +550,7 @@ TEST_SUITE(Foundation_Math_QMC)
             {
                 const double s = radical_inverse<double>(Primes[d], i);
                 
-                std::string fmt = "%.17f";
-                fprintf(file, fmt.c_str(), s);
+                fprintf(file, "%.17f", s);
 
                 if (d < Dimension - 1)
                     fprintf(file, ", ");

--- a/src/appleseed/foundation/meta/tests/test_qmc.cpp
+++ b/src/appleseed/foundation/meta/tests/test_qmc.cpp
@@ -550,7 +550,7 @@ TEST_SUITE(Foundation_Math_QMC)
             {
                 const double s = radical_inverse<double>(Primes[d], i);
 
-                fprintf(file, "%.16f", s);
+                fprintf(file, "%.17f", s);
 
                 if (d < Dimension - 1)
                     fprintf(file, ", ");

--- a/src/appleseed/foundation/meta/tests/test_qmc.cpp
+++ b/src/appleseed/foundation/meta/tests/test_qmc.cpp
@@ -50,7 +50,6 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdio>
-#include <limits>
 #include <string>
 #include <vector>
 
@@ -551,7 +550,7 @@ TEST_SUITE(Foundation_Math_QMC)
             {
                 const double s = radical_inverse<double>(Primes[d], i);
                 
-                std::string fmt = "%." + std::to_string(std::numeric_limits<double>::max_digits10) + "f";
+                std::string fmt = "%.17f";
                 fprintf(file, fmt.c_str(), s);
 
                 if (d < Dimension - 1)

--- a/src/appleseed/foundation/resources/logo/generatelogofiles.cpp
+++ b/src/appleseed/foundation/resources/logo/generatelogofiles.cpp
@@ -135,7 +135,7 @@ TEST_SUITE(Foundation_Resources_Logos)
 
                 color.rgb() = srgb_to_linear_rgb(color.rgb());
 
-                fprintf(file, "%.4ff, %.4ff, %.4ff, %.4ff", color[0], color[1], color[2], color[3]);
+                fprintf(file, "%.9ff, %.9ff, %.9ff, %.9ff", color[0], color[1], color[2], color[3]);
                 ++written_pixels;
             }
         }

--- a/src/appleseed/foundation/resources/logo/generatelogofiles.cpp
+++ b/src/appleseed/foundation/resources/logo/generatelogofiles.cpp
@@ -136,8 +136,7 @@ TEST_SUITE(Foundation_Resources_Logos)
 
                 color.rgb() = srgb_to_linear_rgb(color.rgb());
                 
-                std::string fmt = "%." + std::to_string(std::numeric_limits<float>::max_digits10) + "ff";
-                fprintf(file, (fmt + ", " + fmt + ", " + fmt + ", " + fmt).c_str(), color[0], color[1], color[2], color[3]);
+                fprintf(file, "%.9ff, %.9ff, %.9ff, %.9ff", color[0], color[1], color[2], color[3]);
                 ++written_pixels;
             }
         }

--- a/src/appleseed/foundation/resources/logo/generatelogofiles.cpp
+++ b/src/appleseed/foundation/resources/logo/generatelogofiles.cpp
@@ -44,7 +44,6 @@
 // Standard headers.
 #include <cstddef>
 #include <cstdio>
-#include <limits>
 #include <memory>
 #include <string>
 

--- a/src/appleseed/foundation/resources/logo/generatelogofiles.cpp
+++ b/src/appleseed/foundation/resources/logo/generatelogofiles.cpp
@@ -134,7 +134,7 @@ TEST_SUITE(Foundation_Resources_Logos)
                 image->get_pixel(x, y, color);
 
                 color.rgb() = srgb_to_linear_rgb(color.rgb());
-                
+
                 fprintf(file, "%.9ff, %.9ff, %.9ff, %.9ff", color[0], color[1], color[2], color[3]);
                 ++written_pixels;
             }

--- a/src/appleseed/foundation/resources/logo/generatelogofiles.cpp
+++ b/src/appleseed/foundation/resources/logo/generatelogofiles.cpp
@@ -134,8 +134,9 @@ TEST_SUITE(Foundation_Resources_Logos)
                 image->get_pixel(x, y, color);
 
                 color.rgb() = srgb_to_linear_rgb(color.rgb());
-
-                fprintf(file, "%.9ff, %.9ff, %.9ff, %.9ff", color[0], color[1], color[2], color[3]);
+                
+                std::string fmt = "%." + std::to_string(std::numeric_limits<float>::max_digits10) + "ff";
+                fprintf(file, (fmt + ", " + fmt + ", " + fmt + ", " + fmt).c_str(), color[0], color[1], color[2], color[3]);
                 ++written_pixels;
             }
         }

--- a/src/appleseed/foundation/resources/logo/generatelogofiles.cpp
+++ b/src/appleseed/foundation/resources/logo/generatelogofiles.cpp
@@ -44,6 +44,7 @@
 // Standard headers.
 #include <cstddef>
 #include <cstdio>
+#include <limits>
 #include <memory>
 #include <string>
 

--- a/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
@@ -113,8 +113,8 @@ namespace renderer
 namespace
 {
     // Floating-point formatting settings.
-    const char* MatrixFormat     = "%." + std::to_string(std::numeric_limits<double>::max_digits10) + "f";
-    const char* ColorValueFormat = "%." + std::to_string(std::numeric_limits<float>::max_digits10) + "f";
+    const char* MatrixFormat     = ("%." + std::to_string(std::numeric_limits<double>::max_digits10) + "f").c_str();
+    const char* ColorValueFormat = ("%." + std::to_string(std::numeric_limits<float>::max_digits10) + "f").c_str();
 
     class Writer
     {

--- a/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
@@ -114,8 +114,8 @@ namespace renderer
 namespace
 {
     // Floating-point formatting settings.
-    std::string MatrixFormat     = "%." + std::to_string(std::numeric_limits<double>::max_digits10) + "f";
-    std::string ColorValueFormat = "%." + std::to_string(std::numeric_limits<float>::max_digits10) + "f";
+    const char* MatrixFormat     = "%.17f";
+    const char* ColorValueFormat = "%.9f";
 
     class Writer
     {
@@ -192,7 +192,7 @@ namespace
             const Vec&          v,
             const size_t        size,
             const size_t        columns,
-            const std::string&         fmt)
+            const char*         fmt)
         {
             assert(columns > 0);
 
@@ -204,7 +204,7 @@ namespace
                     fputs(m_indenter.c_str(), m_file);
                 else fputc(' ', m_file);
 
-                fprintf(m_file, fmt.c_str(), v[i]);
+                fprintf(m_file, fmt, v[i]);
 
                 if (col == columns - 1 || i == size - 1)
                     fputc('\n', m_file);

--- a/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
@@ -93,6 +93,7 @@
 #include <cstring>
 #include <exception>
 #include <functional>
+#include <limits>
 #include <map>
 #include <set>
 #include <string>

--- a/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
@@ -98,6 +98,8 @@
 #include <string>
 #include <vector>
 
+#include <iostream>
+
 using namespace boost;
 using namespace foundation;
 using namespace std;
@@ -113,8 +115,8 @@ namespace renderer
 namespace
 {
     // Floating-point formatting settings.
-    const char* MatrixFormat     = ("%." + std::to_string(std::numeric_limits<double>::max_digits10) + "f").c_str();
-    const char* ColorValueFormat = ("%." + std::to_string(std::numeric_limits<float>::max_digits10) + "f").c_str();
+    std::string MatrixFormat     = "%." + std::to_string(std::numeric_limits<double>::max_digits10) + "f";
+    std::string ColorValueFormat = "%." + std::to_string(std::numeric_limits<float>::max_digits10) + "f";
 
     class Writer
     {
@@ -191,7 +193,7 @@ namespace
             const Vec&          v,
             const size_t        size,
             const size_t        columns,
-            const char*         fmt)
+            const std::string&         fmt)
         {
             assert(columns > 0);
 
@@ -203,7 +205,7 @@ namespace
                     fputs(m_indenter.c_str(), m_file);
                 else fputc(' ', m_file);
 
-                fprintf(m_file, fmt, v[i]);
+                fprintf(m_file, fmt.c_str(), v[i]);
 
                 if (col == columns - 1 || i == size - 1)
                     fputc('\n', m_file);

--- a/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
@@ -113,8 +113,8 @@ namespace renderer
 namespace
 {
     // Floating-point formatting settings.
-    const char* MatrixFormat     = "%.15f";
-    const char* ColorValueFormat = "%.6f";
+    const char* MatrixFormat     = "%." + std::to_string(std::numeric_limits<double>::max_digits10) + "f";
+    const char* ColorValueFormat = "%." + std::to_string(std::numeric_limits<float>::max_digits10) + "f";
 
     class Writer
     {

--- a/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
@@ -93,7 +93,6 @@
 #include <cstring>
 #include <exception>
 #include <functional>
-#include <limits>
 #include <map>
 #include <set>
 #include <string>

--- a/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
@@ -98,8 +98,6 @@
 #include <string>
 #include <vector>
 
-#include <iostream>
-
 using namespace boost;
 using namespace foundation;
 using namespace std;


### PR DESCRIPTION
This PR fixes #2514 

Increasing the precision of floats and doubles with respect to the `std::numeric_limits<>::max_digits10` values. Wherever possible and useful, I tried to use non-fixed values (i.e. ask the `numeric_limits`). That way, the precision obeys the precision given by the machine.

Where it wasn't possible or suitable (e.g. in macros), i used the values given by [cppreference.com](https://en.cppreference.com/w/cpp/types/numeric_limits/max_digits10).

In the attachment you can find two project files, each showing the Cornell Box (I left out the mesh files). One has been created using the changes made in this PR (HighPrecision.appleseed), the other one using the current master branch (LowPrecision.appleseed).
A `diff HighPrecision.appleseed LowPrecision.appleseed` shows very well how the precision has increased, e.g.
```
177c177
<                     1.000000000
---
>                     1.000000
```

I couldn't find any problem/issue with the precision in the settings file, so I can't provide any changes there.
[Precision.zip](https://github.com/appleseedhq/appleseed/files/3120997/Precision.zip)

