### PR TITLE
Microfacet-related code cleanups

### DIFF
--- a/src/appleseed/foundation/math/microfacet.cpp
+++ b/src/appleseed/foundation/math/microfacet.cpp
@@ -103,8 +103,7 @@ namespace
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma)
+        const float         alpha_y)
     {
         assert(is_normalized(v));
 
@@ -114,8 +113,8 @@ namespace
             return 0.0f;
 
         return
-            MDF::G1(v, m, alpha_x, alpha_y, gamma) * abs(dot(v, m)) *
-            MDF::D(m, alpha_x, alpha_y, gamma) / abs(cos_theta_v);
+            MDF::G1(v, m, alpha_x, alpha_y) * abs(dot(v, m)) *
+            MDF::D(m, alpha_x, alpha_y) / abs(cos_theta_v);
     }
 }
 
@@ -127,8 +126,7 @@ namespace
 float BlinnMDF::D(
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     return (alpha_x + 2.0f) * RcpTwoPi<float>() * pow(abs(m.y), alpha_x);
 }
@@ -138,20 +136,18 @@ float BlinnMDF::G(
     const Vector3f&     wo,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     return min(
-        G1(wi, m, alpha_x, alpha_y, gamma),
-        G1(wo, m, alpha_x, alpha_y, gamma));
+        G1(wi, m, alpha_x, alpha_y),
+        G1(wo, m, alpha_x, alpha_y));
 }
 
 float BlinnMDF::G1(
     const Vector3f&     v,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     const float cos_vm = dot(v, m);
     if (cos_vm == 0.0f)
@@ -164,8 +160,7 @@ Vector3f BlinnMDF::sample(
     const Vector3f&     v,
     const Vector2f&     s,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     const float cos_theta = pow(1.0f - s[0], 1.0f / (alpha_x + 2.0f));
     const float sin_theta = sqrt(max(0.0f, 1.0f - square(cos_theta)));
@@ -180,10 +175,9 @@ float BlinnMDF::pdf(
     const Vector3f&     v,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
-    return pdf_visible_normals<BlinnMDF>(v, m, alpha_x, alpha_y, gamma);
+    return pdf_visible_normals<BlinnMDF>(v, m, alpha_x, alpha_y);
 }
 
 
@@ -194,8 +188,7 @@ float BlinnMDF::pdf(
 float BeckmannMDF::D(
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     const float cos_theta = m.y;
     if (cos_theta == 0.0f)
@@ -221,27 +214,24 @@ float BeckmannMDF::G(
     const Vector3f&     wo,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
-    return 1.0f / (1.0f + lambda(wo, alpha_x, alpha_y, gamma) + lambda(wi, alpha_x, alpha_y, gamma));
+    return 1.0f / (1.0f + lambda(wo, alpha_x, alpha_y) + lambda(wi, alpha_x, alpha_y));
 }
 
 float BeckmannMDF::G1(
     const Vector3f&     v,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
-    return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y, gamma));
+    return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y));
 }
 
 float BeckmannMDF::lambda(
     const Vector3f&     v,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     const float cos_theta = v.y;
     if (cos_theta == 0.0f)
@@ -276,8 +266,7 @@ Vector3f BeckmannMDF::sample(
     const Vector3f&     v,
     const Vector2f&     s,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     // Preconditions.
     assert(is_normalized(v));
@@ -295,7 +284,7 @@ Vector3f BeckmannMDF::sample(
     const float phi =
         stretched[1] < 0.99999f ? atan2(stretched[2], stretched[0]) : 0.0f;
 
-    Vector2f slope = sample_slope(cos_theta, s, gamma);
+    Vector2f slope = sample_slope(cos_theta, s);
 
     // Rotate.
     const float cos_phi = cos(phi);
@@ -315,8 +304,7 @@ Vector3f BeckmannMDF::sample(
 // This code comes from OpenShadingLanguage test render.
 Vector2f BeckmannMDF::sample_slope(
     const float         cos_theta,
-    const Vector2f&     s,
-    const float         gamma)
+    const Vector2f&     s)
 {
     const float threshold = 1e-06f;
     Vector2f slope;
@@ -378,10 +366,9 @@ float BeckmannMDF::pdf(
     const Vector3f&     v,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
-    return pdf_visible_normals<BeckmannMDF>(v, m, alpha_x, alpha_y, gamma);
+    return pdf_visible_normals<BeckmannMDF>(v, m, alpha_x, alpha_y);
 }
 
 
@@ -392,8 +379,7 @@ float BeckmannMDF::pdf(
 float GGXMDF::D(
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     const float cos_theta = m.y;
     if (cos_theta == 0.0f)
@@ -420,27 +406,24 @@ float GGXMDF::G(
     const Vector3f&     wo,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
-    return 1.0f / (1.0f + lambda(wo, alpha_x, alpha_y, gamma) + lambda(wi, alpha_x, alpha_y, gamma));
+    return 1.0f / (1.0f + lambda(wo, alpha_x, alpha_y) + lambda(wi, alpha_x, alpha_y));
 }
 
 float GGXMDF::G1(
     const Vector3f&     v,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
-    return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y, gamma));
+    return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y));
 }
 
 float GGXMDF::lambda(
     const Vector3f&     v,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     const float cos_theta = v.y;
     if (cos_theta == 0.0f)
@@ -465,8 +448,7 @@ Vector3f GGXMDF::sample(
     const Vector3f&     v,
     const Vector2f&     s,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     // Preconditions.
     assert(is_normalized(v));
@@ -513,10 +495,9 @@ float GGXMDF::pdf(
     const Vector3f&     v,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
-    return pdf_visible_normals<GGXMDF>(v, m, alpha_x, alpha_y, gamma);
+    return pdf_visible_normals<GGXMDF>(v, m, alpha_x, alpha_y);
 }
 
 
@@ -527,8 +508,7 @@ float GGXMDF::pdf(
 float WardMDF::D(
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     const float cos_theta = m.y;
 
@@ -550,20 +530,18 @@ float WardMDF::G(
     const Vector3f&     wo,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     return min(
-        G1(wi, m, alpha_x, alpha_y, gamma),
-        G1(wo, m, alpha_x, alpha_y, gamma));
+        G1(wi, m, alpha_x, alpha_y),
+        G1(wo, m, alpha_x, alpha_y));
 }
 
 float WardMDF::G1(
     const Vector3f&     v,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     if (v.y <= 0.0f)
         return 0.0f;
@@ -582,8 +560,7 @@ Vector3f WardMDF::sample(
     const Vector3f&     v,
     const Vector2f&     s,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     const float tan_alpha_2 = square(alpha_x) * (-std::log(1.0f - s[0]));
     const float cos_alpha = 1.0f / sqrt(1.0f + tan_alpha_2);
@@ -596,10 +573,9 @@ float WardMDF::pdf(
     const Vector3f&     v,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
-    return D(m, alpha_x, alpha_y, gamma);
+    return D(m, alpha_x, alpha_y);
 }
 
 
@@ -610,8 +586,7 @@ float WardMDF::pdf(
 float GTR1MDF::D(
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     const float alpha = clamp(alpha_x, 0.001f, 0.999f);
     const float alpha_x_2 = square(alpha);
@@ -626,27 +601,24 @@ float GTR1MDF::G(
     const Vector3f&     wo,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
-    return 1.0f / (1.0f + lambda(wo, alpha_x, alpha_y, gamma) + lambda(wi, alpha_x, alpha_y, gamma));
+    return 1.0f / (1.0f + lambda(wo, alpha_x, alpha_y) + lambda(wi, alpha_x, alpha_y));
 }
 
 float GTR1MDF::G1(
     const Vector3f&     v,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
-    return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y, gamma));
+    return 1.0f / (1.0f + lambda(v, alpha_x, alpha_y));
 }
 
 float GTR1MDF::lambda(
     const Vector3f&     v,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     const float cos_theta = v.y;
     if (cos_theta == 0.0f)
@@ -677,8 +649,7 @@ Vector3f GTR1MDF::sample(
     const Vector3f&     v,
     const Vector2f&     s,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
     const float alpha = clamp(alpha_x, 0.001f, 0.999f);
     const float alpha_2 = square(alpha);
@@ -696,10 +667,9 @@ float GTR1MDF::pdf(
     const Vector3f&     v,
     const Vector3f&     m,
     const float         alpha_x,
-    const float         alpha_y,
-    const float         gamma)
+    const float         alpha_y)
 {
-    return D(m, alpha_x, alpha_y, gamma) * std::abs(m.y);
+    return D(m, alpha_x, alpha_y) * std::abs(m.y);
 }
 
 

--- a/src/appleseed/foundation/math/microfacet.h
+++ b/src/appleseed/foundation/math/microfacet.h
@@ -58,37 +58,32 @@ class BlinnMDF
     static float D(
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static float G(
         const Vector3f&     wi,
         const Vector3f&     wo,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static Vector3f sample(
         const Vector3f&     v,
         const Vector2f&     s,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static float pdf(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 };
 
 
@@ -121,30 +116,26 @@ class BeckmannMDF
     static float D(
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static float G(
         const Vector3f&     wi,
         const Vector3f&     wo,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static Vector3f sample(
         const Vector3f&     v,
         const Vector2f&     s,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static Vector3f sample(
         const Vector2f&     s,
@@ -154,19 +145,17 @@ class BeckmannMDF
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
+  private:
     static Vector2f sample_slope(
         const float         cos_theta,
-        const Vector2f&     s,
-        const float         gamma);
+        const Vector2f&     s);
 
     static float lambda(
         const Vector3f&     v,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 };
 
 
@@ -194,43 +183,38 @@ class GGXMDF
     static float D(
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static float G(
         const Vector3f&     wi,
         const Vector3f&     wo,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static Vector3f sample(
         const Vector3f&     v,
         const Vector2f&     s,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static float pdf(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
+  private:
     static float lambda(
         const Vector3f&     v,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 };
 
 
@@ -251,37 +235,32 @@ class WardMDF
     static float D(
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static float G(
         const Vector3f&     wi,
         const Vector3f&     wo,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static Vector3f sample(
         const Vector3f&     v,
         const Vector2f&     s,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static float pdf(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 };
 
 
@@ -303,44 +282,38 @@ class GTR1MDF
     static float D(
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static float G(
         const Vector3f&     wi,
         const Vector3f&     wo,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static float G1(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static Vector3f sample(
         const Vector3f&     v,
         const Vector2f&     s,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
     static float pdf(
         const Vector3f&     v,
         const Vector3f&     m,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 
   private:
     static float lambda(
         const Vector3f&     v,
         const float         alpha_x,
-        const float         alpha_y,
-        const float         gamma);
+        const float         alpha_y);
 };
 
 

--- a/src/appleseed/foundation/math/scalar.h
+++ b/src/appleseed/foundation/math/scalar.h
@@ -178,6 +178,10 @@ T cube(const T x);
 template <typename T>
 T rcp(const T x);
 
+// Return 1 / x or eps if the absolute value of x is less than eps.
+template <typename T>
+T safe_rcp(const T x, const T eps);
+
 // Return the square root of x or 0 if x is negative.
 template <typename T>
 T safe_sqrt(const T x);
@@ -427,15 +431,21 @@ inline T cube(const T x)
 }
 
 template <typename T>
-inline T safe_sqrt(const T x)
-{
-    return std::sqrt(std::max(x, T(0.0)));
-}
-
-template <typename T>
 inline T rcp(const T x)
 {
     return T(1.0) / x;
+}
+
+template <typename T>
+inline T safe_rcp(const T x, const T eps)
+{
+    return std::abs(x) < eps ? eps : T(1.0) / x;
+}
+
+template <typename T>
+inline T safe_sqrt(const T x)
+{
+    return std::sqrt(std::max(x, T(0.0)));
 }
 
 template <typename T, size_t P>

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_microfacet.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_microfacet.cpp
@@ -64,8 +64,7 @@ BENCHMARK_SUITE(Foundation_Math_Microfacet)
                     m_outgoing,
                     s,
                     alpha_x,
-                    alpha_y,
-                    0.0f);
+                    alpha_y);
         }
 
         void evaluate(const float alpha_x, const float alpha_y)
@@ -78,8 +77,7 @@ BENCHMARK_SUITE(Foundation_Math_Microfacet)
                 MDFType().D(
                     normalize(Vector3f(s[0], 0.5f, s[1])),
                     alpha_x,
-                    alpha_y,
-                    0.0f);
+                    alpha_y);
         }
     };
 

--- a/src/appleseed/renderer/modeling/bsdf/blinnbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/blinnbrdf.cpp
@@ -155,12 +155,10 @@ namespace
             const InputValues* values = static_cast<const InputValues*>(data);
 
             const FresnelFun f(values->m_precomputed.m_outside_ior / values->m_ior);
-            MicrofacetBRDFHelper<false>::sample(
+            MicrofacetBRDFHelper<BlinnMDF, false>::sample(
                 sampling_context,
-                m_mdf,
                 values->m_exponent,
                 values->m_exponent,
-                0.0f,
                 f,
                 sample);
             sample.m_value.m_beauty = sample.m_value.m_glossy;
@@ -186,11 +184,9 @@ namespace
             const FresnelFun f(values->m_precomputed.m_outside_ior / values->m_ior);
 
             const float pdf =
-                MicrofacetBRDFHelper<false>::evaluate(
-                    m_mdf,
+                MicrofacetBRDFHelper<BlinnMDF, false>::evaluate(
                     values->m_exponent,
                     values->m_exponent,
-                    0.0f,
                     shading_basis,
                     outgoing,
                     incoming,
@@ -218,11 +214,9 @@ namespace
             const InputValues* values = static_cast<const InputValues*>(data);
 
             const float pdf =
-                MicrofacetBRDFHelper<false>::pdf(
-                    m_mdf,
+                MicrofacetBRDFHelper<BlinnMDF, false>::pdf(
                     values->m_exponent,
                     values->m_exponent,
-                    0.0f,
                     shading_basis,
                     outgoing,
                     incoming);
@@ -233,8 +227,6 @@ namespace
 
       private:
         typedef BlinnBRDFInputValues InputValues;
-
-        BlinnMDF m_mdf;
     };
 
     typedef BSDFWrapper<BlinnBRDFImpl> BlinnBRDF;

--- a/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
@@ -456,13 +456,10 @@ namespace
                     values->m_anisotropic,
                     alpha_x,
                     alpha_y);
-                const GGXMDF ggx_mdf;
-                MicrofacetBRDFHelper<false>::sample(
+                MicrofacetBRDFHelper<GGXMDF, false>::sample(
                     sampling_context,
-                    ggx_mdf,
                     alpha_x,
                     alpha_y,
-                    0.0f,
                     DisneySpecularFresnelFun(*values),
                     sample);
                 probability = weights[SpecularComponent] * sample.get_probability();
@@ -471,13 +468,10 @@ namespace
             else
             {
                 const float alpha = clearcoat_roughness(values);
-                const GTR1MDF gtr1_mdf;
-                MicrofacetBRDFHelper<false>::sample(
+                MicrofacetBRDFHelper<GTR1MDF, false>::sample(
                     sampling_context,
-                    gtr1_mdf,
                     alpha,
                     alpha,
-                    0.0f,
                     DisneyClearcoatFresnelFun(*values),
                     sample);
                 probability = weights[ClearcoatComponent] * sample.get_probability();
@@ -527,14 +521,11 @@ namespace
                     alpha_x,
                     alpha_y);
                 Spectrum spec;
-                const GGXMDF ggx_mdf;
                 probability +=
                     weights[SpecularComponent] *
-                    MicrofacetBRDFHelper<false>::evaluate(
-                        ggx_mdf,
+                    MicrofacetBRDFHelper<GGXMDF, false>::evaluate(
                         alpha_x,
                         alpha_y,
-                        0.0f,
                         sample.m_shading_basis,
                         outgoing,
                         incoming,
@@ -547,14 +538,11 @@ namespace
             {
                 const float alpha = clearcoat_roughness(values);
                 Spectrum clear;
-                const GTR1MDF gtr1_mdf;
                 probability +=
                     weights[ClearcoatComponent] *
-                    MicrofacetBRDFHelper<false>::evaluate(
-                        gtr1_mdf,
+                    MicrofacetBRDFHelper<GTR1MDF, false>::evaluate(
                         alpha,
                         alpha,
-                        0.0f,
                         sample.m_shading_basis,
                         outgoing,
                         incoming,
@@ -629,13 +617,10 @@ namespace
                     alpha_y);
 
                 Spectrum spec;
-                const GGXMDF ggx_mdf;
                 const float spec_pdf =
-                    MicrofacetBRDFHelper<false>::evaluate(
-                        ggx_mdf,
+                    MicrofacetBRDFHelper<GGXMDF, false>::evaluate(
                         alpha_x,
                         alpha_y,
-                        0.0f,
                         shading_basis,
                         outgoing,
                         incoming,
@@ -653,13 +638,10 @@ namespace
             {
                 const float alpha = clearcoat_roughness(values);
                 Spectrum clearcoat;
-                const GTR1MDF gtr1_mdf;
                 const float clearcoat_pdf =
-                    MicrofacetBRDFHelper<false>::evaluate(
-                        gtr1_mdf,
+                    MicrofacetBRDFHelper<GTR1MDF, false>::evaluate(
                         alpha,
                         alpha,
-                        0.0f,
                         shading_basis,
                         outgoing,
                         incoming,
@@ -719,14 +701,11 @@ namespace
                     values->m_anisotropic,
                     alpha_x,
                     alpha_y);
-                const GGXMDF ggx_mdf;
                 pdf +=
                     weights[SpecularComponent] *
-                    MicrofacetBRDFHelper<false>::pdf(
-                        ggx_mdf,
+                    MicrofacetBRDFHelper<GGXMDF, false>::pdf(
                         alpha_x,
                         alpha_y,
-                        0.0f,
                         shading_basis,
                         outgoing,
                         incoming);
@@ -735,14 +714,11 @@ namespace
             if (weights[ClearcoatComponent] > 0.0f)
             {
                 const float alpha = clearcoat_roughness(values);
-                const GTR1MDF gtr1_mdf;
                 pdf +=
                     weights[ClearcoatComponent] *
-                    MicrofacetBRDFHelper<false>::pdf(
-                        gtr1_mdf,
+                    MicrofacetBRDFHelper<GTR1MDF, false>::pdf(
                         alpha,
                         alpha,
-                        0.0f,
                         shading_basis,
                         outgoing,
                         incoming);

--- a/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
@@ -179,13 +179,10 @@ namespace
                     alpha_x,
                     alpha_y);
 
-                const GGXMDF mdf;
-                MicrofacetBRDFHelper<true>::sample(
+                MicrofacetBRDFHelper<GGXMDF, true>::sample(
                     sampling_context,
-                    mdf,
                     alpha_x,
                     alpha_y,
-                    1.0f,
                     f,
                     sample);
 
@@ -233,13 +230,10 @@ namespace
                 values->m_precomputed.m_outside_ior / values->m_ior,
                 values->m_fresnel_weight);
 
-            const GGXMDF mdf;
             const float pdf =
-                MicrofacetBRDFHelper<true>::evaluate(
-                    mdf,
+                MicrofacetBRDFHelper<GGXMDF, true>::evaluate(
                     alpha_x,
                     alpha_y,
-                    1.0f,
                     shading_basis,
                     outgoing,
                     incoming,
@@ -279,13 +273,10 @@ namespace
                 alpha_x,
                 alpha_y);
 
-            const GGXMDF mdf;
             const float pdf =
-                MicrofacetBRDFHelper<true>::pdf(
-                    mdf,
+                MicrofacetBRDFHelper<GGXMDF, true>::pdf(
                     alpha_x,
                     alpha_y,
-                    1.0f,
                     shading_basis,
                     outgoing,
                     incoming);

--- a/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.cpp
@@ -86,33 +86,30 @@ namespace
         Vector3f sample(const Vector2f& s) const
         {
             return
-                WardMDF().sample(
+                WardMDF::sample(
                     Vector3f(0.0f, 0.0f, 0.0f),
                     s,
                     m_alpha,
-                    m_alpha,
-                    0.0f);
+                    m_alpha);
         }
 
         float evaluate(const float cos_alpha) const
         {
             return
-                WardMDF().D(
+                WardMDF::D(
                     Vector3f(0.0f, cos_alpha, 0.0f),
                     m_alpha,
-                    m_alpha,
-                    0.0f);
+                    m_alpha);
         }
 
         float evaluate_pdf(const float cos_alpha) const
         {
             return
-                WardMDF().pdf(
+                WardMDF::pdf(
                     Vector3f(0.0f, 0.0f, 0.0f),
                     Vector3f(0.0f, cos_alpha, 0.0f),
                     m_alpha,
-                    m_alpha,
-                    0.0f);
+                    m_alpha);
         }
 
       private:

--- a/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
@@ -180,13 +180,10 @@ namespace
                     alpha_x,
                     alpha_y);
 
-                GGXMDF mdf;
-                MicrofacetBRDFHelper<false>::sample(
+                MicrofacetBRDFHelper<GGXMDF, false>::sample(
                     sampling_context,
-                    mdf,
                     alpha_x,
                     alpha_y,
-                    1.0f,
                     f,
                     sample);
 
@@ -234,13 +231,10 @@ namespace
                 values->m_precomputed.m_outside_ior,
                 values->m_reflectance_multiplier);
 
-            GGXMDF mdf;
             const float pdf =
-                MicrofacetBRDFHelper<false>::evaluate(
-                    mdf,
+                MicrofacetBRDFHelper<GGXMDF, false>::evaluate(
                     alpha_x,
                     alpha_y,
-                    1.0f,
                     shading_basis,
                     outgoing,
                     incoming,
@@ -280,13 +274,10 @@ namespace
                 alpha_x,
                 alpha_y);
 
-            GGXMDF mdf;
             const float pdf =
-                MicrofacetBRDFHelper<false>::pdf(
-                    mdf,
+                MicrofacetBRDFHelper<GGXMDF, false>::pdf(
                     alpha_x,
                     alpha_y,
-                    1.0f,
                     shading_basis,
                     outgoing,
                     incoming);

--- a/src/appleseed/renderer/modeling/bsdf/microfacethelper.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/microfacethelper.cpp
@@ -127,7 +127,6 @@ namespace
             const Vector3f wo(sin_theta, cos_theta, 0.0f);
 
             float R = 0.0f;
-            const MDF mdf;
 
             for (size_t i = 0; i < sample_count; ++i)
             {
@@ -137,7 +136,7 @@ namespace
 
                 Vector3f wi;
                 float probability;
-                const float value = MicrofacetBRDFHelper<false>::sample(mdf, s, alpha, wo, wi, probability);
+                const float value = MicrofacetBRDFHelper<MDF, false>::sample(s, alpha, wo, wi, probability);
 
                 // Skip samples with very low probability.
                 if (probability < 1.0e-6f)

--- a/src/appleseed/renderer/modeling/bsdf/microfacethelper.h
+++ b/src/appleseed/renderer/modeling/bsdf/microfacethelper.h
@@ -85,17 +85,15 @@ inline void microfacet_alpha_from_roughness(
 // Helper class to sample and evaluate microfacet BRDFs.
 //
 
-template <bool Flip>
+template <typename MDF, bool Flip>
 class MicrofacetBRDFHelper
 {
   public:
-    template <typename MDF, typename FresnelFun>
+    template <typename FresnelFun>
     static void sample(
         SamplingContext&                sampling_context,
-        const MDF&                      mdf,
         const float                     alpha_x,
         const float                     alpha_y,
-        const float                     gamma,
         FresnelFun                      f,
         BSDFSample&                     sample)
     {
@@ -112,7 +110,7 @@ class MicrofacetBRDFHelper
         // Compute the incoming direction by sampling the MDF.
         sampling_context.split_in_place(2, 1);
         const foundation::Vector2f s = sampling_context.next2<foundation::Vector2f>();
-        foundation::Vector3f m = mdf.sample(wo, s, alpha_x, alpha_y, gamma);
+        foundation::Vector3f m = MDF::sample(wo, s, alpha_x, alpha_y);
         foundation::Vector3f wi = foundation::reflect(wo, m);
 
         // Force the outgoing direction to lie above the geometric surface.
@@ -127,7 +125,7 @@ class MicrofacetBRDFHelper
         const float cos_oh = foundation::dot(wo, m);
 
         const float probability =
-            mdf.pdf(wo, m, alpha_x, alpha_y, gamma) / std::abs(4.0f * cos_oh);
+            MDF::pdf(wo, m, alpha_x, alpha_y) / std::abs(4.0f * cos_oh);
         assert(probability >= 0.0f);
 
         // Disabled until BSDF are evaluated in local space, because the numerous
@@ -136,10 +134,8 @@ class MicrofacetBRDFHelper
         // #ifndef NDEBUG
         //         const float ref_probability =
         //             pdf(
-        //                 mdf,
         //                 alpha_x,
         //                 alpha_y,
-        //                 gamma,
         //                 sample.m_shading_basis,
         //                 outgoing,
         //                 incoming);
@@ -152,15 +148,14 @@ class MicrofacetBRDFHelper
         {
             sample.set_to_scattering(ScatteringMode::Glossy, probability);
 
-            const float D = mdf.D(m, alpha_x, alpha_y, gamma);
+            const float D = MDF::D(m, alpha_x, alpha_y);
             const float G =
-                mdf.G(
+                MDF::G(
                     wi,
                     wo,
                     m,
                     alpha_x,
-                    alpha_y,
-                    gamma);
+                    alpha_y);
 
             const foundation::Vector3f n(0.0f, 1.0f, 0.0f);
             const float cos_on = wo.y;
@@ -177,12 +172,10 @@ class MicrofacetBRDFHelper
         }
     }
 
-    template <typename MDF, typename FresnelFun>
+    template <typename FresnelFun>
     static float evaluate(
-        const MDF&                      mdf,
         const float                     alpha_x,
         const float                     alpha_y,
-        const float                     gamma,
         const foundation::Basis3f&      shading_basis,
         const foundation::Vector3f&     outgoing,
         const foundation::Vector3f&     incoming,
@@ -210,15 +203,14 @@ class MicrofacetBRDFHelper
         if (cos_oh == 0.0f)
             return 0.0f;
 
-        const float D = mdf.D(m, alpha_x, alpha_y, gamma);
+        const float D = MDF::D(m, alpha_x, alpha_y);
         const float G =
-            mdf.G(
+            MDF::G(
                 wi,
                 wo,
                 m,
                 alpha_x,
-                alpha_y,
-                gamma);
+                alpha_y);
 
         const foundation::Vector3f n(0.0f, 1.0f, 0.0f);
         f(wo, m, n, value);
@@ -228,15 +220,12 @@ class MicrofacetBRDFHelper
 
         value *= D * G / std::abs(4.0f * cos_on * cos_in);
 
-        return mdf.pdf(wo, m, alpha_x, alpha_y, gamma) / std::abs(4.0f * cos_oh);
+        return MDF::pdf(wo, m, alpha_x, alpha_y) / std::abs(4.0f * cos_oh);
     }
 
-    template <typename MDF>
     static float pdf(
-        const MDF&                      mdf,
         const float                     alpha_x,
         const float                     alpha_y,
-        const float                     gamma,
         const foundation::Basis3f&      shading_basis,
         const foundation::Vector3f&     outgoing,
         const foundation::Vector3f&     incoming)
@@ -259,25 +248,22 @@ class MicrofacetBRDFHelper
             return 0.0f;
 
         return
-            mdf.pdf(
+            MDF::pdf(
                 wo,
                 m,
                 alpha_x,
-                alpha_y,
-                gamma) / std::abs(4.0f * cos_oh);
+                alpha_y) / std::abs(4.0f * cos_oh);
     }
 
     // Simplified version of sample used when computing albedo tables.
-    template <typename MDF>
     static float sample(
-        const MDF&                      mdf,
         const foundation::Vector2f&     s,
         const float                     alpha,
         const foundation::Vector3f&     wo,
         foundation::Vector3f&           wi,
         float&                          probability)
     {
-        foundation::Vector3f m = mdf.sample(wo, s, alpha, alpha, 0.0f);
+        foundation::Vector3f m = MDF::sample(wo, s, alpha, alpha);
 
         const float cos_oh = std::abs(foundation::dot(wo, m));
         const float cos_on = std::abs(wo.y);
@@ -303,18 +289,16 @@ class MicrofacetBRDFHelper
             return 0.0f;
         }
 
-        const float gamma = 1.0f;
-        const float D = mdf.D(m, alpha, alpha, gamma);
+        const float D = MDF::D(m, alpha, alpha);
         const float G =
-            mdf.G(
+            MDF::G(
                 wi,
                 wo,
                 m,
                 alpha,
-                alpha,
-                gamma);
+                alpha);
 
-        probability = mdf.pdf(wo, m, alpha, alpha, gamma) / std::abs(4.0f * cos_oh);
+        probability = MDF::pdf(wo, m, alpha, alpha) / std::abs(4.0f * cos_oh);
         assert(probability >= 0.0f);
 
         return D * G / (4.0f * cos_on * cos_in);

--- a/src/appleseed/renderer/modeling/bsdf/plasticbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/plasticbrdf.cpp
@@ -160,7 +160,7 @@ namespace
             const Vector3f m =
                 alpha == 0.0f
                     ? Vector3f(0.0f, 1.0f, 0.0f)
-                    : GGXMDF::sample(wo, Vector2f(s[0], s[1]), alpha, alpha, 0.0f);
+                    : GGXMDF::sample(wo, Vector2f(s[0], s[1]), alpha, alpha);
 
             const float F = fresnel_reflectance(wo, m, values->m_precomputed.m_eta);
             const float specular_probability = choose_specular_probability(*values, F);
@@ -406,8 +406,8 @@ namespace
             }
 
             value = specular_reflectance;
-            const float D = mdf.D(m, alpha, alpha, 0.0f);
-            const float G = mdf.G(wi, wo, m, alpha, alpha, 0.0f);
+            const float D = mdf.D(m, alpha, alpha);
+            const float G = mdf.G(wi, wo, m, alpha, alpha);
             value *= F * D * G / denom;
         }
 
@@ -425,7 +425,7 @@ namespace
                 return 0.0f;
 
             const float jacobian = 1.0f / (4.0f * abs(cos_wom));
-            return jacobian * mdf.pdf(wo, m, alpha, alpha, 0.0f);
+            return jacobian * mdf.pdf(wo, m, alpha, alpha);
         }
 
         static void evaluate_diffuse(


### PR DESCRIPTION
- Do not compute the glass albedo table at startup.
- Remove the gamma parameter from all MDF classes that don't use it.