### PR TITLE
Update travis linux deps and compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,10 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-4.8
-      - g++-4.8
-      - gcc-5
-      - g++-5
       - gcc-6
       - g++-6
+      - gcc-7
+      - g++-7
       - python2.7-dev
       - qtbase5-dev
       - libqt5opengl5-dev
@@ -63,15 +61,11 @@ matrix:
   include:
     - os: linux
       compiler: gcc
-      env: GCC_VERSION=4.8
-
-    - os: linux
-      compiler: gcc
-      env: GCC_VERSION=5
-
-    - os: linux
-      compiler: gcc
       env: GCC_VERSION=6
+
+    - os: linux
+      compiler: gcc
+      env: GCC_VERSION=7
 
   exclude:
     - os: osx

--- a/scripts/travis/build-linux.sh
+++ b/scripts/travis/build-linux.sh
@@ -40,7 +40,7 @@ THISDIR=`pwd`
 echo "travis_fold:start:deps"
 echo "Downloading and unpacking dependencies..."
 
-curl -L "https://github.com/appleseedhq/prebuilt-linux-deps/releases/download/binaries/appleseed-deps-shared-2.0.tgz" > deps.tgz
+curl -L "https://github.com/appleseedhq/prebuilt-linux-deps/releases/download/binaries/appleseed-deps-shared-2.1.tgz" > deps.tgz
 tar xfz deps.tgz
 rm deps.tgz
 
@@ -82,20 +82,19 @@ cmake \
     -Wno-dev \
     -DCMAKE_BUILD_TYPE=Debug \
     -DUSE_SSE42=ON \
-    -DWITH_DISNEY_MATERIAL=OFF \
     -DWITH_EMBREE=ON \
     -DUSE_STATIC_BOOST=OFF \
     -DBOOST_INCLUDEDIR=$APPLESEED_DEPENDENCIES/include/boost_1_61_0 \
     -DBOOST_LIBRARYDIR=$APPLESEED_DEPENDENCIES/lib/ \
-    -DBoost_ATOMIC_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_atomic-gcc48-mt-1_61.so.1.61.0 \
-    -DBoost_CHRONO_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_chrono-gcc48-mt-1_61.so.1.61.0 \
-    -DBoost_DATE_TIME_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_date_time-gcc48-mt-1_61.so.1.61.0 \
-    -DBoost_FILESYSTEM_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_filesystem-gcc48-mt-1_61.so.1.61.0 \
-    -DBoost_PYTHON_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_python-gcc48-mt-1_61.so.1.61.0 \
-    -DBoost_REGEX_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_regex-gcc48-mt-1_61.so.1.61.0 \
-    -DBoost_SYSTEM_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_system-gcc48-mt-1_61.so.1.61.0 \
-    -DBoost_THREAD_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_thread-gcc48-mt-1_61.so.1.61.0 \
-    -DBoost_WAVE_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_wave-gcc48-mt-1_61.so.1.61.0 \
+    -DBoost_ATOMIC_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_atomic-gcc63-mt-1_61.so.1.61.0 \
+    -DBoost_CHRONO_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_chrono-gcc63-mt-1_61.so.1.61.0 \
+    -DBoost_DATE_TIME_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_date_time-gcc63-mt-1_61.so.1.61.0 \
+    -DBoost_FILESYSTEM_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_filesystem-gcc63-mt-1_61.so.1.61.0 \
+    -DBoost_PYTHON_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_python-gcc63-mt-1_61.so.1.61.0 \
+    -DBoost_REGEX_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_regex-gcc63-mt-1_61.so.1.61.0 \
+    -DBoost_SYSTEM_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_system-gcc63-mt-1_61.so.1.61.0 \
+    -DBoost_THREAD_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_thread-gcc63-mt-1_61.so.1.61.0 \
+    -DBoost_WAVE_LIBRARY_DEBUG=$APPLESEED_DEPENDENCIES/lib/libboost_wave-gcc63-mt-1_61.so.1.61.0 \
     -DEMBREE_INCLUDE_DIR=$APPLESEED_DEPENDENCIES/include \
     -DEMBREE_LIBRARY=$APPLESEED_DEPENDENCIES/lib/libembree3.so \
     -DLZ4_INCLUDE_DIR=$APPLESEED_DEPENDENCIES/include \


### PR DESCRIPTION
- Use new linux deps.
- Remove gcc-4.8 and gcc-5. Add gcc-7.
- Re-enable the Disney Material support.
