### PR TITLE
Make use of shape proabilities consistent

### DIFF
--- a/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
@@ -227,8 +227,6 @@ float BackwardLightSampler::evaluate_pdf(
     const ShadingPoint&                 light_shading_point,
     const ShadingPoint&                 surface_shading_point) const
 {
-    assert(light_shading_point.is_triangle_primitive());
-
     const EmittingShapeKey shape_key(
         light_shading_point.get_assembly_instance().get_uid(),
         light_shading_point.get_object_instance_index(),

--- a/src/appleseed/renderer/kernel/lighting/forwardlightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/forwardlightsampler.cpp
@@ -113,7 +113,7 @@ ForwardLightSampler::ForwardLightSampler(const Scene& scene, const ParamArray& p
 
     // Store the shape probability densities into the emitting shapes.
     for (size_t i = 0, e = m_emitting_shapes.size(); i < e; ++i)
-        m_emitting_shapes[i].set_shape_prob(m_emitting_shapes_cdf[i].second);
+        m_emitting_shapes[i].m_shape_prob = m_emitting_shapes_cdf[i].second;
 
    RENDERER_LOG_INFO(
         "found %s %s, %s emitting %s.",

--- a/src/appleseed/renderer/kernel/lighting/lightsamplerbase.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lightsamplerbase.cpp
@@ -642,11 +642,10 @@ void LightSamplerBase::sample_emitting_shapes(
 
     const EmitterCDF::ItemWeightPair result = m_emitting_shapes_cdf.sample(s[0]);
     const size_t emitter_index = result.first;
-    const float emitter_prob = result.second;
 
     light_sample.m_light = nullptr;
     const EmittingShape& emitting_shape = m_emitting_shapes[emitter_index];
-    emitting_shape.sample_uniform(Vector2f(s[1], s[2]), emitter_prob, light_sample);
+    emitting_shape.sample_uniform(Vector2f(s[1], s[2]), light_sample);
 
     assert(light_sample.m_shape);
     assert(light_sample.m_probability > 0.0f);

--- a/src/appleseed/renderer/kernel/lighting/lighttypes.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttypes.cpp
@@ -235,9 +235,10 @@ EmittingShape::EmittingShape(
 
 void EmittingShape::sample_uniform(
     const Vector2f&         s,
-    const float             shape_prob,
     LightSample&            light_sample) const
 {
+    assert(m_shape_prob >= 0.0f);
+
     // Store a pointer to the emitting shape.
     light_sample.m_shape = this;
 
@@ -321,12 +322,13 @@ void EmittingShape::sample_uniform(
     }
 
     // Compute the probability density of this sample.
-    light_sample.m_probability = shape_prob * get_rcp_area();
+    light_sample.m_probability = evaluate_pdf_uniform();
 }
 
 float EmittingShape::evaluate_pdf_uniform() const
 {
-    return get_shape_prob() * get_rcp_area();
+    assert(m_shape_prob >= 0.0f);
+    return m_shape_prob * get_rcp_area();
 }
 
 void EmittingShape::make_shading_point(

--- a/src/appleseed/renderer/kernel/lighting/lighttypes.h
+++ b/src/appleseed/renderer/kernel/lighting/lighttypes.h
@@ -43,6 +43,8 @@
 // Forward declarations.
 namespace renderer  { class AssemblyInstance; }
 namespace renderer  { class BackwardLightSampler; }
+namespace renderer  { class ForwardLightSampler; }
+namespace renderer  { class LightSamplerBase; }
 namespace renderer  { class Intersector; }
 namespace renderer  { class Light; }
 namespace renderer  { class LightSample; }
@@ -140,9 +142,6 @@ class EmittingShape
     float get_area() const;
     float get_rcp_area() const;
 
-    float get_shape_prob() const;
-    void set_shape_prob(const float prob);
-
     const Material* get_material() const;
 
     const foundation::AABB3d& get_bbox() const;
@@ -151,7 +150,6 @@ class EmittingShape
 
     void sample_uniform(
         const foundation::Vector2f& s,
-        const float                 shape_prob,
         LightSample&                light_sample) const;
 
     float evaluate_pdf_uniform() const;
@@ -171,8 +169,9 @@ class EmittingShape
     float get_max_flux() const;
 
   private:
-    friend class LightSamplerBase;
     friend class BackwardLightSampler;
+    friend class ForwardLightSampler;
+    friend class LightSamplerBase;
 
     struct Triangle
     {
@@ -273,16 +272,6 @@ inline float EmittingShape::get_area() const
 inline float EmittingShape::get_rcp_area() const
 {
     return m_rcp_area;
-}
-
-inline float EmittingShape::get_shape_prob() const
-{
-    return m_shape_prob;
-}
-
-inline void EmittingShape::set_shape_prob(const float prob)
-{
-    m_shape_prob = prob;
 }
 
 inline const Material* EmittingShape::get_material() const


### PR DESCRIPTION
`shape_prob` argument of `sample_uniform` contains exactly the same value as `m_shape_prob`. This PR makes sure we don't have two variables for the same thing.

In the future, we would like to completly remove the shape prob (`m_shape_prob`)  from the emitting shape.