### PR TITLE
Allow Travis OSX build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,10 @@ matrix:
       compiler: gcc
       env: GCC_VERSION=7
 
+  allow_failures:
+      - os: osx
+        compiler: clang
+
   exclude:
     - os: osx
       compiler: gcc


### PR DESCRIPTION
The build is broken too frequently. Tracking random configuration and dependency version changes is just too time consuming for a platform we don't really support.
