### PR TITLE
Improve CUDA facilities

### DIFF
--- a/sandbox/stylesheets/default.qss
+++ b/sandbox/stylesheets/default.qss
@@ -560,7 +560,7 @@ QPushButton
         if defined(X) || defined(Y) is not supported by our preprocessor at this time.
     */
 #ifdef __APPLE__
-    min-width: 50px;
+    min-width: 60px;
 #endif
 #ifdef _WIN32
     min-width: 50px;

--- a/scripts/travis/build-linux.sh
+++ b/scripts/travis/build-linux.sh
@@ -40,7 +40,7 @@ THISDIR=`pwd`
 echo "travis_fold:start:deps"
 echo "Downloading and unpacking dependencies..."
 
-curl -L "https://github.com/appleseedhq/prebuilt-linux-deps/releases/download/binaries/appleseed-deps-shared-2.1.tgz" > deps.tgz
+curl -L "https://github.com/appleseedhq/prebuilt-linux-deps/releases/download/v2.1/appleseed-deps-shared-2.1.tgz" > deps.tgz
 tar xfz deps.tgz
 rm deps.tgz
 

--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -120,7 +120,7 @@ if (WITH_GPU)
     source_group ("foundation\\cuda" FILES
         ${foundation_cuda_sources}
     )
-endif()
+endif ()
 
 set (foundation_curve_sources
     foundation/curve/binarycurvefilereader.cpp

--- a/src/appleseed/foundation/cuda/cudadevice.h
+++ b/src/appleseed/foundation/cuda/cudadevice.h
@@ -30,14 +30,13 @@
 
 // appleseed.foundation headers.
 #include "foundation/core/concepts/noncopyable.h"
-#include "foundation/utility/api/apistring.h"
 
 // CUDA headers.
 #include <cuda.h>
 
 // Standard headers.
 #include <cstddef>
-#include <utility>
+#include <string>
 
 namespace foundation
 {
@@ -49,27 +48,28 @@ class CUDADevice
     explicit CUDADevice(const CUdevice device_number);
 
     // Device properties.
-    CUdevice            m_cuda_device_number;
-    APIString           m_name;
-    std::pair<int, int> m_compute_capability;
-    int                 m_compute_mode;
 
-    std::size_t         m_total_mem;
+    CUdevice        m_cuda_device;
+    std::string     m_name;
+    int             m_compute_capability_major;
+    int             m_compute_capability_minor;
+    int             m_compute_mode;
 
-    int                 m_max_threads_per_block;
-    int                 m_max_block_dim_x;
-    int                 m_max_block_dim_y;
-    int                 m_max_block_dim_z;
-    int                 m_max_grid_dim_x;
-    int                 m_max_grid_dim_y;
-    int                 m_max_grid_dim_z;
+    size_t          m_total_mem;
 
-    int                 m_max_registers;
+    int             m_max_threads_per_block;
+    int             m_max_block_dim_x;
+    int             m_max_block_dim_y;
+    int             m_max_block_dim_z;
+    int             m_max_grid_dim_x;
+    int             m_max_grid_dim_y;
+    int             m_max_grid_dim_z;
+
+    int             m_max_registers;
 };
 
-
 class CUDADeviceList
-  : NonCopyable
+  : public NonCopyable
 {
   public:
     static const CUDADeviceList& instance();
@@ -78,9 +78,9 @@ class CUDADeviceList
 
     bool empty() const;
 
-    std::size_t size() const;
+    size_t size() const;
 
-    const CUDADevice& get_device(const std::size_t device_number) const;
+    const CUDADevice& get_device(const size_t device_number) const;
 
     CUcontext get_primary_context(const CUDADevice& device) const;
 
@@ -91,4 +91,4 @@ class CUDADeviceList
     CUDADeviceList();
 };
 
-}       // namespace foundation
+}   // namespace foundation

--- a/src/appleseed/foundation/cuda/exception.cpp
+++ b/src/appleseed/foundation/cuda/exception.cpp
@@ -41,7 +41,7 @@ namespace foundation
 // ExceptionCUDAError class implementation.
 //
 
-ExceptionCUDAError::ExceptionCUDAError(CUresult error)
+ExceptionCUDAError::ExceptionCUDAError(const CUresult error)
 {
     string err;
     const char* error_string;
@@ -58,10 +58,10 @@ ExceptionCUDAError::ExceptionCUDAError(CUresult error)
     set_what(err.c_str());
 }
 
-void check_cuda_error(const CUresult error)
+void check_cuda_result(const CUresult error)
 {
     if (error != CUDA_SUCCESS)
         throw ExceptionCUDAError(error);
 }
 
-}       // namespace foundation
+}   // namespace foundation

--- a/src/appleseed/foundation/cuda/exception.h
+++ b/src/appleseed/foundation/cuda/exception.h
@@ -46,9 +46,10 @@ class ExceptionCUDAError
 {
   public:
     // Constructor.
-    explicit ExceptionCUDAError(CUresult error);
+    explicit ExceptionCUDAError(const CUresult error);
 };
 
-void check_cuda_error(const CUresult error);
+// Throws a ExceptionCUDAError exception if `error` is different than CUDA_SUCCESS.
+void check_cuda_result(const CUresult error);
 
-}       // namespace foundation
+}   // namespace foundation

--- a/src/appleseed/foundation/math/scalar.h
+++ b/src/appleseed/foundation/math/scalar.h
@@ -313,20 +313,13 @@ T inverse_lerp(const T a, const T b, const U x);
 // fit() remaps a variable x from the range [min_x, max_x] to the
 // range [min_y, max_y]. When x is outside the [min_x, max_x] range,
 // a linear extrapolation outside the [min_y, max_y] range is used.
-template <typename T>
-T fit(
-    const T x,
-    const T min_x,
-    const T max_x,
-    const T min_y,
-    const T max_y);
-template <typename U, typename V>
-V fit(
-    const U x,
-    const U min_x,
-    const U max_x,
-    const V min_y,
-    const V max_y);
+template <typename In, typename Out = In, typename Interpolant = Out>
+Out fit(
+    const In x,
+    const In min_x,
+    const In max_x,
+    const Out min_y,
+    const Out max_y);
 
 
 //
@@ -937,38 +930,21 @@ template <typename T, typename U>
 inline T inverse_lerp(const T a, const T b, const U x)
 {
     assert(a != b);
-
     return (x - a) / (b - a);
 }
 
-template <typename T>
-inline T fit(
-    const T x,
-    const T min_x,
-    const T max_x,
-    const T min_y,
-    const T max_y)
+template <typename In, typename Out, typename Interpolant>
+inline Out fit(
+    const In x,
+    const In min_x,
+    const In max_x,
+    const Out min_y,
+    const Out max_y)
 {
     assert(min_x != max_x);
-
-    const T k = (x - min_x) / (max_x - min_x);
-
-    return min_y * (T(1.0) - k) + max_y * k;
-}
-
-template <typename U, typename V>
-inline V fit(
-    const U x,
-    const U min_x,
-    const U max_x,
-    const V min_y,
-    const V max_y)
-{
-    assert(min_x != max_x);
-
-    const V k = static_cast<V>(x - min_x) / (max_x - min_x);
-
-    return min_y * (V(1.0) - k) + max_y * k;
+    const Interpolant k = Interpolant(x - min_x) / Interpolant(max_x - min_x);
+    const Out result = min_y * (Interpolant(1.0) - k) + max_y * k;
+    return result;
 }
 
 

--- a/src/appleseed/foundation/platform/arch.h
+++ b/src/appleseed/foundation/platform/arch.h
@@ -47,18 +47,18 @@
 //
 
 #if !defined(APPLESEED_ARCH32) && !defined(APPLESEED_ARCH64)
-    #if defined __x86_64__      || \
-        defined _M_X64          || \
-        defined _WIN64          || \
-        defined __powerpc64__   || \
-        defined __ppc64__       || \
-        defined __PPC64__       || \
-        defined __64BIT__       || \
-        defined _LP64           || \
-        defined __LP64__        || \
-        defined __ia64          || \
-        defined __itanium__     || \
-        defined _M_IA64         || \
+    #if defined __x86_64__                      || \
+        defined _M_X64                          || \
+        defined _WIN64                          || \
+        defined __powerpc64__                   || \
+        defined __ppc64__                       || \
+        defined __PPC64__                       || \
+        defined __64BIT__                       || \
+        defined _LP64                           || \
+        defined __LP64__                        || \
+        defined __ia64                          || \
+        defined __itanium__                     || \
+        defined _M_IA64                         || \
         defined APPLESEED_DEVICE_COMPILATION
         #define APPLESEED_ARCH64
     #else

--- a/src/appleseed/foundation/platform/compiler.h
+++ b/src/appleseed/foundation/platform/compiler.h
@@ -320,22 +320,18 @@ namespace foundation
     #define APPLESEED_HOST                  __host__
     #define APPLESEED_DEVICE                __device__
     #define APPLESEED_HOST_DEVICE           __host__ __device__
-
     #define APPLESEED_DEVICE_INLINE         __forceinline__ __device__
     #define APPLESEED_HOST_DEVICE_INLINE    __forceinline__ __host__ __device__
-
-    #define APPLESEED_DEVICE_ALIGN(n) __align__(n)
+    #define APPLESEED_DEVICE_ALIGN(n)       __align__(n)
 #else
     #define APPLESEED_HOST
-    #define APPLESEED_DEVICE
     #define APPLESEED_HOST_DEVICE
-    #define APPLESEED_HOST_DEVICE_INLINE inline
-
+    #define APPLESEED_HOST_DEVICE_INLINE    inline
     #define APPLESEED_DEVICE_ALIGN(n)
 #endif
 
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ > 0
-    #define APPLESEED_DEVICE_COMPILATION // Defined when compiling CUDA device code.
+    #define APPLESEED_DEVICE_COMPILATION    // defined when compiling CUDA device code
 #endif
 
 

--- a/src/appleseed/foundation/platform/types.h
+++ b/src/appleseed/foundation/platform/types.h
@@ -33,6 +33,7 @@
 #include "foundation/platform/arch.h"
 
 // Standard headers.
+#include <cinttypes>
 #include <cstddef>
 #include <cstdint>
 
@@ -43,73 +44,14 @@ namespace foundation
 // Define fixed-size integral types.
 //
 
-// Visual C++.
-#if defined _MSC_VER
-
-    typedef signed char                 int8;
-    typedef unsigned char               uint8;
-
-    typedef signed short int            int16;
-    typedef unsigned short int          uint16;
-
-    typedef signed int                  int32;
-    typedef unsigned int                uint32;
-
-    typedef signed long long int        int64;
-    typedef unsigned long long int      uint64;
-
-// gcc.
-#elif defined __GNUC__
-
-    typedef signed char                 int8;
-    typedef unsigned char               uint8;
-
-    typedef signed short int            int16;
-    typedef unsigned short int          uint16;
-
-    typedef signed int                  int32;
-    typedef unsigned int                uint32;
-
-    #if defined APPLESEED_ARCH32
-        typedef signed long long int    int64;
-        typedef unsigned long long int  uint64;
-    #elif defined APPLESEED_ARCH64
-        typedef signed long int         int64;
-        typedef unsigned long int       uint64;
-    #else
-        #error Cannot determine machine architecture.
-    #endif
-
-// CUDA device compilation.
-#elif defined APPLESEED_DEVICE_COMPILATION
-
-    typedef int8_t                      int8;
-    typedef uint8_t                     uint8;
-
-    typedef int16_t                     int16;
-    typedef uint16_t                    uint16;
-
-    typedef int32_t                     int32;
-    typedef uint32_t                    uint32;
-
-    typedef int64_t                     int64;
-    typedef uint64_t                    uint64;
-
-// Other platforms.
-#else
-
-    #error Fixed-size integral types are not defined on this platform.
-
-#endif
-
-static_assert(sizeof(int8)   == 1, "The size of foundation::int8 must be exactly 1 byte");
-static_assert(sizeof(int16)  == 2, "The size of foundation::int16 must be exactly 2 bytes");
-static_assert(sizeof(int32)  == 4, "The size of foundation::int32 must be exactly 4 bytes");
-static_assert(sizeof(int64)  == 8, "The size of foundation::int64 must be exactly 8 bytes");
-static_assert(sizeof(uint8)  == 1, "The size of foundation::uint8 must be exactly 1 byte");
-static_assert(sizeof(uint16) == 2, "The size of foundation::uint16 must be exactly 2 bytes");
-static_assert(sizeof(uint32) == 4, "The size of foundation::uint32 must be exactly 4 bytes");
-static_assert(sizeof(uint64) == 8, "The size of foundation::uint64 must be exactly 8 bytes");
+using int8   = std::int8_t;
+using int16  = std::int16_t;
+using int32  = std::int32_t;
+using int64  = std::int64_t;
+using uint8  = std::uint8_t;
+using uint16 = std::uint16_t;
+using uint32 = std::uint32_t;
+using uint64 = std::uint64_t;
 
 
 //
@@ -133,39 +75,8 @@ static_assert(
 // Format strings to use with std::printf() variants.
 //
 
-// Visual C++.
-#if defined _MSC_VER
-
-    #define FMT_UINT64              "%llu"
-    #define FMT_UINT64_HEX          "%llx"
-    #define FMT_SIZE_T              "%Iu"
-
-// gcc.
-#elif defined __GNUC__
-
-    #if defined APPLESEED_ARCH32
-        #define FMT_UINT64          "%llu"
-        #define FMT_UINT64_HEX      "%llx"
-    #elif defined APPLESEED_ARCH64
-        #define FMT_UINT64          "%lu"
-        #define FMT_UINT64_HEX      "%lx"
-    #else
-        #error Cannot determine machine architecture.
-    #endif
-
-    #define FMT_SIZE_T              "%zu"
-
-#elif defined __CUDACC__
-
-    #define FMT_UINT64              "%lu"
-    #define FMT_UINT64_HEX          "%llx"
-    #define FMT_SIZE_T              "%zu"
-
-// Other compilers.
-#else
-
-    #error Format strings are not defined on this platform.
-
-#endif
+#define FMT_UINT64          "%" PRIu64
+#define FMT_UINT64_HEX      "%" PRIx64
+#define FMT_SIZE_T          "%zu"
 
 }   // namespace foundation

--- a/src/appleseed/foundation/platform/types.h
+++ b/src/appleseed/foundation/platform/types.h
@@ -136,30 +136,30 @@ static_assert(
 // Visual C++.
 #if defined _MSC_VER
 
-    #define FMT_UINT64          "%llu"
-    #define FMT_UINT64_HEX      "%llx"
-    #define FMT_SIZE_T          "%Iu"
+    #define FMT_UINT64              "%llu"
+    #define FMT_UINT64_HEX          "%llx"
+    #define FMT_SIZE_T              "%Iu"
 
 // gcc.
 #elif defined __GNUC__
 
     #if defined APPLESEED_ARCH32
-        #define FMT_UINT64      "%llu"
-        #define FMT_UINT64_HEX  "%llx"
+        #define FMT_UINT64          "%llu"
+        #define FMT_UINT64_HEX      "%llx"
     #elif defined APPLESEED_ARCH64
-        #define FMT_UINT64      "%lu"
-        #define FMT_UINT64_HEX  "%lx"
+        #define FMT_UINT64          "%lu"
+        #define FMT_UINT64_HEX      "%lx"
     #else
         #error Cannot determine machine architecture.
     #endif
 
-    #define FMT_SIZE_T "%zu"
+    #define FMT_SIZE_T              "%zu"
 
 #elif defined __CUDACC__
 
-    #define FMT_UINT64      "%lu"
-    #define FMT_UINT64_HEX  "%llx"
-    #define FMT_SIZE_T      "%zu"
+    #define FMT_UINT64              "%lu"
+    #define FMT_UINT64_HEX          "%llx"
+    #define FMT_SIZE_T              "%zu"
 
 // Other compilers.
 #else

--- a/src/appleseed/foundation/utility/statistics.h
+++ b/src/appleseed/foundation/utility/statistics.h
@@ -318,9 +318,9 @@ void Statistics::insert(
 }
 
 template <>
-inline void Statistics::insert<int32>(
+inline void Statistics::insert<int>(
     const std::string&                  name,
-    const int32&                        value,
+    const int&                          value,
     const std::string&                  unit)
 {
     insert(
@@ -329,9 +329,9 @@ inline void Statistics::insert<int32>(
 }
 
 template <>
-inline void Statistics::insert<uint32>(
+inline void Statistics::insert<unsigned int>(
     const std::string&                  name,
-    const uint32&                       value,
+    const unsigned int&                 value,
     const std::string&                  unit)
 {
     insert(
@@ -340,9 +340,9 @@ inline void Statistics::insert<uint32>(
 }
 
 template <>
-inline void Statistics::insert<int64>(
+inline void Statistics::insert<long>(
     const std::string&                  name,
-    const int64&                        value,
+    const long&                         value,
     const std::string&                  unit)
 {
     insert(
@@ -351,9 +351,9 @@ inline void Statistics::insert<int64>(
 }
 
 template <>
-inline void Statistics::insert<uint64>(
+inline void Statistics::insert<unsigned long>(
     const std::string&                  name,
-    const uint64&                       value,
+    const unsigned long&                value,
     const std::string&                  unit)
 {
     insert(
@@ -361,6 +361,27 @@ inline void Statistics::insert<uint64>(
             new UnsignedIntegerEntry(name, unit, value)));
 }
 
+template <>
+inline void Statistics::insert<long long>(
+    const std::string&                  name,
+    const long long&                    value,
+    const std::string&                  unit)
+{
+    insert(
+        std::unique_ptr<IntegerEntry>(
+            new IntegerEntry(name, unit, value)));
+}
+
+template <>
+inline void Statistics::insert<unsigned long long>(
+    const std::string&                  name,
+    const unsigned long long&           value,
+    const std::string&                  unit)
+{
+    insert(
+        std::unique_ptr<UnsignedIntegerEntry>(
+            new UnsignedIntegerEntry(name, unit, value)));
+}
 template <>
 inline void Statistics::insert<float>(
     const std::string&                  name,


### PR DESCRIPTION
- Fix incorrect reporting of CUDA device compute capability (it was reporting major.major instead of major.minor)
- Change "driver version" to "CUDA version" in log since that's what it really is
- Fix deprecation warning about `cuDeviceComputeCapability()`
- Report driver version in a human-readable format
- Improve formatting of GPU information written to log
- Add CUDA API call result checks
- Don't define `APPLESEED_DEVICE` in CPU-only mode
- Rename `foundation::check_cuda_error()` to `check_cuda_result()`
- Simplify data member types in `foundation::CUDADevice`
- Simplify code and follow coding conventions more closely