### PR TITLE
Fix ScatteringMode bug

### DIFF
--- a/src/appleseed/renderer/kernel/lighting/scatteringmode.h
+++ b/src/appleseed/renderer/kernel/lighting/scatteringmode.h
@@ -113,7 +113,7 @@ inline bool ScatteringMode::has_diffuse_and_glossy(const int modes)
 
 inline bool ScatteringMode::has_diffuse_or_volume(const int modes)
 {
-    return (modes & (Diffuse | Volume)) == (Diffuse | Volume);
+    return (modes & (Diffuse | Volume)) != 0;
 }
 
 inline bool ScatteringMode::has_glossy_or_specular(const int modes)


### PR DESCRIPTION
ScatteringMode::has_diffuse_or_volume() would return true only when the
mode had both diffuse and volume. Fixed to return true when either mode
is present.