### PR TITLE
Allow input file of mitsuba2appleseed.py to be anywhere

### DIFF
--- a/sandbox/share/mitsuba2appleseed.py
+++ b/sandbox/share/mitsuba2appleseed.py
@@ -949,8 +949,8 @@ def main():
 
     project = convert(tree)
 
-    asr.ProjectFileWriter().write(project, args.output_file,
-    asr.ProjectFileWriterOptions.OmitHandlingAssetFiles)
+    asr.ProjectFileWriter().write(project, args.output_file, 
+                                  asr.ProjectFileWriterOptions.OmitHandlingAssetFiles)
 
 if __name__ == '__main__':
     main()

--- a/sandbox/share/mitsuba2appleseed.py
+++ b/sandbox/share/mitsuba2appleseed.py
@@ -33,6 +33,7 @@ from xml.etree.ElementTree import ElementTree
 import appleseed as asr
 import argparse
 import math
+import os.path
 import sys
 import traceback
 
@@ -941,10 +942,15 @@ def main():
     except IOError:
         fatal("Failed to load {0}".format(args.input_file))
 
+    for child in tree.getroot():
+        filepath= child.find("string[@name='filename']")
+        if filepath is not None:
+            filepath.attrib["value"] = os.path.join(os.path.dirname(args.input_file), filepath.attrib["value"])
+
     project = convert(tree)
 
     asr.ProjectFileWriter().write(project, args.output_file,
-                                  asr.ProjectFileWriterOptions.OmitHandlingAssetFiles)
+    asr.ProjectFileWriterOptions.OmitHandlingAssetFiles)
 
 if __name__ == '__main__':
     main()

--- a/sandbox/share/mitsuba2appleseed.py
+++ b/sandbox/share/mitsuba2appleseed.py
@@ -941,7 +941,8 @@ def main():
         tree.parse(args.input_file)
     except IOError:
         fatal("Failed to load {0}".format(args.input_file))
-
+    
+    # Add input file as a path to filename allowing input file to be anywhere.
     for child in tree.getroot():
         filepath = child.find("string[@name='filename']")
         if filepath is not None:
@@ -949,7 +950,7 @@ def main():
 
     project = convert(tree)
 
-    asr.ProjectFileWriter().write(project, args.output_file, 
+    asr.ProjectFileWriter().write(project, args.output_file,
                                   asr.ProjectFileWriterOptions.OmitHandlingAssetFiles)
 
 if __name__ == '__main__':

--- a/sandbox/share/mitsuba2appleseed.py
+++ b/sandbox/share/mitsuba2appleseed.py
@@ -943,7 +943,7 @@ def main():
         fatal("Failed to load {0}".format(args.input_file))
 
     for child in tree.getroot():
-        filepath= child.find("string[@name='filename']")
+        filepath = child.find("string[@name='filename']")
         if filepath is not None:
             filepath.attrib["value"] = os.path.join(os.path.dirname(args.input_file), filepath.attrib["value"])
 

--- a/sandbox/share/mitsuba2appleseed.py
+++ b/sandbox/share/mitsuba2appleseed.py
@@ -942,7 +942,7 @@ def main():
     except IOError:
         fatal("Failed to load {0}".format(args.input_file))
     
-    # Add input file as a path to filename allowing input file to be anywhere.
+    # Make asset paths in the Mitsuba file relative to the Mitsuba file itself.
     for child in tree.getroot():
         filepath = child.find("string[@name='filename']")
         if filepath is not None:


### PR DESCRIPTION
Now, when converting mitsuba scene to applessed we need to have the scene and mitsuba2appleseed.py in the same directory. This allows the mitsuba scene to be in any other directory.