### PR TITLE
Improve retrieval of last Windows error message

### DIFF
--- a/src/appleseed/foundation/meta/tests/test_windows.cpp
+++ b/src/appleseed/foundation/meta/tests/test_windows.cpp
@@ -40,17 +40,31 @@ using namespace std;
 
 TEST_SUITE(Foundation_Platform_Windows)
 {
-    TEST_CASE(GetWindowsLastErrorMessage_LastErrorCodeIsSuccess)
+    TEST_CASE(GetLastWindowsErrorMessage_LastErrorCodeIsSuccess_MessageIsNotEmpty)
     {
         SetLastError(ERROR_SUCCESS);
-        const string msg = get_windows_last_error_message();
+        const string msg = get_last_windows_error_message();
         EXPECT_FALSE(msg.empty());
     }
 
-    TEST_CASE(GetWindowsLastErrorMessage_LastErrorCodeIsFileNotFound)
+    TEST_CASE(GetLastWindowsErrorMessageWide_LastErrorCodeIsSuccess_MessageIsNotEmpty)
+    {
+        SetLastError(ERROR_SUCCESS);
+        const wstring msg = get_last_windows_error_message_wide();
+        EXPECT_FALSE(msg.empty());
+    }
+
+    TEST_CASE(GetLastWindowsErrorMessage_LastErrorCodeIsFileNotFound_MessageIsNotEmpty)
     {
         SetLastError(ERROR_FILE_NOT_FOUND);
-        const string msg = get_windows_last_error_message();
+        const string msg = get_last_windows_error_message();
+        EXPECT_FALSE(msg.empty());
+    }
+
+    TEST_CASE(GetLastWindowsErrorMessageWide_LastErrorCodeIsFileNotFound_MessageIsNotEmpty)
+    {
+        SetLastError(ERROR_FILE_NOT_FOUND);
+        const wstring msg = get_last_windows_error_message_wide();
         EXPECT_FALSE(msg.empty());
     }
 }

--- a/src/appleseed/foundation/platform/sharedlibrary.cpp
+++ b/src/appleseed/foundation/platform/sharedlibrary.cpp
@@ -96,7 +96,7 @@ namespace
     string get_last_error_message()
     {
 #ifdef _WIN32
-        return get_windows_last_error_message();
+        return get_last_windows_error_message();
 #else
         return dlerror();
 #endif

--- a/src/appleseed/foundation/platform/windows.cpp
+++ b/src/appleseed/foundation/platform/windows.cpp
@@ -56,40 +56,6 @@ void disable_all_windows_abort_dialogs()
     _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 }
 
-string get_windows_last_error_message()
-{
-    //
-    // Relevant articles:
-    //
-    //   http://coolcowstudio.wordpress.com/2012/10/19/getlasterror-as-stdstring/
-    //   http://blogs.msdn.com/b/oldnewthing/archive/2007/11/28/6564257.aspx
-    //
-
-    LPVOID buf;
-
-    const DWORD buf_len =
-        FormatMessageA(
-            FORMAT_MESSAGE_ALLOCATE_BUFFER              // allocate the output buffer
-                | FORMAT_MESSAGE_FROM_SYSTEM            // the message number is a system error code
-                | FORMAT_MESSAGE_IGNORE_INSERTS,        // don't process %1... placeholders
-            0,                                          // format string (unused)
-            GetLastError(),                             // error code
-            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),  // use default language
-            reinterpret_cast<LPTSTR>(&buf),             // output buffer
-            0,                                          // size of the output buffer in TCHARs (unused)
-            0);                                         // argument list (unused)
-
-    if (buf_len == 0)
-        return "FormatMessageA() call failed.";
-
-    LPCSTR msg = reinterpret_cast<LPCSTR>(buf);
-    const string result(msg, msg + buf_len);
-
-    LocalFree(buf);
-
-    return result;
-}
-
 }   // namespace foundation
 
 #endif


### PR DESCRIPTION
- Rename `foundation::get_windows_last_error_message()` to `get_last_windows_error_message()`
- Add `foundation::get_windows_last_error_message_wide()` (wide-string variant)
- Make both functions inline to allow using them outside of appleseed (e.g. in plugins)