### PR TITLE
Fix a number of problems around checkpointing

### DIFF
--- a/src/appleseed/renderer/kernel/rendering/final/adaptivetilerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/adaptivetilerenderer.cpp
@@ -257,7 +257,7 @@ namespace
                 // The AOV takes care of normalizing values depending on sampling parameters.
                 sample_aov->set_normalization_range(
                     m_params.m_min_samples,
-                    m_params.m_max_samples * m_params.m_passes);
+                    m_params.m_max_samples * m_params.m_pass_count);
             }
         }
 
@@ -346,7 +346,7 @@ namespace
                     frame.aov_images().size(),
                     tile_bbox));
 
-            if (m_params.m_passes > 1)
+            if (m_params.m_pass_count > 1)
                 second_framebuffer->copy_from(*framebuffer);
             else second_framebuffer->clear();
 
@@ -621,7 +621,7 @@ namespace
             const size_t                        m_max_samples;
             const float                         m_noise_threshold;
             const float                         m_splitting_threshold;
-            const size_t                        m_passes;
+            const size_t                        m_pass_count;
 
             explicit Parameters(const ParamArray& params)
               : m_sampling_mode(get_sampling_context_mode(params))
@@ -630,7 +630,7 @@ namespace
               , m_max_samples(params.get_required<size_t>("max_samples", 256))
               , m_noise_threshold(params.get_required<float>("noise_threshold", 1.0f))
               , m_splitting_threshold(m_noise_threshold * 256.0f)
-              , m_passes(params.get_optional<size_t>("passes", 1))
+              , m_pass_count(params.get_optional<size_t>("passes", 1))
             {
             }
         };

--- a/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
@@ -385,6 +385,7 @@ namespace
                         assert(!m_job_queue.has_scheduled_or_running_jobs());
                     }
 
+                    // Optionally write a checkpoint file to disk.
                     m_frame.save_checkpoint(m_framebuffer_factory, pass);
                 }
 

--- a/src/appleseed/renderer/modeling/frame/frame.h
+++ b/src/appleseed/renderer/modeling/frame/frame.h
@@ -184,14 +184,16 @@ class APPLESEED_DLLSYMBOL Frame
         const size_t                                thread_count,
         foundation::IAbortSwitch*                   abort_switch) const;
 
-    // Open the checkpoint if the chekpoint resume option is enabled.
+    // Load a checkpoint file from disk if checkpoint resuming is enabled.
     // Returns true if successful, false otherwise.
-    bool load_checkpoint(IShadingResultFrameBufferFactory*  buffer_factory);
+    bool load_checkpoint(
+        IShadingResultFrameBufferFactory*           buffer_factory,
+        const size_t                                pass_count);        // total number of passes to render
 
-    // Create a checkpoint file for the resuming the render at the current pass.
+    // Save a checkpoint file to disk if checkpoint creation is enabled.
     void save_checkpoint(
         IShadingResultFrameBufferFactory*           buffer_factory,
-        const size_t                                pass) const;
+        const size_t                                pass_index) const;  // index of the pass to be written
 
     // Write the main image to disk.
     // Return true if successful, false otherwise.


### PR DESCRIPTION
This fixes issue #2597.

Changes:
  - By default, use the number of passes specified in the project file when resuming a render from a checkpoint file.
  - Handle failures to load a checkpoint file.
  - Fixed assertion when loading a checkpoint file failed.
  - Resuming rendering from a checkpoint file that contains all the requested passes is no longer an error (and appleseed.cli will now return a success code).
  - Fix off-by-one error in log message when resuming rendering from a checkpoint file.