### PR TITLE
Unified Viewport

### DIFF
--- a/sandbox/settings/appleseed.studio.xml
+++ b/sandbox/settings/appleseed.studio.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
     <parameter name="autosave" value="false" />
-    <parameter name="message_verbosity" value="info" />
+    <parameter name="message_verbosity" value="debug" />
     <parameter name="print_final_average_luminance" value="false" />
     <parameter name="rendering_threads" value="auto" />
     <parameter name="sampling_mode" value="qmc" />

--- a/src/appleseed.studio/CMakeLists.txt
+++ b/src/appleseed.studio/CMakeLists.txt
@@ -250,12 +250,12 @@ set (mainwindow_rendering_sources
     mainwindow/rendering/cameracontroller.h
     mainwindow/rendering/glscenelayer.h
     mainwindow/rendering/glscenelayer.cpp
-    # mainwindow/rendering/lightpathspickinghandler.cpp
-    # mainwindow/rendering/lightpathspickinghandler.h
-    # mainwindow/rendering/lightpathsviewportmanager.cpp
-    # mainwindow/rendering/lightpathsviewportmanager.h
-    # mainwindow/rendering/lightpathslayer.cpp
-    # mainwindow/rendering/lightpathslayer.h
+    mainwindow/rendering/lightpathspickinghandler.cpp
+    mainwindow/rendering/lightpathspickinghandler.h
+    mainwindow/rendering/lightpathsviewportmanager.cpp
+    mainwindow/rendering/lightpathsviewportmanager.h
+    mainwindow/rendering/lightpathslayer.cpp
+    mainwindow/rendering/lightpathslayer.h
     mainwindow/rendering/materialdrophandler.cpp
     mainwindow/rendering/materialdrophandler.h
     mainwindow/rendering/pixelcolortracker.cpp
@@ -271,12 +271,12 @@ set (mainwindow_rendering_sources
     mainwindow/rendering/renderingmanager.cpp
     mainwindow/rendering/renderingmanager.h
     mainwindow/rendering/renderingtimer.h
-    mainwindow/rendering/renderregionhandler.cpp
-    mainwindow/rendering/renderregionhandler.h
     mainwindow/rendering/renderlayer.cpp
     mainwindow/rendering/renderlayer.h
     mainwindow/rendering/scenepickinghandler.cpp
     mainwindow/rendering/scenepickinghandler.h
+    mainwindow/rendering/viewportregionselectionhandler.cpp
+    mainwindow/rendering/viewportregionselectionhandler.h
     mainwindow/rendering/viewporttab.cpp
     mainwindow/rendering/viewporttab.h
     mainwindow/rendering/viewportwidget.h

--- a/src/appleseed.studio/CMakeLists.txt
+++ b/src/appleseed.studio/CMakeLists.txt
@@ -365,6 +365,8 @@ set (utility_sources
     utility/doubleslider.h
     utility/foldablepanelwidget.cpp
     utility/foldablepanelwidget.h
+    utility/gl.cpp
+    utility/gl.h
     utility/inputwidgetproxies.cpp
     utility/inputwidgetproxies.h
     utility/interop.h

--- a/src/appleseed.studio/CMakeLists.txt
+++ b/src/appleseed.studio/CMakeLists.txt
@@ -248,12 +248,14 @@ source_group ("mainwindow\\pythonconsole" FILES
 set (mainwindow_rendering_sources
     mainwindow/rendering/cameracontroller.cpp
     mainwindow/rendering/cameracontroller.h
-    mainwindow/rendering/lightpathspickinghandler.cpp
-    mainwindow/rendering/lightpathspickinghandler.h
-    mainwindow/rendering/lightpathstab.cpp
-    mainwindow/rendering/lightpathstab.h
-    mainwindow/rendering/lightpathswidget.cpp
-    mainwindow/rendering/lightpathswidget.h
+    # mainwindow/rendering/glscenelayer.h
+    # mainwindow/rendering/glscenelayer.cpp
+    # mainwindow/rendering/lightpathspickinghandler.cpp
+    # mainwindow/rendering/lightpathspickinghandler.h
+    # mainwindow/rendering/lightpathsviewportmanager.cpp
+    # mainwindow/rendering/lightpathsviewportmanager.h
+    # mainwindow/rendering/lightpathslayer.cpp
+    # mainwindow/rendering/lightpathslayer.h
     mainwindow/rendering/materialdrophandler.cpp
     mainwindow/rendering/materialdrophandler.h
     mainwindow/rendering/pixelcolortracker.cpp
@@ -273,10 +275,12 @@ set (mainwindow_rendering_sources
     mainwindow/rendering/renderregionhandler.h
     mainwindow/rendering/rendertab.cpp
     mainwindow/rendering/rendertab.h
-    mainwindow/rendering/renderwidget.cpp
-    mainwindow/rendering/renderwidget.h
+    mainwindow/rendering/renderlayer.cpp
+    mainwindow/rendering/renderlayer.h
     mainwindow/rendering/scenepickinghandler.cpp
     mainwindow/rendering/scenepickinghandler.h
+    mainwindow/rendering/viewportwidget.h
+    mainwindow/rendering/viewportwidget.cpp
 )
 list (APPEND appleseed.studio_sources
     ${mainwindow_rendering_sources}

--- a/src/appleseed.studio/CMakeLists.txt
+++ b/src/appleseed.studio/CMakeLists.txt
@@ -248,8 +248,8 @@ source_group ("mainwindow\\pythonconsole" FILES
 set (mainwindow_rendering_sources
     mainwindow/rendering/cameracontroller.cpp
     mainwindow/rendering/cameracontroller.h
-    # mainwindow/rendering/glscenelayer.h
-    # mainwindow/rendering/glscenelayer.cpp
+    mainwindow/rendering/glscenelayer.h
+    mainwindow/rendering/glscenelayer.cpp
     # mainwindow/rendering/lightpathspickinghandler.cpp
     # mainwindow/rendering/lightpathspickinghandler.h
     # mainwindow/rendering/lightpathsviewportmanager.cpp
@@ -273,12 +273,12 @@ set (mainwindow_rendering_sources
     mainwindow/rendering/renderingtimer.h
     mainwindow/rendering/renderregionhandler.cpp
     mainwindow/rendering/renderregionhandler.h
-    mainwindow/rendering/rendertab.cpp
-    mainwindow/rendering/rendertab.h
     mainwindow/rendering/renderlayer.cpp
     mainwindow/rendering/renderlayer.h
     mainwindow/rendering/scenepickinghandler.cpp
     mainwindow/rendering/scenepickinghandler.h
+    mainwindow/rendering/viewporttab.cpp
+    mainwindow/rendering/viewporttab.h
     mainwindow/rendering/viewportwidget.h
     mainwindow/rendering/viewportwidget.cpp
 )

--- a/src/appleseed.studio/main/main.cpp
+++ b/src/appleseed.studio/main/main.cpp
@@ -329,7 +329,7 @@ int main(int argc, char* argv[])
     // Set default surface format before creating application instance. This is
     // required on macOS in order to use an OpenGL Core profile context.
     QSurfaceFormat default_format;
-    default_format.setVersion(3, 3);
+    default_format.setVersion(4, 1);
     default_format.setProfile(QSurfaceFormat::CoreProfile);
     QSurfaceFormat::setDefaultFormat(default_format);
 

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -202,7 +202,7 @@ bool MainWindow::open_project(const QString& filepath)
         m_rendering_manager.wait_until_rendering_end();
     }
 
-    remove_render_tabs();
+    remove_viewport_tabs();
 
     set_file_widgets_enabled(false, NotRendering);
     set_project_explorer_enabled(false);
@@ -217,7 +217,7 @@ bool MainWindow::open_project(const QString& filepath)
     }
     else
     {
-        recreate_render_tabs();
+        recreate_viewport_tabs();
         update_workspace();
     }
 
@@ -234,7 +234,7 @@ void MainWindow::open_project_async(const QString& filepath)
         m_rendering_manager.wait_until_rendering_end();
     }
 
-    remove_render_tabs();
+    remove_viewport_tabs();
 
     set_file_widgets_enabled(false, NotRendering);
     set_project_explorer_enabled(false);
@@ -743,10 +743,17 @@ void MainWindow::update_workspace()
     m_ui->attribute_editor_scrollarea_contents->setEnabled(true);
 
     // Add/remove light paths tab.
-    //if (m_project_manager.is_project_open() &&
-    //    m_project_manager.get_project()->get_light_path_recorder().get_light_path_count() > 0)
-    //    add_light_paths_tab();
-    //else remove_light_paths_tab();
+    if (m_project_manager.is_project_open() &&
+        m_project_manager.get_project()->get_light_path_recorder().get_light_path_count() > 0)
+    {
+        for (const_each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
+            i->second->enable_light_paths_toggle();
+    }
+    else
+    {
+        for (const_each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
+            i->second->disable_light_paths_toggle();
+    }
 }
 
 void MainWindow::update_project_explorer()
@@ -891,21 +898,21 @@ void MainWindow::set_rendering_widgets_enabled(const bool is_enabled, const Rend
     const int current_tab_index = m_ui->tab_render_channels->currentIndex();
     if (current_tab_index != -1)
     {
-        const auto render_tab_it = m_tab_index_to_render_tab.find(current_tab_index);
-        if (render_tab_it != m_tab_index_to_render_tab.end())
+        const auto viewport_tab_it = m_tab_index_to_viewport_tab.find(current_tab_index);
+        if (viewport_tab_it != m_tab_index_to_viewport_tab.end())
         {
-            RenderTab* render_tab = render_tab_it->second;
+            ViewportTab* viewport_tab = viewport_tab_it->second;
 
             // Clear frame.
-            render_tab->set_clear_frame_button_enabled(
+            viewport_tab->set_clear_frame_button_enabled(
                 is_enabled && is_project_open && rendering_mode == NotRendering);
 
             // Set/clear rendering region.
-            render_tab->set_render_region_buttons_enabled(
+            viewport_tab->set_render_region_buttons_enabled(
                 is_enabled && is_project_open && rendering_mode != FinalRendering);
 
             // Scene picker.
-            render_tab->get_scene_picking_handler()->set_enabled(
+            viewport_tab->get_scene_picking_handler()->set_enabled(
                 is_enabled && is_project_open && rendering_mode != FinalRendering);
         }
     }
@@ -925,18 +932,18 @@ void MainWindow::save_state_before_project_open()
 
     m_state_before_project_open->m_is_rendering = m_rendering_manager.is_rendering();
 
-    for (const_each<RenderTabCollection> i = m_render_tabs; i; ++i)
-        m_state_before_project_open->m_render_tab_states[i->first] = i->second->save_state();
+    for (const_each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
+        m_state_before_project_open->m_viewport_tab_states[i->first] = i->second->save_state();
 }
 
 void MainWindow::restore_state_after_project_open()
 {
     if (m_state_before_project_open.get())
     {
-        for (const_each<RenderTabCollection> i = m_render_tabs; i; ++i)
+        for (const_each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
         {
-            const RenderTabStateCollection& tab_states = m_state_before_project_open->m_render_tab_states;
-            const RenderTabStateCollection::const_iterator tab_state_it = tab_states.find(i->first);
+            const ViewportTabStateCollection& tab_states = m_state_before_project_open->m_viewport_tab_states;
+            const ViewportTabStateCollection::const_iterator tab_state_it = tab_states.find(i->first);
 
             if (tab_state_it != tab_states.end())
                 i->second->load_state(tab_state_it->second);
@@ -947,31 +954,31 @@ void MainWindow::restore_state_after_project_open()
     }
 }
 
-void MainWindow::recreate_render_tabs()
+void MainWindow::recreate_viewport_tabs()
 {
-    remove_render_tabs();
+    remove_viewport_tabs();
 
     if (m_project_manager.is_project_open())
-        add_render_tab("RGB");
+        add_viewport_tab("RGB");
 }
 
-void MainWindow::remove_render_tabs()
+void MainWindow::remove_viewport_tabs()
 {
-    for (const_each<RenderTabCollection> i = m_render_tabs; i; ++i)
+    for (const_each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
         delete i->second;
 
-    m_render_tabs.clear();
-    m_tab_index_to_render_tab.clear();
+    m_viewport_tabs.clear();
+    m_tab_index_to_viewport_tab.clear();
 
     while (m_ui->tab_render_channels->count() > 0)
         m_ui->tab_render_channels->removeTab(0);
 }
 
-void MainWindow::add_render_tab(const QString& label)
+void MainWindow::add_viewport_tab(const QString& label)
 {
     // Create render tab.
-    RenderTab* render_tab =
-        new RenderTab(
+    ViewportTab* viewport_tab =
+        new ViewportTab(
             *m_project_explorer,
             *m_project_manager.get_project(),
             m_rendering_manager,
@@ -979,45 +986,45 @@ void MainWindow::add_render_tab(const QString& label)
 
     // Connect the render tab to the main window and the rendering manager.
     connect(
-        render_tab->get_viewport_widget(), SIGNAL(signal_viewport_widget_context_menu(const QPoint&)),
+        viewport_tab, SIGNAL(signal_viewport_widget_context_menu(const QPoint&)),
         SLOT(slot_viewport_widget_context_menu(const QPoint&)));
     connect(
-        render_tab, SIGNAL(signal_set_render_region(const QRect&)),
+        viewport_tab, SIGNAL(signal_set_render_region(const QRect&)),
         SLOT(slot_set_render_region(const QRect&)));
     connect(
-        render_tab, SIGNAL(signal_clear_render_region()),
+        viewport_tab, SIGNAL(signal_clear_render_region()),
         SLOT(slot_clear_render_region()));
     connect(
-        render_tab, SIGNAL(signal_save_frame_and_aovs()),
+        viewport_tab, SIGNAL(signal_save_frame_and_aovs()),
         SLOT(slot_save_frame_and_aovs()));
     connect(
-        render_tab, SIGNAL(signal_quicksave_frame_and_aovs()),
+        viewport_tab, SIGNAL(signal_quicksave_frame_and_aovs()),
         SLOT(slot_quicksave_frame_and_aovs()));
     connect(
-        render_tab, SIGNAL(signal_reset_zoom()),
+        viewport_tab, SIGNAL(signal_reset_zoom()),
         SLOT(slot_reset_zoom()));
     connect(
-        render_tab, SIGNAL(signal_clear_frame()),
+        viewport_tab, SIGNAL(signal_clear_frame()),
         SLOT(slot_clear_frame()));
     connect(
-        render_tab, SIGNAL(signal_entity_picked(renderer::ScenePicker::PickingResult)),
+        viewport_tab, SIGNAL(signal_entity_picked(renderer::ScenePicker::PickingResult)),
         SLOT(slot_clear_filter()));
     connect(
-        render_tab, SIGNAL(signal_camera_change_begin()),
+        viewport_tab, SIGNAL(signal_camera_change_begin()),
         &m_rendering_manager, SLOT(slot_camera_change_begin()));
     connect(
-        render_tab, SIGNAL(signal_camera_change_end()),
+        viewport_tab, SIGNAL(signal_camera_change_end()),
         &m_rendering_manager, SLOT(slot_camera_change_end()));
     connect(
-        render_tab, SIGNAL(signal_camera_changed()),
+        viewport_tab, SIGNAL(signal_camera_changed()),
         &m_rendering_manager, SLOT(slot_camera_changed()));
 
     // Add the render tab to the tab bar.
-    const int tab_index = m_ui->tab_render_channels->addTab(render_tab, label);
+    const int tab_index = m_ui->tab_render_channels->addTab(viewport_tab, label);
 
     // Update mappings.
-    m_render_tabs[label.toStdString()] = render_tab;
-    m_tab_index_to_render_tab[tab_index] = render_tab;
+    m_viewport_tabs[label.toStdString()] = viewport_tab;
+    m_tab_index_to_viewport_tab[tab_index] = viewport_tab;
 }
 
 ParamArray MainWindow::get_project_params(const char* configuration_name) const
@@ -1093,7 +1100,7 @@ bool MainWindow::can_close_project()
 void MainWindow::on_project_change()
 {
     update_project_explorer();
-    recreate_render_tabs();
+    recreate_viewport_tabs();
 
     update_override_shading_menu_item();
     m_false_colors_window.reset();
@@ -1209,7 +1216,7 @@ void MainWindow::start_rendering(const RenderingMode rendering_mode)
     frame->clear_main_and_aov_images();
 
     // Darken render widgets.
-    for (const_each<RenderTabCollection> i = m_render_tabs; i; ++i)
+    for (const_each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
     {
         i->second->get_viewport_widget()->get_render_layer()->darken();
         i->second->update();
@@ -1227,7 +1234,7 @@ void MainWindow::start_rendering(const RenderingMode rendering_mode)
         rendering_mode == InteractiveRendering
             ? RenderingManager::InteractiveRendering
             : RenderingManager::FinalRendering,
-        m_render_tabs["RGB"]);
+        m_viewport_tabs["RGB"]);
 }
 
 void MainWindow::apply_false_colors_settings()
@@ -1265,7 +1272,7 @@ void MainWindow::apply_false_colors_settings()
     else
     {
         // Blit the regular frame into the render widget.
-        for (const_each<RenderTabCollection> i = m_render_tabs; i; ++i)
+        for (const_each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
         {
             i->second->get_viewport_widget()->get_render_layer()->blit_frame(*frame);
             i->second->get_viewport_widget()->get_render_layer()->update();
@@ -1288,7 +1295,7 @@ void MainWindow::apply_post_processing_stage(
         stage.execute(working_frame);
 
         // Blit the frame copy into the render widget.
-        for (const_each<RenderTabCollection> i = m_render_tabs; i; ++i)
+        for (const_each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
         {
             i->second->get_viewport_widget()->get_render_layer()->blit_frame(working_frame);
             i->second->get_viewport_widget()->get_render_layer()->update();
@@ -1339,7 +1346,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
     if (m_benchmark_window.get())
         m_benchmark_window->close();
 
-    remove_render_tabs();
+    remove_viewport_tabs();
 
     m_project_manager.close_project();
 
@@ -1459,7 +1466,7 @@ void MainWindow::slot_open_project_complete(const QString& filepath, const bool 
     else
     {
         show_project_file_loading_failed_message_box(this, filepath);
-        recreate_render_tabs();
+        recreate_viewport_tabs();
         update_workspace();
     }
 }
@@ -2035,7 +2042,7 @@ void MainWindow::slot_save_render_widget_content()
         return;
 
     // todo: this is sketchy. The render tab should be retrieved from the signal.
-    m_render_tabs["RGB"]->get_viewport_widget()->get_render_layer()->capture().save(filepath);
+    m_viewport_tabs["RGB"]->get_viewport_widget()->get_render_layer()->capture().save(filepath);
 
     RENDERER_LOG_INFO("wrote image file %s.", filepath.toStdString().c_str());
 }
@@ -2046,7 +2053,7 @@ void MainWindow::slot_clear_frame()
     frame->clear_main_and_aov_images();
 
     // In the UI, clear all render widgets to black.
-    for (const_each<RenderTabCollection> i = m_render_tabs; i; ++i)
+    for (const_each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
     {
         i->second->get_viewport_widget()->get_render_layer()->clear();
         i->second->get_viewport_widget()->repaint();
@@ -2056,9 +2063,9 @@ void MainWindow::slot_clear_frame()
 void MainWindow::slot_reset_zoom()
 {
     const int current_tab_index = m_ui->tab_render_channels->currentIndex();
-    const auto render_tab_it = m_tab_index_to_render_tab.find(current_tab_index);
-    if (render_tab_it != m_tab_index_to_render_tab.end())
-        render_tab_it->second->reset_zoom();
+    const auto viewport_tab_it = m_tab_index_to_viewport_tab.find(current_tab_index);
+    if (viewport_tab_it != m_tab_index_to_viewport_tab.end())
+        viewport_tab_it->second->reset_zoom();
 }
 
 void MainWindow::slot_filter_text_changed(const QString& pattern)
@@ -2074,7 +2081,7 @@ void MainWindow::slot_clear_filter()
 
 void MainWindow::slot_frame_modified()
 {
-    for (each<RenderTabCollection> i = m_render_tabs; i; ++i)
+    for (each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
         i->second->update_size();
 }
 

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -742,17 +742,17 @@ void MainWindow::update_workspace()
     update_pause_resume_checkbox(false);
     m_ui->attribute_editor_scrollarea_contents->setEnabled(true);
 
-    // Add/remove light paths tab.
+    // Enable/disable light paths
     if (m_project_manager.is_project_open() &&
         m_project_manager.get_project()->get_light_path_recorder().get_light_path_count() > 0)
     {
         for (const_each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
-            i->second->enable_light_paths_toggle();
+            i->second->set_light_paths_enabled(true);
     }
     else
     {
         for (const_each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
-            i->second->disable_light_paths_toggle();
+            i->second->set_light_paths_enabled(false);
     }
 }
 
@@ -894,7 +894,7 @@ void MainWindow::set_rendering_widgets_enabled(const bool is_enabled, const Rend
     // Rendering -> Render Settings.
     m_ui->action_rendering_rendering_settings->setEnabled(allow_start);
 
-    // Render tab buttons.
+    // Viewport tab buttons.
     const int current_tab_index = m_ui->tab_render_channels->currentIndex();
     if (current_tab_index != -1)
     {
@@ -982,7 +982,8 @@ void MainWindow::add_viewport_tab(const QString& label)
             *m_project_explorer,
             *m_project_manager.get_project(),
             m_rendering_manager,
-            m_ocio_config);
+            m_ocio_config,
+            m_application_settings);
 
     // Connect the render tab to the main window and the rendering manager.
     connect(
@@ -1218,8 +1219,7 @@ void MainWindow::start_rendering(const RenderingMode rendering_mode)
     // Darken render widgets.
     for (const_each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
     {
-        i->second->get_viewport_widget()->get_render_layer()->darken();
-        i->second->update();
+        i->second->render_began();
     }
 
     // Retrieve the appropriate rendering configuration.

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -747,12 +747,12 @@ void MainWindow::update_workspace()
         m_project_manager.get_project()->get_light_path_recorder().get_light_path_count() > 0)
     {
         for (const_each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
-            i->second->set_light_paths_enabled(true);
+            i->second->set_light_paths_toggle_enabled(true);
     }
     else
     {
         for (const_each<ViewportTabCollection> i = m_viewport_tabs; i; ++i)
-            i->second->set_light_paths_enabled(false);
+            i->second->set_light_paths_toggle_enabled(false);
     }
 }
 

--- a/src/appleseed.studio/mainwindow/mainwindow.h
+++ b/src/appleseed.studio/mainwindow/mainwindow.h
@@ -209,8 +209,6 @@ class MainWindow
     void recreate_render_tabs();
     void remove_render_tabs();
     void add_render_tab(const QString& label);
-    void add_light_paths_tab();
-    void remove_light_paths_tab();
 
     // Project file handling.
     renderer::ParamArray get_project_params(const char* configuration_name) const;
@@ -287,7 +285,7 @@ class MainWindow
     void slot_set_render_region(const QRect& rect);
 
     // Render widget actions.
-    void slot_render_widget_context_menu(const QPoint& point);
+    void slot_viewport_widget_context_menu(const QPoint& point);
     void slot_save_frame();
     void slot_save_frame_and_aovs();
     void slot_quicksave_frame_and_aovs();

--- a/src/appleseed.studio/mainwindow/mainwindow.h
+++ b/src/appleseed.studio/mainwindow/mainwindow.h
@@ -37,7 +37,7 @@
 #include "mainwindow/project/projectmanager.h"
 #include "mainwindow/qtlogtarget.h"
 #include "mainwindow/rendering/renderingmanager.h"
-#include "mainwindow/rendering/rendertab.h"
+#include "mainwindow/rendering/viewporttab.h"
 #include "mainwindow/renderingsettingswindow.h"
 #include "mainwindow/statusbar.h"
 
@@ -159,17 +159,17 @@ class MainWindow
     AttributeEditor*                            m_attribute_editor;
     RenderingManager                            m_rendering_manager;
 
-    typedef std::map<std::string, RenderTab*> RenderTabCollection;
-    typedef std::map<std::string, RenderTab::State> RenderTabStateCollection;
+    typedef std::map<std::string, ViewportTab*> ViewportTabCollection;
+    typedef std::map<std::string, ViewportTab::State> ViewportTabStateCollection;
 
-    RenderTabCollection                         m_render_tabs;
-    std::map<int, RenderTab*>                   m_tab_index_to_render_tab;
+    ViewportTabCollection                       m_viewport_tabs;
+    std::map<int, ViewportTab*>                 m_tab_index_to_viewport_tab;
     LightPathsTab*                              m_light_paths_tab;
 
     struct StateBeforeProjectOpen
     {
         bool                                    m_is_rendering;
-        RenderTabStateCollection                m_render_tab_states;
+        ViewportTabStateCollection              m_viewport_tab_states;
     };
 
     std::unique_ptr<StateBeforeProjectOpen>     m_state_before_project_open;
@@ -206,9 +206,9 @@ class MainWindow
     void restore_state_after_project_open();
 
     // Render tabs.
-    void recreate_render_tabs();
-    void remove_render_tabs();
-    void add_render_tab(const QString& label);
+    void recreate_viewport_tabs();
+    void remove_viewport_tabs();
+    void add_viewport_tab(const QString& label);
 
     // Project file handling.
     renderer::ParamArray get_project_params(const char* configuration_name) const;

--- a/src/appleseed.studio/mainwindow/rendering/glscenelayer.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/glscenelayer.cpp
@@ -458,7 +458,7 @@ namespace {
     }
 }
 
-void GLSceneLayer::initialize(QSurfaceFormat format)
+void GLSceneLayer::init_gl(QSurfaceFormat format)
 {
     // If there was already previous data, clean up
     GLSceneLayer::cleanup_gl_data();
@@ -509,11 +509,6 @@ void GLSceneLayer::initialize(QSurfaceFormat format)
     load_scene_data();
 
     m_initialized = true;
-}
-
-bool GLSceneLayer::is_initialized()
-{
-    return m_initialized;
 }
 
 void GLSceneLayer::cleanup_gl_data()

--- a/src/appleseed.studio/mainwindow/rendering/glscenelayer.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/glscenelayer.cpp
@@ -27,7 +27,7 @@
 //
 
 // Interface header.
-#include "lightpathswidget.h"
+#include "glscenelayer.h"
 
 // appleseed.studio headers.
 #include "utility/miscellaneous.h"
@@ -51,6 +51,7 @@
 // Qt headers.
 #include <QKeyEvent>
 #include <QOpenGLFunctions_3_3_Core>
+#include <QGLFormat>
 #include <QSurfaceFormat>
 #include <QString>
 
@@ -122,116 +123,56 @@ namespace {
     };
 }
 
-LightPathsWidget::LightPathsWidget(
-    const Project&          project,
-    const size_t            width,
-    const size_t            height)
+GLSceneLayer::GLSceneLayer(
+    const Project&                  project,
+    const size_t                    width,
+    const size_t                    height,
+    QOpenGLFunctions_3_3_Core*      functions,
+    QSurfaceFormat                  format)
   : m_project(project)
   , m_camera(*m_project.get_uncached_active_camera())
   , m_backface_culling_enabled(false)
-  , m_selected_light_path_index(-1)
+  , m_gl(functions)
   , m_gl_initialized(false)
+  , m_format(format)
 {
-    setFocusPolicy(Qt::StrongFocus);
-    setFixedWidth(static_cast<int>(width));
-    setFixedHeight(static_cast<int>(height));
-
     const float time = m_camera.get_shutter_middle_time();
     set_transform(m_camera.transform_sequence().evaluate(time));
+
+    init_gl();
 }
 
-QImage LightPathsWidget::capture()
+void GLSceneLayer::set_gl_functions(QOpenGLFunctions_3_3_Core* functions)
 {
-    return grabFramebuffer();
+    m_gl = functions;
 }
 
-void LightPathsWidget::set_transform(const Transformd& transform)
+void GLSceneLayer::set_transform(const Transformd& transform)
 {
     m_camera_matrix = transform.get_parent_to_local();
     m_gl_view_matrix = transpose(m_camera_matrix);
     m_camera_position = Vector3f(m_camera_matrix.extract_translation());
 }
 
-void LightPathsWidget::set_light_paths(const LightPathArray& light_paths)
-{
-    m_light_paths = light_paths;
-
-    if (m_light_paths.size() > 1)
-    {
-        // Sort paths by descending radiance at the camera.
-        const auto& light_path_recorder = m_project.get_light_path_recorder();
-        sort(
-            &m_light_paths[0],
-            &m_light_paths[0] + m_light_paths.size(),
-            [&light_path_recorder](const LightPath& lhs, const LightPath& rhs)
-            {
-                LightPathVertex lhs_v;
-                light_path_recorder.get_light_path_vertex(lhs.m_vertex_end_index - 1, lhs_v);
-
-                LightPathVertex rhs_v;
-                light_path_recorder.get_light_path_vertex(rhs.m_vertex_end_index - 1, rhs_v);
-
-                return
-                    sum_value(Color3f::from_array(lhs_v.m_radiance)) >
-                    sum_value(Color3f::from_array(rhs_v.m_radiance));
-            });
-    }
-
-    // Display all paths by default.
-    set_selected_light_path_index(-1);
-    load_light_paths_data();
-}
-
-void LightPathsWidget::set_selected_light_path_index(const int selected_light_path_index)
-{
-    m_selected_light_path_index = selected_light_path_index;
-
-    dump_selected_light_path();
-    update();
-
-    emit signal_light_path_selection_changed(
-        m_selected_light_path_index,
-        static_cast<int>(m_light_paths.size()));
-}
-
-void LightPathsWidget::slot_display_all_light_paths()
-{
-    if (m_selected_light_path_index > -1)
-        set_selected_light_path_index(-1);
-}
-
-void LightPathsWidget::slot_display_previous_light_path()
-{
-    if (m_selected_light_path_index > -1)
-        set_selected_light_path_index(m_selected_light_path_index - 1);
-}
-
-void LightPathsWidget::slot_display_next_light_path()
-{
-    if (m_selected_light_path_index < static_cast<int>(m_light_paths.size()) - 1)
-        set_selected_light_path_index(m_selected_light_path_index + 1);
-}
-
-void LightPathsWidget::slot_toggle_backface_culling(const bool checked)
+void GLSceneLayer::slot_toggle_backface_culling(const bool checked)
 {
     m_backface_culling_enabled = checked;
-    update();
 }
 
-void LightPathsWidget::slot_synchronize_camera()
+void GLSceneLayer::slot_synchronize_camera()
 {
     m_camera.transform_sequence().clear();
     m_camera.transform_sequence().set_transform(0.0f,
         Transformd::from_local_to_parent(inverse(m_camera_matrix)));
 }
 
-void LightPathsWidget::load_object_instance(
+void GLSceneLayer::load_object_instance(
     const ObjectInstance&   object_instance,
     const Matrix4f&         assembly_transform_matrix)
 {
     Object* object = object_instance.find_object();
 
-    // This would already be logged in LightPathsWidget::load_scene_data
+    // This would already be logged in GLSceneLayer::load_scene_data
     if (object == nullptr)
         return;
 
@@ -258,13 +199,13 @@ void LightPathsWidget::load_object_instance(
         reinterpret_cast<const GLvoid*>(&gl_matrix[0]));
 }
 
-void LightPathsWidget::load_assembly_instance(
+void GLSceneLayer::load_assembly_instance(
     const AssemblyInstance& assembly_instance,
     const float             time)
 {
     const Assembly* assembly = assembly_instance.find_assembly();
 
-    // This would already be logged in LightPathsWidget::load_scene_data
+    // This would already be logged in GLSceneLayer::load_scene_data
     if (assembly == nullptr)
         return;
 
@@ -279,7 +220,7 @@ void LightPathsWidget::load_assembly_instance(
         load_assembly_instance(child_assembly_instance, time);
 }
 
-void LightPathsWidget::load_object_data(const Object& object)
+void GLSceneLayer::load_object_data(const Object& object)
 {
     const string obj_name = string(object.get_name());
     RENDERER_LOG_DEBUG("opengl: uploading mesh data for object \"%s\"...", obj_name.c_str());
@@ -328,7 +269,7 @@ void LightPathsWidget::load_object_data(const Object& object)
     }
 }
 
-void LightPathsWidget::load_assembly_data(const Assembly& assembly)
+void GLSceneLayer::load_assembly_data(const Assembly& assembly)
 {
     for (const auto& object : assembly.objects())
         load_object_data(object);
@@ -337,7 +278,7 @@ void LightPathsWidget::load_assembly_data(const Assembly& assembly)
         load_assembly_data(child_assembly);
 }
 
-void LightPathsWidget::load_scene_data()
+void GLSceneLayer::load_scene_data()
 {
     const float time = m_camera.get_shutter_middle_time();
 
@@ -428,61 +369,6 @@ void LightPathsWidget::load_scene_data()
         load_assembly_instance(assembly_instance, time);
 }
 
-void LightPathsWidget::load_light_paths_data()
-{
-    m_light_paths_index_offsets.clear();
-    if (!m_light_paths.empty())
-    {
-        m_light_paths_index_offsets.push_back(0);
-
-        const auto& light_path_recorder = m_project.get_light_path_recorder();
-
-        const size_t total_gl_vertex_count = 2 * (light_path_recorder.get_vertex_count() - 2) + 2;
-
-        GLsizei total_index_count = 0;
-        vector<float> buffer;
-        buffer.reserve(total_gl_vertex_count * LightPathVertexFloatStride);
-        for (size_t light_path_idx = 0; light_path_idx < m_light_paths.size(); light_path_idx++)
-        {
-            const auto& path = m_light_paths[light_path_idx];
-            assert(path.m_vertex_end_index - path.m_vertex_begin_index >= 2);
-
-            LightPathVertex prev;
-            light_path_recorder.get_light_path_vertex(path.m_vertex_begin_index, prev);
-            for (size_t vertex_idx = path.m_vertex_begin_index + 1; vertex_idx < path.m_vertex_end_index; vertex_idx++)
-            {
-                LightPathVertex curr;
-                light_path_recorder.get_light_path_vertex(vertex_idx, curr);
-
-                auto piece_radiance = Color3f::from_array(curr.m_radiance);
-                piece_radiance /= piece_radiance + Color3f(1.0f);   // Reinhard tone mapping
-                piece_radiance = linear_rgb_to_srgb(piece_radiance);
-
-                const float temp_store[LightPathVertexLineFloatStride] =
-                {
-                    prev.m_position[0], prev.m_position[1], prev.m_position[2],
-                    piece_radiance[0], piece_radiance[1], piece_radiance[2],
-
-                    curr.m_position[0], curr.m_position[1], curr.m_position[2],
-                    piece_radiance[0], piece_radiance[1], piece_radiance[2],
-                };
-                buffer.insert(buffer.end(), temp_store, temp_store + 12);
-
-                total_index_count += 2;
-                prev = curr;
-            }
-            m_light_paths_index_offsets.push_back(total_index_count);
-        }
-
-        m_gl->glBindBuffer(GL_ARRAY_BUFFER, m_light_paths_vbo);
-        m_gl->glBufferData(
-            GL_ARRAY_BUFFER,
-            buffer.size() * sizeof(float),
-            reinterpret_cast<const GLvoid*>(&buffer[0]),
-            GL_STATIC_DRAW);
-    }
-}
-
 namespace {
     const string shader_kind_to_string(const GLint shader_kind)
     {
@@ -568,24 +454,17 @@ namespace {
     }
 }
 
-void LightPathsWidget::initializeGL()
+void GLSceneLayer::init_gl(QSurfaceFormat format)
 {
-    m_gl = QOpenGLContext::currentContext()->versionFunctions<QOpenGLFunctions_3_3_Core>();
     // If there was already previous data, clean up
-    LightPathsWidget::cleanup_gl_data();
+    GLSceneLayer::cleanup_gl_data();
 
-    const auto qgl_format = format();
-
-    if (!m_gl->initializeOpenGLFunctions())
+    bool manual_srgb_conversion = false;
+    if (format.colorSpace() != QSurfaceFormat::sRGBColorSpace)
     {
-        const int major_version = qgl_format.majorVersion();
-        const int minor_version = qgl_format.minorVersion();
-        RENDERER_LOG_ERROR(
-            "opengl: could not load required gl functions: loaded version %d.%d, required version 3.3.",
-            major_version,
-            minor_version);
-        m_gl_initialized = false;
-        return;
+        manual_srgb_conversion = true;
+        RENDERER_LOG_WARNING(
+            "opengl: srgb framebuffer extensions not supported, using slower manual conversion.");
     }
 
     glEnable(GL_DEPTH_TEST);
@@ -598,18 +477,9 @@ void LightPathsWidget::initializeGL()
         load_gl_shader("scene.vert"),
         load_gl_shader("scene.frag"));
 
-    create_shader_program(
-        m_gl,
-        m_light_paths_shader_program,
-        load_gl_shader("lightpaths.vert"),
-        load_gl_shader("lightpaths.frag"));
-
     m_scene_view_mat_location = m_gl->glGetUniformLocation(m_scene_shader_program, "u_view");
     m_scene_proj_mat_location = m_gl->glGetUniformLocation(m_scene_shader_program, "u_proj");
     m_scene_camera_pos_location = m_gl->glGetUniformLocation(m_scene_shader_program, "u_camera_pos");
-
-    m_light_paths_view_mat_location = m_gl->glGetUniformLocation(m_light_paths_shader_program, "u_view");
-    m_light_paths_proj_mat_location = m_gl->glGetUniformLocation(m_light_paths_shader_program, "u_proj");
 
     const float z_near = 0.01f;
     const float z_far = 1000.0f;
@@ -631,41 +501,12 @@ void LightPathsWidget::initializeGL()
     // from the FBO to the default framebuffer, which flips the image.
     m_gl_proj_matrix = transpose(Matrix4f::make_frustum(top, bottom, left, right, z_near, z_far));
 
-    GLuint temp_light_paths_vao = 0;
-    GLuint temp_light_paths_vbo = 0;
-    m_gl->glGenVertexArrays(1, &temp_light_paths_vao);
-    m_gl->glGenBuffers(1, &temp_light_paths_vbo);
-    m_light_paths_vao = temp_light_paths_vao;
-    m_light_paths_vbo = temp_light_paths_vbo;
-
-    m_gl->glBindVertexArray(m_light_paths_vao);
-    m_gl->glBindBuffer(GL_ARRAY_BUFFER, m_light_paths_vbo);
-    m_gl->glVertexAttribPointer(
-        0,
-        3,
-        GL_FLOAT,
-        GL_FALSE,
-        LightPathVertexByteStride,
-        reinterpret_cast<const GLvoid*>(0));
-    m_gl->glVertexAttribPointer(
-        1,
-        3,
-        GL_FLOAT,
-        GL_FALSE,
-        LightPathVertexByteStride,
-        reinterpret_cast<const GLvoid*>(LightPathVertexByteStride / 2));
-    m_gl->glEnableVertexAttribArray(0);
-    m_gl->glEnableVertexAttribArray(1);
-
-    m_gl->glBindVertexArray(0);
-
     load_scene_data();
-    load_light_paths_data();
 
     m_gl_initialized = true;
 }
 
-void LightPathsWidget::cleanup_gl_data()
+void GLSceneLayer::cleanup_gl_data()
 {
     if (!m_scene_object_vaos.empty())
     {
@@ -692,24 +533,28 @@ void LightPathsWidget::cleanup_gl_data()
     {
         m_gl->glDeleteProgram(m_scene_shader_program);
     }
-    if (m_light_paths_shader_program != 0)
-    {
-        m_gl->glDeleteProgram(m_light_paths_shader_program);
-    }
     m_scene_object_index_map.clear();
     m_scene_object_data_index_counts.clear();
     m_scene_object_instance_counts.clear();
     m_scene_object_current_instances.clear();
 }
 
-void LightPathsWidget::resizeGL(int w, int h)
+void GLSceneLayer::draw()
 {
-    glViewport(0, 0, static_cast<GLsizei>(w), static_cast<GLsizei>(h));
+    if (!m_gl_initialized)
+        return;
+
+    if (m_backface_culling_enabled)
+        glEnable(GL_CULL_FACE);
+    else glDisable(GL_CULL_FACE);
+
+    m_gl->glUseProgram(m_scene_shader_program);
+    render_scene();
 }
 
-void LightPathsWidget::paintGL()
+void GLSceneLayer::draw_depth_only()
 {
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glClear(GL_DEPTH_BUFFER_BIT);
 
     if (!m_gl_initialized)
         return;
@@ -718,38 +563,13 @@ void LightPathsWidget::paintGL()
         glEnable(GL_CULL_FACE);
     else glDisable(GL_CULL_FACE);
 
-    render_geometry();
-    render_light_paths();
+    m_gl->glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+    m_gl->glUseProgram(m_depthonly_shader_program);
+    render_scene();
 }
 
-void LightPathsWidget::keyPressEvent(QKeyEvent* event)
+void GLSceneLayer::render_scene()
 {
-    switch (event->key())
-    {
-      // Home key: display all paths.
-      case Qt::Key_Home:
-        slot_display_all_light_paths();
-        break;
-
-      // Left key: display previous path.
-      case Qt::Key_Left:
-        slot_display_previous_light_path();
-        break;
-
-      // Right key: display next path.
-      case Qt::Key_Right:
-        slot_display_next_light_path();
-        break;
-
-      default:
-        QOpenGLWidget::keyPressEvent(event);
-        break;
-    }
-}
-
-void LightPathsWidget::render_geometry()
-{
-    m_gl->glUseProgram(m_scene_shader_program);
     m_gl->glUniformMatrix4fv(
         m_scene_view_mat_location,
         1,
@@ -778,82 +598,6 @@ void LightPathsWidget::render_geometry()
             0,
             index_count,
             instance_count);
-    }
-}
-
-void LightPathsWidget::render_light_paths()
-{
-    if (m_light_paths_index_offsets.size() > 1)
-    {
-        m_gl->glUseProgram(m_light_paths_shader_program);
-        m_gl->glUniformMatrix4fv(
-            m_light_paths_view_mat_location,
-            1,
-            false,
-            const_cast<const GLfloat*>(&m_gl_view_matrix[0]));
-        m_gl->glUniformMatrix4fv(
-            m_light_paths_proj_mat_location,
-            1,
-            false,
-            const_cast<const GLfloat*>(&m_gl_proj_matrix[0]));
-
-        m_gl->glBindVertexArray(m_light_paths_vao);
-
-        GLint first;
-        GLsizei count;
-        assert(m_selected_light_path_index >= -1);
-        if (m_selected_light_path_index == -1)
-        {
-            first = 0;
-            count = m_light_paths_index_offsets[m_light_paths_index_offsets.size() - 1];
-        }
-        else
-        {
-            first = static_cast<GLint>(m_light_paths_index_offsets[m_selected_light_path_index]);
-            count = m_light_paths_index_offsets[m_selected_light_path_index + 1] - first;
-        }
-        glDrawArrays(GL_LINES, first, count);
-    }
-}
-
-void LightPathsWidget::dump_selected_light_path() const
-{
-    if (m_selected_light_path_index == -1)
-    {
-        if (m_light_paths.empty())
-            RENDERER_LOG_INFO("no light path to display.");
-        else
-        {
-            RENDERER_LOG_INFO("displaying all %s light path%s.",
-                pretty_uint(m_light_paths.size()).c_str(),
-                m_light_paths.size() > 1 ? "s" : "");
-        }
-    }
-    else
-    {
-        RENDERER_LOG_INFO("displaying light path %s:",
-            pretty_int(m_selected_light_path_index + 1).c_str());
-
-        const auto& light_path_recorder = m_project.get_light_path_recorder();
-        const auto& path = m_light_paths[m_selected_light_path_index];
-
-        for (size_t i = path.m_vertex_begin_index; i < path.m_vertex_end_index; ++i)
-        {
-            LightPathVertex v;
-            light_path_recorder.get_light_path_vertex(i, v);
-
-            const string entity_name =
-                v.m_entity != nullptr
-                    ? foundation::format("\"{0}\"", v.m_entity->get_path().c_str())
-                    : "n/a";
-
-            RENDERER_LOG_INFO("  vertex " FMT_SIZE_T ": entity: %s - position: (%f, %f, %f) - radiance: (%f, %f, %f) - total radiance: %f",
-                i - path.m_vertex_begin_index + 1,
-                entity_name.c_str(),
-                v.m_position[0], v.m_position[1], v.m_position[2],
-                v.m_radiance[0], v.m_radiance[1], v.m_radiance[2],
-                v.m_radiance[0] + v.m_radiance[1] + v.m_radiance[2]);
-        }
     }
 }
 

--- a/src/appleseed.studio/mainwindow/rendering/glscenelayer.h
+++ b/src/appleseed.studio/mainwindow/rendering/glscenelayer.h
@@ -79,16 +79,14 @@ class GLSceneLayer
         const size_t                        width,
         const size_t                        height);
 
+    void init_gl(
+        QSurfaceFormat                      format);
+
     void set_transform(
         const foundation::Transformd&       transform);
 
     void set_gl_functions(
         QOpenGLFunctions_3_3_Core*          functions);
-
-    void initialize(
-        QSurfaceFormat                      format);
-
-    bool is_initialized();
 
     void draw();
     void draw_depth_only();

--- a/src/appleseed.studio/mainwindow/rendering/glscenelayer.h
+++ b/src/appleseed.studio/mainwindow/rendering/glscenelayer.h
@@ -85,7 +85,10 @@ class GLSceneLayer
     void set_gl_functions(
         QOpenGLFunctions_3_3_Core*          functions);
 
-    void init_gl(QSurfaceFormat             format);
+    void initialize(
+        QSurfaceFormat                      format);
+
+    bool is_initialized();
 
     void draw();
     void draw_depth_only();
@@ -112,13 +115,16 @@ class GLSceneLayer
     std::vector<GLuint>                     m_scene_object_vaos;
     std::unordered_map<std::string, size_t> m_scene_object_index_map;
     GLuint                                  m_scene_shader_program;
-    GLuint                                  m_depthonly_shader_program;
     GLint                                   m_scene_view_mat_location;
     GLint                                   m_scene_proj_mat_location;
     GLint                                   m_scene_camera_pos_location;
+    GLuint                                  m_depthonly_shader_program;
+    GLint                                   m_depthonly_view_mat_location;
+    GLint                                   m_depthonly_proj_mat_location;
+    GLint                                   m_depthonly_camera_pos_location;
     foundation::Matrix4f                    m_gl_view_matrix;
     foundation::Matrix4f                    m_gl_proj_matrix;
-    bool                                    m_gl_initialized;
+    bool                                    m_initialized;
 
     void render_scene();
 

--- a/src/appleseed.studio/mainwindow/rendering/glscenelayer.h
+++ b/src/appleseed.studio/mainwindow/rendering/glscenelayer.h
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2018 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2018 Gray Olson, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -59,46 +59,38 @@ namespace renderer  { class Project; }
 class QKeyEvent;
 class QImage;
 class QOpenGLFunctions_3_3_Core;
+class QSurfaceFormat;
 
 namespace appleseed {
 namespace studio {
 
 //
-// A widget providing an hardware-accelerated visualization of recorded light paths.
+// A widget providing an hardware-accelerated visualization of the loaded scene.
 //
 
-class LightPathsWidget
-  : public QOpenGLWidget
-  , public ICapturableWidget
+class GLSceneLayer
+  : public QObject
 {
     Q_OBJECT
 
   public:
-    LightPathsWidget(
+    GLSceneLayer(
         const renderer::Project&            project,
         const size_t                        width,
         const size_t                        height);
 
-    QImage capture() override;
-
     void set_transform(
         const foundation::Transformd&       transform);
 
-    void set_light_paths(
-        const renderer::LightPathArray&     light_paths);
+    void set_gl_functions(
+        QOpenGLFunctions_3_3_Core*          functions);
 
-    void set_selected_light_path_index(
-        const int                           selected_light_path_index);
+    void init_gl(QSurfaceFormat             format);
 
-  signals:
-    void signal_light_path_selection_changed(
-        const int                           selected_light_path_index,
-        const int                           total_light_paths) const;
+    void draw();
+    void draw_depth_only();
 
   public slots:
-    void slot_display_all_light_paths();
-    void slot_display_previous_light_path();
-    void slot_display_next_light_path();
     void slot_toggle_backface_culling(const bool checked);
     void slot_synchronize_camera();
 
@@ -110,9 +102,6 @@ class LightPathsWidget
 
     bool                                    m_backface_culling_enabled;
 
-    renderer::LightPathArray                m_light_paths;
-    int                                     m_selected_light_path_index;    // -1 == display all paths
-
     QOpenGLFunctions_3_3_Core*              m_gl;
 
     std::vector<GLuint>                     m_scene_object_data_vbos;
@@ -123,27 +112,18 @@ class LightPathsWidget
     std::vector<GLuint>                     m_scene_object_vaos;
     std::unordered_map<std::string, size_t> m_scene_object_index_map;
     GLuint                                  m_scene_shader_program;
+    GLuint                                  m_depthonly_shader_program;
     GLint                                   m_scene_view_mat_location;
     GLint                                   m_scene_proj_mat_location;
     GLint                                   m_scene_camera_pos_location;
-    GLuint                                  m_light_paths_vbo;
-    std::vector<GLsizei>                    m_light_paths_index_offsets;
-    GLuint                                  m_light_paths_vao;
-    GLuint                                  m_light_paths_shader_program;
-    GLint                                   m_light_paths_view_mat_location;
-    GLint                                   m_light_paths_proj_mat_location;
     foundation::Matrix4f                    m_gl_view_matrix;
     foundation::Matrix4f                    m_gl_proj_matrix;
     bool                                    m_gl_initialized;
 
-    void initializeGL() override;
-    void resizeGL(int w, int h) override;
-    void paintGL() override;
-    void keyPressEvent(QKeyEvent* event) override;
+    void render_scene();
 
     void cleanup_gl_data();
     void load_scene_data();
-    void load_light_paths_data();
 
     void load_assembly_data(
         const renderer::Assembly&           object);
@@ -158,11 +138,6 @@ class LightPathsWidget
     void load_object_instance(
         const renderer::ObjectInstance&     object_instance,
         const foundation::Matrix4f&         assembly_transform_matrix);
-
-    void render_geometry();
-    void render_light_paths();
-
-    void dump_selected_light_path() const;
 };
 
 }   // namespace studio

--- a/src/appleseed.studio/mainwindow/rendering/glscenelayer.h
+++ b/src/appleseed.studio/mainwindow/rendering/glscenelayer.h
@@ -58,7 +58,7 @@ namespace renderer  { class ObjectInstance; }
 namespace renderer  { class Project; }
 class QKeyEvent;
 class QImage;
-class QOpenGLFunctions_3_3_Core;
+class QOpenGLFunctions_4_1_Core;
 class QSurfaceFormat;
 
 namespace appleseed {
@@ -79,6 +79,8 @@ class GLSceneLayer
         const size_t                        width,
         const size_t                        height);
 
+    ~GLSceneLayer();
+
     void init_gl(
         QSurfaceFormat                      format);
 
@@ -86,7 +88,7 @@ class GLSceneLayer
         const foundation::Transformd&       transform);
 
     void set_gl_functions(
-        QOpenGLFunctions_3_3_Core*          functions);
+        QOpenGLFunctions_4_1_Core*          functions);
 
     void draw();
     void draw_depth_only();
@@ -103,7 +105,7 @@ class GLSceneLayer
 
     bool                                    m_backface_culling_enabled;
 
-    QOpenGLFunctions_3_3_Core*              m_gl;
+    QOpenGLFunctions_4_1_Core*              m_gl;
 
     std::vector<GLuint>                     m_scene_object_data_vbos;
     std::vector<GLsizei>                    m_scene_object_data_index_counts;
@@ -125,7 +127,6 @@ class GLSceneLayer
     bool                                    m_initialized;
 
     void render_scene();
-
     void cleanup_gl_data();
     void load_scene_data();
 

--- a/src/appleseed.studio/mainwindow/rendering/lightpathslayer.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathslayer.cpp
@@ -85,7 +85,6 @@ LightPathsLayer::LightPathsLayer(
     const size_t               height)
   : m_project(project)
   , m_camera(*m_project.get_uncached_active_camera())
-  , m_backface_culling_enabled(false)
   , m_selected_light_path_index(-1)
   , m_gl_initialized(false)
   , m_width(width)
@@ -180,11 +179,6 @@ void LightPathsLayer::slot_display_next_light_path()
 {
     if (m_selected_light_path_index < static_cast<int>(m_light_paths.size()) - 1)
         set_selected_light_path_index(m_selected_light_path_index + 1);
-}
-
-void LightPathsLayer::slot_toggle_backface_culling(const bool checked)
-{
-    m_backface_culling_enabled = checked;
 }
 
 void LightPathsLayer::slot_synchronize_camera()
@@ -515,14 +509,6 @@ void LightPathsLayer::render_scene(const GLfloat* gl_view_matrix) const
 {
     if (!m_gl_initialized)
         return;
-
-    if (m_backface_culling_enabled)
-        m_gl->glEnable(GL_CULL_FACE);
-    else m_gl->glDisable(GL_CULL_FACE);
-
-    m_gl->glDepthMask(GL_TRUE);
-    m_gl->glEnable(GL_DEPTH_TEST);
-    m_gl->glDepthFunc(GL_LEQUAL);
 
     if (m_index_offsets.size() > 1)
     {

--- a/src/appleseed.studio/mainwindow/rendering/lightpathslayer.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathslayer.cpp
@@ -1,0 +1,534 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Francois Beaune, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "lightpathslayer.h"
+
+// appleseed.studio headers.
+#include "utility/miscellaneous.h"
+
+// appleseed.renderer headers.
+#include "renderer/api/camera.h"
+#include "renderer/api/entity.h"
+#include "renderer/api/object.h"
+#include "renderer/api/project.h"
+#include "renderer/api/rasterization.h"
+#include "renderer/api/scene.h"
+#include "renderer/api/utility.h"
+
+// appleseed.foundation headers.
+#include "foundation/image/color.h"
+#include "foundation/image/colorspace.h"
+#include "foundation/math/scalar.h"
+#include "foundation/utility/api/apistring.h"
+#include "foundation/utility/string.h"
+
+// Qt headers.
+#include <QKeyEvent>
+#include <QOpenGLFunctions_3_3_Core>
+#include <QSurfaceFormat>
+#include <QString>
+
+// Standard headers.
+#include <algorithm>
+#include <cmath>
+
+using namespace foundation;
+using namespace renderer;
+using namespace std;
+
+namespace appleseed {
+namespace studio {
+
+namespace {
+    // Number of floats per OpenGL vertex for a piece of scene geometry
+    // Vector3 position and Vector3 normal.
+    const size_t SceneVertexFloatStride = 6;
+    // Number of bytes per OpenGL vertex for a piece of scene geometry.
+    const size_t SceneVertexByteStride = SceneVertexFloatStride * sizeof(float);
+    // Number of floats per triangle for a piece of scene geometry.
+    const size_t SceneTriangleFloatStride = SceneVertexFloatStride * 3;
+
+    // Number of floats per OpenGL vertex for a light path
+    // Vector3 position and Vector3 color.
+    const size_t LightPathVertexFloatStride = 6;
+    // Number of bytes per OpenGL vertex for a piece of scene geometry.
+    const size_t LightPathVertexByteStride = LightPathVertexFloatStride * sizeof(float);
+    // Number of floats per line for a light path.
+    const size_t LightPathVertexLineFloatStride = LightPathVertexFloatStride * 2;
+
+    // Number of floats per OpenGL transform matrix.
+    const size_t TransformFloatStride = 16;
+    // Number of bytes per OpenGL transform matrix.
+    const size_t TransformByteStride = TransformFloatStride * sizeof(float);
+
+    struct OpenGLRasterizer
+      : public ObjectRasterizer
+    {
+        vector<float>   m_buffer;
+        size_t          m_prim_count;
+
+        void begin_object(const size_t triangle_count_hint) override
+        {
+            m_buffer.clear();
+            m_buffer.reserve(triangle_count_hint * SceneTriangleFloatStride);
+            m_prim_count = 0;
+        }
+
+        void end_object() override {}
+
+        void rasterize(const Triangle& triangle) override
+        {
+            const float temp_store[SceneTriangleFloatStride] =
+            {
+                static_cast<float>(triangle.m_v0[0]), static_cast<float>(triangle.m_v0[1]), static_cast<float>(triangle.m_v0[2]),
+                static_cast<float>(triangle.m_n0[0]), static_cast<float>(triangle.m_n0[1]), static_cast<float>(triangle.m_n0[2]),
+
+                static_cast<float>(triangle.m_v1[0]), static_cast<float>(triangle.m_v1[1]), static_cast<float>(triangle.m_v1[2]),
+                static_cast<float>(triangle.m_n1[0]), static_cast<float>(triangle.m_n1[1]), static_cast<float>(triangle.m_n1[2]),
+
+                static_cast<float>(triangle.m_v2[0]), static_cast<float>(triangle.m_v2[1]), static_cast<float>(triangle.m_v2[2]),
+                static_cast<float>(triangle.m_n2[0]), static_cast<float>(triangle.m_n2[1]), static_cast<float>(triangle.m_n2[2]),
+            };
+            m_buffer.reserve(m_buffer.size() + SceneTriangleFloatStride);
+            m_buffer.insert(m_buffer.end(), temp_store, temp_store + SceneTriangleFloatStride);
+            m_prim_count++;
+        }
+    };
+}
+
+LightPathsLayer::LightPathsLayer(
+    const Project&             project,
+    const size_t               width,
+    const size_t               height)
+  : m_project(project)
+  , m_camera(*m_project.get_uncached_active_camera())
+  , m_backface_culling_enabled(false)
+  , m_selected_light_path_index(-1)
+  , m_gl_initialized(false)
+{
+
+    const float time = m_camera.get_shutter_middle_time();
+    set_transform(m_camera.transform_sequence().evaluate(time));
+}
+
+void LightPathsLayer::set_gl_functions(QOpenGLFunctions_3_3_Core* functions)
+{
+    m_gl = functions;
+}
+
+void LightPathsLayer::set_transform(const Transformd& transform)
+{
+    m_camera_matrix = transform.get_parent_to_local();
+    m_gl_view_matrix = transpose(m_camera_matrix);
+    m_camera_position = Vector3f(m_camera_matrix.extract_translation());
+}
+
+void LightPathsLayer::set_light_paths(const LightPathArray& light_paths)
+{
+    m_light_paths = light_paths;
+
+    if (m_light_paths.size() > 1)
+    {
+        // Sort paths by descending radiance at the camera.
+        const auto& light_path_recorder = m_project.get_light_path_recorder();
+        sort(
+            &m_light_paths[0],
+            &m_light_paths[0] + m_light_paths.size(),
+            [&light_path_recorder](const LightPath& lhs, const LightPath& rhs)
+            {
+                LightPathVertex lhs_v;
+                light_path_recorder.get_light_path_vertex(lhs.m_vertex_end_index - 1, lhs_v);
+
+                LightPathVertex rhs_v;
+                light_path_recorder.get_light_path_vertex(rhs.m_vertex_end_index - 1, rhs_v);
+
+                return
+                    sum_value(Color3f::from_array(lhs_v.m_radiance)) >
+                    sum_value(Color3f::from_array(rhs_v.m_radiance));
+            });
+    }
+
+    // Display all paths by default.
+    set_selected_light_path_index(-1);
+    load_light_paths_data();
+}
+
+void LightPathsLayer::set_selected_light_path_index(const int selected_light_path_index)
+{
+    m_selected_light_path_index = selected_light_path_index;
+
+    dump_selected_light_path();
+
+    emit signal_light_path_selection_changed(
+        m_selected_light_path_index,
+        static_cast<int>(m_light_paths.size()));
+}
+
+void LightPathsLayer::slot_display_all_light_paths()
+{
+    if (m_selected_light_path_index > -1)
+        set_selected_light_path_index(-1);
+}
+
+void LightPathsLayer::slot_display_previous_light_path()
+{
+    if (m_selected_light_path_index > -1)
+        set_selected_light_path_index(m_selected_light_path_index - 1);
+}
+
+void LightPathsLayer::slot_display_next_light_path()
+{
+    if (m_selected_light_path_index < static_cast<int>(m_light_paths.size()) - 1)
+        set_selected_light_path_index(m_selected_light_path_index + 1);
+}
+
+void LightPathsLayer::slot_toggle_backface_culling(const bool checked)
+{
+    m_backface_culling_enabled = checked;
+}
+
+void LightPathsLayer::slot_synchronize_camera()
+{
+    m_camera.transform_sequence().clear();
+    m_camera.transform_sequence().set_transform(0.0f,
+        Transformd::from_local_to_parent(inverse(m_camera_matrix)));
+}
+
+void LightPathsLayer::load_light_paths_data()
+{
+    m_light_paths_index_offsets.clear();
+    if (!m_light_paths.empty())
+    {
+        m_light_paths_index_offsets.push_back(0);
+
+        const auto& light_path_recorder = m_project.get_light_path_recorder();
+
+        const size_t total_gl_vertex_count = 2 * (light_path_recorder.get_vertex_count() - 2) + 2;
+
+        GLsizei total_index_count = 0;
+        vector<float> buffer;
+        buffer.reserve(total_gl_vertex_count * LightPathVertexFloatStride);
+        for (size_t light_path_idx = 0; light_path_idx < m_light_paths.size(); light_path_idx++)
+        {
+            const auto& path = m_light_paths[light_path_idx];
+            assert(path.m_vertex_end_index - path.m_vertex_begin_index >= 2);
+
+            LightPathVertex prev;
+            light_path_recorder.get_light_path_vertex(path.m_vertex_begin_index, prev);
+            for (size_t vertex_idx = path.m_vertex_begin_index + 1; vertex_idx < path.m_vertex_end_index; vertex_idx++)
+            {
+                LightPathVertex curr;
+                light_path_recorder.get_light_path_vertex(vertex_idx, curr);
+
+                auto piece_radiance = Color3f::from_array(curr.m_radiance);
+                piece_radiance /= piece_radiance + Color3f(1.0f);
+                piece_radiance = linear_rgb_to_srgb(piece_radiance);
+
+                const float temp_store[LightPathVertexLineFloatStride] =
+                {
+                    prev.m_position[0], prev.m_position[1], prev.m_position[2],
+                    piece_radiance[0], piece_radiance[1], piece_radiance[2],
+
+                    curr.m_position[0], curr.m_position[1], curr.m_position[2],
+                    piece_radiance[0], piece_radiance[1], piece_radiance[2],
+                };
+                buffer.insert(buffer.end(), temp_store, temp_store + 12);
+
+                total_index_count += 2;
+                prev = curr;
+            }
+            m_light_paths_index_offsets.push_back(total_index_count);
+        }
+
+        m_gl->glBindBuffer(GL_ARRAY_BUFFER, m_light_paths_vbo);
+        m_gl->glBufferData(
+            GL_ARRAY_BUFFER,
+            buffer.size() * sizeof(float),
+            reinterpret_cast<const GLvoid*>(&buffer[0]),
+            GL_STATIC_DRAW);
+    }
+}
+
+namespace {
+    const string shader_kind_to_string(const GLint shader_kind)
+    {
+        switch (shader_kind) {
+            case GL_VERTEX_SHADER:
+                return "Vertex";
+            case GL_FRAGMENT_SHADER:
+                return "Fragment";
+            default:
+                return "Unknown Kind";
+        }
+    }
+
+    void compile_shader(
+        QOpenGLFunctions_3_3_Core* f,
+        const GLuint               shader,
+        const GLsizei              count,
+        const GLchar**             src_string,
+        const GLint*               length)
+    {
+        f->glShaderSource(shader, count, src_string, length);
+        f->glCompileShader(shader);
+        GLint success;
+        f->glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+
+        if (!success)
+        {
+            char info_log[1024];
+            f->glGetShaderInfoLog(shader, 1024, NULL, info_log);
+
+            GLint shader_kind;
+            f->glGetShaderiv(shader, GL_SHADER_TYPE, &shader_kind);
+            string shader_kind_string = shader_kind_to_string(shader_kind);
+
+            RENDERER_LOG_ERROR("opengl: %s shader compilation failed:\n%s", shader_kind_string.c_str(), info_log);
+        }
+    }
+
+    void link_shader_program(
+        QOpenGLFunctions_3_3_Core*  f,
+        const GLuint                program,
+        const GLuint                vert,
+        const GLuint                frag)
+    {
+        f->glAttachShader(program, vert);
+        f->glAttachShader(program, frag);
+        f->glLinkProgram(program);
+
+        GLint success;
+        f->glGetProgramiv(program, GL_LINK_STATUS, &success);
+
+        if (!success)
+        {
+            char info_log[1024];
+            f->glGetProgramInfoLog(program, 1024, NULL, info_log);
+            RENDERER_LOG_ERROR("opengl: shader program linking failed:\n%s", info_log);
+        }
+    }
+
+    void create_shader_program(
+        QOpenGLFunctions_3_3_Core*  f,
+        GLuint&                     program,
+        const QByteArray&               vert_source,
+        const QByteArray&               frag_source)
+    {
+        GLuint vert = f->glCreateShader(GL_VERTEX_SHADER);
+        GLuint frag = f->glCreateShader(GL_FRAGMENT_SHADER);
+
+        auto gl_vert_source = static_cast<const GLchar*>(vert_source.constData());
+        auto gl_vert_source_length = static_cast<const GLint>(vert_source.size());
+
+        auto gl_frag_source = static_cast<const GLchar*>(frag_source.constData());
+        auto gl_frag_source_length = static_cast<const GLint>(frag_source.size());
+
+        compile_shader(f, vert, 1, &gl_vert_source, &gl_vert_source_length);
+        compile_shader(f, frag, 1, &gl_frag_source, &gl_frag_source_length);
+
+        program = f->glCreateProgram();
+        link_shader_program(f, program, vert, frag);
+
+        f->glDeleteShader(vert);
+        f->glDeleteShader(frag);
+    }
+}
+
+void LightPathsLayer::init_gl(QSurfaceFormat format)
+{
+    // If there was already previous data, clean up
+    LightPathsLayer::cleanup_gl_data();
+
+    bool manual_srgb_conversion = false;
+    if (format.colorSpace() != QSurfaceFormat::sRGBColorSpace)
+    {
+        manual_srgb_conversion = true;
+        RENDERER_LOG_WARNING(
+            "opengl: srgb framebuffer extensions not supported, using slower manual conversion.");
+    }
+
+    glEnable(GL_DEPTH_TEST);
+
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+
+    create_shader_program(
+        m_gl,
+        m_light_paths_shader_program,
+        load_gl_shader("lightpaths.vert"),
+        load_gl_shader("lightpaths.frag"));
+
+    m_light_paths_view_mat_location = m_gl->glGetUniformLocation(m_light_paths_shader_program, "u_view");
+    m_light_paths_proj_mat_location = m_gl->glGetUniformLocation(m_light_paths_shader_program, "u_proj");
+
+    const float z_near = 0.01f;
+    const float z_far = 1000.0f;
+
+    const auto& rc = m_camera.get_rasterization_camera();
+
+    const float fy = tan(rc.m_hfov / rc.m_aspect_ratio * 0.5) * z_near;
+    const float fx = fy * rc.m_aspect_ratio;
+
+    const float shift_x = rc.m_shift_x * 2.0 * fx;
+    const float shift_y = rc.m_shift_y * 2.0 * fy;
+
+    const float left   = -fx + shift_x;
+    const float right  =  fx + shift_x;
+    const float top    = -fy + shift_y;
+    const float bottom =  fy + shift_y;
+
+    // Top and bottom are flipped because QOpenGLWidget draws to a framebuffer object and then blits
+    // from the FBO to the default framebuffer, which flips the image.
+    m_gl_proj_matrix = transpose(Matrix4f::make_frustum(top, bottom, left, right, z_near, z_far));
+
+    GLuint temp_light_paths_vao = 0;
+    GLuint temp_light_paths_vbo = 0;
+    m_gl->glGenVertexArrays(1, &temp_light_paths_vao);
+    m_gl->glGenBuffers(1, &temp_light_paths_vbo);
+    m_light_paths_vao = temp_light_paths_vao;
+    m_light_paths_vbo = temp_light_paths_vbo;
+
+    m_gl->glBindVertexArray(m_light_paths_vao);
+    m_gl->glBindBuffer(GL_ARRAY_BUFFER, m_light_paths_vbo);
+    m_gl->glVertexAttribPointer(
+        0,
+        3,
+        GL_FLOAT,
+        GL_FALSE,
+        LightPathVertexByteStride,
+        reinterpret_cast<const GLvoid*>(0));
+    m_gl->glVertexAttribPointer(
+        1,
+        3,
+        GL_FLOAT,
+        GL_FALSE,
+        LightPathVertexByteStride,
+        reinterpret_cast<const GLvoid*>(LightPathVertexByteStride / 2));
+    m_gl->glEnableVertexAttribArray(0);
+    m_gl->glEnableVertexAttribArray(1);
+
+    m_gl->glBindVertexArray(0);
+
+    load_light_paths_data();
+
+    m_gl_initialized = true;
+}
+
+void LightPathsLayer::cleanup_gl_data()
+{
+    if (m_light_paths_shader_program != 0)
+    {
+        m_gl->glDeleteProgram(m_light_paths_shader_program);
+    }
+}
+
+void LightPathsLayer::draw()
+{
+    if (!m_gl_initialized)
+        return;
+
+    if (m_backface_culling_enabled)
+        glEnable(GL_CULL_FACE);
+    else glDisable(GL_CULL_FACE);
+
+    if (m_light_paths_index_offsets.size() > 1)
+    {
+        m_gl->glUseProgram(m_light_paths_shader_program);
+        m_gl->glUniformMatrix4fv(
+            m_light_paths_view_mat_location,
+            1,
+            false,
+            const_cast<const GLfloat*>(&m_gl_view_matrix[0]));
+        m_gl->glUniformMatrix4fv(
+            m_light_paths_proj_mat_location,
+            1,
+            false,
+            const_cast<const GLfloat*>(&m_gl_proj_matrix[0]));
+
+        m_gl->glBindVertexArray(m_light_paths_vao);
+
+        GLint first;
+        GLsizei count;
+        assert(m_selected_light_path_index >= -1);
+        if (m_selected_light_path_index == -1)
+        {
+            first = 0;
+            count = m_light_paths_index_offsets[m_light_paths_index_offsets.size() - 1];
+        }
+        else
+        {
+            first = static_cast<GLint>(m_light_paths_index_offsets[m_selected_light_path_index]);
+            count = m_light_paths_index_offsets[m_selected_light_path_index + 1] - first;
+        }
+        glDrawArrays(GL_LINES, first, count);
+    }
+}
+
+void LightPathsLayer::dump_selected_light_path() const
+{
+    if (m_selected_light_path_index == -1)
+    {
+        if (m_light_paths.empty())
+            RENDERER_LOG_INFO("no light path to display.");
+        else
+        {
+            RENDERER_LOG_INFO("displaying all %s light path%s.",
+                pretty_uint(m_light_paths.size()).c_str(),
+                m_light_paths.size() > 1 ? "s" : "");
+        }
+    }
+    else
+    {
+        RENDERER_LOG_INFO("displaying light path %s:",
+            pretty_int(m_selected_light_path_index + 1).c_str());
+
+        const auto& light_path_recorder = m_project.get_light_path_recorder();
+        const auto& path = m_light_paths[m_selected_light_path_index];
+
+        for (size_t i = path.m_vertex_begin_index; i < path.m_vertex_end_index; ++i)
+        {
+            LightPathVertex v;
+            light_path_recorder.get_light_path_vertex(i, v);
+
+            const string entity_name =
+                v.m_entity != nullptr
+                    ? foundation::format("\"{0}\"", v.m_entity->get_path().c_str())
+                    : "n/a";
+
+            RENDERER_LOG_INFO("  vertex " FMT_SIZE_T ": entity: %s - position: (%f, %f, %f) - radiance: (%f, %f, %f) - total radiance: %f",
+                i - path.m_vertex_begin_index + 1,
+                entity_name.c_str(),
+                v.m_position[0], v.m_position[1], v.m_position[2],
+                v.m_radiance[0], v.m_radiance[1], v.m_radiance[2],
+                v.m_radiance[0] + v.m_radiance[1] + v.m_radiance[2]);
+        }
+    }
+}
+
+}   // namespace studio
+}   // namespace appleseed

--- a/src/appleseed.studio/mainwindow/rendering/lightpathslayer.h
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathslayer.h
@@ -77,6 +77,7 @@ class LightPathsLayer: public QObject
         const size_t                        width,
         const size_t                        height);
 
+    void resize(const size_t width, const size_t height);
 
     void update_render_camera_transform();
 
@@ -120,15 +121,26 @@ class LightPathsLayer: public QObject
 
     renderer::LightPathArray                m_light_paths;
     int                                     m_selected_light_path_index;    // -1 == display all paths
+    float                                   m_max_luminance;
+    float                                   m_max_thickness;
+    float                                   m_min_thickness;
+    size_t                                  m_width;
+    size_t                                  m_height;
 
     QOpenGLFunctions_3_3_Core*              m_gl;
 
-    GLuint                                  m_light_paths_vbo;
-    std::vector<GLsizei>                    m_light_paths_index_offsets;
+    GLuint                                  m_positions_vbo;
+    GLuint                                  m_others_vbo;
+    GLuint                                  m_indices_ebo;
+    std::vector<GLsizei>                    m_index_offsets;
     GLuint                                  m_light_paths_vao;
-    GLuint                                  m_light_paths_shader_program;
-    GLint                                   m_light_paths_view_mat_location;
-    GLint                                   m_light_paths_proj_mat_location;
+    GLuint                                  m_shader_program;
+    GLint                                   m_view_mat_loc;
+    GLint                                   m_proj_mat_loc;
+    GLint                                   m_res_loc;
+    GLint                                   m_max_luminance_loc;
+    GLint                                   m_min_thickness_loc;
+    GLint                                   m_max_thickness_loc;
     foundation::Matrix4f                    m_gl_render_view_matrix;
     foundation::Matrix4f                    m_gl_view_matrix;
     foundation::Matrix4f                    m_gl_proj_matrix;

--- a/src/appleseed.studio/mainwindow/rendering/lightpathslayer.h
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathslayer.h
@@ -1,0 +1,138 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Francois Beaune, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.studio headers.
+#include "mainwindow/rendering/renderclipboardhandler.h"
+
+// appleseed.renderer headers.
+#include "renderer/api/lighting.h"
+
+// appleseed.foundation headers.
+#include "foundation/math/matrix.h"
+#include "foundation/math/transform.h"
+#include "foundation/math/vector.h"
+
+// Qt headers.
+#include <QOpenGLWidget>
+#include <QObject>
+
+// Standard headers.
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// Forward declarations.
+namespace renderer  { class Assembly; }
+namespace renderer  { class AssemblyInstance; }
+namespace renderer  { class Camera; }
+namespace renderer  { class Object; }
+namespace renderer  { class ObjectInstance; }
+namespace renderer  { class Project; }
+class QKeyEvent;
+class QImage;
+class QOpenGLFunctions_3_3_Core;
+
+namespace appleseed {
+namespace studio {
+
+//
+// A widget providing an hardware-accelerated visualization of recorded light paths.
+//
+
+class LightPathsLayer
+{
+    Q_OBJECT
+
+  public:
+    LightPathsLayer(
+        const renderer::Project&            project,
+        const size_t                        width,
+        const size_t                        height);
+
+    void set_transform(
+        const foundation::Transformd&       transform);
+
+    void set_light_paths(
+        const renderer::LightPathArray&     light_paths);
+
+    void set_selected_light_path_index(
+        const int                           selected_light_path_index);
+
+    void set_gl_functions(
+        QOpenGLFunctions_3_3_Core*          functions);
+
+    void init_gl(QSurfaceFormat format);
+
+    void draw();
+
+  signals:
+    void signal_light_path_selection_changed(
+        const int                           selected_light_path_index,
+        const int                           total_light_paths) const;
+
+  public slots:
+    void slot_display_all_light_paths();
+    void slot_display_previous_light_path();
+    void slot_display_next_light_path();
+    void slot_toggle_backface_culling(const bool checked);
+    void slot_synchronize_camera();
+
+  private:
+    const renderer::Project&                m_project;
+    renderer::Camera&                       m_camera;
+    foundation::Matrix4d                    m_camera_matrix;
+    foundation::Vector3f                    m_camera_position;
+
+    bool                                    m_backface_culling_enabled;
+
+    renderer::LightPathArray                m_light_paths;
+    int                                     m_selected_light_path_index;    // -1 == display all paths
+
+    QOpenGLFunctions_3_3_Core*              m_gl;
+
+    GLuint                                  m_light_paths_vbo;
+    std::vector<GLsizei>                    m_light_paths_index_offsets;
+    GLuint                                  m_light_paths_vao;
+    GLuint                                  m_light_paths_shader_program;
+    GLint                                   m_light_paths_view_mat_location;
+    GLint                                   m_light_paths_proj_mat_location;
+    foundation::Matrix4f                    m_gl_view_matrix;
+    foundation::Matrix4f                    m_gl_proj_matrix;
+    bool                                    m_gl_initialized;
+
+    void cleanup_gl_data();
+    void load_light_paths_data();
+
+    void dump_selected_light_path() const;
+};
+
+}   // namespace studio
+}   // namespace appleseed

--- a/src/appleseed.studio/mainwindow/rendering/lightpathslayer.h
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathslayer.h
@@ -58,7 +58,7 @@ namespace renderer  { class ObjectInstance; }
 namespace renderer  { class Project; }
 class QKeyEvent;
 class QImage;
-class QOpenGLFunctions_3_3_Core;
+class QOpenGLFunctions_4_1_Core;
 
 namespace appleseed {
 namespace studio {
@@ -91,7 +91,7 @@ class LightPathsLayer: public QObject
         const int                           selected_light_path_index);
 
     void set_gl_functions(
-        QOpenGLFunctions_3_3_Core*          functions);
+        QOpenGLFunctions_4_1_Core*          functions);
 
     void init_gl(QSurfaceFormat format);
 
@@ -127,7 +127,7 @@ class LightPathsLayer: public QObject
     size_t                                  m_width;
     size_t                                  m_height;
 
-    QOpenGLFunctions_3_3_Core*              m_gl;
+    QOpenGLFunctions_4_1_Core*              m_gl;
 
     GLuint                                  m_positions_vbo;
     GLuint                                  m_others_vbo;

--- a/src/appleseed.studio/mainwindow/rendering/lightpathslayer.h
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathslayer.h
@@ -129,7 +129,8 @@ class LightPathsLayer: public QObject
     GLuint                                  m_positions_vbo;
     GLuint                                  m_others_vbo;
     GLuint                                  m_indices_ebo;
-    std::vector<GLsizei>                    m_index_offsets;
+    std::vector<GLsizei>                    m_path_terminator_vertex_indices;
+    GLsizei                                 m_total_triangle_count;
     GLuint                                  m_light_paths_vao;
     GLuint                                  m_shader_program;
     GLint                                   m_view_mat_loc;
@@ -138,6 +139,8 @@ class LightPathsLayer: public QObject
     GLint                                   m_max_luminance_loc;
     GLint                                   m_min_thickness_loc;
     GLint                                   m_max_thickness_loc;
+    GLint                                   m_first_selected_loc;
+    GLint                                   m_last_selected_loc;
     foundation::Matrix4f                    m_gl_render_view_matrix;
     foundation::Matrix4f                    m_gl_view_matrix;
     foundation::Matrix4f                    m_gl_proj_matrix;

--- a/src/appleseed.studio/mainwindow/rendering/lightpathslayer.h
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathslayer.h
@@ -67,7 +67,7 @@ namespace studio {
 // A widget providing an hardware-accelerated visualization of recorded light paths.
 //
 
-class LightPathsLayer
+class LightPathsLayer: public QObject
 {
     Q_OBJECT
 
@@ -76,6 +76,9 @@ class LightPathsLayer
         const renderer::Project&            project,
         const size_t                        width,
         const size_t                        height);
+
+
+    void update_render_camera_transform();
 
     void set_transform(
         const foundation::Transformd&       transform);
@@ -91,7 +94,9 @@ class LightPathsLayer
 
     void init_gl(QSurfaceFormat format);
 
-    void draw();
+    void draw() const;
+
+    void draw_render_camera() const;
 
   signals:
     void signal_light_path_selection_changed(
@@ -109,7 +114,7 @@ class LightPathsLayer
     const renderer::Project&                m_project;
     renderer::Camera&                       m_camera;
     foundation::Matrix4d                    m_camera_matrix;
-    foundation::Vector3f                    m_camera_position;
+    foundation::Matrix4d                    m_render_camera_matrix;
 
     bool                                    m_backface_culling_enabled;
 
@@ -124,12 +129,15 @@ class LightPathsLayer
     GLuint                                  m_light_paths_shader_program;
     GLint                                   m_light_paths_view_mat_location;
     GLint                                   m_light_paths_proj_mat_location;
+    foundation::Matrix4f                    m_gl_render_view_matrix;
     foundation::Matrix4f                    m_gl_view_matrix;
     foundation::Matrix4f                    m_gl_proj_matrix;
     bool                                    m_gl_initialized;
 
     void cleanup_gl_data();
     void load_light_paths_data();
+
+    void render_scene(const GLfloat* gl_view_matrix) const;
 
     void dump_selected_light_path() const;
 };

--- a/src/appleseed.studio/mainwindow/rendering/lightpathslayer.h
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathslayer.h
@@ -108,7 +108,6 @@ class LightPathsLayer: public QObject
     void slot_display_all_light_paths();
     void slot_display_previous_light_path();
     void slot_display_next_light_path();
-    void slot_toggle_backface_culling(const bool checked);
     void slot_synchronize_camera();
 
   private:
@@ -116,8 +115,6 @@ class LightPathsLayer: public QObject
     renderer::Camera&                       m_camera;
     foundation::Matrix4d                    m_camera_matrix;
     foundation::Matrix4d                    m_render_camera_matrix;
-
-    bool                                    m_backface_culling_enabled;
 
     renderer::LightPathArray                m_light_paths;
     int                                     m_selected_light_path_index;    // -1 == display all paths

--- a/src/appleseed.studio/mainwindow/rendering/lightpathspickinghandler.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathspickinghandler.cpp
@@ -57,7 +57,7 @@ namespace appleseed {
 namespace studio {
 
 LightPathsPickingHandler::LightPathsPickingHandler(
-    LightPathsWidget*               light_paths_widget,
+    LightPathsLayer*               light_paths_widget,
     const MouseCoordinatesTracker&  mouse_tracker,
     const Project&                  project)
   : m_light_paths_widget(light_paths_widget)

--- a/src/appleseed.studio/mainwindow/rendering/lightpathspickinghandler.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathspickinghandler.cpp
@@ -30,7 +30,8 @@
 #include "lightpathspickinghandler.h"
 
 // appleseed.studio headers.
-#include "mainwindow/rendering/lightpathswidget.h"
+#include "mainwindow/rendering/lightpathslayer.h"
+#include "mainwindow/rendering/viewportwidget.h"
 #include "utility/mousecoordinatestracker.h"
 
 // appleseed.renderer headers.
@@ -57,20 +58,13 @@ namespace appleseed {
 namespace studio {
 
 LightPathsPickingHandler::LightPathsPickingHandler(
-    LightPathsLayer*               light_paths_widget,
+    ViewportWidget*                 viewport_widget,
     const MouseCoordinatesTracker&  mouse_tracker,
     const Project&                  project)
-  : m_light_paths_widget(light_paths_widget)
-  , m_mouse_tracker(mouse_tracker)
-  , m_project(project)
+  : m_project(project)
   , m_enabled(true)
+  , m_viewport_widget(viewport_widget)
 {
-    m_light_paths_widget->installEventFilter(this);
-}
-
-LightPathsPickingHandler::~LightPathsPickingHandler()
-{
-    m_light_paths_widget->removeEventFilter(this);
 }
 
 void LightPathsPickingHandler::set_enabled(const bool enabled)
@@ -108,8 +102,8 @@ void LightPathsPickingHandler::pick(const Vector2i& pixel) const
                 pixel.y);
         }
 
-        m_light_paths_widget->set_light_paths(light_paths);
-        m_light_paths_widget->update();
+        m_viewport_widget->get_light_paths_layer()->set_light_paths(light_paths);
+        m_viewport_widget->update();
     }
 }
 
@@ -156,30 +150,9 @@ void LightPathsPickingHandler::pick(const AABB2i& rect) const
                 final_rect.max.y);
         }
 
-        m_light_paths_widget->set_light_paths(light_paths);
-        m_light_paths_widget->update();
+        m_viewport_widget->get_light_paths_layer()->set_light_paths(light_paths);
+        m_viewport_widget->update();
     }
-}
-
-bool LightPathsPickingHandler::eventFilter(QObject* object, QEvent* event)
-{
-    if (m_enabled)
-    {
-        if (event->type() == QEvent::MouseButtonPress)
-        {
-            const QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
-            if (!(mouse_event->modifiers() & (Qt::AltModifier | Qt::ShiftModifier | Qt::ControlModifier)))
-            {
-                if (mouse_event->button() == Qt::LeftButton)
-                {
-                    pick(m_mouse_tracker.widget_to_pixel(mouse_event->pos()));
-                    return true;
-                }
-            }
-        }
-    }
-
-    return QObject::eventFilter(object, event);
 }
 
 }   // namespace studio

--- a/src/appleseed.studio/mainwindow/rendering/lightpathspickinghandler.h
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathspickinghandler.h
@@ -38,6 +38,7 @@
 // Forward declarations.
 namespace appleseed { namespace studio { class LightPathsLayer; } }
 namespace appleseed { namespace studio { class MouseCoordinatesTracker; } }
+namespace appleseed { namespace studio { class ViewportWidget; } }
 namespace renderer  { class Project; }
 class QEvent;
 
@@ -51,11 +52,9 @@ class LightPathsPickingHandler
 
   public:
     LightPathsPickingHandler(
-        LightPathsLayer*                   light_paths_widget,
+        ViewportWidget*                     viewport_widget,
         const MouseCoordinatesTracker&      mouse_tracker,
         const renderer::Project&            project);
-
-    ~LightPathsPickingHandler() override;
 
     void set_enabled(const bool enabled);
 
@@ -63,12 +62,9 @@ class LightPathsPickingHandler
     void pick(const foundation::AABB2i& rect) const;
 
   private:
-    LightPathsLayer*                       m_light_paths_widget;
-    const MouseCoordinatesTracker&          m_mouse_tracker;
+    ViewportWidget*                         m_viewport_widget;
     const renderer::Project&                m_project;
     bool                                    m_enabled;
-
-    bool eventFilter(QObject* object, QEvent* event) override;
 };
 
 }   // namespace studio

--- a/src/appleseed.studio/mainwindow/rendering/lightpathspickinghandler.h
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathspickinghandler.h
@@ -36,7 +36,7 @@
 #include <QObject>
 
 // Forward declarations.
-namespace appleseed { namespace studio { class LightPathsWidget; } }
+namespace appleseed { namespace studio { class LightPathsLayer; } }
 namespace appleseed { namespace studio { class MouseCoordinatesTracker; } }
 namespace renderer  { class Project; }
 class QEvent;
@@ -51,7 +51,7 @@ class LightPathsPickingHandler
 
   public:
     LightPathsPickingHandler(
-        LightPathsWidget*                   light_paths_widget,
+        LightPathsLayer*                   light_paths_widget,
         const MouseCoordinatesTracker&      mouse_tracker,
         const renderer::Project&            project);
 
@@ -63,7 +63,7 @@ class LightPathsPickingHandler
     void pick(const foundation::AABB2i& rect) const;
 
   private:
-    LightPathsWidget*                       m_light_paths_widget;
+    LightPathsLayer*                       m_light_paths_widget;
     const MouseCoordinatesTracker&          m_mouse_tracker;
     const renderer::Project&                m_project;
     bool                                    m_enabled;

--- a/src/appleseed.studio/mainwindow/rendering/lightpathsviewportmanager.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathsviewportmanager.cpp
@@ -87,7 +87,7 @@ LightPathsViewportManager::LightPathsViewportManager(
     LightPathsLayer* light_paths_layer = m_viewport_tab->get_viewport_widget()->get_light_paths_layer();
     connect(
         light_paths_layer, SIGNAL(signal_light_path_selection_changed(const int, const int)),
-        SLOT(slot_light_path_selection_changed));
+        SLOT(slot_light_path_selection_changed(const int, const int)));
 
     create_toolbar();
 
@@ -101,6 +101,7 @@ void LightPathsViewportManager::set_enabled(const bool enabled)
         m_toolbar->show();
     else
         m_toolbar->hide();
+
     m_toolbar->setDisabled(!enabled);
     m_screen_space_paths_picking_handler->set_enabled(enabled);
 }
@@ -115,7 +116,6 @@ void LightPathsViewportManager::slot_entity_picked(const ScenePicker::PickingRes
     if (!m_enabled) return;
 
     const CanvasProperties& props = m_project.get_frame()->image().properties();
-
     m_screen_space_paths_picking_handler->pick(
         Vector2i(
             result.m_ndc[0] * static_cast<int>(props.m_canvas_width),
@@ -188,14 +188,6 @@ void LightPathsViewportManager::create_toolbar()
     m_toolbar = new QToolBar();
     m_toolbar->setObjectName("render_toolbar");
     m_toolbar->setIconSize(QSize(18, 18));
-
-    //// Pick paths button
-    //QToolButton* m_pick_paths_button = new QToolButton();
-    //m_pick_paths_button->setText("Pick Light Paths");
-    //m_pick_paths_button->setToolTip("Pick Light Paths");
-    //connect(
-    //    m_pick_paths_button, SIGNAL(clicked()),
-    //    SIGNAL(slot_light_paths_pick_button_clicked));
 
     // Save Light Paths button.
     QToolButton* save_light_paths_button = new QToolButton();

--- a/src/appleseed.studio/mainwindow/rendering/lightpathsviewportmanager.h
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathsviewportmanager.h
@@ -47,7 +47,7 @@
 #include <memory>
 
 // Forward declarations.
-namespace appleseed { namespace studio { class LightPathsLayer; } }
+namespace appleseed { namespace studio { class ViewportTab; } }
 namespace renderer  { class ParamArray; }
 namespace renderer  { class Project; }
 class QLabel;
@@ -71,42 +71,44 @@ class LightPathsViewportManager
 
   public:
     LightPathsViewportManager(
+        ViewportTab*            viewport_tab,
         renderer::Project&      project,
         renderer::ParamArray&   settings);
+
+    QToolBar* toolbar() const;
+
+    void set_enabled(const bool enabled);
 
   public slots:
     void slot_entity_picked(const renderer::ScenePicker::PickingResult& result);
     void slot_rectangle_selection(const QRect& rect);
+    void slot_light_paths_display_toggled(const bool active);
 
   private slots:
     void slot_light_path_selection_changed(
         const int               selected_light_path_index,
         const int               total_light_paths) const;
-    void slot_context_menu(const QPoint& point);
     void slot_save_light_paths();
     void slot_camera_changed();
 
   private:
+    bool                                        m_enabled;
+
     renderer::Project&                          m_project;
     renderer::ParamArray&                       m_settings;
-    LightPathsLayer*                            m_light_paths_layer;
-    QScrollArea*                                m_scroll_area;
+    ViewportTab*                                m_viewport_tab;
     QToolBar*                                   m_toolbar;
+    //QToolButton*                                m_pick_paths_button;
     QToolButton*                                m_prev_path_button;
     QToolButton*                                m_next_path_button;
     QLabel*                                     m_info_label;
 
-    std::unique_ptr<WidgetZoomHandler>          m_zoom_handler;
     std::unique_ptr<ScrollAreaPanHandler>       m_pan_handler;
     std::unique_ptr<MouseCoordinatesTracker>    m_mouse_tracker;
-    std::unique_ptr<CameraController>           m_camera_controller;
     std::unique_ptr<LightPathsPickingHandler>   m_screen_space_paths_picking_handler;
     std::unique_ptr<LightPathsPickingHandler>   m_world_space_paths_picking_handler;
-    std::unique_ptr<RenderClipboardHandler>     m_clipboard_handler;
 
-    void create_light_paths_widget();
     void create_toolbar();
-    void create_scrollarea();
     void recreate_handlers();
 
 };

--- a/src/appleseed.studio/mainwindow/rendering/lightpathsviewportmanager.h
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathsviewportmanager.h
@@ -32,6 +32,7 @@
 #include "mainwindow/rendering/cameracontroller.h"
 #include "mainwindow/rendering/lightpathspickinghandler.h"
 #include "mainwindow/rendering/renderclipboardhandler.h"
+#include "mainwindow/rendering/viewportwidget.h"
 #include "utility/mousecoordinatestracker.h"
 #include "utility/scrollareapanhandler.h"
 #include "utility/widgetzoomhandler.h"
@@ -72,12 +73,19 @@ class LightPathsViewportManager
   public:
     LightPathsViewportManager(
         ViewportTab*            viewport_tab,
-        renderer::Project&      project,
+        renderer::Project*      project,
         renderer::ParamArray&   settings);
+
+    void reset(renderer::Project* project);
 
     QToolBar* toolbar() const;
 
     void set_enabled(const bool enabled);
+    void set_picking_enabled(const bool enabled);
+    void set_display_enabled(const bool enabled);
+
+  signals:
+    void signal_should_display(const bool should_display);
 
   public slots:
     void slot_entity_picked(const renderer::ScenePicker::PickingResult& result);
@@ -85,16 +93,19 @@ class LightPathsViewportManager
     void slot_light_paths_display_toggled(const bool active);
 
   private slots:
+    void slot_base_layer_changed(const ViewportWidget::BaseLayer layer);
     void slot_light_path_selection_changed(
         const int               selected_light_path_index,
-        const int               total_light_paths) const;
+        const int               total_light_paths);
     void slot_save_light_paths();
     void slot_camera_changed();
 
   private:
     bool                                        m_enabled;
+    bool                                        m_picking_enabled;
+    bool                                        m_paths_display_active;
 
-    renderer::Project&                          m_project;
+    renderer::Project*                          m_project;
     renderer::ParamArray&                       m_settings;
     ViewportTab*                                m_viewport_tab;
     QToolBar*                                   m_toolbar;

--- a/src/appleseed.studio/mainwindow/rendering/lightpathsviewportmanager.h
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathsviewportmanager.h
@@ -98,7 +98,6 @@ class LightPathsViewportManager
     renderer::ParamArray&                       m_settings;
     ViewportTab*                                m_viewport_tab;
     QToolBar*                                   m_toolbar;
-    //QToolButton*                                m_pick_paths_button;
     QToolButton*                                m_prev_path_button;
     QToolButton*                                m_next_path_button;
     QLabel*                                     m_info_label;
@@ -110,7 +109,6 @@ class LightPathsViewportManager
 
     void create_toolbar();
     void recreate_handlers();
-
 };
 
 }   // namespace studio

--- a/src/appleseed.studio/mainwindow/rendering/lightpathsviewportmanager.h
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathsviewportmanager.h
@@ -47,7 +47,7 @@
 #include <memory>
 
 // Forward declarations.
-namespace appleseed { namespace studio { class LightPathsWidget; } }
+namespace appleseed { namespace studio { class LightPathsLayer; } }
 namespace renderer  { class ParamArray; }
 namespace renderer  { class Project; }
 class QLabel;
@@ -61,16 +61,16 @@ namespace appleseed {
 namespace studio {
 
 //
-// A tab providing an hardware-accelerated visualization of recorded light paths.
+// Manager for the light paths display overlay into the viewport
 //
 
-class LightPathsTab
-  : public QWidget
+class LightPathsViewportManager
+  : public QObject
 {
     Q_OBJECT
 
   public:
-    LightPathsTab(
+    LightPathsViewportManager(
         renderer::Project&      project,
         renderer::ParamArray&   settings);
 
@@ -89,7 +89,7 @@ class LightPathsTab
   private:
     renderer::Project&                          m_project;
     renderer::ParamArray&                       m_settings;
-    LightPathsWidget*                           m_light_paths_widget;
+    LightPathsLayer*                            m_light_paths_layer;
     QScrollArea*                                m_scroll_area;
     QToolBar*                                   m_toolbar;
     QToolButton*                                m_prev_path_button;

--- a/src/appleseed.studio/mainwindow/rendering/qttilecallback.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/qttilecallback.cpp
@@ -31,7 +31,8 @@
 #include "qttilecallback.h"
 
 // appleseed.studio headers.
-#include "mainwindow/rendering/renderwidget.h"
+#include "mainwindow/rendering/renderlayer.h"
+#include "mainwindow/rendering/viewportwidget.h"
 
 // Qt headers.
 #include <QObject>
@@ -59,12 +60,12 @@ namespace
         Q_OBJECT
 
       public:
-        explicit QtTileCallback(RenderWidget* render_widget)
-          : m_render_widget(render_widget)
+        explicit QtTileCallback(ViewportWidget* viewport_widget)
+          : m_render_layer(viewport_widget->get_render_layer())
         {
             connect(
                 this, SIGNAL(signal_update()),
-                m_render_widget, SLOT(update()),
+                viewport_widget, SLOT(repaint()),
                 Qt::QueuedConnection);
         }
 
@@ -78,8 +79,8 @@ namespace
             const size_t    tile_x,
             const size_t    tile_y) override
         {
-            assert(m_render_widget);
-            m_render_widget->highlight_tile(*frame, tile_x, tile_y);
+            assert(m_render_layer);
+            m_render_layer->highlight_tile(*frame, tile_x, tile_y);
             emit signal_update();
         }
 
@@ -88,16 +89,16 @@ namespace
             const size_t    tile_x,
             const size_t    tile_y) override
         {
-            assert(m_render_widget);
-            m_render_widget->blit_tile(*frame, tile_x, tile_y);
+            assert(m_render_layer);
+            m_render_layer->blit_tile(*frame, tile_x, tile_y);
             emit signal_update();
         }
 
         void on_progressive_frame_update(
             const Frame*    frame) override
         {
-            assert(m_render_widget);
-            m_render_widget->blit_frame(*frame);
+            assert(m_render_layer);
+            m_render_layer->blit_frame(*frame);
             emit signal_update();
         }
 
@@ -105,7 +106,7 @@ namespace
         void signal_update();
 
       private:
-        RenderWidget* m_render_widget;
+        RenderLayer* m_render_layer;
     };
 }
 
@@ -114,8 +115,8 @@ namespace
 // QtTileCallbackFactory class implementation.
 //
 
-QtTileCallbackFactory::QtTileCallbackFactory(RenderWidget* render_widget)
-  : m_render_widget(render_widget)
+QtTileCallbackFactory::QtTileCallbackFactory(ViewportWidget* viewport_widget)
+  : m_viewport_widget(viewport_widget)
 {
 }
 
@@ -126,7 +127,7 @@ void QtTileCallbackFactory::release()
 
 ITileCallback* QtTileCallbackFactory::create()
 {
-    return new QtTileCallback(m_render_widget);
+    return new QtTileCallback(m_viewport_widget);
 }
 
 }   // namespace studio

--- a/src/appleseed.studio/mainwindow/rendering/qttilecallback.h
+++ b/src/appleseed.studio/mainwindow/rendering/qttilecallback.h
@@ -36,7 +36,7 @@
 #include "foundation/platform/compiler.h"
 
 // Forward declarations.
-namespace appleseed { namespace studio { class RenderWidget; } }
+namespace appleseed { namespace studio { class ViewportWidget; } }
 
 namespace appleseed {
 namespace studio {
@@ -46,7 +46,7 @@ class QtTileCallbackFactory
 {
   public:
     // Constructor.
-    explicit QtTileCallbackFactory(RenderWidget* render_widget);
+    explicit QtTileCallbackFactory(ViewportWidget* viewport_widget);
 
     // Delete this instance.
     void release() override;
@@ -55,7 +55,7 @@ class QtTileCallbackFactory
     renderer::ITileCallback* create() override;
 
   private:
-    RenderWidget* m_render_widget;
+    ViewportWidget* m_viewport_widget;
 };
 
 }   // namespace studio

--- a/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
@@ -34,7 +34,7 @@
 #include "mainwindow/rendering/cameracontroller.h"
 #include "mainwindow/rendering/qttilecallback.h"
 #include "mainwindow/rendering/rendertab.h"
-#include "mainwindow/rendering/renderwidget.h"
+#include "mainwindow/rendering/viewportwidget.h"
 #include "mainwindow/statusbar.h"
 
 // appleseed.shared headers.
@@ -203,14 +203,14 @@ void RenderingManager::start_rendering(
     m_rendering_mode = rendering_mode;
     m_render_tab = render_tab;
 
-    m_render_tab->get_render_widget()->start_render();
+    m_render_tab->get_viewport_widget()->get_render_layer()->start_render();
 
     TileCallbackCollectionFactory* tile_callback_collection_factory = 
         new TileCallbackCollectionFactory();
 
     tile_callback_collection_factory->insert(
         new QtTileCallbackFactory(
-            m_render_tab->get_render_widget()));
+            m_render_tab->get_viewport_widget()));
 
     tile_callback_collection_factory->insert(
         new ProgressTileCallbackFactory(
@@ -507,7 +507,7 @@ void RenderingManager::slot_frame_end()
     m_status_bar.stop_rendering_time_display();
 
     // Ensure that the render widget is up-to-date.
-    m_render_tab->get_render_widget()->update();
+    m_render_tab->get_viewport_widget()->update();
 }
 
 void RenderingManager::slot_camera_change_begin()

--- a/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
@@ -192,6 +192,11 @@ RenderingManager::~RenderingManager()
     clear_sticky_actions();
 }
 
+RenderingManager::RenderingMode RenderingManager::get_rendering_mode() const
+{
+    return m_rendering_mode;
+}
+
 void RenderingManager::start_rendering(
     Project*                    project,
     const ParamArray&           params,

--- a/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
@@ -33,7 +33,7 @@
 // appleseed.studio headers.
 #include "mainwindow/rendering/cameracontroller.h"
 #include "mainwindow/rendering/qttilecallback.h"
-#include "mainwindow/rendering/rendertab.h"
+#include "mainwindow/rendering/viewporttab.h"
 #include "mainwindow/rendering/viewportwidget.h"
 #include "mainwindow/statusbar.h"
 
@@ -125,7 +125,7 @@ namespace
 RenderingManager::RenderingManager(StatusBar& status_bar)
   : m_status_bar(status_bar)
   , m_project(nullptr)
-  , m_render_tab(nullptr)
+  , m_viewport_tab(nullptr)
 {
     Application::initialize_resource_search_paths(m_resource_search_paths);
 
@@ -196,21 +196,21 @@ void RenderingManager::start_rendering(
     Project*                    project,
     const ParamArray&           params,
     const RenderingMode         rendering_mode,
-    RenderTab*                  render_tab)
+    ViewportTab*                viewport_tab)
 {
     m_project = project;
     m_params = params;
     m_rendering_mode = rendering_mode;
-    m_render_tab = render_tab;
+    m_viewport_tab = viewport_tab;
 
-    m_render_tab->get_viewport_widget()->get_render_layer()->start_render();
+    m_viewport_tab->get_viewport_widget()->get_render_layer()->start_render();
 
     TileCallbackCollectionFactory* tile_callback_collection_factory = 
         new TileCallbackCollectionFactory();
 
     tile_callback_collection_factory->insert(
         new QtTileCallbackFactory(
-            m_render_tab->get_viewport_widget()));
+            m_viewport_tab->get_viewport_widget()));
 
     tile_callback_collection_factory->insert(
         new ProgressTileCallbackFactory(
@@ -437,7 +437,7 @@ void RenderingManager::slot_rendering_begin()
     run_scheduled_actions();
 
     if (m_rendering_mode == InteractiveRendering)
-        m_render_tab->get_camera_controller()->set_enabled(true);
+        m_viewport_tab->get_camera_controller()->set_enabled(true);
 
     m_rendering_timer.clear();
 
@@ -461,10 +461,10 @@ void RenderingManager::slot_rendering_resume()
 void RenderingManager::slot_rendering_end()
 {
     if (m_rendering_mode == InteractiveRendering)
-        m_render_tab->get_camera_controller()->set_enabled(false);
+        m_viewport_tab->get_camera_controller()->set_enabled(false);
 
     // Save the controller target point into the camera when rendering ends.
-    m_render_tab->get_camera_controller()->save_camera_target();
+    m_viewport_tab->get_camera_controller()->save_camera_target();
 
     print_final_rendering_time();
 
@@ -480,10 +480,10 @@ void RenderingManager::slot_rendering_end()
 void RenderingManager::slot_rendering_failed()
 {
     if (m_rendering_mode == InteractiveRendering)
-        m_render_tab->get_camera_controller()->set_enabled(false);
+        m_viewport_tab->get_camera_controller()->set_enabled(false);
 
     // Save the controller target point into the camera when rendering ends.
-    m_render_tab->get_camera_controller()->save_camera_target();
+    m_viewport_tab->get_camera_controller()->save_camera_target();
 }
 
 void RenderingManager::slot_frame_begin()
@@ -491,7 +491,7 @@ void RenderingManager::slot_frame_begin()
     // Update the scene's camera before rendering the frame.
     if (m_has_camera_changed)
     {
-        m_render_tab->get_camera_controller()->update_camera_transform();
+        m_viewport_tab->get_camera_controller()->update_camera_transform();
         m_has_camera_changed = false;
     }
 
@@ -507,7 +507,7 @@ void RenderingManager::slot_frame_end()
     m_status_bar.stop_rendering_time_display();
 
     // Ensure that the render widget is up-to-date.
-    m_render_tab->get_viewport_widget()->update();
+    m_viewport_tab->get_viewport_widget()->update();
 }
 
 void RenderingManager::slot_camera_change_begin()

--- a/src/appleseed.studio/mainwindow/rendering/renderingmanager.h
+++ b/src/appleseed.studio/mainwindow/rendering/renderingmanager.h
@@ -56,7 +56,7 @@
 #include <vector>
 
 // Forward declarations.
-namespace appleseed     { namespace studio { class RenderTab; } }
+namespace appleseed     { namespace studio { class ViewportTab; } }
 namespace appleseed     { namespace studio { class StatusBar; } }
 namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class Frame; }
@@ -88,7 +88,7 @@ class RenderingManager
         renderer::Project*              project,
         const renderer::ParamArray&     params,
         const RenderingMode             rendering_mode,
-        RenderTab*                      render_tab);
+        ViewportTab*                    viewport_tab);
 
     // Return true if currently rendering, false otherwise.
     bool is_rendering() const;
@@ -166,7 +166,7 @@ class RenderingManager
     renderer::ParamArray                        m_params;
     foundation::SearchPaths                     m_resource_search_paths;
     RenderingMode                               m_rendering_mode;
-    RenderTab*                                  m_render_tab;
+    ViewportTab*                                m_viewport_tab;
 
     std::unique_ptr<renderer::TileCallbackCollectionFactory>      
                                                 m_tile_callback_factory;

--- a/src/appleseed.studio/mainwindow/rendering/renderingmanager.h
+++ b/src/appleseed.studio/mainwindow/rendering/renderingmanager.h
@@ -90,6 +90,9 @@ class RenderingManager
         const RenderingMode             rendering_mode,
         ViewportTab*                    viewport_tab);
 
+    // Get current rendering mode
+    RenderingMode get_rendering_mode() const;
+
     // Return true if currently rendering, false otherwise.
     bool is_rendering() const;
 

--- a/src/appleseed.studio/mainwindow/rendering/renderlayer.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/renderlayer.cpp
@@ -28,7 +28,7 @@
 //
 
 // Interface header.
-#include "renderwidget.h"
+#include "renderlayer.h"
 
 // appleseed.renderer headers.
 #include "renderer/api/frame.h"
@@ -48,6 +48,7 @@
 #include <QDropEvent>
 #include <QMimeData>
 #include <QMutexLocker>
+#include <QRect>
 #include <Qt>
 
 // Standard headers.
@@ -62,10 +63,10 @@ namespace appleseed {
 namespace studio {
 
 //
-// RenderWidget class implementation.
+// RenderLayer class implementation.
 //
 
-RenderWidget::RenderWidget(
+RenderLayer::RenderLayer(
     const size_t            width,
     const size_t            height,
     OCIO::ConstConfigRcPtr  ocio_config,
@@ -87,14 +88,19 @@ RenderWidget::RenderWidget(
     setAcceptDrops(true);
 }
 
-QImage RenderWidget::capture()
+QImage RenderLayer::capture()
 {
     QMutexLocker locker(&m_mutex);
 
     return m_image.copy();
 }
 
-void RenderWidget::resize(
+void RenderLayer::darken()
+{
+    multiply(0.2f);
+}
+
+void RenderLayer::resize(
     const size_t    width,
     const size_t    height)
 {
@@ -112,7 +118,7 @@ void RenderWidget::resize(
     clear();
 }
 
-void RenderWidget::clear()
+void RenderLayer::clear()
 {
     QMutexLocker locker(&m_mutex);
 
@@ -137,14 +143,14 @@ namespace
     }
 }
 
-void RenderWidget::start_render()
+void RenderLayer::start_render()
 {
     // Clear the image storage.
     if (m_image_storage)
         m_image_storage->clear(Color4f(0.0f));
 }
 
-void RenderWidget::multiply(const float multiplier)
+void RenderLayer::multiply(const float multiplier)
 {
     QMutexLocker locker(&m_mutex);
 
@@ -200,7 +206,7 @@ namespace
     }
 }
 
-void RenderWidget::highlight_tile(
+void RenderLayer::highlight_tile(
     const Frame&    frame,
     const size_t    tile_x,
     const size_t    tile_y)
@@ -243,7 +249,7 @@ void RenderWidget::highlight_tile(
         sizeof(BracketColor));
 }
 
-void RenderWidget::blit_tile(
+void RenderLayer::blit_tile(
     const Frame&    frame,
     const size_t    tile_x,
     const size_t    tile_y)
@@ -256,7 +262,7 @@ void RenderWidget::blit_tile(
     update_tile_no_lock(tile_x, tile_y);
 }
 
-void RenderWidget::blit_frame(const Frame& frame)
+void RenderLayer::blit_frame(const Frame& frame)
 {
     QMutexLocker locker(&m_mutex);
 
@@ -274,7 +280,7 @@ void RenderWidget::blit_frame(const Frame& frame)
     }
 }
 
-void RenderWidget::slot_display_transform_changed(const QString& transform)
+void RenderLayer::slot_display_transform_changed(const QString& transform)
 {
     {
         QMutexLocker locker(&m_mutex);
@@ -321,7 +327,7 @@ namespace
     }
 }
 
-void RenderWidget::allocate_working_storage(const CanvasProperties& frame_props)
+void RenderLayer::allocate_working_storage(const CanvasProperties& frame_props)
 {
     if (!m_image_storage || !is_compatible(*m_image_storage, frame_props))
     {
@@ -356,7 +362,7 @@ void RenderWidget::allocate_working_storage(const CanvasProperties& frame_props)
     }
 }
 
-void RenderWidget::blit_tile_no_lock(
+void RenderLayer::blit_tile_no_lock(
     const Frame&    frame,
     const size_t    tile_x,
     const size_t    tile_y)
@@ -369,7 +375,7 @@ void RenderWidget::blit_tile_no_lock(
     dst_tile.copy_from(src_tile);
 }
 
-void RenderWidget::update_tile_no_lock(const size_t tile_x, const size_t tile_y)
+void RenderLayer::update_tile_no_lock(const size_t tile_x, const size_t tile_y)
 {
     // Retrieve the source tile.
     const Tile& src_tile = m_image_storage->tile(tile_x, tile_y);
@@ -419,39 +425,11 @@ void RenderWidget::update_tile_no_lock(const size_t tile_x, const size_t tile_y)
     NativeDrawing::blit(dest, dest_stride, uint8_rgb_tile);
 }
 
-void RenderWidget::paintEvent(QPaintEvent* event)
+void RenderLayer::paint(const QRect& rect, QPainter& painter)
 {
     QMutexLocker locker(&m_mutex);
 
-    m_painter.begin(this);
-    m_painter.drawImage(rect(), m_image);
-    m_painter.end();
-}
-
-void RenderWidget::dragEnterEvent(QDragEnterEvent* event)
-{
-    if (event->mimeData()->hasFormat("text/plain"))
-        event->acceptProposedAction();
-}
-
-void RenderWidget::dragMoveEvent(QDragMoveEvent* event)
-{
-    if (pos().x() <= event->pos().x() && pos().y() <= event->pos().y()
-        && event->pos().x() < pos().x() + width() && event->pos().y() < pos().y() + height())
-    {
-        event->accept();
-    }
-    else
-        event->ignore();
-}
-
-void RenderWidget::dropEvent(QDropEvent* event)
-{
-    emit signal_material_dropped(
-        Vector2d(
-            static_cast<double>(event->pos().x()) / width(),
-            static_cast<double>(event->pos().y()) / height()),
-        event->mimeData()->text());
+    painter.drawImage(rect, m_image);
 }
 
 }   // namespace studio

--- a/src/appleseed.studio/mainwindow/rendering/renderlayer.h
+++ b/src/appleseed.studio/mainwindow/rendering/renderlayer.h
@@ -1,0 +1,174 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2010-2013 Francois Beaune, Jupiter Jazz Limited
+// Copyright (c) 2014-2018 Francois Beaune, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.studio headers.
+#include "mainwindow/rendering/renderclipboardhandler.h"
+
+// appleseed.foundation headers.
+#include "foundation/image/image.h"
+#include "foundation/image/tile.h"
+#include "foundation/math/vector.h"
+
+// OpenColorIO headers.
+#include <OpenColorIO/OpenColorIO.h>
+namespace OCIO = OCIO_NAMESPACE;
+
+// Qt headers.
+#include <QImage>
+#include <QMutex>
+#include <QPainter>
+#include <QWidget>
+
+// Standard headers.
+#include <cstddef>
+#include <memory>
+#include <string>
+
+// Forward declarations.
+namespace foundation    { class CanvasProperties; }
+namespace renderer      { class Frame; }
+class QDragEnterEvent;
+class QDragMoveEvent;
+class QDropEvent;
+class QPaintEvent;
+class QRect;
+
+namespace appleseed {
+namespace studio {
+
+//
+// A render widget based on QImage.
+//
+
+class RenderLayer
+  : public QWidget
+  , public ICapturableWidget
+{
+    Q_OBJECT
+
+  public:
+    // Constructor.
+    RenderLayer(
+        const size_t                width,
+        const size_t                height,
+        OCIO::ConstConfigRcPtr      ocio_config,
+        QWidget*                    parent = nullptr);
+
+    // Thread-safe.
+    QImage capture() override;
+
+    // Thread-safe.
+    void darken();
+
+    // Thread-safe.
+    void resize(
+        const size_t            width,
+        const size_t            height);
+
+    // Thread-safe.
+    void clear();
+
+    // Called before rendering begins.
+    void start_render();
+
+    // Thread-safe.
+    void multiply(const float multiplier);
+
+    // Thread-safe.
+    void highlight_tile(
+        const renderer::Frame&  frame,
+        const size_t            tile_x,
+        const size_t            tile_y);
+
+    // Thread-safe.
+    void blit_tile(
+        const renderer::Frame&  frame,
+        const size_t            tile_x,
+        const size_t            tile_y);
+
+    // Thread-safe.
+    void blit_frame(const renderer::Frame& frame);
+
+    // Thread-safe. Paint self into specified painter.
+    void paint(const QRect& rect, QPainter& painter);
+
+    // Direct access to internals for high-performance drawing.
+    QMutex& mutex();
+    QImage& image();
+
+  signals:
+    void signal_material_dropped(
+        const foundation::Vector2d& drop_pos,
+        const QString&          material_name);
+
+  public slots:
+    void slot_display_transform_changed(const QString& transform);
+
+  private:
+    mutable QMutex                      m_mutex;
+    QImage                              m_image;
+    QPainter                            m_painter;
+    std::unique_ptr<foundation::Tile>   m_float_tile_storage;
+    std::unique_ptr<foundation::Tile>   m_uint8_tile_storage;
+    std::unique_ptr<foundation::Image>  m_image_storage;
+
+    OCIO::ConstConfigRcPtr              m_ocio_config;
+    OCIO::ConstProcessorRcPtr           m_ocio_processor;
+
+    void allocate_working_storage(const foundation::CanvasProperties& frame_props);
+
+    void blit_tile_no_lock(
+        const renderer::Frame&  frame,
+        const size_t            tile_x,
+        const size_t            tile_y);
+
+    void update_tile_no_lock(
+        const size_t            tile_x,
+        const size_t            tile_y);
+};
+
+
+//
+// RenderLayer class implementation.
+//
+
+inline QMutex& RenderLayer::mutex()
+{
+    return m_mutex;
+}
+
+inline QImage& RenderLayer::image()
+{
+    return m_image;
+}
+
+}   // namespace studio
+}   // namespace appleseed

--- a/src/appleseed.studio/mainwindow/rendering/renderlayer.h
+++ b/src/appleseed.studio/mainwindow/rendering/renderlayer.h
@@ -44,6 +44,7 @@ namespace OCIO = OCIO_NAMESPACE;
 // Qt headers.
 #include <QImage>
 #include <QMutex>
+#include <QOpenGLWidget>
 #include <QPainter>
 #include <QWidget>
 
@@ -58,6 +59,8 @@ namespace renderer      { class Frame; }
 class QDragEnterEvent;
 class QDragMoveEvent;
 class QDropEvent;
+class QOpenGLFunctions_4_1_Core;
+class QOpenGLTexture;
 class QPaintEvent;
 class QRect;
 
@@ -117,8 +120,10 @@ class RenderLayer
     // Thread-safe.
     void blit_frame(const renderer::Frame& frame);
 
-    // Thread-safe. Paint self into specified painter.
-    void paint(const QRect& rect, QPainter& painter);
+    void draw(GLuint empty_vao, bool paths_display_active);
+    void init_gl(QSurfaceFormat format);
+    void set_gl_functions(
+        QOpenGLFunctions_4_1_Core*          functions);
 
     // Direct access to internals for high-performance drawing.
     QMutex& mutex();
@@ -135,10 +140,15 @@ class RenderLayer
   private:
     mutable QMutex                      m_mutex;
     QImage                              m_image;
-    QPainter                            m_painter;
     std::unique_ptr<foundation::Tile>   m_float_tile_storage;
     std::unique_ptr<foundation::Tile>   m_uint8_tile_storage;
     std::unique_ptr<foundation::Image>  m_image_storage;
+
+    QOpenGLFunctions_4_1_Core*          m_gl;
+    QOpenGLTexture*                     m_gl_tex;
+    GLuint                              m_shader_program;
+    GLint                               m_mult_loc;
+    bool                                m_gl_initialized;
 
     OCIO::ConstConfigRcPtr              m_ocio_config;
     OCIO::ConstProcessorRcPtr           m_ocio_processor;

--- a/src/appleseed.studio/mainwindow/rendering/rendertab.h
+++ b/src/appleseed.studio/mainwindow/rendering/rendertab.h
@@ -54,7 +54,7 @@ namespace OCIO = OCIO_NAMESPACE;
 
 // Forward declarations.
 namespace appleseed { namespace studio { class ProjectExplorer; } }
-namespace appleseed { namespace studio { class RenderWidget; } }
+namespace appleseed { namespace studio { class ViewportWidget; } }
 namespace renderer  { class Entity; }
 namespace renderer  { class Project; }
 namespace renderer  { class RenderingManager; }
@@ -85,15 +85,13 @@ class RenderTab
         RenderingManager&       rendering_manager,
         OCIO::ConstConfigRcPtr  ocio_config);
 
-    RenderWidget* get_render_widget() const;
+    ViewportWidget* get_viewport_widget() const;
     CameraController* get_camera_controller() const;
     ScenePickingHandler* get_scene_picking_handler() const;
 
     void set_clear_frame_button_enabled(const bool enabled);
     void set_render_region_buttons_enabled(const bool enabled);
 
-    void clear();
-    void darken();
     void reset_zoom();
 
     void update();
@@ -113,7 +111,6 @@ class RenderTab
     void signal_quicksave_frame_and_aovs();
     void signal_set_render_region(const QRect& rect);
     void signal_clear_render_region();
-    void signal_render_widget_context_menu(const QPoint& point);
     void signal_reset_zoom();
     void signal_clear_frame();
 
@@ -125,19 +122,19 @@ class RenderTab
     void signal_rectangle_selection(const QRect& rect);
 
   private slots:
-    void slot_render_widget_context_menu(const QPoint& point);
     void slot_toggle_render_region(const bool checked);
     void slot_set_render_region(const QRect& rect);
     void slot_toggle_pixel_inspector(const bool checked);
 
   private:
-    RenderWidget*                               m_render_widget;
+    ViewportWidget*                             m_viewport_widget;
     QScrollArea*                                m_scroll_area;
     QToolBar*                                   m_toolbar;
     QToolButton*                                m_set_render_region_button;
     QToolButton*                                m_clear_render_region_button;
     QToolButton*                                m_clear_frame_button;
     QComboBox*                                  m_picking_mode_combo;
+    QComboBox*                                  m_display_transform_combo;
     QLabel*                                     m_info_label;
     QLabel*                                     m_r_label;
     QLabel*                                     m_g_label;
@@ -161,7 +158,7 @@ class RenderTab
 
     OCIO::ConstConfigRcPtr                      m_ocio_config;
 
-    void create_render_widget();
+    void create_viewport_widget();
     void create_toolbar();
     void create_scrollarea();
     void recreate_handlers();

--- a/src/appleseed.studio/mainwindow/rendering/viewportregionselectionhandler.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/viewportregionselectionhandler.cpp
@@ -28,7 +28,7 @@
 //
 
 // Interface header.
-#include "renderregionhandler.h"
+#include "viewportregionselectionhandler.h"
 
 // appleseed.studio headers.
 #include "utility/mousecoordinatestracker.h"
@@ -54,7 +54,7 @@ using namespace std;
 namespace appleseed {
 namespace studio {
 
-RenderRegionHandler::RenderRegionHandler(
+ViewportRegionSelectionHandler::ViewportRegionSelectionHandler(
     QWidget*                        widget,
     const MouseCoordinatesTracker&  mouse_tracker)
   : m_widget(widget)
@@ -66,22 +66,22 @@ RenderRegionHandler::RenderRegionHandler(
     m_widget->installEventFilter(this);
 }
 
-RenderRegionHandler::~RenderRegionHandler()
+ViewportRegionSelectionHandler::~ViewportRegionSelectionHandler()
 {
     m_widget->removeEventFilter(this);
 }
 
-void RenderRegionHandler::set_enabled(const bool enabled)
+void ViewportRegionSelectionHandler::set_enabled(const bool enabled)
 {
     m_enabled = enabled;
 }
 
-void RenderRegionHandler::set_mode(const Mode mode)
+void ViewportRegionSelectionHandler::set_mode(const Mode mode)
 {
     m_mode = mode;
 }
 
-bool RenderRegionHandler::eventFilter(QObject* object, QEvent* event)
+bool ViewportRegionSelectionHandler::eventFilter(QObject* object, QEvent* event)
 {
     if (m_enabled)
     {

--- a/src/appleseed.studio/mainwindow/rendering/viewportregionselectionhandler.h
+++ b/src/appleseed.studio/mainwindow/rendering/viewportregionselectionhandler.h
@@ -43,18 +43,18 @@ class QWidget;
 namespace appleseed {
 namespace studio {
 
-class RenderRegionHandler
+class ViewportRegionSelectionHandler
   : public QObject
 {
     Q_OBJECT
 
   public:
     // Default mode is RectangleSelectionMode.
-    RenderRegionHandler(
+    ViewportRegionSelectionHandler(
         QWidget*                            widget,
         const MouseCoordinatesTracker&      mouse_tracker);
 
-    ~RenderRegionHandler() override;
+    ~ViewportRegionSelectionHandler() override;
 
     void set_enabled(const bool enabled);
 

--- a/src/appleseed.studio/mainwindow/rendering/viewporttab.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/viewporttab.cpp
@@ -132,8 +132,8 @@ void ViewportTab::set_render_region_buttons_enabled(const bool enabled)
 
 void ViewportTab::render_began()
 {
-    get_viewport_widget()->get_render_layer()->darken();
-    get_viewport_widget()->get_light_paths_layer()->update_render_camera_transform();
+    m_viewport_widget->get_render_layer()->darken();
+    m_viewport_widget->get_light_paths_layer()->update_render_camera_transform();
     set_light_paths_enabled(false);
     update();
 }

--- a/src/appleseed.studio/mainwindow/rendering/viewporttab.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/viewporttab.cpp
@@ -189,17 +189,16 @@ void ViewportTab::slot_base_layer_changed(int index)
 
     switch (base_layer)
     {
-        case ViewportWidget::BaseLayer::FinalRender:
-            if (m_rendering_manager.is_rendering()
-                && m_rendering_manager.get_rendering_mode() == RenderingManager::RenderingMode::InteractiveRendering)
-                m_camera_controller.get()->set_enabled(true);
-            else
-                m_camera_controller.get()->set_enabled(false);
-            break;
-
-        case ViewportWidget::BaseLayer::OpenGL:
+    case ViewportWidget::BaseLayer::FinalRender:
+        if (m_rendering_manager.is_rendering()
+            && m_rendering_manager.get_rendering_mode() == RenderingManager::RenderingMode::InteractiveRendering)
             m_camera_controller.get()->set_enabled(true);
-            break;
+        else
+            m_camera_controller.get()->set_enabled(false);
+        break;
+    case ViewportWidget::BaseLayer::OpenGL:
+        m_camera_controller.get()->set_enabled(true);
+        break;
     }
 }
 
@@ -298,14 +297,6 @@ void ViewportTab::create_toolbar()
     m_light_paths_toggle_button->setText("Display Light Paths Overlay");
     m_light_paths_toggle_button->setCheckable(true);
     m_toolbar->addWidget(m_light_paths_toggle_button);
-    connect(
-        m_light_paths_toggle_button, SIGNAL(toggled(bool)),
-        m_viewport_widget, SLOT(slot_light_paths_toggled(bool))
-    );
-    connect(
-        m_light_paths_toggle_button, SIGNAL(toggled(bool)),
-        m_light_paths_manager, SLOT(slot_light_paths_display_toggled(bool))
-    );
 
     m_toolbar->addSeparator();
 

--- a/src/appleseed.studio/mainwindow/rendering/viewporttab.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/viewporttab.cpp
@@ -32,7 +32,7 @@
 
 // appleseed.studio headers.
 #include "mainwindow/project/projectexplorer.h"
-#include "mainwindow/rendering/lightpathsviewportmanager.h"
+//#include "mainwindow/rendering/lightpathsviewportmanager.h"
 #include "mainwindow/rendering/renderingmanager.h"
 #include "utility/miscellaneous.h"
 

--- a/src/appleseed.studio/mainwindow/rendering/viewporttab.h
+++ b/src/appleseed.studio/mainwindow/rendering/viewporttab.h
@@ -73,13 +73,13 @@ namespace studio {
 // A tab wrapping a render widget and its toolbar.
 //
 
-class RenderTab
+class ViewportTab
   : public QWidget
 {
     Q_OBJECT
 
   public:
-    RenderTab(
+    ViewportTab(
         ProjectExplorer&        project_explorer,
         renderer::Project&      project,
         RenderingManager&       rendering_manager,
@@ -88,6 +88,9 @@ class RenderTab
     ViewportWidget* get_viewport_widget() const;
     CameraController* get_camera_controller() const;
     ScenePickingHandler* get_scene_picking_handler() const;
+
+    void enable_light_paths_toggle();
+    void disable_light_paths_toggle();
 
     void set_clear_frame_button_enabled(const bool enabled);
     void set_render_region_buttons_enabled(const bool enabled);
@@ -113,6 +116,7 @@ class RenderTab
     void signal_clear_render_region();
     void signal_reset_zoom();
     void signal_clear_frame();
+    void signal_viewport_widget_context_menu(const QPoint& point);
 
     void signal_camera_change_begin();
     void signal_camera_changed();
@@ -122,6 +126,7 @@ class RenderTab
     void signal_rectangle_selection(const QRect& rect);
 
   private slots:
+    void slot_viewport_widget_context_menu(const QPoint& point);
     void slot_toggle_render_region(const bool checked);
     void slot_set_render_region(const QRect& rect);
     void slot_toggle_pixel_inspector(const bool checked);
@@ -133,8 +138,10 @@ class RenderTab
     QToolButton*                                m_set_render_region_button;
     QToolButton*                                m_clear_render_region_button;
     QToolButton*                                m_clear_frame_button;
+    QToolButton*                                m_light_paths_toggle_button;
     QComboBox*                                  m_picking_mode_combo;
     QComboBox*                                  m_display_transform_combo;
+    QComboBox*                                  m_base_layer_combo;
     QLabel*                                     m_info_label;
     QLabel*                                     m_r_label;
     QLabel*                                     m_g_label;

--- a/src/appleseed.studio/mainwindow/rendering/viewporttab.h
+++ b/src/appleseed.studio/mainwindow/rendering/viewporttab.h
@@ -37,6 +37,7 @@
 #include "mainwindow/rendering/renderclipboardhandler.h"
 #include "mainwindow/rendering/scenepickinghandler.h"
 #include "mainwindow/rendering/viewportregionselectionhandler.h"
+#include "mainwindow/rendering/viewportwidget.h"
 #include "utility/mousecoordinatestracker.h"
 #include "utility/scrollareapanhandler.h"
 #include "utility/widgetzoomhandler.h"
@@ -55,7 +56,6 @@ namespace OCIO = OCIO_NAMESPACE;
 // Forward declarations.
 namespace appleseed { namespace studio { class LightPathsViewportManager; } }
 namespace appleseed { namespace studio { class ProjectExplorer; } }
-namespace appleseed { namespace studio { class ViewportWidget; } }
 namespace renderer  { class Entity; }
 namespace renderer  { class Project; }
 namespace renderer  { class RenderingManager; }
@@ -91,8 +91,8 @@ class ViewportTab
     CameraController* get_camera_controller() const;
     ScenePickingHandler* get_scene_picking_handler() const;
 
-    void set_light_paths_enabled(const bool enabled);
     void set_clear_frame_button_enabled(const bool enabled);
+    void set_light_paths_toggle_enabled(const bool enabled);
     void set_render_region_buttons_enabled(const bool enabled);
 
     void render_began();
@@ -128,7 +128,7 @@ class ViewportTab
 
   private slots:
     void slot_camera_changed();
-    void slot_base_layer_changed(int index);
+    void slot_base_layer_changed(const ViewportWidget::BaseLayer base_layer);
     void slot_set_render_region(const QRect& rect);
     void slot_toggle_pixel_inspector(const bool checked);
     void slot_toggle_render_region(const bool checked);
@@ -136,7 +136,6 @@ class ViewportTab
 
   private:
     ViewportWidget*                                 m_viewport_widget;
-    LightPathsViewportManager*                      m_light_paths_manager;
 
     QScrollArea*                                    m_scroll_area;
     QToolBar*                                       m_toolbar;
@@ -158,6 +157,7 @@ class ViewportTab
     RenderingManager&                               m_rendering_manager;
     renderer::ParamArray                            m_application_settings;
 
+    std::unique_ptr<LightPathsViewportManager>      m_light_paths_manager;
     std::unique_ptr<WidgetZoomHandler>              m_zoom_handler;
     std::unique_ptr<ScrollAreaPanHandler>           m_pan_handler;
     std::unique_ptr<MaterialDropHandler>            m_material_drop_handler;
@@ -171,7 +171,7 @@ class ViewportTab
 
     OCIO::ConstConfigRcPtr                          m_ocio_config;
 
-    void create_light_paths_manager(renderer::ParamArray application_settings);
+    void create_light_paths_manager();
     void create_scrollarea();
     void create_toolbar();
     void create_viewport_widget();

--- a/src/appleseed.studio/mainwindow/rendering/viewporttab.h
+++ b/src/appleseed.studio/mainwindow/rendering/viewporttab.h
@@ -31,6 +31,7 @@
 
 // appleseed.studio headers.
 #include "mainwindow/rendering/cameracontroller.h"
+#include "mainwindow/rendering/lightpathsviewportmanager.h"
 #include "mainwindow/rendering/materialdrophandler.h"
 #include "mainwindow/rendering/pixelcolortracker.h"
 #include "mainwindow/rendering/pixelinspectorhandler.h"
@@ -54,7 +55,6 @@ namespace OCIO = OCIO_NAMESPACE;
 #include <memory>
 
 // Forward declarations.
-namespace appleseed { namespace studio { class LightPathsViewportManager; } }
 namespace appleseed { namespace studio { class ProjectExplorer; } }
 namespace renderer  { class Entity; }
 namespace renderer  { class Project; }

--- a/src/appleseed.studio/mainwindow/rendering/viewporttab.h
+++ b/src/appleseed.studio/mainwindow/rendering/viewporttab.h
@@ -35,8 +35,8 @@
 #include "mainwindow/rendering/pixelcolortracker.h"
 #include "mainwindow/rendering/pixelinspectorhandler.h"
 #include "mainwindow/rendering/renderclipboardhandler.h"
-#include "mainwindow/rendering/renderregionhandler.h"
 #include "mainwindow/rendering/scenepickinghandler.h"
+#include "mainwindow/rendering/viewportregionselectionhandler.h"
 #include "utility/mousecoordinatestracker.h"
 #include "utility/scrollareapanhandler.h"
 #include "utility/widgetzoomhandler.h"
@@ -53,6 +53,7 @@ namespace OCIO = OCIO_NAMESPACE;
 #include <memory>
 
 // Forward declarations.
+namespace appleseed { namespace studio { class LightPathsViewportManager; } }
 namespace appleseed { namespace studio { class ProjectExplorer; } }
 namespace appleseed { namespace studio { class ViewportWidget; } }
 namespace renderer  { class Entity; }
@@ -83,18 +84,18 @@ class ViewportTab
         ProjectExplorer&        project_explorer,
         renderer::Project&      project,
         RenderingManager&       rendering_manager,
-        OCIO::ConstConfigRcPtr  ocio_config);
+        OCIO::ConstConfigRcPtr  ocio_config,
+        renderer::ParamArray    application_settings);
 
     ViewportWidget* get_viewport_widget() const;
     CameraController* get_camera_controller() const;
     ScenePickingHandler* get_scene_picking_handler() const;
 
-    void enable_light_paths_toggle();
-    void disable_light_paths_toggle();
-
+    void set_light_paths_enabled(const bool enabled);
     void set_clear_frame_button_enabled(const bool enabled);
     void set_render_region_buttons_enabled(const bool enabled);
 
+    void render_began();
     void reset_zoom();
 
     void update();
@@ -126,48 +127,54 @@ class ViewportTab
     void signal_rectangle_selection(const QRect& rect);
 
   private slots:
-    void slot_viewport_widget_context_menu(const QPoint& point);
-    void slot_toggle_render_region(const bool checked);
+    void slot_camera_changed();
+    void slot_base_layer_changed(int index);
     void slot_set_render_region(const QRect& rect);
     void slot_toggle_pixel_inspector(const bool checked);
+    void slot_toggle_render_region(const bool checked);
+    void slot_viewport_widget_context_menu(const QPoint& point);
 
   private:
-    ViewportWidget*                             m_viewport_widget;
-    QScrollArea*                                m_scroll_area;
-    QToolBar*                                   m_toolbar;
-    QToolButton*                                m_set_render_region_button;
-    QToolButton*                                m_clear_render_region_button;
-    QToolButton*                                m_clear_frame_button;
-    QToolButton*                                m_light_paths_toggle_button;
-    QComboBox*                                  m_picking_mode_combo;
-    QComboBox*                                  m_display_transform_combo;
-    QComboBox*                                  m_base_layer_combo;
-    QLabel*                                     m_info_label;
-    QLabel*                                     m_r_label;
-    QLabel*                                     m_g_label;
-    QLabel*                                     m_b_label;
-    QLabel*                                     m_a_label;
+    ViewportWidget*                                 m_viewport_widget;
+    LightPathsViewportManager*                      m_light_paths_manager;
 
-    ProjectExplorer&                            m_project_explorer;
-    renderer::Project&                          m_project;
-    RenderingManager&                           m_rendering_manager;
+    QScrollArea*                                    m_scroll_area;
+    QToolBar*                                       m_toolbar;
+    QToolButton*                                    m_set_render_region_button;
+    QToolButton*                                    m_clear_render_region_button;
+    QToolButton*                                    m_clear_frame_button;
+    QToolButton*                                    m_light_paths_toggle_button;
+    QComboBox*                                      m_picking_mode_combo;
+    QComboBox*                                      m_display_transform_combo;
+    QComboBox*                                      m_base_layer_combo;
+    QLabel*                                         m_info_label;
+    QLabel*                                         m_r_label;
+    QLabel*                                         m_g_label;
+    QLabel*                                         m_b_label;
+    QLabel*                                         m_a_label;
 
-    std::unique_ptr<WidgetZoomHandler>          m_zoom_handler;
-    std::unique_ptr<ScrollAreaPanHandler>       m_pan_handler;
-    std::unique_ptr<MaterialDropHandler>        m_material_drop_handler;
-    std::unique_ptr<MouseCoordinatesTracker>    m_mouse_tracker;
-    std::unique_ptr<PixelColorTracker>          m_pixel_color_tracker;
-    std::unique_ptr<PixelInspectorHandler>      m_pixel_inspector_handler;
-    std::unique_ptr<CameraController>           m_camera_controller;
-    std::unique_ptr<ScenePickingHandler>        m_scene_picking_handler;
-    std::unique_ptr<RenderRegionHandler>        m_render_region_handler;
-    std::unique_ptr<RenderClipboardHandler>     m_clipboard_handler;
+    ProjectExplorer&                                m_project_explorer;
+    renderer::Project&                              m_project;
+    RenderingManager&                               m_rendering_manager;
+    renderer::ParamArray                            m_application_settings;
 
-    OCIO::ConstConfigRcPtr                      m_ocio_config;
+    std::unique_ptr<WidgetZoomHandler>              m_zoom_handler;
+    std::unique_ptr<ScrollAreaPanHandler>           m_pan_handler;
+    std::unique_ptr<MaterialDropHandler>            m_material_drop_handler;
+    std::unique_ptr<MouseCoordinatesTracker>        m_mouse_tracker;
+    std::unique_ptr<PixelColorTracker>              m_pixel_color_tracker;
+    std::unique_ptr<PixelInspectorHandler>          m_pixel_inspector_handler;
+    std::unique_ptr<CameraController>               m_camera_controller;
+    std::unique_ptr<ScenePickingHandler>            m_scene_picking_handler;
+    std::unique_ptr<ViewportRegionSelectionHandler> m_viewport_selection_handler;
+    std::unique_ptr<RenderClipboardHandler>         m_clipboard_handler;
 
-    void create_viewport_widget();
-    void create_toolbar();
+    OCIO::ConstConfigRcPtr                          m_ocio_config;
+
+    void create_light_paths_manager(renderer::ParamArray application_settings);
     void create_scrollarea();
+    void create_toolbar();
+    void create_viewport_widget();
     void recreate_handlers();
 };
 

--- a/src/appleseed.studio/mainwindow/rendering/viewportwidget.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/viewportwidget.cpp
@@ -285,12 +285,6 @@ void ViewportWidget::resizeGL(
     m_gl->glBindTexture(GL_TEXTURE_2D, 0);
 }
 
-void ViewportWidget::set_draw_light_paths_enabled(const bool enabled)
-{
-    m_draw_light_paths = enabled;
-    update();
-}
-
 void ViewportWidget::paintGL()
 {
 
@@ -407,11 +401,14 @@ void ViewportWidget::slot_base_layer_changed(int index)
     assert(index < BaseLayer::BASE_LAYER_MAX_VALUE);
     m_active_base_layer = static_cast<BaseLayer>(index);
     update();
+
+    emit signal_base_layer_changed(m_active_base_layer);
 }
 
-void ViewportWidget::slot_light_paths_toggled(bool checked)
+void ViewportWidget::slot_light_paths_should_display(const bool should_display)
 {
-    set_draw_light_paths_enabled(checked);
+    m_draw_light_paths = should_display;
+    update();
 }
 
 }   // namespace studio

--- a/src/appleseed.studio/mainwindow/rendering/viewportwidget.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/viewportwidget.cpp
@@ -1,0 +1,210 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2019 Gray Olson, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "viewportwidget.h"
+
+// appleseed.renderer headers.
+#include "renderer/api/frame.h"
+
+// appleseed.foundation headers.
+#include "foundation/image/canvasproperties.h"
+#include "foundation/image/image.h"
+#include "foundation/image/nativedrawing.h"
+#include "foundation/image/tile.h"
+#include "foundation/math/scalar.h"
+#include "foundation/platform/types.h"
+
+// Qt headers.
+#include <QColor>
+#include <QDragEnterEvent>
+#include <QDragMoveEvent>
+#include <QDropEvent>
+#include <QMimeData>
+#include <QMutexLocker>
+#include <QOpenGLFunctions_3_3_Core>
+#include <Qt>
+
+// Standard headers.
+#include <algorithm>
+#include <cassert>
+
+using namespace foundation;
+using namespace renderer;
+using namespace std;
+
+namespace appleseed {
+namespace studio {
+
+//
+// ViewportWidget class implementation.
+//
+
+ViewportWidget::ViewportWidget(
+    const renderer::Project&    project,
+    const size_t                width,
+    const size_t                height,
+    OCIO::ConstConfigRcPtr      ocio_config,
+    QWidget*                    parent)
+  : QOpenGLWidget(parent)
+  , m_project(project)
+{
+    setFocusPolicy(Qt::StrongFocus);
+    setFixedWidth(static_cast<int>(width));
+    setFixedHeight(static_cast<int>(height));
+    setAutoFillBackground(false);
+    setAttribute(Qt::WA_OpaquePaintEvent, true);
+
+    create_render_layer(ocio_config);
+    //create_gl_scene_layer();
+    //create_light_paths_layer();
+
+    resize(width, height);
+
+    setAcceptDrops(true);
+}
+
+void ViewportWidget::create_render_layer(OCIO::ConstConfigRcPtr  ocio_config)
+{
+    m_render_layer =
+        std::unique_ptr<RenderLayer>(new RenderLayer(
+            m_width,
+            m_height,
+            ocio_config));
+}
+
+//void ViewportWidget::create_gl_scene_layer()
+//{
+//    m_gl_scene_layer =
+//        std::unique_ptr<GLSceneLayer>(new GLSceneLayer(
+//            m_project,
+//            m_width,
+//            m_height));
+//}
+//
+//void ViewportWidget::create_light_paths_layer()
+//{
+//    m_light_paths_layer =
+//        std::unique_ptr<LightPathsLayer>(new LightPathsLayer(
+//            m_project,
+//            m_width,
+//            m_height));
+//}
+
+RenderLayer* ViewportWidget::get_render_layer()
+{
+    return m_render_layer.get();
+}
+
+//LightPathsLayer* ViewportWidget::get_light_paths_layer()
+//{
+//    return m_light_paths_layer.get();
+//}
+//
+//GLSceneLayer* ViewportWidget::get_gl_scene_layer()
+//{
+//    return m_gl_scene_layer.get();
+//}
+
+QImage ViewportWidget::capture()
+{
+    return grabFramebuffer();
+}
+
+void ViewportWidget::initializeGL() {
+    m_gl = QOpenGLContext::currentContext()->versionFunctions<QOpenGLFunctions_3_3_Core>();
+
+    const auto qs_format = format();
+    if (!m_gl->initializeOpenGLFunctions())
+    {
+        const int major_version = qs_format.majorVersion();
+        const int minor_version = qs_format.minorVersion();
+        RENDERER_LOG_ERROR(
+            "opengl: could not load required gl functions. loaded version %d.%d, required version 3.3",
+            major_version,
+            minor_version);
+        return;
+    }
+
+    //m_gl_scene_layer->set_gl_functions(m_gl);
+    //m_gl_scene_layer->init_gl(qs_format);
+    //m_light_paths_layer->set_gl_functions(m_gl);
+    //m_light_paths_layer->init_gl(qs_format);
+}
+
+void ViewportWidget::resize(
+    const size_t    width,
+    const size_t    height)
+{
+    m_render_layer->resize(width, height);
+}
+
+void ViewportWidget::paintEvent(QPaintEvent* event)
+{
+    m_painter.begin(this);
+    m_render_layer->paint(rect(), m_painter);
+    m_painter.end();
+    //m_painter.beginNativePainting();
+    //m_gl_scene_layer->draw_depth_only();
+    //m_light_paths_layer->draw();
+    //m_painter.endNativePainting();
+}
+
+void ViewportWidget::dragEnterEvent(QDragEnterEvent* event)
+{
+    if (event->mimeData()->hasFormat("text/plain"))
+        event->acceptProposedAction();
+}
+
+void ViewportWidget::dragMoveEvent(QDragMoveEvent* event)
+{
+    if (pos().x() <= event->pos().x() && pos().y() <= event->pos().y()
+        && event->pos().x() < pos().x() + width() && event->pos().y() < pos().y() + height())
+    {
+        event->accept();
+    }
+    else
+        event->ignore();
+}
+
+void ViewportWidget::dropEvent(QDropEvent* event)
+{
+    emit signal_material_dropped(
+        Vector2d(
+            static_cast<double>(event->pos().x()) / width(),
+            static_cast<double>(event->pos().y()) / height()),
+        event->mimeData()->text());
+}
+
+void ViewportWidget::slot_viewport_widget_context_menu(const QPoint& point)
+{
+    emit signal_viewport_widget_context_menu(mapToGlobal(point));
+}
+
+}   // namespace studio
+}   // namespace appleseed

--- a/src/appleseed.studio/mainwindow/rendering/viewportwidget.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/viewportwidget.cpp
@@ -303,7 +303,6 @@ void ViewportWidget::paintGL()
     // Clear the main framebuffers
     GLfloat main_clear[]{ 0.0, 0.0, 0.0, 0.0 };
     m_gl->glClearBufferfv(GL_COLOR, 0, main_clear);
-    GLfloat depth_clear = 1.0;
     m_gl->glClearBufferfi(GL_DEPTH_STENCIL, 0, 1.0, 0);
 
     if (m_active_base_layer == BaseLayer::FinalRender)

--- a/src/appleseed.studio/mainwindow/rendering/viewportwidget.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/viewportwidget.cpp
@@ -174,10 +174,18 @@ void ViewportWidget::initializeGL() {
 }
 
 void ViewportWidget::resize(
-    const size_t    width,
-    const size_t    height)
+    const size_t width,
+    const size_t height)
 {
     m_render_layer->resize(width, height);
+    m_light_paths_layer->resize(width, height);
+}
+
+void ViewportWidget::resizeGL(
+    int width,
+    int height)
+{
+    m_light_paths_layer->resize(width, height);
 }
 
 void ViewportWidget::set_draw_light_paths_enabled(const bool enabled)

--- a/src/appleseed.studio/mainwindow/rendering/viewportwidget.h
+++ b/src/appleseed.studio/mainwindow/rendering/viewportwidget.h
@@ -109,15 +109,16 @@ class ViewportWidget
     GLSceneLayer* get_gl_scene_layer();
     LightPathsLayer* get_light_paths_layer();
 
-    void set_draw_light_paths_enabled(const bool enabled);
-
   signals:
     void signal_material_dropped(
         const foundation::Vector2d& drop_pos,
         const QString&          material_name);
+    void signal_base_layer_changed(const ViewportWidget::BaseLayer layer);
+
+  public slots:
+    void slot_light_paths_should_display(const bool should_display);
 
   private slots:
-    void slot_light_paths_toggled(bool checked);
     void slot_base_layer_changed(int index);
 
   private:

--- a/src/appleseed.studio/mainwindow/rendering/viewportwidget.h
+++ b/src/appleseed.studio/mainwindow/rendering/viewportwidget.h
@@ -63,7 +63,7 @@ class QDragEnterEvent;
 class QDragMoveEvent;
 class QDropEvent;
 class QPaintEvent;
-class QOpenGLFunctions_3_3_Core;
+class QOpenGLFunctions_4_1_Core;
 
 namespace appleseed {
 namespace studio {
@@ -86,6 +86,8 @@ class ViewportWidget
         const size_t                height,
         OCIO::ConstConfigRcPtr      ocio_config,
         QWidget*                    parent = nullptr);
+
+    ~ViewportWidget();
 
     enum BaseLayer {
         FinalRender,
@@ -123,8 +125,21 @@ class ViewportWidget
     int                                 m_width;
     int                                 m_height;
 
-    QOpenGLFunctions_3_3_Core*          m_gl;
+    QOpenGLFunctions_4_1_Core*          m_gl;
     QPainter                            m_painter;
+
+    GLuint                              m_depth_tex;
+    GLuint                              m_color_tex;
+    GLuint                              m_accum_tex;
+    GLuint                              m_revealage_tex;
+    GLuint                              m_main_fb;
+    GLuint                              m_accum_revealage_fb;
+    GLuint                              m_empty_vao;
+    GLuint                              m_empty_vbo;
+
+    GLuint                              m_resolve_program;
+    GLint                               m_accum_loc;
+    GLint                               m_revealage_loc;
 
     std::unique_ptr<RenderLayer>        m_render_layer;
     std::unique_ptr<GLSceneLayer>       m_gl_scene_layer;

--- a/src/appleseed.studio/mainwindow/rendering/viewportwidget.h
+++ b/src/appleseed.studio/mainwindow/rendering/viewportwidget.h
@@ -86,6 +86,14 @@ class ViewportWidget
         OCIO::ConstConfigRcPtr      ocio_config,
         QWidget*                    parent = nullptr);
 
+    enum BaseLayer {
+        FinalRender,
+        OpenGL,
+        BASE_LAYER_MAX_VALUE
+    };
+
+    static QString base_layer_string(BaseLayer layer);
+
     // Thread-safe.
     QImage capture() override;
 
@@ -95,23 +103,17 @@ class ViewportWidget
         const size_t            height);
 
     RenderLayer* get_render_layer();
-    //GLSceneLayer* get_gl_scene_layer();
+    GLSceneLayer* get_gl_scene_layer();
     //LightPathsLayer* get_light_paths_layer();
-
-    // Thread-safe.
-    //void highlight_tile(
-    //    const renderer::Frame&  frame,
-    //    const size_t            tile_x,
-    //    const size_t            tile_y);
 
   signals:
     void signal_material_dropped(
         const foundation::Vector2d& drop_pos,
         const QString&          material_name);
-    void signal_viewport_widget_context_menu(const QPoint& point);
 
   private slots:
-    void slot_viewport_widget_context_menu(const QPoint& point);
+    void slot_light_paths_toggled(bool checked);
+    void slot_base_layer_changed(int index);
 
   private:
     const renderer::Project&            m_project;
@@ -121,21 +123,23 @@ class ViewportWidget
     QOpenGLFunctions_3_3_Core*          m_gl;
     QPainter                            m_painter;
 
-    std::unique_ptr<RenderLayer>       m_render_layer;
-    //std::unique_ptr<GLSceneLayer>      m_gl_scene_layer;
+    std::unique_ptr<RenderLayer>        m_render_layer;
+    std::unique_ptr<GLSceneLayer>       m_gl_scene_layer;
     //std::unique_ptr<LightPathsLayer>   m_light_paths_layer;
 
+    bool                                m_draw_light_paths;
+    BaseLayer                           m_active_base_layer;
+
     void create_render_layer(OCIO::ConstConfigRcPtr  ocio_config);
-    //void create_gl_scene_layer();
+    void create_gl_scene_layer();
     //void create_light_paths_layer();
 
     void initializeGL() override;
-    void paintEvent(QPaintEvent* event) override;
+    void paintGL() override;
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dragMoveEvent(QDragMoveEvent* event) override;
     void dropEvent(QDropEvent* event) override;
 };
-
 
 }   // namespace studio
 }   // namespace appleseed

--- a/src/appleseed.studio/mainwindow/rendering/viewportwidget.h
+++ b/src/appleseed.studio/mainwindow/rendering/viewportwidget.h
@@ -138,6 +138,7 @@ class ViewportWidget
     void create_render_layer(OCIO::ConstConfigRcPtr  ocio_config);
 
     void initializeGL() override;
+    void resizeGL(int width, int height) override;
     void paintGL() override;
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dragMoveEvent(QDragMoveEvent* event) override;

--- a/src/appleseed.studio/mainwindow/rendering/viewportwidget.h
+++ b/src/appleseed.studio/mainwindow/rendering/viewportwidget.h
@@ -30,9 +30,10 @@
 
 // appleseed.studio headers.
 #include "mainwindow/rendering/lightpathslayer.h"
+#include "mainwindow/rendering/glscenelayer.h"
 #include "mainwindow/rendering/renderclipboardhandler.h"
 #include "mainwindow/rendering/renderlayer.h"
-#include "mainwindow/rendering/glscenelayer.h"
+
 
 // appleseed.foundation headers.
 #include "foundation/image/image.h"
@@ -104,7 +105,9 @@ class ViewportWidget
 
     RenderLayer* get_render_layer();
     GLSceneLayer* get_gl_scene_layer();
-    //LightPathsLayer* get_light_paths_layer();
+    LightPathsLayer* get_light_paths_layer();
+
+    void set_draw_light_paths_enabled(const bool enabled);
 
   signals:
     void signal_material_dropped(
@@ -125,14 +128,14 @@ class ViewportWidget
 
     std::unique_ptr<RenderLayer>        m_render_layer;
     std::unique_ptr<GLSceneLayer>       m_gl_scene_layer;
-    //std::unique_ptr<LightPathsLayer>   m_light_paths_layer;
+    std::unique_ptr<LightPathsLayer>    m_light_paths_layer;
 
     bool                                m_draw_light_paths;
     BaseLayer                           m_active_base_layer;
 
-    void create_render_layer(OCIO::ConstConfigRcPtr  ocio_config);
+    void create_light_paths_layer();
     void create_gl_scene_layer();
-    //void create_light_paths_layer();
+    void create_render_layer(OCIO::ConstConfigRcPtr  ocio_config);
 
     void initializeGL() override;
     void paintGL() override;

--- a/src/appleseed.studio/resources/resources.qrc
+++ b/src/appleseed.studio/resources/resources.qrc
@@ -1,8 +1,11 @@
 <RCC>
     <qresource prefix="/">
         <file>images/appleseed-logo-256.png</file>
+        <file>shaders/final_render.frag</file>
+        <file>shaders/fullscreen_tri.vert</file>
         <file>shaders/lightpaths.frag</file>
         <file>shaders/lightpaths.vert</file>
+        <file>shaders/oit_resolve.frag</file>
         <file>shaders/scene.frag</file>
         <file>shaders/scene.vert</file>
         <file>widgets/checkbox_checked_disabled.png</file>

--- a/src/appleseed.studio/resources/shaders/final_render.frag
+++ b/src/appleseed.studio/resources/shaders/final_render.frag
@@ -26,22 +26,16 @@
 //
 
 #version 410
-#extension GL_ARB_separate_shader_objects : enable
 
-layout(location = 0) in vec3 a_pos;
-layout(location = 1) in vec3 a_norm;
-layout(location = 2) in mat4 i_model;
+in vec2 f_uv;
 
-uniform mat4 u_view;
-uniform mat4 u_proj;
+uniform sampler2D u_render_tex;
+uniform float u_mult;
 
-layout(location = 1) out vec3 v_world_pos;
-layout(location = 0) out vec3 v_norm;
+out vec4 Target0;
 
-void main()
-{
-    vec4 world_pos = i_model * vec4(a_pos, 1.0);
-    v_world_pos = world_pos.xyz;
-    v_norm = a_norm;
-    gl_Position = u_proj * u_view * world_pos;
+void main() {
+    vec3 col = texture(u_render_tex, f_uv, 0).rgb;
+ 
+    Target0 = vec4(col * u_mult, 1.0);
 }

--- a/src/appleseed.studio/resources/shaders/fullscreen_tri.vert
+++ b/src/appleseed.studio/resources/shaders/fullscreen_tri.vert
@@ -26,22 +26,23 @@
 //
 
 #version 410
-#extension GL_ARB_separate_shader_objects : enable
 
-layout(location = 0) in vec3 a_pos;
-layout(location = 1) in vec3 a_norm;
-layout(location = 2) in mat4 i_model;
+const vec2 verts[3] = vec2[](
+    vec2(3.0, 1.0),
+    vec2(-1.0, -3.0),
+    vec2(-1.0, 1.0)
+);
 
-uniform mat4 u_view;
-uniform mat4 u_proj;
+const vec2 uvs[3] = vec2[](
+    vec2(2.0, 0.0),
+    vec2(0.0, 2.0),
+    vec2(0.0, 0.0)
+);
 
-layout(location = 1) out vec3 v_world_pos;
-layout(location = 0) out vec3 v_norm;
+out vec2 f_uv;
 
-void main()
+void main() 
 {
-    vec4 world_pos = i_model * vec4(a_pos, 1.0);
-    v_world_pos = world_pos.xyz;
-    v_norm = a_norm;
-    gl_Position = u_proj * u_view * world_pos;
+    f_uv = uvs[gl_VertexID];
+    gl_Position = vec4(verts[gl_VertexID], 0.0, 1.0);
 }

--- a/src/appleseed.studio/resources/shaders/lightpaths.frag
+++ b/src/appleseed.studio/resources/shaders/lightpaths.frag
@@ -28,7 +28,7 @@
 #version 410
 #extension GL_ARB_separate_shader_objects : enable
 
-flat in vec3 f_color;
+flat in vec4 f_color;
 in float f_aa_norm;
 flat in float f_thickness;
 flat in float f_total_thickness;
@@ -40,7 +40,7 @@ layout(location = 0) out vec4 accum_target;
 layout(location = 1) out float revealage_target;
 
 void write_pixel(vec4 premultiplied_col, vec3 transmit) { 
-    // premultiplied_col.a *= 1.0 - clamp((transmit.r + transmit.g + transmit.b) * (1.0 / 3.0), 0, 1);
+    premultiplied_col.a *= 1.0 - clamp((transmit.r + transmit.g + transmit.b) * (1.0 / 3.0), 0, 1);
  
     float a = min(1.0, premultiplied_col.a) * 8.0 + 0.01;
     float b = -gl_FragCoord.z * 0.95 + 1.0;
@@ -55,7 +55,8 @@ void main()
     float dist = abs(f_aa_norm) * f_total_thickness - 0.5 / f_aspect_expansion_len;
     float eps = fwidth(dist);
     float a = 1.0 - smoothstep(f_thickness - eps, f_thickness + eps, dist);
+    a *= f_color.a;
 
-    vec4 premult = vec4(f_color * a, a);
-    write_pixel(premult, vec3(1.0));
+    vec4 premult = vec4(f_color.rgb * a, a);
+    write_pixel(premult, vec3(0.0));
 }

--- a/src/appleseed.studio/resources/shaders/lightpaths.frag
+++ b/src/appleseed.studio/resources/shaders/lightpaths.frag
@@ -28,11 +28,20 @@
 #version 330
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(location = 0) in vec3 v_color;
+flat in vec3 f_color;
+in float f_aa_norm;
+flat in float f_thickness;
+flat in float f_total_thickness;
+flat in float f_aspect_expansion_len;
+
+uniform vec2 u_res;
 
 out vec4 Target0;
 
 void main()
 {
-    Target0 = vec4(v_color, 1.0);
+    float dist = abs(f_aa_norm) * f_total_thickness - 0.5 / f_aspect_expansion_len;
+    float eps = fwidth(dist);
+    float a = 1.0 - smoothstep(f_thickness - eps, f_thickness + eps, dist);
+    Target0 = vec4(f_color, a);
 }

--- a/src/appleseed.studio/resources/shaders/lightpaths.vert
+++ b/src/appleseed.studio/resources/shaders/lightpaths.vert
@@ -44,7 +44,10 @@ uniform float u_max_luminance;
 uniform float u_max_thickness;
 uniform float u_min_thickness;
 
-flat out vec3 f_color;
+uniform int u_first_selected;
+uniform int u_last_selected;
+
+flat out vec4 f_color;
 out float f_aa_norm;
 flat out float f_thickness;
 flat out float f_total_thickness;
@@ -105,5 +108,8 @@ void main() {
 
     gl_Position = vec4((curr_screen + expansion) / aspect_vec, curr_proj.z / curr_proj.w, 1.0);
     f_aa_norm = orientation;
-    f_color = v_color;
+
+    bool is_selected = gl_VertexID >= u_first_selected && gl_VertexID < u_last_selected;
+    float a = is_selected ? 1.0 : 0.2;
+    f_color = vec4(v_color, a);
 }

--- a/src/appleseed.studio/resources/shaders/lightpaths.vert
+++ b/src/appleseed.studio/resources/shaders/lightpaths.vert
@@ -25,7 +25,7 @@
 // THE SOFTWARE.
 //
 
-#version 330
+#version 410
 
 const float AA_BUFFER_SIZE = 1.0;
 

--- a/src/appleseed.studio/resources/shaders/lightpaths.vert
+++ b/src/appleseed.studio/resources/shaders/lightpaths.vert
@@ -26,18 +26,84 @@
 //
 
 #version 330
-#extension GL_ARB_separate_shader_objects : enable
 
-layout(location = 0) in vec3 a_pos;
-layout(location = 1) in vec3 a_color;
+const float AA_BUFFER_SIZE = 1.0;
 
-uniform mat4 u_view;
+layout(location = 0) in vec3 v_previous;
+layout(location = 1) in vec3 v_position;
+layout(location = 2) in vec3 v_next;
+layout(location = 3) in float v_luminance;
+layout(location = 4) in int v_direction_start_end;
+layout(location = 5) in vec3 v_color;
+layout(location = 6) in vec3 v_surface_normal;
+
 uniform mat4 u_proj;
+uniform mat4 u_view;
+uniform vec2 u_res;
+uniform float u_max_luminance;
+uniform float u_max_thickness;
+uniform float u_min_thickness;
 
-layout(location = 0) out vec3 v_color;
+flat out vec3 f_color;
+out float f_aa_norm;
+flat out float f_thickness;
+flat out float f_total_thickness;
+flat out float f_aspect_expansion_len;
 
-void main()
-{
-    v_color = a_color;
-    gl_Position = u_proj * u_view * vec4(a_pos, 1.0);
+void main() {
+    float aspect = u_res.x / u_res.y;
+    vec2 aspect_vec = vec2(aspect, 1.0);
+    mat4 vp = u_proj * u_view;
+    vec4 prev_proj = vp * vec4(v_previous, 1.0);
+    vec4 curr_proj = vp * vec4(v_position, 1.0);
+    vec4 next_proj = vp * vec4(v_next, 1.0);
+
+    //get 2D screen space with W divide and aspect correction
+    vec2 curr_screen = curr_proj.xy / curr_proj.w * aspect_vec;
+    vec2 prev_screen = prev_proj.xy / prev_proj.w * aspect_vec;
+    vec2 next_screen = next_proj.xy / next_proj.w * aspect_vec;
+
+    float orientation = 1.0;
+    if ((v_direction_start_end & 1) == 1)
+    {
+        orientation = -1.0;
+    }
+
+    vec2 dir = vec2(0.0);
+    if ((v_direction_start_end & 2) == 2)
+    {
+        //starting point uses (next - current)
+        dir = normalize(next_screen - curr_screen);
+    } 
+    else if ((v_direction_start_end & 4) == 4)
+    {
+        //ending point uses (current - v_previous)
+        dir = normalize(curr_screen - prev_screen);
+    }
+    vec2 perp_dir = vec2(-dir.y, dir.x);
+
+    vec4 normal_clip = vp * vec4(v_surface_normal, 0.0);
+    normal_clip.xy *= aspect_vec;
+    normal_clip = normalize(normal_clip);
+    vec2 tang_clip = vec2(-normal_clip.y, normal_clip.x);
+
+    float tdp = dot(tang_clip, perp_dir);
+    vec2 expansion = perp_dir;
+    if (tdp > 0.05)
+        expansion = tang_clip / tdp;
+    
+    vec2 norm_exp = normalize(expansion);
+    vec2 res_exp_dir = vec2(norm_exp.x * u_res.x, norm_exp.y * u_res.y);
+    f_aspect_expansion_len = length(res_exp_dir);
+
+    f_thickness = (max(max(min(v_luminance / u_max_luminance, 1.0), 0.0) * u_max_thickness, u_min_thickness) / 2.0) / f_aspect_expansion_len;
+
+    f_total_thickness = f_thickness + AA_BUFFER_SIZE / f_aspect_expansion_len;
+
+    expansion *= f_total_thickness;
+    expansion *= orientation;
+
+    gl_Position = vec4((curr_screen + expansion) / aspect_vec, curr_proj.z / curr_proj.w, 1.0);
+    f_aa_norm = orientation;
+    f_color = v_color;
 }

--- a/src/appleseed.studio/resources/shaders/scene.frag
+++ b/src/appleseed.studio/resources/shaders/scene.frag
@@ -25,7 +25,7 @@
 // THE SOFTWARE.
 //
 
-#version 330
+#version 410
 #extension GL_ARB_separate_shader_objects : enable
 
 layout(location = 0) in vec3 v_world_pos;

--- a/src/appleseed.studio/utility/gl.cpp
+++ b/src/appleseed.studio/utility/gl.cpp
@@ -1,0 +1,149 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2019 Gray Olson, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "gl.h"
+
+// appleseed.studio headers.
+#include "renderer/api/utility.h"
+#include "utility/miscellaneous.h"
+
+// Qt headers.
+#include <QByteArray>
+#include <QFile>
+#include <QString>
+
+using namespace std;
+using namespace renderer;
+
+namespace appleseed {
+namespace studio {
+
+const string shader_kind_to_string(const GLint shader_kind)
+{
+    switch (shader_kind) {
+        case GL_VERTEX_SHADER:
+            return "Vertex";
+        case GL_FRAGMENT_SHADER:
+            return "Fragment";
+    }
+    return "Unknown Kind";
+}
+
+void compile_shader(
+    QOpenGLFunctions_4_1_Core* f,
+    const GLuint               shader,
+    const GLsizei              count,
+    const GLchar**             src_string,
+    const GLint*               length)
+{
+    f->glShaderSource(shader, count, src_string, length);
+    f->glCompileShader(shader);
+    GLint success;
+    f->glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+
+    if (!success)
+    {
+        char info_log[1024];
+        f->glGetShaderInfoLog(shader, 1024, NULL, info_log);
+
+        GLint shader_kind;
+        f->glGetShaderiv(shader, GL_SHADER_TYPE, &shader_kind);
+        string shader_kind_string = shader_kind_to_string(shader_kind);
+
+        RENDERER_LOG_ERROR("opengl: %s shader compilation failed:\n%s", shader_kind_string.c_str(), info_log);
+    }
+}
+
+void link_shader_program(
+    QOpenGLFunctions_4_1_Core*  f,
+    const GLuint                program,
+    const GLuint                vert,
+    const GLuint                frag)
+{
+    f->glAttachShader(program, vert);
+
+    if (frag != 0)
+        f->glAttachShader(program, frag);
+
+    f->glLinkProgram(program);
+
+    GLint success;
+    f->glGetProgramiv(program, GL_LINK_STATUS, &success);
+
+    if (!success)
+    {
+        char info_log[1024];
+        f->glGetProgramInfoLog(program, 1024, NULL, info_log);
+        RENDERER_LOG_ERROR("opengl: shader program linking failed:\n%s", info_log);
+    }
+}
+
+void create_shader_program(
+    QOpenGLFunctions_4_1_Core*  f,
+    GLuint&                     program,
+    const QByteArray*           vert_source,
+    const QByteArray*           frag_source)
+{
+    assert(vert_source != nullptr);
+    bool has_frag_shader = frag_source != nullptr;
+
+    GLuint vert = f->glCreateShader(GL_VERTEX_SHADER);
+    GLuint frag = has_frag_shader ? f->glCreateShader(GL_FRAGMENT_SHADER) : 0;
+
+    auto gl_vert_source = static_cast<const GLchar*>(vert_source->constData());
+    auto gl_vert_source_length = static_cast<const GLint>(vert_source->size());
+
+    compile_shader(f, vert, 1, &gl_vert_source, &gl_vert_source_length);
+
+    if (has_frag_shader)
+    {
+        auto gl_frag_source = static_cast<const GLchar*>(frag_source->constData());
+        auto gl_frag_source_length = static_cast<const GLint>(frag_source->size());
+        compile_shader(f, frag, 1, &gl_frag_source, &gl_frag_source_length);
+    }
+
+    program = f->glCreateProgram();
+    link_shader_program(f, program, vert, frag);
+
+    f->glDeleteShader(vert);
+    if (has_frag_shader)
+        f->glDeleteShader(frag);
+}
+
+QByteArray load_gl_shader(const QString& base_name)
+{
+    const QString resource_path(QString(":/shaders/%1").arg(base_name));
+
+    QFile file(resource_path);
+    file.open(QFile::ReadOnly);
+
+    return file.readAll();
+}
+
+}   // namespace studio
+}   // namespace appleseed

--- a/src/appleseed.studio/utility/gl.h
+++ b/src/appleseed.studio/utility/gl.h
@@ -1,3 +1,4 @@
+
 //
 // This source file is part of appleseed.
 // Visit https://appleseedhq.net/ for additional information and resources.
@@ -25,23 +26,50 @@
 // THE SOFTWARE.
 //
 
-#version 410
-#extension GL_ARB_separate_shader_objects : enable
+#pragma once
 
-layout(location = 0) in vec3 a_pos;
-layout(location = 1) in vec3 a_norm;
-layout(location = 2) in mat4 i_model;
+// Qt headers.
+#include <QOpenGLWidget>
+#include <QOpenGLFunctions_4_1_Core>
 
-uniform mat4 u_view;
-uniform mat4 u_proj;
+// standard headers.
+#include <string>
 
-layout(location = 1) out vec3 v_world_pos;
-layout(location = 0) out vec3 v_norm;
+// Forward declarations.
+class QByteArray;
+class QString;
 
-void main()
-{
-    vec4 world_pos = i_model * vec4(a_pos, 1.0);
-    v_world_pos = world_pos.xyz;
-    v_norm = a_norm;
-    gl_Position = u_proj * u_view * world_pos;
-}
+namespace appleseed {
+namespace studio {
+
+// Get a string from an OpenGL shader kind value.
+const std::string shader_kind_to_string(const GLint shader_kind);
+
+// Compile a GL shader.
+void compile_shader(
+    QOpenGLFunctions_4_1_Core* f,
+    const GLuint               shader,
+    const GLsizei              count,
+    const GLchar**             src_string,
+    const GLint*               length);
+
+// Link a GL shader program.
+void link_shader_program(
+    QOpenGLFunctions_4_1_Core*  f,
+    const GLuint                program,
+    const GLuint                vert,
+    const GLuint                frag);
+
+// Create a GL shader program with a vertex and optional fragment shader.
+void create_shader_program(
+    QOpenGLFunctions_4_1_Core*  f,
+    GLuint&                     program,
+    const QByteArray*           vert_source,
+    const QByteArray*           frag_source);
+
+// Load a GLSL shader from file into a QByteArray.
+QByteArray load_gl_shader(const QString& base_name);
+
+}   // namespace studio
+}   // namespace appleseed
+

--- a/src/appleseed.studio/utility/miscellaneous.cpp
+++ b/src/appleseed.studio/utility/miscellaneous.cpp
@@ -197,16 +197,6 @@ bool file_exists(const QString& path)
     return info.exists() && info.isFile();
 }
 
-QByteArray load_gl_shader(const QString& base_name)
-{
-    const QString resource_path(QString(":/shaders/%1").arg(base_name));
-
-    QFile file(resource_path);
-    file.open(QFile::ReadOnly);
-
-    return file.readAll();
-}
-
 QIcon load_icons(const QString& base_name)
 {
     const QString base_icon_filepath(make_app_path("icons/%1.png").arg(base_name));

--- a/src/appleseed.studio/utility/miscellaneous.h
+++ b/src/appleseed.studio/utility/miscellaneous.h
@@ -80,9 +80,6 @@ QString combine_name_and_shortcut(const QString& name, const QKeySequence& short
 // Check whether a file exists.
 bool file_exists(const QString& path);
 
-// Load a GLSL shader from file into a QByteArray.
-QByteArray load_gl_shader(const QString& base_name);
-
 // Load an icon and its variants (hover, disabled...) from the application's icons directory.
 QIcon load_icons(const QString& base_name);
 

--- a/src/appleseed/renderer/kernel/lighting/directlightingintegrator.cpp
+++ b/src/appleseed/renderer/kernel/lighting/directlightingintegrator.cpp
@@ -466,6 +466,7 @@ void DirectLightingIntegrator::add_emitting_shape_sample_contribution(
         light_path_stream->sampled_emitting_shape(
             *sample.m_shape,
             sample.m_point,
+            sample.m_geometric_normal,
             material_value.m_beauty,
             edf_value);
     }
@@ -541,6 +542,7 @@ void DirectLightingIntegrator::add_non_physical_light_sample_contribution(
         light_path_stream->sampled_non_physical_light(
             *light,
             emission_position,
+            m_material_sampler.get_shading_point().get_geometric_normal(),
             material_value.m_beauty,
             light_value);
     }

--- a/src/appleseed/renderer/kernel/lighting/lightpathrecorder.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lightpathrecorder.cpp
@@ -276,6 +276,10 @@ void LightPathRecorder::get_light_path_vertex(
     result.m_radiance[0] = source_vertex.m_radiance[0];
     result.m_radiance[1] = source_vertex.m_radiance[1];
     result.m_radiance[2] = source_vertex.m_radiance[2];
+
+    result.m_surface_normal[0] = source_vertex.m_surface_normal[0];
+    result.m_surface_normal[1] = source_vertex.m_surface_normal[1];
+    result.m_surface_normal[2] = source_vertex.m_surface_normal[2];
 }
 
 bool LightPathRecorder::write(const char* filename) const

--- a/src/appleseed/renderer/kernel/lighting/lightpathrecorder.h
+++ b/src/appleseed/renderer/kernel/lighting/lightpathrecorder.h
@@ -68,6 +68,7 @@ struct LightPathVertex
     const Entity*   m_entity;
     float           m_position[3];
     float           m_radiance[3];
+    float           m_surface_normal[3];
 };
 
 

--- a/src/appleseed/renderer/kernel/lighting/lightpathstream.h
+++ b/src/appleseed/renderer/kernel/lighting/lightpathstream.h
@@ -67,7 +67,8 @@ class LightPathStream
     void begin_path(
         const PixelContext&             pixel_context,
         const Camera*                   camera,
-        const foundation::Vector3d&     camera_vertex_position);
+        const foundation::Vector3d&     camera_vertex_position,
+        const foundation::Vector3d&     camera_vertex_normal);
 
     void hit_reflector(
         const PathVertex&               vertex);
@@ -79,12 +80,14 @@ class LightPathStream
     void sampled_emitting_shape(
         const EmittingShape&            shape,
         const foundation::Vector3d&     emission_position,
+        const foundation::Vector3d&     emission_normal,
         const Spectrum&                 material_value,
         const Spectrum&                 emitted_radiance);
 
     void sampled_non_physical_light(
         const Light&                    light,
         const foundation::Vector3d&     emission_position,
+        const foundation::Vector3d&     emission_normal,
         const Spectrum&                 material_value,
         const Spectrum&                 emitted_radiance);
 
@@ -117,6 +120,7 @@ class LightPathStream
     {
         const ObjectInstance*       m_object_instance;          // object instance that was hit
         foundation::Vector3f        m_vertex_position;          // world space position of the hit point on the reflector
+        foundation::Vector3f        m_surface_normal;           // world space normal of the surface of the reflector
         foundation::Color3f         m_path_throughput;          // cumulative path throughput up to but excluding this vertex, in reverse order (i.e. in the order from camera to light source)
     };
 
@@ -130,6 +134,7 @@ class LightPathStream
     {
         const Entity*               m_entity;                   // object instance or non-physical light that was sampled
         foundation::Vector3f        m_vertex_position;          // world space position of the emitting point on the emitter
+        foundation::Vector3f        m_surface_normal;           // world space normal of the surface of the emitter
         foundation::Color3f         m_material_value;           // BSDF value at the previous vertex
         foundation::Color3f         m_emitted_radiance;         // emitted radiance in W.sr^-1.m^-2
     };
@@ -157,6 +162,7 @@ class LightPathStream
         const Entity*               m_entity;                   // object instance or non-physical light
         foundation::Vector3f        m_position;                 // world space position of this vertex
         foundation::Color3f         m_radiance;                 // radiance arriving at this vertex, in W.sr^-1.m^-2
+        foundation::Vector3f        m_surface_normal;
     };
 
     // Scene.
@@ -168,6 +174,7 @@ class LightPathStream
     foundation::Vector2i            m_pixel_coords;
     foundation::Vector2f            m_sample_position;
     foundation::Vector3f            m_camera_vertex_position;
+    foundation::Vector3f            m_camera_vertex_normal;
 
     // Scattering events (transient).
     std::vector<Event>              m_events;

--- a/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.cpp
@@ -169,7 +169,8 @@ namespace
                 m_light_path_stream->begin_path(
                     pixel_context,
                     shading_point.get_scene().get_active_camera(),
-                    shading_point.get_ray().m_org);
+                    shading_point.get_ray().m_org,
+                    shading_point.get_ray().m_dir);
             }
 
             if (m_params.m_next_event_estimation)

--- a/src/appleseed/renderer/modeling/camera/orthographiccamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/orthographiccamera.cpp
@@ -81,6 +81,15 @@ namespace
             const ParamArray&       params)
           : Camera(name, params)
         {
+            // Extract the film dimensions from the camera parameters.
+            m_film_dimensions = extract_film_dimensions();
+
+            // Extract the abscissa of the near plane from the camera parameters.
+            m_near_z = extract_near_z();
+
+            // Precompute reciprocals of film dimensions.
+            m_rcp_film_width = 1.0 / m_film_dimensions[0];
+            m_rcp_film_height = 1.0 / m_film_dimensions[1];
         }
 
         void release() override
@@ -126,18 +135,8 @@ namespace
             if (!Camera::on_render_begin(project, parent, recorder, abort_switch))
                 return false;
 
-            // Extract the film dimensions from the camera parameters.
-            m_film_dimensions = extract_film_dimensions();
-
-            // Extract the abscissa of the near plane from the camera parameters.
-            m_near_z = extract_near_z();
-
             // Retrieve the scene diameter that will be used to position the camera.
             m_safe_scene_diameter = project.get_scene()->get_render_data().m_safe_diameter;
-
-            // Precompute reciprocals of film dimensions.
-            m_rcp_film_width = 1.0 / m_film_dimensions[0];
-            m_rcp_film_height = 1.0 / m_film_dimensions[1];
 
             // Precompute pixel area.
             const size_t pixel_count = project.get_frame()->image().properties().m_pixel_count;
@@ -291,6 +290,9 @@ namespace
                     0.5 + point.x * m_rcp_film_width,
                     0.5 - point.y * m_rcp_film_height);
         }
+
+      private:
+        bool m_extracted_params;
     };
 }
 

--- a/src/appleseed/renderer/modeling/camera/perspectivecamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/perspectivecamera.cpp
@@ -54,6 +54,18 @@ namespace renderer
 PerspectiveCamera::PerspectiveCamera(const char* name, const ParamArray& params)
   : Camera(name, params)
 {
+    // Extract the film dimensions from the camera parameters.
+    m_film_dimensions = extract_film_dimensions();
+
+    // Extract the focal length from the camera parameters.
+    m_focal_length = extract_focal_length(m_film_dimensions[0]);
+    // Extract the abscissa of the near plane from the camera parameters.
+    m_near_z = extract_near_z();
+    // Extract the shift from the camera parameters.
+    m_shift = extract_shift();
+    // Precompute reciprocals of film dimensions.
+    m_rcp_film_width = 1.0 / m_film_dimensions[0];
+    m_rcp_film_height = 1.0 / m_film_dimensions[1];
 }
 
 const foundation::Vector2d& PerspectiveCamera::get_film_dimensions() const
@@ -79,22 +91,6 @@ bool PerspectiveCamera::on_render_begin(
 {
     if (!Camera::on_render_begin(project, parent, recorder, abort_switch))
         return false;
-
-    // Extract the film dimensions from the camera parameters.
-    m_film_dimensions = extract_film_dimensions();
-
-    // Extract the focal length from the camera parameters.
-    m_focal_length = extract_focal_length(m_film_dimensions[0]);
-
-    // Extract the abscissa of the near plane from the camera parameters.
-    m_near_z = extract_near_z();
-
-    // Extract the shift from the camera parameters.
-    m_shift = extract_shift();
-
-    // Precompute reciprocals of film dimensions.
-    m_rcp_film_width = 1.0 / m_film_dimensions[0];
-    m_rcp_film_height = 1.0 / m_film_dimensions[1];
 
     // Precompute pixel area.
     const size_t pixel_count = project.get_frame()->image().properties().m_pixel_count;


### PR DESCRIPTION
* Fixes some ways to get into invalid states by going into and out of light path display toggle/base layer modes and restarting rendering
* No longer does a light path picking event when moving the camera in OpenGL view
* No longer does a light path picking event at all when in OpenGL view until I implement better filtering modes/scene space picking
* Dims the final render when you have at least one light path selected

To be implemented in this PR:
* Selected individual light paths are not drawn solo but rather the rest of the picked light paths have lower transparency.

=======

https://www.grayolson.me/blog/posts/gsoc-2019/