### PR TITLE
Remove using namespace std; from appleseed.python

### DIFF
--- a/src/appleseed.python/bindaov.cpp
+++ b/src/appleseed.python/bindaov.cpp
@@ -44,7 +44,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -59,8 +58,8 @@ namespace boost
 namespace
 {
     auto_release_ptr<AOV> create_aov(
-        const string&      model,
-        const bpy::dict&   params)
+        const std::string&    model,
+        const bpy::dict&      params)
     {
         AOVFactoryRegistrar factories;
         const IAOVFactory* factory = factories.lookup(model.c_str());

--- a/src/appleseed.python/bindassembly.cpp
+++ b/src/appleseed.python/bindassembly.cpp
@@ -46,7 +46,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -61,22 +60,22 @@ namespace boost
 
 namespace
 {
-    auto_release_ptr<Assembly> create_assembly(const string& name)
+    auto_release_ptr<Assembly> create_assembly(const std::string& name)
     {
         return AssemblyFactory().create(name.c_str(), ParamArray());
     }
 
     auto_release_ptr<Assembly> create_assembly_with_params(
-        const string&       name,
-        const bpy::dict&    params)
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         return AssemblyFactory().create(name.c_str(), bpy_dict_to_param_array(params));
     }
 
     auto_release_ptr<Assembly> create_assembly_with_model_and_params(
-        const string&       model,
-        const string&       name,
-        const bpy::dict&    params)
+        const std::string&    model,
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         AssemblyFactoryRegistrar factories;
         const IAssemblyFactory* factory = factories.lookup(model.c_str());
@@ -101,9 +100,9 @@ namespace
     }
 
     auto_release_ptr<AssemblyInstance> create_assembly_instance(
-        const string&       name,
-        const bpy::dict&    params,
-        const string&       assembly_name)
+        const std::string&    name,
+        const bpy::dict&      params,
+        const std::string&    assembly_name)
     {
         return
             AssemblyInstanceFactory::create(
@@ -122,7 +121,7 @@ namespace
         instance->transform_sequence() = seq;
     }
 
-    string get_assembly_name(AssemblyInstance* instance)
+    std::string get_assembly_name(AssemblyInstance* instance)
     {
         return instance->get_assembly_name();
     }

--- a/src/appleseed.python/bindbasis.cpp
+++ b/src/appleseed.python/bindbasis.cpp
@@ -37,7 +37,6 @@
 
 namespace bpy = boost::python;
 using namespace foundation;
-using namespace std;
 
 namespace
 {

--- a/src/appleseed.python/bindbsdf.cpp
+++ b/src/appleseed.python/bindbsdf.cpp
@@ -44,7 +44,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -59,9 +58,9 @@ namespace boost
 namespace
 {
     auto_release_ptr<BSDF> create_bsdf(
-        const string&    model,
-        const string&    name,
-        const bpy::dict& params)
+        const std::string&    model,
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         BSDFFactoryRegistrar factories;
         const IBSDFFactory* factory = factories.lookup(model.c_str());

--- a/src/appleseed.python/bindbssrdf.cpp
+++ b/src/appleseed.python/bindbssrdf.cpp
@@ -43,7 +43,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -58,9 +57,9 @@ namespace boost
 namespace
 {
     auto_release_ptr<BSSRDF> create_bssrdf(
-        const string&    model,
-        const string&    name,
-        const bpy::dict& params)
+        const std::string&    model,
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         BSSRDFFactoryRegistrar factories;
         const IBSSRDFFactory* factory = factories.lookup(model.c_str());

--- a/src/appleseed.python/bindcamera.cpp
+++ b/src/appleseed.python/bindcamera.cpp
@@ -45,7 +45,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -60,9 +59,9 @@ namespace boost
 namespace
 {
     auto_release_ptr<Camera> create_camera(
-        const string&       model,
-        const string&       name,
-        const bpy::dict&    params)
+        const std::string&    model,
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         CameraFactoryRegistrar factories;
         const ICameraFactory* factory = factories.lookup(model.c_str());
@@ -96,9 +95,9 @@ namespace
         camera->transform_sequence() = seq;
     }
 
-    shared_ptr<ProjectPoints> create_project_points(auto_release_ptr<Camera> camera, const Vector2u& resolution)
+    std::shared_ptr<ProjectPoints> create_project_points(auto_release_ptr<Camera> camera, const Vector2u& resolution)
     {
-        return make_shared<ProjectPoints>(camera, resolution);
+        return std::make_shared<ProjectPoints>(camera, resolution);
     }
 
     bpy::object project_point(const ProjectPoints* proj, const float time, const Vector3d& point)
@@ -146,7 +145,7 @@ void bind_camera()
     bpy::class_<CameraFactoryRegistrar, boost::noncopyable>("CameraFactoryRegistrar", bpy::no_init)
         .def("lookup", &CameraFactoryRegistrar::lookup, bpy::return_value_policy<bpy::reference_existing_object>());
 
-    bpy::class_<ProjectPoints, shared_ptr<ProjectPoints>, boost::noncopyable>("ProjectPoints", bpy::no_init)
+    bpy::class_<ProjectPoints, std::shared_ptr<ProjectPoints>, boost::noncopyable>("ProjectPoints", bpy::no_init)
         .def("__init__", bpy::make_constructor(create_project_points))
         .def("is_initialized", &ProjectPoints::is_initialized)
         .def("project_point", project_point)

--- a/src/appleseed.python/bindcurveobject.cpp
+++ b/src/appleseed.python/bindcurveobject.cpp
@@ -48,7 +48,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -61,8 +60,8 @@ namespace boost
 namespace
 {
     auto_release_ptr<CurveObject> create_curve_obj(
-        const string&       name,
-        const bpy::dict&    params)
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         return
             auto_release_ptr<CurveObject>(
@@ -72,9 +71,9 @@ namespace
     }
 
     auto_release_ptr<CurveObject> read_curve_object(
-        const bpy::list&    search_paths,
-        const string&       object_name,
-        const bpy::dict&    params)
+        const bpy::list&      search_paths,
+        const std::string&    object_name,
+        const bpy::dict&      params)
     {
         SearchPaths paths;
 
@@ -103,8 +102,8 @@ namespace
     }
 
     bool write_curve_object(
-        const CurveObject*   object,
-        const string&        filename)
+        const CurveObject*    object,
+        const std::string&    filename)
     {
         return CurveObjectWriter::write(*object, filename.c_str());
     }

--- a/src/appleseed.python/bindedf.cpp
+++ b/src/appleseed.python/bindedf.cpp
@@ -41,7 +41,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -56,9 +55,9 @@ namespace boost
 namespace
 {
     auto_release_ptr<EDF> create_edf(
-        const string&      model,
-        const string&      name,
-        const bpy::dict&   params)
+        const std::string&    model,
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         EDFFactoryRegistrar factories;
         const IEDFFactory* factory = factories.lookup(model.c_str());

--- a/src/appleseed.python/bindentity.cpp
+++ b/src/appleseed.python/bindentity.cpp
@@ -49,7 +49,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900

--- a/src/appleseed.python/bindenvironment.cpp
+++ b/src/appleseed.python/bindenvironment.cpp
@@ -43,7 +43,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -61,9 +60,9 @@ namespace boost
 namespace
 {
     auto_release_ptr<EnvironmentEDF> create_environment_edf(
-        const string&       model,
-        const string&       name,
-        const bpy::dict&    params)
+        const std::string&    model,
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         EnvironmentEDFFactoryRegistrar factories;
         const IEnvironmentEDFFactory* factory = factories.lookup(model.c_str());
@@ -98,9 +97,9 @@ namespace
     }
 
     auto_release_ptr<EnvironmentShader> create_environment_shader(
-        const string&       env_shader_type,
-        const string&       name,
-        const bpy::dict&    params)
+        const std::string&    env_shader_type,
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         EnvironmentShaderFactoryRegistrar factories;
         const IEnvironmentShaderFactory* factory = factories.lookup(env_shader_type.c_str());
@@ -117,8 +116,8 @@ namespace
     }
 
     auto_release_ptr<Environment> create_environment(
-        const string&       name,
-        const bpy::dict&    params)
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         return EnvironmentFactory::create(name.c_str(), bpy_dict_to_param_array(params));
     }

--- a/src/appleseed.python/bindframe.cpp
+++ b/src/appleseed.python/bindframe.cpp
@@ -43,7 +43,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -57,16 +56,16 @@ namespace boost
 namespace
 {
     auto_release_ptr<Frame> create_frame(
-        const string&       name,
-        const bpy::dict&    params)
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         return FrameFactory::create(name.c_str(), bpy_dict_to_param_array(params));
     }
 
     auto_release_ptr<Frame> create_frame_with_aovs(
-        const string&       name,
-        const bpy::dict&    params,
-        const AOVContainer& aovs)
+        const std::string&    name,
+        const bpy::dict&      params,
+        const AOVContainer&   aovs)
     {
         return FrameFactory::create(name.c_str(), bpy_dict_to_param_array(params), aovs);
     }

--- a/src/appleseed.python/bindlight.cpp
+++ b/src/appleseed.python/bindlight.cpp
@@ -42,7 +42,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -57,9 +56,9 @@ namespace boost
 namespace
 {
     auto_release_ptr<Light> create_light(
-        const string&      model,
-        const string&      name,
-        const bpy::dict&   params)
+        const std::string&    model,
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         LightFactoryRegistrar factories;
         const ILightFactory* factory = factories.lookup(model.c_str());

--- a/src/appleseed.python/bindmaterial.cpp
+++ b/src/appleseed.python/bindmaterial.cpp
@@ -44,7 +44,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -59,9 +58,9 @@ namespace boost
 namespace
 {
     auto_release_ptr<Material> create_material(
-        const string&       model,
-        const string&       name,
-        const bpy::dict&    params)
+        const std::string&    model,
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         MaterialFactoryRegistrar factories;
         const IMaterialFactory* factory = factories.lookup(model.c_str());

--- a/src/appleseed.python/bindmatrix.cpp
+++ b/src/appleseed.python/bindmatrix.cpp
@@ -39,7 +39,6 @@
 
 namespace bpy = boost::python;
 using namespace foundation;
-using namespace std;
 
 namespace
 {
@@ -52,7 +51,7 @@ namespace
             bpy::throw_error_already_set();
         }
 
-        unique_ptr<UnalignedMatrix44<T>> r(new UnalignedMatrix44<T>());
+        std::unique_ptr<UnalignedMatrix44<T>> r(new UnalignedMatrix44<T>());
 
         for (size_t i = 0; i < 4 * 4; ++i)
         {

--- a/src/appleseed.python/bindmeshobject.cpp
+++ b/src/appleseed.python/bindmeshobject.cpp
@@ -46,7 +46,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -59,8 +58,8 @@ namespace boost
 namespace
 {
     auto_release_ptr<MeshObject> create_mesh_obj(
-        const string&       name,
-        const bpy::dict&    params)
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         return
             auto_release_ptr<MeshObject>(
@@ -78,9 +77,9 @@ namespace
     }
 
     bpy::list read_mesh_objects(
-        const bpy::list&    search_paths,
-        const string&       base_object_name,
-        const bpy::dict&    params)
+        const bpy::list&      search_paths,
+        const std::string&    base_object_name,
+        const bpy::dict&      params)
     {
         SearchPaths paths;
 
@@ -118,16 +117,16 @@ namespace
     }
 
     bool write_mesh_object(
-        const MeshObject*   object,
-        const string&       object_name,
-        const string&       filename)
+        const MeshObject*     object,
+        const std::string&    object_name,
+        const std::string&    filename)
     {
         return MeshObjectWriter::write(*object, object_name.c_str(), filename.c_str());
     }
 
     auto_release_ptr<MeshObject> create_mesh_prim(
-        const string&       name,
-        const bpy::dict&    params)
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         return create_primitive_mesh(name.c_str(), bpy_dict_to_param_array(params));
     }

--- a/src/appleseed.python/bindobject.cpp
+++ b/src/appleseed.python/bindobject.cpp
@@ -44,7 +44,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -68,9 +67,9 @@ namespace
     }
 
     auto_release_ptr<Object> create_object(
-        const string&    model,
-        const string&    name,
-        const bpy::dict& params)
+        const std::string&    model,
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         const ObjectFactoryRegistrar factories;
         const IObjectFactory* factory = factories.lookup(model.c_str());
@@ -97,9 +96,9 @@ namespace
     }
 
     auto_release_ptr<ObjectInstance> create_obj_instance_with_back_mat(
-        const string&                   name,
+        const std::string&              name,
         const bpy::dict&                params,
-        const string&                   object_name,
+        const std::string&              object_name,
         const UnalignedTransformd&      transform,
         const bpy::dict&                front_material_mappings,
         const bpy::dict&                back_material_mappings)
@@ -115,9 +114,9 @@ namespace
     }
 
     auto_release_ptr<ObjectInstance> create_obj_instance(
-        const string&                   name,
+        const std::string&              name,
         const bpy::dict&                params,
-        const string&                   object_name,
+        const std::string&              object_name,
         const UnalignedTransformd&      transform,
         const bpy::dict&                front_material_mappings)
     {
@@ -136,7 +135,7 @@ namespace
         return UnalignedTransformd(obj->get_transform());
     }
 
-    string obj_inst_get_obj_name(const ObjectInstance* obj)
+    std::string obj_inst_get_obj_name(const ObjectInstance* obj)
     {
         return obj->get_object_name();
     }

--- a/src/appleseed.python/bindpostprocessingstage.cpp
+++ b/src/appleseed.python/bindpostprocessingstage.cpp
@@ -43,7 +43,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -58,9 +57,9 @@ namespace boost
 namespace
 {
     auto_release_ptr<PostProcessingStage> create_post_processing_stage(
-        const string&    model,
-        const string&    name,
-        const bpy::dict& params)
+        const std::string&    model,
+        const std::string&    name,
+        const bpy::dict&      params)
     {
         PostProcessingStageFactoryRegistrar factories;
         const IPostProcessingStageFactory* factory = factories.lookup(model.c_str());

--- a/src/appleseed.python/bindproject.cpp
+++ b/src/appleseed.python/bindproject.cpp
@@ -63,7 +63,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -76,7 +75,7 @@ namespace boost
 
 namespace
 {
-    auto_release_ptr<Project> create_project(const string& name)
+    auto_release_ptr<Project> create_project(const std::string& name)
     {
         return ProjectFactory::create(name.c_str());
     }
@@ -160,13 +159,13 @@ namespace
         return ProjectFileWriter::write(*project, filepath, opts, extra_comments);
     }
 
-    auto_release_ptr<Configuration> create_config(const string& name)
+    auto_release_ptr<Configuration> create_config(const std::string& name)
     {
         return ConfigurationFactory::create(name.c_str());
     }
 
     auto_release_ptr<Configuration> create_config_with_params(
-        const string&                       name,
+        const std::string&                  name,
         const bpy::dict&                    params)
     {
         return ConfigurationFactory::create(name.c_str(), bpy_dict_to_param_array(params));
@@ -282,10 +281,10 @@ namespace
         return bpy::object(project);
     }
 
-    string qualify_path(const Project* project, const char* filepath)
+    std::string qualify_path(const Project* project, const char* filepath)
     {
         const SearchPaths& search_paths = project->search_paths();
-        return string(search_paths.qualify(filepath).c_str());
+        return std::string(search_paths.qualify(filepath).c_str());
     }
 }
 

--- a/src/appleseed.python/bindshadercompiler.cpp
+++ b/src/appleseed.python/bindshadercompiler.cpp
@@ -43,7 +43,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 namespace
 {
@@ -52,7 +51,7 @@ namespace
         return ShaderCompilerFactory::create(stdosl_path);
     }
 
-    bpy::object compile_buffer(const ShaderCompiler* compiler, const string& buffer)
+    bpy::object compile_buffer(const ShaderCompiler* compiler, const std::string& buffer)
     {
         APIString result;
 

--- a/src/appleseed.python/bindshadergroup.cpp
+++ b/src/appleseed.python/bindshadergroup.cpp
@@ -46,7 +46,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -58,28 +57,28 @@ namespace boost
 
 namespace
 {
-    auto_release_ptr<ShaderGroup> create_shader_group(const string& name)
+    auto_release_ptr<ShaderGroup> create_shader_group(const std::string& name)
     {
         return ShaderGroupFactory::create(name.c_str());
     }
 
     void add_shader(
-        ShaderGroup*   sg,
-        const string&  type,
-        const string&  name,
-        const string&  layer,
-        bpy::dict      params)
+        ShaderGroup*        sg,
+        const std::string&  type,
+        const std::string&  name,
+        const std::string&  layer,
+        bpy::dict           params)
     {
         sg->add_shader(type.c_str(), name.c_str(), layer.c_str(), bpy_dict_to_param_array(params));
     }
 
     void add_source_shader(
-        ShaderGroup*   sg,
-        const string&  type,
-        const string&  name,
-        const string&  layer,
-        const string&  source,
-        bpy::dict      params)
+        ShaderGroup*        sg,
+        const std::string&  type,
+        const std::string&  name,
+        const std::string&  layer,
+        const std::string&  source,
+        bpy::dict           params)
     {
         sg->add_source_shader(type.c_str(), name.c_str(), layer.c_str(), source.c_str(), bpy_dict_to_param_array(params));
     }

--- a/src/appleseed.python/bindshaderquery.cpp
+++ b/src/appleseed.python/bindshaderquery.cpp
@@ -45,7 +45,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 namespace
 {
@@ -91,12 +90,12 @@ namespace
             return m_shader_query->open_bytecode(shader_code);
         }
 
-        string get_shader_name() const
+        std::string get_shader_name() const
         {
             return m_shader_query->get_shader_name();
         }
 
-        string get_shader_type() const
+        std::string get_shader_type() const
         {
             return m_shader_query->get_shader_type();
         }

--- a/src/appleseed.python/bindsurfaceshader.cpp
+++ b/src/appleseed.python/bindsurfaceshader.cpp
@@ -41,7 +41,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -56,8 +55,8 @@ namespace boost
 namespace
 {
     auto_release_ptr<SurfaceShader> create_surface_shader(
-        const string& model,
-        const string& name)
+        const std::string& model,
+        const std::string& name)
     {
         SurfaceShaderFactoryRegistrar factories;
         const ISurfaceShaderFactory* factory = factories.lookup(model.c_str());
@@ -74,9 +73,9 @@ namespace
     }
 
     auto_release_ptr<SurfaceShader> create_surface_shader_with_params(
-        const string&        model,
-        const string&        name,
-        const bpy::dict&     params)
+        const std::string&     model,
+        const std::string&     name,
+        const bpy::dict&       params)
     {
         SurfaceShaderFactoryRegistrar factories;
         const ISurfaceShaderFactory* factory = factories.lookup(model.c_str());

--- a/src/appleseed.python/bindtexture.cpp
+++ b/src/appleseed.python/bindtexture.cpp
@@ -44,7 +44,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -77,8 +76,8 @@ namespace
     }
 
     auto_release_ptr<Texture> create_texture(
-        const string&              model,
-        const string&              name,
+        const std::string&         model,
+        const std::string&         name,
         const bpy::dict&           params,
         const bpy::list&           search_paths)
     {
@@ -114,9 +113,9 @@ namespace
     }
 
     auto_release_ptr<TextureInstance> create_texture_instance(
-        const string&                   name,
+        const std::string&                   name,
         const bpy::dict&                params,
-        const string&                   texture_name,
+        const std::string&                   texture_name,
         const UnalignedTransformf&      transform)
     {
         return
@@ -132,7 +131,7 @@ namespace
         return UnalignedTransformf(tx->get_transform());
     }
 
-    string texture_inst_get_texture_name(const TextureInstance* tx)
+    std::string texture_inst_get_texture_name(const TextureInstance* tx)
     {
         return tx->get_texture_name();
     }

--- a/src/appleseed.python/bindutility.cpp
+++ b/src/appleseed.python/bindutility.cpp
@@ -42,16 +42,15 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 namespace
 {
 
 void make_texture(
-    const string&   in_filename,
-    const string&   out_filename,
-    const string&   in_colorspace,
-    const string&   out_depth)
+    const std::string&   in_filename,
+    const std::string&   out_filename,
+    const std::string&   in_colorspace,
+    const std::string&   out_depth)
 {
     APIString error_msg;
     const bool success = oiio_make_texture(

--- a/src/appleseed.python/bindvector.cpp
+++ b/src/appleseed.python/bindvector.cpp
@@ -39,7 +39,6 @@
 
 namespace bpy = boost::python;
 using namespace foundation;
-using namespace std;
 
 namespace
 {
@@ -52,7 +51,7 @@ namespace
             bpy::throw_error_already_set();
         }
 
-        unique_ptr<Vector<T, N>> r(new Vector<T, N>());
+        std::unique_ptr<Vector<T, N>> r(new Vector<T, N>());
 
         for (size_t i = 0; i < N; ++i)
         {

--- a/src/appleseed.python/bindvolume.cpp
+++ b/src/appleseed.python/bindvolume.cpp
@@ -43,7 +43,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 // Work around a regression in Visual Studio 2015 Update 3.
 #if defined(_MSC_VER) && _MSC_VER == 1900
@@ -58,8 +57,8 @@ namespace boost
 namespace
 {
     auto_release_ptr<Volume> create_volume(
-        const string&    model,
-        const string&    name,
+        const std::string&    model,
+        const std::string&    name,
         const bpy::dict& params)
     {
         VolumeFactoryRegistrar factories;

--- a/src/appleseed.python/dict2dict.cpp
+++ b/src/appleseed.python/dict2dict.cpp
@@ -44,7 +44,6 @@
 namespace bpy = boost::python;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 namespace
 {
@@ -202,7 +201,7 @@ namespace
         return result;
     }
 
-    bpy::object obj_from_string(const string& str)
+    bpy::object obj_from_string(const std::string& str)
     {
         // Try to guess the type of the value represented by str.
 


### PR DESCRIPTION
This PR part of a series.
Fixes Issue#2641 for appleseed.python.
I tried to keep the formatting up and also to detect all missing `std::`s, which are in Windows/macOS-only code.