### PR TITLE
Increase precision of noise level log output

### DIFF
--- a/src/appleseed/renderer/kernel/rendering/final/adaptivetilerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/adaptivetilerenderer.cpp
@@ -565,7 +565,7 @@ namespace
                     pretty_uint(tile_converged_pixel_count),
                     converged_pixels_string));
             stats.insert("samples/pixel", m_spp);
-            stats.insert("average noise level", average_noise_level);
+            stats.insert("average noise level", pretty_scalar(average_noise_level, 3));
             RENDERER_LOG_DEBUG(
                 "tile (" FMT_SIZE_T ", " FMT_SIZE_T ") final statistics:\n%s",
                 tile_x,


### PR DESCRIPTION
Increases the precision of the displayed average noise level value in the debug render log to 4 digits.
One significant digit (current form) is not sufficient, more converged render will show 0.0 noise level values while noise is still visible (see screenshot).

There is probably an easier method to do this with stats.insert() but it didn't accept a std::streamsize precision specifier when I tried.  

![Capture](https://user-images.githubusercontent.com/22252558/59507045-80ef4c80-8eb2-11e9-8e99-c2a84f7a6613.PNG)
