### PR TITLE
Light paths recording annotations and tweaks

### DIFF
--- a/src/appleseed.studio/mainwindow/rendering/lightpathswidget.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathswidget.cpp
@@ -385,7 +385,7 @@ void LightPathsWidget::render_light_path(const size_t light_path_index) const
         light_path_recorder.get_light_path_vertex(i, v1);
 
         auto radiance = Color3f::from_array(v1.m_radiance);
-        radiance /= sum_value(radiance);
+        radiance /= radiance + Color3f(1.0);
         radiance = linear_rgb_to_srgb(radiance);
 
         glColor(radiance);

--- a/src/appleseed/renderer/kernel/lighting/lightpathstream.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lightpathstream.cpp
@@ -267,9 +267,19 @@ void LightPathStream::create_path_from_hit_emitter(const size_t emitter_event_in
             reflector_vertex.m_radiance = current_radiance;
             m_vertices.push_back(reflector_vertex);
 
+            // If the hit is an emitter, add the radiance to current
+            if (event.m_type == EventType::HitEmitter)
+            {
+                const auto& event = m_events[event_index];
+                current_radiance += m_hit_emitter_data[event.m_data_index].m_emitted_radiance;
+            }
+
             // Update current radiance.
             const auto& throughput = event_data.m_path_throughput;
+            // Multiply by previous throughput to attenuate by the next hit
             current_radiance *= prev_throughput;
+            // Divide by throughput before previous so that we isolate only throughput from the light source to current vertex,
+            // since throughput is cumulative in reverse
             current_radiance /= throughput;
             prev_throughput = throughput;
         }
@@ -333,9 +343,19 @@ void LightPathStream::create_path_from_sampled_emitter(const size_t emitter_even
             reflector_vertex.m_radiance = current_radiance;
             m_vertices.push_back(reflector_vertex);
 
+            // If the hit is an emitter, add the radiance to current
+            if (event.m_type == EventType::HitEmitter)
+            {
+                const auto& event = m_events[event_index];
+                current_radiance += m_hit_emitter_data[event.m_data_index].m_emitted_radiance;
+            }
+
             // Update current radiance.
             const auto& throughput = event_data.m_path_throughput;
+            // Multiply by previous throughput to attenuate by the next hit
             current_radiance *= prev_throughput;
+            // Divide by throughput before previous so that we isolate only throughput from the light source to current vertex,
+            // since throughput is cumulative in reverse
             current_radiance /= throughput;
             prev_throughput = throughput;
         }
@@ -399,9 +419,19 @@ void LightPathStream::create_path_from_sampled_environment(const size_t env_even
             reflector_vertex.m_radiance = current_radiance;
             m_vertices.push_back(reflector_vertex);
 
+            // If the hit is an emitter, add the radiance to current
+            if (event.m_type == EventType::HitEmitter)
+            {
+                const auto& event = m_events[event_index];
+                current_radiance += m_hit_emitter_data[event.m_data_index].m_emitted_radiance;
+            }
+
             // Update current radiance.
             const auto& throughput = event_data.m_path_throughput;
+            // Multiply by previous throughput to attenuate by the next hit
             current_radiance *= prev_throughput;
+            // Divide by throughput before previous so that we isolate only throughput from the light source to current vertex,
+            // since throughput is cumulative in reverse
             current_radiance /= throughput;
             prev_throughput = throughput;
         }

--- a/src/appleseed/renderer/kernel/lighting/lightpathstream.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lightpathstream.cpp
@@ -267,13 +267,6 @@ void LightPathStream::create_path_from_hit_emitter(const size_t emitter_event_in
             reflector_vertex.m_radiance = current_radiance;
             m_vertices.push_back(reflector_vertex);
 
-            // If the hit is an emitter, add the radiance to current
-            if (event.m_type == EventType::HitEmitter)
-            {
-                const auto& event = m_events[event_index];
-                current_radiance += m_hit_emitter_data[event.m_data_index].m_emitted_radiance;
-            }
-
             // Update current radiance.
             const auto& throughput = event_data.m_path_throughput;
             // Multiply by previous throughput to attenuate by the next hit
@@ -282,6 +275,12 @@ void LightPathStream::create_path_from_hit_emitter(const size_t emitter_event_in
             // since throughput is cumulative in reverse
             current_radiance /= throughput;
             prev_throughput = throughput;
+
+            // If the hit is an emitter, add the radiance to current
+            if (event.m_type == EventType::HitEmitter)
+            {
+                current_radiance += m_hit_emitter_data[event.m_data_index].m_emitted_radiance;
+            }
         }
     }
 
@@ -343,13 +342,6 @@ void LightPathStream::create_path_from_sampled_emitter(const size_t emitter_even
             reflector_vertex.m_radiance = current_radiance;
             m_vertices.push_back(reflector_vertex);
 
-            // If the hit is an emitter, add the radiance to current
-            if (event.m_type == EventType::HitEmitter)
-            {
-                const auto& event = m_events[event_index];
-                current_radiance += m_hit_emitter_data[event.m_data_index].m_emitted_radiance;
-            }
-
             // Update current radiance.
             const auto& throughput = event_data.m_path_throughput;
             // Multiply by previous throughput to attenuate by the next hit
@@ -358,6 +350,12 @@ void LightPathStream::create_path_from_sampled_emitter(const size_t emitter_even
             // since throughput is cumulative in reverse
             current_radiance /= throughput;
             prev_throughput = throughput;
+
+            // If the hit is an emitter, add the radiance to current
+            if (event.m_type == EventType::HitEmitter)
+            {
+                current_radiance += m_hit_emitter_data[event.m_data_index].m_emitted_radiance;
+            }
         }
     }
 
@@ -419,13 +417,6 @@ void LightPathStream::create_path_from_sampled_environment(const size_t env_even
             reflector_vertex.m_radiance = current_radiance;
             m_vertices.push_back(reflector_vertex);
 
-            // If the hit is an emitter, add the radiance to current
-            if (event.m_type == EventType::HitEmitter)
-            {
-                const auto& event = m_events[event_index];
-                current_radiance += m_hit_emitter_data[event.m_data_index].m_emitted_radiance;
-            }
-
             // Update current radiance.
             const auto& throughput = event_data.m_path_throughput;
             // Multiply by previous throughput to attenuate by the next hit
@@ -434,6 +425,12 @@ void LightPathStream::create_path_from_sampled_environment(const size_t env_even
             // since throughput is cumulative in reverse
             current_radiance /= throughput;
             prev_throughput = throughput;
+
+            // If the hit is an emitter, add the radiance to current
+            if (event.m_type == EventType::HitEmitter)
+            {
+                current_radiance += m_hit_emitter_data[event.m_data_index].m_emitted_radiance;
+            }
         }
     }
 

--- a/src/appleseed/renderer/kernel/lighting/lightpathstream.h
+++ b/src/appleseed/renderer/kernel/lighting/lightpathstream.h
@@ -117,7 +117,7 @@ class LightPathStream
     {
         const ObjectInstance*       m_object_instance;          // object instance that was hit
         foundation::Vector3f        m_vertex_position;          // world space position of the hit point on the reflector
-        foundation::Color3f         m_path_throughput;          // cumulative path throughput up to but excluding this vertex
+        foundation::Color3f         m_path_throughput;          // cumulative path throughput up to but excluding this vertex, in reverse order (i.e. in the order from camera to light source)
     };
 
     struct HitEmitterData

--- a/src/appleseed/renderer/kernel/lighting/pathvertex.h
+++ b/src/appleseed/renderer/kernel/lighting/pathvertex.h
@@ -70,7 +70,7 @@ class PathVertex
     // Path properties.
     size_t                      m_path_length;
     int                         m_scattering_modes;
-    Spectrum                    m_throughput;
+    Spectrum                    m_throughput;   // Cumulative throughput (percent of incoming light which is reflected as outgoing light) of this path, up to but excluding this vertex
 
     // Current vertex properties.
     const ShadingPoint*         m_shading_point;

--- a/src/appleseed/renderer/kernel/lighting/pathvertex.h
+++ b/src/appleseed/renderer/kernel/lighting/pathvertex.h
@@ -70,7 +70,7 @@ class PathVertex
     // Path properties.
     size_t                      m_path_length;
     int                         m_scattering_modes;
-    Spectrum                    m_throughput;   // Cumulative throughput (percent of incoming light which is reflected as outgoing light) of this path, up to but excluding this vertex
+    Spectrum                    m_throughput;   // cumulative throughput (percent of incoming light which is reflected as outgoing light) of this path, up to but excluding this vertex
 
     // Current vertex properties.
     const ShadingPoint*         m_shading_point;


### PR DESCRIPTION
* Annotates light path creation code
* Uses reinhard tonemapping (`x/(1+x)`) for displaying the radiance as color when drawing. This gives much more helpful color results than previously when displaying light paths, since it gives a sense of intensity as well as just hue:

old: 
![image](https://user-images.githubusercontent.com/887711/58444120-760f7c00-80ab-11e9-9242-3e1341d93eef.png) 
![image](https://user-images.githubusercontent.com/887711/58444135-8de70000-80ab-11e9-8945-c62d44c1fbb1.png)


new: 
![image](https://user-images.githubusercontent.com/887711/58444169-b7a02700-80ab-11e9-93ab-bcf1c857a7f1.png) 
![image](https://user-images.githubusercontent.com/887711/58444189-d7374f80-80ab-11e9-91a2-cc96c85d3c23.png)



* Takes into account secondary emitter radiance in the middle of a light path. Previously if a path intersected with an emitter that was also a reflector that was not the origin of the path, the emitted radiance of said emitter would not be added to the path's total radiance.