### PR TITLE
Add spectral and gpu build info in studio about dialog

### DIFF
--- a/src/appleseed.shared/application/commandlinehandlerbase.cpp
+++ b/src/appleseed.shared/application/commandlinehandlerbase.cpp
@@ -97,7 +97,7 @@ struct CommandLineHandlerBase::Impl
             "%s, using %s version %s, %s configuration\n"
             "compiled on %s at %s using %s version %s\n"
             "copyright (c) 2010-2013 Francois Beaune, Jupiter Jazz Limited\n"
-            "copyright (c) 2014-2018 The appleseedhq Organization\n"
+            "copyright (c) 2014-2019 The appleseedhq Organization\n"
             "this software is released under the MIT license (https://opensource.org/licenses/MIT).\n"
             "visit https://appleseedhq.net/ for additional information and resources.",
             m_application_name.c_str(),
@@ -123,15 +123,33 @@ struct CommandLineHandlerBase::Impl
             false;
 #endif
 
+        const bool WithSpectralSupport =
+#ifdef APPLESEED_WITH_SPECTRAL_SUPPORT
+            true;
+#else
+            false;
+#endif
+
+        const bool WithGPUSupport =
+#ifdef APPLESEED_WITH_GPU
+            true;
+#else
+            false;
+#endif
+
         LOG_INFO(
             logger,
             "library features:\n"
-            "  instruction sets              %s\n"
-            "  Disney material               %s\n"
-            "  Embree                        %s",
+            "  Instruction sets                         %s\n"
+            "  Disney material with SeExpr support      %s\n"
+            "  Embree                                   %s\n"
+            "  Spectral support                         %s\n"
+            "  GPU support                              %s",
             Appleseed::get_lib_cpu_features(),
             to_enabled_disabled(WithDisneyMaterial),
-            to_enabled_disabled(WithEmbree));
+            to_enabled_disabled(WithEmbree),
+            to_enabled_disabled(WithSpectralSupport),
+            to_enabled_disabled(WithGPUSupport));
     }
 
     static void print_libraries_information(SuperLogger& logger)

--- a/src/appleseed.studio/help/about/aboutwindow.cpp
+++ b/src/appleseed.studio/help/about/aboutwindow.cpp
@@ -127,11 +127,27 @@ void AboutWindow::set_library_features()
         false;
 #endif
 
+    const bool WithSpectralSupport =
+#ifdef APPLESEED_WITH_SPECTRAL_SUPPORT
+        true;
+#else
+        false;
+#endif
+
+    const bool WithGPUSupport =
+#ifdef APPLESEED_WITH_GPU
+        true;
+#else
+        false;
+#endif
+
     QString details;
     details += "This build of appleseed has the following features:\n\n";
     details += QString("  Instruction sets: %1\n").arg(Appleseed::get_lib_cpu_features());
-    details += QString("  Disney material: %1\n").arg(to_enabled_disabled(WithDisneyMaterial));
+    details += QString("  Disney material with SeExpr support: %1\n").arg(to_enabled_disabled(WithDisneyMaterial));
     details += QString("  Embree: %1\n").arg(to_enabled_disabled(WithEmbree));
+    details += QString("  Spectral support: %1\n").arg(to_enabled_disabled(WithSpectralSupport));
+    details += QString("  GPU support: %1\n").arg(to_enabled_disabled(WithGPUSupport));
     details += "\n";
     m_ui->label_details->setText(m_ui->label_details->text() + details);
 }

--- a/src/appleseed.studio/help/about/aboutwindow.ui
+++ b/src/appleseed.studio/help/about/aboutwindow.ui
@@ -114,7 +114,7 @@
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Copyright © 2010-2013 François Beaune, Jupiter Jazz Limited&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Copyright © 2014-2018 The appleseedhq Organization&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Copyright © 2014-2019 The appleseedhq Organization&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This software is released under the &lt;a href=&quot;https://opensource.org/licenses/MIT&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#be8c32;&quot;&gt;MIT license&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;


### PR DESCRIPTION
- Adds build options information for spectral and GPU support enabled/disabled to the about window in appleseed.studio 
- Renamed build option info `Disney material` to `Disney SeExpr` to avoid confusing it with the asDisney shader. 
