### PR TITLE
Remove 'using namespace std' from appleseed/renderer/modeling

### DIFF
--- a/src/appleseed/renderer/modeling/aov/albedoaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/albedoaov.cpp
@@ -47,7 +47,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/aov/cryptomatteaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/cryptomatteaov.cpp
@@ -81,7 +81,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace
@@ -98,7 +97,7 @@ namespace
 
             if (m_writer == nullptr)
             {
-                const string msg = OIIO::geterror();
+                const std::string msg = OIIO::geterror();
                 throw ExceptionIOError(msg.c_str());
             }
 
@@ -122,7 +121,7 @@ namespace
 
             if (!m_writer->open(m_filename, m_spec))
             {
-                const string msg = m_writer->geterror();
+                const std::string msg = m_writer->geterror();
                 throw ExceptionIOError(msg.c_str());
             }
 
@@ -135,8 +134,8 @@ namespace
             for (const auto& attribute : image_attributes)
             {
                 // Fetch the name and the value of the attribute.
-                const string attr_name = attribute.key();
-                const string attr_value = attribute.value<string>();
+                const std::string attr_name = attribute.key();
+                const std::string attr_value = attribute.value<std::string>();
 
                 if (attr_name == "software")
                     m_spec.attribute("Software", attr_value.c_str());
@@ -164,7 +163,7 @@ namespace
 
         void set_image_channels(
             const size_t            channel_count,
-            const vector<string>&   channel_names)
+            const std::vector<std::string>&   channel_names)
         {
             m_spec.nchannels = static_cast<int>(channel_count);
 
@@ -178,7 +177,7 @@ namespace
         const ICanvas*                      m_canvas;
         OIIO::ImageSpec                     m_spec;
 #if OIIO_VERSION >= 20000
-        unique_ptr<OIIO::ImageOutput>       m_writer;
+        std::unique_ptr<OIIO::ImageOutput>  m_writer;
 #else
         OIIO::ImageOutput*                  m_writer;
 #endif
@@ -189,7 +188,7 @@ namespace
             // Close the image file.
             if (!m_writer->close())
             {
-                const string msg = m_writer->geterror();
+                const std::string msg = m_writer->geterror();
                 throw ExceptionIOError(msg.c_str());
             }
         }
@@ -258,7 +257,7 @@ namespace
                             xstride,
                             ystride))
                     {
-                        const string msg = m_writer->geterror();
+                        const std::string msg = m_writer->geterror();
                         close_file();
                         throw ExceptionIOError(msg.c_str());
                     }
@@ -403,7 +402,7 @@ namespace renderer
 namespace
 {
 
-    typedef map<uint32, string> NameMap;
+    typedef std::map<uint32, std::string> NameMap;
 
 
     //
@@ -416,7 +415,7 @@ namespace
       public:
         CryptomatteAOVAccumulator(
             Image&                              aov_image,
-            vector<WeightMap>&                  pixel_samples,
+            std::vector<WeightMap>&             pixel_samples,
             NameMap*                            tile_name_array,
             size_t                              num_layers,
             CryptomatteAOV::CryptomatteType     layer_type)
@@ -464,9 +463,9 @@ namespace
             const size_t                tile_x,
             const size_t                tile_y) override
         {
-            vector<pair<float, uint32>> ranked_vector;
-            vector<float> pixel_values;
-            const float uint32_max_rcp = 1.0f / numeric_limits<uint32>::max();
+            std::vector<std::pair<float, uint32>> ranked_vector;
+            std::vector<float> pixel_values;
+            const float uint32_max_rcp = 1.0f / std::numeric_limits<uint32>::max();
 
             for (size_t ry = m_tile_origin_y; ry <= m_tile_end_y; ++ry)
             {
@@ -487,10 +486,10 @@ namespace
                             total_weight = 1.0f;
 
                         for (const auto& item : weight_map)
-                            ranked_vector.push_back(make_pair(item.value, item.key));
+                            ranked_vector.push_back(std::make_pair(item.value, item.key));
 
                         sort(ranked_vector.begin(), ranked_vector.end(),
-                            [](pair<float, uint32> const& a, pair<float, uint32> const& b)
+                            [](std::pair<float, uint32> const& a, std::pair<float, uint32> const& b)
                             {
                                 return a.first > b.first;
                             });
@@ -568,7 +567,7 @@ namespace
             ShadingResult&              shading_result) override
         {
             uint32 m3hash = 0;
-            string obj_name;
+            std::string obj_name;
 
             if (shading_point.hit_surface())
             {
@@ -620,7 +619,7 @@ namespace
         AABB2u                          m_crop_window;
         Image&                          m_aov_image;
         size_t                          m_num_layers;
-        vector<WeightMap>&              m_pixel_samples;
+        std::vector<WeightMap>&         m_pixel_samples;
         NameMap*                        m_tile_name_array;
         CryptomatteAOV::CryptomatteType m_layer_type;
     };
@@ -636,9 +635,9 @@ namespace
 
 struct CryptomatteAOV::Impl
 {
-    vector<WeightMap>                   m_pixel_samples;
+    std::vector<WeightMap>              m_pixel_samples;
     NameMap*                            m_tile_name_array;
-    unique_ptr<Image>                   m_image;
+    std::unique_ptr<Image>              m_image;
     size_t                              m_num_layers;
     CryptomatteAOV::CryptomatteType     m_layer_type;
 
@@ -652,7 +651,7 @@ CryptomatteAOV::CryptomatteAOV(const ParamArray& params)
   : AOV("cryptomatte", params)
   , impl(new Impl())
 {
-    const string cryptomatte_type = params.get_optional<string>("cryptomatte_type", "object_names", make_vector("object_names" , "material_names"));
+    const std::string cryptomatte_type = params.get_optional<std::string>("cryptomatte_type", "object_names", make_vector("object_names" , "material_names"));
 
     if (cryptomatte_type == "object_names")
     {
@@ -733,7 +732,7 @@ void CryptomatteAOV::clear_image()
     const auto& image_props = impl->m_image->properties();
 
     const size_t num_channels = (impl->m_num_layers * 2) + 3;
-    const vector<float> pixel_values(num_channels, 0.0f);
+    const std::vector<float> pixel_values(num_channels, 0.0f);
     for (size_t ry = 0, ey = image_props.m_canvas_height; ry < ey; ++ry)
     {
         for (size_t rx = 0, ex = image_props.m_canvas_width; rx < ex; ++rx)
@@ -761,13 +760,13 @@ bool CryptomatteAOV::write_images(
 {
     const bf::path boost_file_path(file_path);
     const bf::path directory = boost_file_path.parent_path();
-    const string base_file_name = boost_file_path.stem().string();
-    const string extension = boost_file_path.extension().string();
+    const std::string base_file_name = boost_file_path.stem().string();
+    const std::string extension = boost_file_path.extension().string();
 
-    const string exr_file_name = base_file_name + ".cryptomatte" + extension;
-    const string exr_file_path = (directory / exr_file_name).string();
+    const std::string exr_file_name = base_file_name + ".cryptomatte" + extension;
+    const std::string exr_file_path = (directory / exr_file_name).string();
 
-    string layer_name;
+    std::string layer_name;
 
     switch (impl->m_layer_type)
     {
@@ -791,8 +790,8 @@ bool CryptomatteAOV::write_images(
     ImageAttributes image_attributes_copy(image_attributes);
     image_attributes_copy.insert("color_space", "linear");
 
-    string layer_prefix("cryptomatte/");
-    layer_prefix.append(string(type_name_hex).erase(7));
+    std::string layer_prefix("cryptomatte/");
+    layer_prefix.append(std::string(type_name_hex).erase(7));
     image_attributes_copy.insert(layer_prefix + "/conversion", "uint32_to_float32");
     image_attributes_copy.insert(layer_prefix + "/hash", "MurmurHash3_32");
     image_attributes_copy.insert(layer_prefix + "/name", layer_name);
@@ -811,7 +810,7 @@ bool CryptomatteAOV::write_images(
         }
     }
 
-    stringstream manifest_str;
+    std::stringstream manifest_str;
     manifest_str << "{";
 
     for (const auto& hash : name_map)
@@ -829,7 +828,7 @@ bool CryptomatteAOV::write_images(
     image_attributes_copy.insert(layer_prefix + "/manifest", manifest_str.str());
 
     const size_t num_channels = (impl->m_num_layers * 2) + 3;
-    vector<string> channel_names;
+    std::vector<std::string> channel_names;
     channel_names.reserve(num_channels);
     channel_names.push_back("R");
     channel_names.push_back("G");
@@ -838,7 +837,7 @@ bool CryptomatteAOV::write_images(
     const size_t num_exr_layers = truncate<size_t>(ceil(impl->m_num_layers / 2.0));
     for (size_t i = 0; i < num_exr_layers; ++i)
     {
-        const string layer_number = get_numbered_string("##", i);
+        const std::string layer_number = get_numbered_string("##", i);
         channel_names.push_back(format("{0}{1}.R", layer_name, layer_number));
         channel_names.push_back(format("{0}{1}.G", layer_name, layer_number));
         channel_names.push_back(format("{0}{1}.B", layer_name, layer_number));
@@ -854,7 +853,7 @@ bool CryptomatteAOV::write_images(
         writer.set_image_attributes(image_attributes_copy);
         writer.write();
     }
-    catch (const exception& e)
+    catch (const std::exception& e)
     {
         RENDERER_LOG_ERROR(
             "failed to write cryptomatte file %s: %s.",

--- a/src/appleseed/renderer/modeling/aov/cryptomatteaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/cryptomatteaov.cpp
@@ -162,7 +162,7 @@ namespace
         }
 
         void set_image_channels(
-            const size_t            channel_count,
+            const size_t                      channel_count,
             const std::vector<std::string>&   channel_names)
         {
             m_spec.nchannels = static_cast<int>(channel_count);
@@ -566,7 +566,7 @@ namespace
             const AOVComponents&        aov_components,
             ShadingResult&              shading_result) override
         {
-            uint32 m3hash = 0;
+            uint32      m3hash = 0;
             std::string obj_name;
 
             if (shading_point.hit_surface())

--- a/src/appleseed/renderer/modeling/aov/denoiseraov.cpp
+++ b/src/appleseed/renderer/modeling/aov/denoiseraov.cpp
@@ -62,7 +62,6 @@
 
 using namespace bcd;
 using namespace foundation;
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace renderer
@@ -477,8 +476,8 @@ bool DenoiserAOV::write_images(
 
     const bf::path boost_file_path(file_path);
     const bf::path directory = boost_file_path.parent_path();
-    const string base_file_name = boost_file_path.stem().string();
-    const string extension = boost_file_path.extension().string();
+    const std::string base_file_name = boost_file_path.stem().string();
+    const std::string extension = boost_file_path.extension().string();
 
     bool success = true;
 
@@ -486,8 +485,8 @@ bool DenoiserAOV::write_images(
 
     // Write histograms.
     stopwatch.start();
-    const string hist_file_name = base_file_name + ".hist" + extension;
-    const string hist_file_path = (directory / hist_file_name).string();
+    const std::string hist_file_name = base_file_name + ".hist" + extension;
+    const std::string hist_file_path = (directory / hist_file_name).string();
     if (ImageIO::writeMultiChannelsEXR(histograms_image(), hist_file_path.c_str()))
     {
         stopwatch.measure();
@@ -512,8 +511,8 @@ bool DenoiserAOV::write_images(
 
     // Write covariances image.
     stopwatch.start();
-    const string cov_file_name = base_file_name + ".cov" + extension;
-    const string cov_file_path = (directory / cov_file_name).string();
+    const std::string cov_file_name = base_file_name + ".cov" + extension;
+    const std::string cov_file_path = (directory / cov_file_name).string();
     if (ImageIO::writeMultiChannelsEXR(covariances_image, cov_file_path.c_str()))
     {
         stopwatch.measure();

--- a/src/appleseed/renderer/modeling/aov/depthaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/depthaov.cpp
@@ -52,7 +52,6 @@
 #include <utility>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
@@ -47,7 +47,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/aov/emissionaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/emissionaov.cpp
@@ -47,7 +47,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/aov/glossyaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/glossyaov.cpp
@@ -46,7 +46,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/aov/invalidsamplesaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/invalidsamplesaov.cpp
@@ -51,7 +51,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/aov/normalaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/normalaov.cpp
@@ -48,7 +48,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/aov/npraovs.cpp
+++ b/src/appleseed/renderer/modeling/aov/npraovs.cpp
@@ -47,7 +47,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
+++ b/src/appleseed/renderer/modeling/aov/pixelerroraov.cpp
@@ -50,7 +50,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/aov/pixelsamplecountaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/pixelsamplecountaov.cpp
@@ -48,7 +48,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/aov/pixeltimeaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/pixeltimeaov.cpp
@@ -54,7 +54,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/aov/pixelvariationaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/pixelvariationaov.cpp
@@ -51,7 +51,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/aov/positionaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/positionaov.cpp
@@ -48,7 +48,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/aov/screenspacevelocityaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/screenspacevelocityaov.cpp
@@ -50,7 +50,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/aov/uvaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/uvaov.cpp
@@ -48,7 +48,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/ashikhminbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/ashikhminbrdf.cpp
@@ -56,7 +56,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/blinnbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/blinnbrdf.cpp
@@ -64,7 +64,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/bsdfblend.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfblend.cpp
@@ -61,7 +61,6 @@ namespace renderer      { class Project; }
 namespace renderer      { class ShadingPoint; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -114,13 +113,13 @@ namespace
             if (m_bsdf[0] == nullptr)
             {
                 RENDERER_LOG_ERROR("while preparing bsdf \"%s\": cannot find bsdf \"%s\".",
-                    get_path().c_str(), m_params.get_optional<string>("bsdf0", "").c_str());
+                    get_path().c_str(), m_params.get_optional<std::string>("bsdf0", "").c_str());
             }
 
             if (m_bsdf[1] == nullptr)
             {
                 RENDERER_LOG_ERROR("while preparing bsdf \"%s\": cannot find bsdf \"%s\".",
-                    get_path().c_str(), m_params.get_optional<string>("bsdf1", "").c_str());
+                    get_path().c_str(), m_params.get_optional<std::string>("bsdf1", "").c_str());
             }
 
             if (m_bsdf[0] == nullptr || m_bsdf[1] == nullptr)

--- a/src/appleseed/renderer/modeling/bsdf/bsdfmix.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfmix.cpp
@@ -61,7 +61,6 @@ namespace renderer      { class Project; }
 namespace renderer      { class ShadingPoint; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -115,13 +114,13 @@ namespace
             if (m_bsdf[0] == nullptr)
             {
                 RENDERER_LOG_ERROR("while preparing bsdf \"%s\": cannot find bsdf \"%s\".",
-                    get_path().c_str(), m_params.get_optional<string>("bsdf0", "").c_str());
+                    get_path().c_str(), m_params.get_optional<std::string>("bsdf0", "").c_str());
             }
 
             if (m_bsdf[1] == nullptr)
             {
                 RENDERER_LOG_ERROR("while preparing bsdf \"%s\": cannot find bsdf \"%s\".",
-                    get_path().c_str(), m_params.get_optional<string>("bsdf1", "").c_str());
+                    get_path().c_str(), m_params.get_optional<std::string>("bsdf1", "").c_str());
             }
 
             if (m_bsdf[0] == nullptr || m_bsdf[1] == nullptr)

--- a/src/appleseed/renderer/modeling/bsdf/bsdfsample.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfsample.cpp
@@ -35,7 +35,6 @@
 #include <cmath>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/diffusebtdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/diffusebtdf.cpp
@@ -52,7 +52,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
@@ -60,7 +60,6 @@ namespace renderer      { class Project; }
 namespace renderer      { class ShadingPoint; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/disneylayeredbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/disneylayeredbrdf.cpp
@@ -48,7 +48,6 @@
 #include <cstring>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/energycompensation.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/energycompensation.cpp
@@ -46,7 +46,6 @@
 #include <iomanip>
 
 using namespace foundation;
-using namespace std;
 
 namespace bfs = boost::filesystem;
 
@@ -68,11 +67,11 @@ namespace
         assert(array_size % num_columns == 0);
 
         bfs::ofstream of(filename);
-        of << setprecision(6) << fixed;
+        of << std::setprecision(6) << std::fixed;
 
-        of << "extern const float " << array_name << "[" << array_size << "] = " << endl;
-        of << "{" << endl;
-        of << "    // Directional albedo." << endl;
+        of << "extern const float " << array_name << "[" << array_size << "] = " << std::endl;
+        of << "{" << std::endl;
+        of << "    // Directional albedo." << std::endl;
 
         size_t i = 0;
         const float* p = dir_table;
@@ -87,10 +86,10 @@ namespace
                 ++i;
             }
 
-            of << endl;
+            of << std::endl;
         }
 
-        of << "    // Average albedo." << endl;
+        of << "    // Average albedo." << std::endl;
 
         i = 0;
         p = avg_table;
@@ -108,10 +107,10 @@ namespace
                 ++i;
             }
 
-            of << endl;
+            of << std::endl;
         }
 
-        of << "};" << endl;
+        of << "};" << std::endl;
     }
 }
 
@@ -163,8 +162,8 @@ float AlbedoTable2D::get_directional_albedo(const float cos_theta, const float r
     const float s = floor_frac(x, i);
     const float t = floor_frac(y, j);
 
-    const size_t i1 = min(i + 1, TableSize - 1);
-    const size_t j1 = min(j + 1, TableSize - 1);
+    const size_t i1 = std::min(i + 1, TableSize - 1);
+    const size_t j1 = std::min(j + 1, TableSize - 1);
 
     // Fetch the values.
     const float a = dir_table(i , j );
@@ -186,7 +185,7 @@ float AlbedoTable2D::get_average_albedo(const float roughness) const
 
     size_t i;
     const float t = floor_frac(x, i);
-    const size_t i1 = min(i + 1, TableSize - 1);
+    const size_t i1 = std::min(i + 1, TableSize - 1);
 
     // Fetch the values.
     const float a = avg_table(i );
@@ -319,9 +318,9 @@ float AlbedoTable3D::get_directional_albedo(const float eta, const float roughne
     const float t = floor_frac(y, iy);
     const float u = floor_frac(z, iz);
 
-    const size_t ix1 = min(ix + 1, TableSize - 1);
-    const size_t iy1 = min(iy + 1, TableSize - 1);
-    const size_t iz1 = min(iz + 1, TableSize - 1);
+    const size_t ix1 = std::min(ix + 1, TableSize - 1);
+    const size_t iy1 = std::min(iy + 1, TableSize - 1);
+    const size_t iz1 = std::min(iz + 1, TableSize - 1);
 
     // Fetch the values.
     const float a = dir_table(ix , iy , iz);
@@ -355,8 +354,8 @@ float AlbedoTable3D::get_average_albedo(const float eta, const float roughness) 
     const float s = floor_frac(x, ix);
     const float t = floor_frac(y, iy);
 
-    const size_t ix1 = min(ix + 1, TableSize - 1);
-    const size_t iy1 = min(iy + 1, TableSize - 1);
+    const size_t ix1 = std::min(ix + 1, TableSize - 1);
+    const size_t iy1 = std::min(iy + 1, TableSize - 1);
 
     // Fetch the values.
     const float a = avg_table(ix , iy );
@@ -485,7 +484,7 @@ float average_albedo(
     }
 
     avg /= table_size;
-    return min(2.0f * avg, 1.0f);
+    return std::min(2.0f * avg, 1.0f);
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
@@ -69,7 +69,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace bfs = boost::filesystem;
 
@@ -194,8 +193,8 @@ namespace
 
             const OnFrameBeginMessageContext context("bsdf", this);
 
-            const string volume_parameterization =
-                m_params.get_required<string>(
+            const std::string volume_parameterization =
+                m_params.get_required<std::string>(
                     "volume_parameterization",
                     "transmittance",
                     make_vector("transmittance", "absorption"),

--- a/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
@@ -65,7 +65,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.cpp
@@ -68,7 +68,6 @@
 namespace foundation    { class IAbortSwitch; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -513,27 +512,27 @@ namespace
       private:
         APPLESEED_DECLARE_INPUT_VALUES(InputValues)
         {
-            Spectrum            m_rm;                           // matte reflectance of the substrate
-            float               m_rm_multiplier;                // matte reflectance multiplier
-            Spectrum            m_rs;                           // specular reflectance at normal incidence
-            float               m_rs_multiplier;                // specular reflectance multiplier
-            float               m_roughness;                    // technically, root-mean-square of the microfacets slopes
+            Spectrum                 m_rm;                           // matte reflectance of the substrate
+            float                    m_rm_multiplier;                // matte reflectance multiplier
+            Spectrum                 m_rs;                           // specular reflectance at normal incidence
+            float                    m_rs_multiplier;                // specular reflectance multiplier
+            float                    m_roughness;                    // technically, root-mean-square of the microfacets slopes
         };
 
         typedef WardMDFAdapter MDFType;
 
-        unique_ptr<MDFType>     m_mdf;                          // Microfacet Distribution Function
-        Spectrum                m_a_spec[AlbedoTableSize];      // albedo of the specular component as V varies
-        Spectrum                m_s;                            // normalization constant for the matte component
+        std::unique_ptr<MDFType>     m_mdf;                          // Microfacet Distribution Function
+        Spectrum                     m_a_spec[AlbedoTableSize];      // albedo of the specular component as V varies
+        Spectrum                     m_s;                            // normalization constant for the matte component
 
         // Evaluate the specular component of the BRDF (equation 3).
         template <typename MDF>
         static void evaluate_fr_spec(
-            const MDF&          mdf,
-            const Spectrum&     rs,
-            const float         dot_HL,     // cos_beta in the paper
-            const float         dot_HN,
-            Spectrum&           fr_spec)
+            const MDF&               mdf,
+            const Spectrum&          rs,
+            const float              dot_HL,     // cos_beta in the paper
+            const float              dot_HN,
+            Spectrum&                fr_spec)
         {
             assert(dot_HL >  0.0f);
             assert(dot_HN >= 0.0f);
@@ -688,7 +687,7 @@ namespace
 
         template <typename MDF>
         static void generate_specular_albedo_plot_data(
-            const string&       mdf_name,
+            const std::string&  mdf_name,
             const float         m,
             const MDF&          mdf,
             const Spectrum&     rs)
@@ -696,7 +695,7 @@ namespace
             Spectrum a_spec[AlbedoTableSize];
             compute_specular_albedo(mdf, rs, a_spec);
 
-            vector<Vector2f> tabulated_albedos(AlbedoTableSize);
+            std::vector<Vector2f> tabulated_albedos(AlbedoTableSize);
 
             for (size_t i = 0; i < AlbedoTableSize; ++i)
             {
@@ -707,7 +706,7 @@ namespace
             }
 
             const size_t PointCount = 256;
-            vector<Vector2f> reconstructed_albedos(PointCount);
+            std::vector<Vector2f> reconstructed_albedos(PointCount);
 
             for (size_t i = 0; i < PointCount; ++i)
             {
@@ -738,7 +737,7 @@ namespace
                 .set_style("lines")
                 .set_color("blue");
 
-            stringstream filename;
+            std::stringstream filename;
             filename << "kelemen_albedo";
             filename << "_" << lower_case(mdf_name);
             filename << "_" << replace(to_string(m), ".", "_");

--- a/src/appleseed/renderer/modeling/bsdf/lambertianbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/lambertianbrdf.cpp
@@ -54,7 +54,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
@@ -64,7 +64,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/microfacethelper.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/microfacethelper.cpp
@@ -48,7 +48,6 @@
 #include <cmath>
 
 using namespace foundation;
-using namespace std;
 
 namespace bf = boost::filesystem;
 

--- a/src/appleseed/renderer/modeling/bsdf/orennayarbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/orennayarbrdf.cpp
@@ -54,7 +54,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/oslbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/oslbsdf.cpp
@@ -68,7 +68,6 @@
 namespace foundation    { class IAbortSwitch; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/plasticbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/plasticbrdf.cpp
@@ -66,7 +66,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/sheenbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/sheenbrdf.cpp
@@ -52,7 +52,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/specularbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/specularbrdf.cpp
@@ -46,7 +46,6 @@
 #include "foundation/utility/containers/dictionary.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bsdf/specularbtdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/specularbtdf.cpp
@@ -51,7 +51,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bssrdf/betterdipolebssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/betterdipolebssrdf.cpp
@@ -49,7 +49,6 @@
 namespace foundation    { class Arena; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.cpp
@@ -38,7 +38,6 @@
 #include "foundation/utility/containers/dictionary.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bssrdf/directionaldipolebssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/directionaldipolebssrdf.cpp
@@ -51,7 +51,6 @@
 namespace foundation    { class Arena; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
@@ -51,7 +51,6 @@ namespace renderer      { class BSSRDFSample; }
 namespace renderer      { class ShadingContext; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.cpp
@@ -49,7 +49,6 @@ namespace renderer      { class BSSRDFSample; }
 namespace renderer      { class ShadingContext; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bssrdf/randomwalkbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/randomwalkbssrdf.cpp
@@ -66,7 +66,6 @@ namespace renderer  { class BSSRDFSample; }
 namespace renderer  { class ShadingContext; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -110,7 +109,7 @@ namespace
             m_inputs.declare("volume_anisotropy", InputFormatFloat, "0.0");
             m_inputs.declare("surface_roughness", InputFormatFloat, "0.01");
 
-            const string lambertian_brdf_name = string(name) + "_lambertian_brdf";
+            const std::string lambertian_brdf_name = std::string(name) + "_lambertian_brdf";
             m_lambertian_brdf = LambertianBRDFFactory().create(lambertian_brdf_name.c_str(), ParamArray());
             m_lambertian_brdf_data.m_reflectance.set(1.0f);
             m_lambertian_brdf_data.m_reflectance_multiplier = 1.0f;
@@ -139,8 +138,8 @@ namespace
 
             const OnFrameBeginMessageContext context("bssrdf", this);
 
-            const string surface_bsdf =
-                m_params.get_optional<string>(
+            const std::string surface_bsdf =
+                m_params.get_optional<std::string>(
                     "surface_bsdf_model",
                     "diffuse",
                     make_vector("diffuse", "glass"),
@@ -452,7 +451,7 @@ namespace
             const char*             bssrdf_name,
             const char*             mdf_name)
         {
-            const string glass_bsdf_name = string(bssrdf_name) + "_glass_bsdf_" + mdf_name;
+            const std::string glass_bsdf_name = std::string(bssrdf_name) + "_glass_bsdf_" + mdf_name;
 
             auto_release_ptr<BSDF> bsdf =
                 GlassBSDFFactory().create(

--- a/src/appleseed/renderer/modeling/bssrdf/separablebssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/separablebssrdf.cpp
@@ -60,7 +60,6 @@
 namespace renderer  { class Material; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -343,7 +342,7 @@ SeparableBSSRDF::SeparableBSSRDF(
     const ParamArray&       params)
   : BSSRDF(name, params)
 {
-    const string brdf_name = string(name) + "_brdf";
+    const std::string brdf_name = std::string(name) + "_brdf";
     m_brdf = LambertianBRDFFactory().create(brdf_name.c_str(), ParamArray()).release();
     m_brdf_data.m_reflectance.set(1.0f);
     m_brdf_data.m_reflectance_multiplier = 1.0f;

--- a/src/appleseed/renderer/modeling/bssrdf/sss.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/sss.cpp
@@ -39,7 +39,6 @@
 #include <cmath>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/bssrdf/standarddipolebssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/standarddipolebssrdf.cpp
@@ -49,7 +49,6 @@
 namespace foundation    { class Arena; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/camera/camera.cpp
+++ b/src/appleseed/renderer/modeling/camera/camera.cpp
@@ -51,7 +51,6 @@
 #include <limits>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -491,7 +490,7 @@ void Camera::initialize_ray(
     ShadingRay&             ray) const
 {
     ray.m_tmin = 0.0;
-    ray.m_tmax = numeric_limits<double>::max();
+    ray.m_tmax = std::numeric_limits<double>::max();
     ray.m_flags = VisibilityFlags::CameraRay;
     ray.m_depth = 0;
 

--- a/src/appleseed/renderer/modeling/camera/fisheyelenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/fisheyelenscamera.cpp
@@ -56,7 +56,6 @@ namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class OnRenderBeginRecorder; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -146,7 +145,7 @@ namespace
             if (!PerspectiveCamera::on_render_begin(project, parent, recorder, abort_switch))
                 return false;
 
-            const string projection_type = m_params.get_required<string>("projection_type", "equisolid_angle");
+            const std::string projection_type = m_params.get_required<std::string>("projection_type", "equisolid_angle");
 
             if (projection_type == "equisolid_angle")
                  m_projection_type = Projection::EquisolidAngle;

--- a/src/appleseed/renderer/modeling/camera/orthographiccamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/orthographiccamera.cpp
@@ -59,7 +59,6 @@ namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class OnRenderBeginRecorder; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
@@ -56,7 +56,6 @@ namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class OnRenderBeginRecorder; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/sphericalcamera.cpp
@@ -57,7 +57,6 @@ namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class OnRenderBeginRecorder; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -402,25 +402,25 @@ namespace
 
       private:
         // Parameters.
-        double              m_f_number;                 // F-number
-        bool                m_autofocus_enabled;        // is autofocus enabled?
-        Vector2d            m_autofocus_target;         // autofocus target on film plane, in NDC
-        double              m_focal_distance;           // focal distance in camera space
-        bool                m_diaphragm_map_bound;      // is a diaphragm map bound to the camera
-        size_t              m_diaphragm_blade_count;    // number of blades of the diaphragm, 0 for round aperture
-        double              m_diaphragm_tilt_angle;     // tilt angle of the diaphragm in radians
+        double                   m_f_number;                 // F-number
+        bool                     m_autofocus_enabled;        // is autofocus enabled?
+        Vector2d                 m_autofocus_target;         // autofocus target on film plane, in NDC
+        double                   m_focal_distance;           // focal distance in camera space
+        bool                     m_diaphragm_map_bound;      // is a diaphragm map bound to the camera
+        size_t                   m_diaphragm_blade_count;    // number of blades of the diaphragm, 0 for round aperture
+        double                   m_diaphragm_tilt_angle;     // tilt angle of the diaphragm in radians
 
         // Precomputed values.
-        double              m_lens_radius;              // radius of the lens in camera space
-        double              m_focal_ratio;              // focal distance / focal length
-        double              m_rcp_focal_ratio;          // focal length / focal distance
+        double                   m_lens_radius;              // radius of the lens in camera space
+        double                   m_focal_ratio;              // focal distance / focal length
+        double                   m_rcp_focal_ratio;          // focal length / focal distance
 
         // Vertices of the diaphragm polygon.
         std::vector<Vector2d>    m_diaphragm_vertices;
 
         // Importance sampler to sample the diaphragm map.
         std::unique_ptr<ImageImportanceSamplerType>
-                            m_importance_sampler;
+                                 m_importance_sampler;
 
         void extract_diaphragm_blade_count()
         {

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -77,7 +77,6 @@ namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class OnRenderBeginRecorder; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -417,10 +416,10 @@ namespace
         double              m_rcp_focal_ratio;          // focal length / focal distance
 
         // Vertices of the diaphragm polygon.
-        vector<Vector2d>    m_diaphragm_vertices;
+        std::vector<Vector2d>    m_diaphragm_vertices;
 
         // Importance sampler to sample the diaphragm map.
-        unique_ptr<ImageImportanceSamplerType>
+        std::unique_ptr<ImageImportanceSamplerType>
                             m_importance_sampler;
 
         void extract_diaphragm_blade_count()
@@ -534,7 +533,7 @@ namespace
             ray.m_org = transform.get_local_to_parent().extract_translation();
             ray.m_dir = normalize(transform.vector_to_parent(-ndc_to_camera(m_autofocus_target)));
             ray.m_tmin = 0.0;
-            ray.m_tmax = numeric_limits<double>::max();
+            ray.m_tmax = std::numeric_limits<double>::max();
             ray.m_time =
                 ShadingRay::Time::create_with_normalized_time(
                     0.5f,

--- a/src/appleseed/renderer/modeling/color/colorentity.cpp
+++ b/src/appleseed/renderer/modeling/color/colorentity.cpp
@@ -45,7 +45,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -135,7 +134,7 @@ void ColorEntity::extract_parameters()
     // Retrieve the color space.
     const ColorSpace DefaultColorSpace = ColorSpaceSRGB;
     const char* DefaultColorSpaceName = color_space_name(DefaultColorSpace);
-    const string color_space = m_params.get_required<string>("color_space", DefaultColorSpaceName);
+    const std::string color_space = m_params.get_required<std::string>("color_space", DefaultColorSpaceName);
     if (color_space == "linear_rgb")
         impl->m_color_space = ColorSpaceLinearRGB;
     else if (color_space == "srgb")

--- a/src/appleseed/renderer/modeling/color/wavelengths.cpp
+++ b/src/appleseed/renderer/modeling/color/wavelengths.cpp
@@ -39,7 +39,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -108,7 +107,7 @@ void spectral_values_to_spectrum(
     assert(low_wavelength < high_wavelength);
 
     // Generate the wavelengths for which this spectrum is defined.
-    vector<float> wavelengths(input_spectrum_count);
+    std::vector<float> wavelengths(input_spectrum_count);
     generate_wavelengths(
         low_wavelength,
         high_wavelength,

--- a/src/appleseed/renderer/modeling/display/display.cpp
+++ b/src/appleseed/renderer/modeling/display/display.cpp
@@ -45,7 +45,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -90,7 +89,7 @@ void Display::release()
 
 bool Display::open(const Project& project)
 {
-    string plugin_path;
+    std::string plugin_path;
 
     // Retrieve plugin name.
     try

--- a/src/appleseed/renderer/modeling/edf/coneedf.cpp
+++ b/src/appleseed/renderer/modeling/edf/coneedf.cpp
@@ -52,7 +52,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/edf/diffuseedf.cpp
+++ b/src/appleseed/renderer/modeling/edf/diffuseedf.cpp
@@ -52,7 +52,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/edf/edf.cpp
+++ b/src/appleseed/renderer/modeling/edf/edf.cpp
@@ -46,7 +46,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -137,7 +136,7 @@ float EDF::get_max_contribution_scalar(const Source* source) const
     assert(source);
 
     if (!source->is_uniform())
-        return numeric_limits<float>::max();
+        return std::numeric_limits<float>::max();
 
     float value;
     source->evaluate_uniform(value);
@@ -150,7 +149,7 @@ float EDF::get_max_contribution_spectrum(const Source* source) const
     assert(source);
 
     if (!source->is_uniform())
-        return numeric_limits<float>::max();
+        return std::numeric_limits<float>::max();
 
     Spectrum spectrum;
     source->evaluate_uniform(spectrum);
@@ -165,18 +164,18 @@ float EDF::get_max_contribution(
 {
     const float max_contribution_input = get_max_contribution_spectrum(input);
 
-    if (max_contribution_input == numeric_limits<float>::max())
-        return numeric_limits<float>::max();
+    if (max_contribution_input == std::numeric_limits<float>::max())
+        return std::numeric_limits<float>::max();
 
     const float max_contribution_multiplier = get_max_contribution_scalar(multiplier);
 
-    if (max_contribution_multiplier == numeric_limits<float>::max())
-        return numeric_limits<float>::max();
+    if (max_contribution_multiplier == std::numeric_limits<float>::max())
+        return std::numeric_limits<float>::max();
 
     const float max_contribution_exposure = get_max_contribution_scalar(exposure);
 
-    if (max_contribution_exposure == numeric_limits<float>::max())
-        return numeric_limits<float>::max();
+    if (max_contribution_exposure == std::numeric_limits<float>::max())
+        return std::numeric_limits<float>::max();
 
     return max_contribution_input * max_contribution_multiplier * pow(2.0f, max_contribution_exposure);
 }

--- a/src/appleseed/renderer/modeling/edf/osledf.cpp
+++ b/src/appleseed/renderer/modeling/edf/osledf.cpp
@@ -49,7 +49,6 @@
 #include <limits>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -228,7 +227,7 @@ namespace
         float get_uncached_max_contribution() const override
         {
             // We can't know the max contribution of OSL EDFs.
-            return numeric_limits<float>::max();
+            return std::numeric_limits<float>::max();
         }
 
       private:

--- a/src/appleseed/renderer/modeling/entity/entity.cpp
+++ b/src/appleseed/renderer/modeling/entity/entity.cpp
@@ -43,14 +43,13 @@
 #include "foundation/platform/_endoiioheaders.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
 
 struct Entity::Impl
 {
-    string          m_name;
+    std::string     m_name;
     OIIO::ustring   m_oiio_name;
 };
 

--- a/src/appleseed/renderer/modeling/entity/entitymap.cpp
+++ b/src/appleseed/renderer/modeling/entity/entitymap.cpp
@@ -38,15 +38,14 @@
 #include <map>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
 
 struct EntityMap::Impl
 {
-    typedef map<UniqueID, Entity*> Storage;
-    typedef map<string, Entity*> Index;
+    typedef std::map<UniqueID, Entity*> Storage;
+    typedef std::map<std::string, Entity*> Index;
 
     Storage m_storage;
     Index   m_index;

--- a/src/appleseed/renderer/modeling/entity/entityvector.cpp
+++ b/src/appleseed/renderer/modeling/entity/entityvector.cpp
@@ -39,16 +39,15 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
 
 struct EntityVector::Impl
 {
-    typedef vector<Entity*> Storage;
-    typedef map<UniqueID, size_t> IDIndex;
-    typedef map<string, size_t> NameIndex;
+    typedef std::vector<Entity*> Storage;
+    typedef std::map<UniqueID, size_t> IDIndex;
+    typedef std::map<std::string, size_t> NameIndex;
 
     Storage     m_storage;
     IDIndex     m_id_index;

--- a/src/appleseed/renderer/modeling/entity/onframebeginrecorder.cpp
+++ b/src/appleseed/renderer/modeling/entity/onframebeginrecorder.cpp
@@ -36,7 +36,6 @@
 #include <cassert>
 #include <stack>
 
-using namespace std;
 
 namespace renderer
 {
@@ -49,7 +48,7 @@ struct OnFrameBeginRecorder::Impl
         const BaseGroup*    m_parent;
     };
 
-    stack<Record> m_records;
+    std::stack<Record> m_records;
 };
 
 OnFrameBeginRecorder::OnFrameBeginRecorder()

--- a/src/appleseed/renderer/modeling/entity/onrenderbeginrecorder.cpp
+++ b/src/appleseed/renderer/modeling/entity/onrenderbeginrecorder.cpp
@@ -36,7 +36,6 @@
 #include <cassert>
 #include <stack>
 
-using namespace std;
 
 namespace renderer
 {
@@ -49,7 +48,7 @@ struct OnRenderBeginRecorder::Impl
         const BaseGroup*    m_parent;
     };
 
-    stack<Record> m_records;
+    std::stack<Record> m_records;
 };
 
 OnRenderBeginRecorder::OnRenderBeginRecorder()

--- a/src/appleseed/renderer/modeling/environment/environment.cpp
+++ b/src/appleseed/renderer/modeling/environment/environment.cpp
@@ -40,7 +40,6 @@
 #include "foundation/utility/containers/dictionary.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/environmentedf/constantenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/constantenvironmentedf.cpp
@@ -52,7 +52,6 @@ namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/environmentedf/constanthemisphereenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/constanthemisphereenvironmentedf.cpp
@@ -54,7 +54,6 @@ namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/environmentedf/gradientenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/gradientenvironmentedf.cpp
@@ -56,7 +56,6 @@ namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/environmentedf/hosekenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/hosekenvironmentedf.cpp
@@ -65,7 +65,6 @@ namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/environmentedf/latlongmapenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/latlongmapenvironmentedf.cpp
@@ -76,7 +76,6 @@ namespace renderer  { class OnFrameBeginRecorder; }
 namespace renderer  { class OnRenderBeginRecorder; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -407,7 +406,7 @@ namespace
         float   m_rcp_importance_map_height;
         float   m_probability_scale;
 
-        unique_ptr<ImageImportanceSamplerType> m_importance_sampler;
+        std::unique_ptr<ImageImportanceSamplerType> m_importance_sampler;
 
         void build_importance_map(const Scene& scene, IAbortSwitch* abort_switch)
         {

--- a/src/appleseed/renderer/modeling/environmentedf/mirrorballmapenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/mirrorballmapenvironmentedf.cpp
@@ -58,7 +58,6 @@ namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/environmentedf/oslenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/oslenvironmentedf.cpp
@@ -57,7 +57,6 @@ namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/environmentedf/preethamenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/preethamenvironmentedf.cpp
@@ -63,7 +63,6 @@ namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/environmentshader/edfenvironmentshader.cpp
+++ b/src/appleseed/renderer/modeling/environmentshader/edfenvironmentshader.cpp
@@ -56,7 +56,6 @@ namespace renderer      { class PixelContext; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -113,7 +112,7 @@ namespace
                 RENDERER_LOG_ERROR(
                     "%scannot find environment edf \"%s\".",
                     context.get(),
-                    m_params.get_required<string>("environment_edf", "").c_str());
+                    m_params.get_required<std::string>("environment_edf", "").c_str());
                 return false;
             }
 

--- a/src/appleseed/renderer/modeling/frame/frame.cpp
+++ b/src/appleseed/renderer/modeling/frame/frame.cpp
@@ -86,7 +86,6 @@
 
 using namespace bcd;
 using namespace foundation;
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace renderer
@@ -109,37 +108,37 @@ UniqueID Frame::get_class_uid()
 struct Frame::Impl
 {
     // Parameters.
-    size_t                          m_frame_width;
-    size_t                          m_frame_height;
-    size_t                          m_tile_width;
-    size_t                          m_tile_height;
-    string                          m_filter_name;
-    float                           m_filter_radius;
-    AABB2u                          m_crop_window;
-    bool                            m_enable_dithering;
-    uint32                          m_noise_seed;
-    DenoisingMode                   m_denoising_mode;
-    bool                            m_checkpoint_create;
-    string                          m_checkpoint_create_path;
-    bool                            m_checkpoint_resume;
-    string                          m_checkpoint_resume_path;
-    string                          m_ref_image_path;
+    size_t                               m_frame_width;
+    size_t                               m_frame_height;
+    size_t                               m_tile_width;
+    size_t                               m_tile_height;
+    std::string                          m_filter_name;
+    float                                m_filter_radius;
+    AABB2u                               m_crop_window;
+    bool                                 m_enable_dithering;
+    uint32                               m_noise_seed;
+    DenoisingMode                        m_denoising_mode;
+    bool                                 m_checkpoint_create;
+    std::string                          m_checkpoint_create_path;
+    bool                                 m_checkpoint_resume;
+    std::string                          m_checkpoint_resume_path;
+    std::string                          m_ref_image_path;
 
     // Child entities.
-    AOVContainer                    m_aovs;
-    DenoiserAOV*                    m_denoiser_aov;
-    AOVContainer                    m_internal_aovs;
-    PostProcessingStageContainer    m_post_processing_stages;
+    AOVContainer                         m_aovs;
+    DenoiserAOV*                         m_denoiser_aov;
+    AOVContainer                         m_internal_aovs;
+    PostProcessingStageContainer         m_post_processing_stages;
 
     // Images.
-    unique_ptr<Image>               m_image;
-    unique_ptr<Image>               m_ref_image;
-    unique_ptr<ImageStack>          m_aov_images;
+    std::unique_ptr<Image>               m_image;
+    std::unique_ptr<Image>               m_ref_image;
+    std::unique_ptr<ImageStack>          m_aov_images;
 
     // Internal state.
-    unique_ptr<FilterSamplingTable> m_filter_sampling_table;
-    ParamArray                      m_render_info;
-    size_t                          m_initial_pass = 0;
+    std::unique_ptr<FilterSamplingTable> m_filter_sampling_table;
+    ParamArray                           m_render_info;
+    size_t                               m_initial_pass = 0;
 
     explicit Impl(Frame* parent)
       : m_aovs(parent)
@@ -537,7 +536,7 @@ namespace
         return ShadingResultFrameBuffer::get_total_channel_count(aov_count) + 1;
     }
 
-    typedef vector<tuple<string, CanvasProperties, ImageAttributes>> CheckpointProperties;
+    typedef std::vector<std::tuple<std::string, CanvasProperties, ImageAttributes>> CheckpointProperties;
 
 
     //
@@ -626,36 +625,36 @@ namespace
     };
 
     void get_denoiser_checkpoint_paths(
-        const string&                   checkpoint_path,
-        string&                         hist_path,
-        string&                         cov_path,
-        string&                         sum_path)
+        const std::string&                   checkpoint_path,
+        std::string&                         hist_path,
+        std::string&                         cov_path,
+        std::string&                         sum_path)
     {
         const bf::path boost_file_path(checkpoint_path);
         const bf::path directory = boost_file_path.parent_path();
-        const string base_file_name = boost_file_path.stem().string() + ".denoiser";
-        const string extension = boost_file_path.extension().string();
+        const std::string base_file_name = boost_file_path.stem().string() + ".denoiser";
+        const std::string extension = boost_file_path.extension().string();
 
-        const string hist_file_name = base_file_name + ".hist" + extension;
+        const std::string hist_file_name = base_file_name + ".hist" + extension;
         hist_path = (directory / hist_file_name).string();
 
-        const string cov_file_name = base_file_name + ".cov" + extension;
+        const std::string cov_file_name = base_file_name + ".cov" + extension;
         cov_path = (directory / cov_file_name).string();
 
-        const string sum_file_name = base_file_name + ".sum" + extension;
+        const std::string sum_file_name = base_file_name + ".sum" + extension;
         sum_path = (directory / sum_file_name).string();
     }
 
     bool is_checkpoint_compatible(
-        const string&                   checkpoint_path,
+        const std::string&              checkpoint_path,
         const Frame&                    frame,
         const CheckpointProperties&     checkpoint_props)
     {
         const Image& frame_image = frame.image();
         const CanvasProperties& frame_props = frame_image.properties();
-        const CanvasProperties& beauty_props = get<1>(checkpoint_props[0]);
-        const ImageAttributes& exr_attributes = get<2>(checkpoint_props[0]);
-        const string initial_layer_name = get<0>(checkpoint_props[0]);
+        const CanvasProperties& beauty_props = std::get<1>(checkpoint_props[0]);
+        const ImageAttributes& exr_attributes = std::get<2>(checkpoint_props[0]);
+        const std::string initial_layer_name = std::get<0>(checkpoint_props[0]);
 
         // Check for atttributes.
         if (!exr_attributes.exist("appleseed:LastPass"))
@@ -672,7 +671,7 @@ namespace
         }
 
         // Check for shading buffer layer.
-        const string second_layer_name = get<0>(checkpoint_props[1]);
+        const std::string second_layer_name = std::get<0>(checkpoint_props[1]);
         if (second_layer_name != "appleseed:RenderingBuffer")
         {
             RENDERER_LOG_ERROR("incorrect checkpoint: rendering buffer layer is missing.");
@@ -682,7 +681,7 @@ namespace
         // Check that the shading buffer layer has correct amount of channel.
         // The checkpoint should contain the beauty image and the shading buffer.
         const size_t expect_channel_count = get_checkpoint_total_channel_count(frame.aov_images().size());
-        if (get<1>(checkpoint_props[1]).m_channel_count != expect_channel_count)
+        if (std::get<1>(checkpoint_props[1]).m_channel_count != expect_channel_count)
         {
             RENDERER_LOG_ERROR("incorrect checkpoint: the shading buffer doesn't contain the correct number of channels.");
             return false;
@@ -710,7 +709,7 @@ namespace
         // Check if denoising is enabled and pass exists.
         if (frame.get_denoising_mode() != Frame::DenoisingMode::Off)
         {
-            string hist_file_path, cov_file_path, sum_file_path;
+            std::string hist_file_path, cov_file_path, sum_file_path;
             get_denoiser_checkpoint_paths(
                 checkpoint_path,
                 hist_file_path,
@@ -730,7 +729,7 @@ namespace
     }
 
     bool load_denoiser_checkpoint(
-        const string&                   checkpoint_path,
+        const std::string&              checkpoint_path,
         DenoiserAOV*                    denoiser_aov)
     {
         // todo: reload denoiser checkpoint from the same file.
@@ -738,7 +737,7 @@ namespace
         Deepimf& covariance_image = denoiser_aov->covariance_image();
         Deepimf& sum_image = denoiser_aov->sum_image();
 
-        string hist_file_path, cov_file_path, sum_file_path;
+        std::string hist_file_path, cov_file_path, sum_file_path;
         get_denoiser_checkpoint_paths(checkpoint_path, hist_file_path, cov_file_path, sum_file_path);
 
         // Load histograms.
@@ -757,7 +756,7 @@ namespace
     }
 
     void save_denoiser_checkpoint(
-        const string&                   checkpoint_path,
+        const std::string&              checkpoint_path,
         const DenoiserAOV*              denoiser_aov)
     {
         // todo: save denoiser checkpoint in the same file.
@@ -765,7 +764,7 @@ namespace
         const Deepimf& covariance_image = denoiser_aov->covariance_image();
         const Deepimf& sum_image = denoiser_aov->sum_image();
 
-        string hist_file_path, cov_file_path, sum_file_path;
+        std::string hist_file_path, cov_file_path, sum_file_path;
         get_denoiser_checkpoint_paths(checkpoint_path, hist_file_path, cov_file_path, sum_file_path);
 
         // Add histograms layer.
@@ -813,9 +812,9 @@ bool Frame::load_checkpoint(
         ImageAttributes layer_attributes;
         reader.read_image_attributes(layer_attributes);
 
-        const string layer_name =
+        const std::string layer_name =
             layer_attributes.exist("name")
-                ? layer_attributes.get<string>("name")
+                ? layer_attributes.get<std::string>("name")
                 : "undefined";
 
         checkpoint_props.emplace_back(
@@ -831,7 +830,7 @@ bool Frame::load_checkpoint(
         return false;
 
     // Compute the index of the first pass to render.
-    const size_t start_pass = get<2>(checkpoint_props[0]).get<size_t>("appleseed:LastPass") + 1;
+    const size_t start_pass = std::get<2>(checkpoint_props[0]).get<size_t>("appleseed:LastPass") + 1;
 
     // Check if passes have already been rendered.
     if (start_pass < pass_count)
@@ -842,7 +841,7 @@ bool Frame::load_checkpoint(
         try
         {
             // Load tiles from the checkpoint.
-            const CanvasProperties& beauty_props = get<1>(checkpoint_props[0]);
+            const CanvasProperties& beauty_props = std::get<1>(checkpoint_props[0]);
             for (size_t tile_y = 0; tile_y < beauty_props.m_tile_count_y; ++tile_y)
             {
                 for (size_t tile_x = 0; tile_x < beauty_props.m_tile_count_x; ++tile_x)
@@ -856,21 +855,21 @@ bool Frame::load_checkpoint(
                     // are in the shading buffer.
 
                     // Read unfiltered AOV layers.
-                    vector<unique_ptr<Tile>> aov_tiles;
-                    vector<const float*> aov_ptrs;
+                    std::vector<std::unique_ptr<Tile>> aov_tiles;
+                    std::vector<const float*> aov_ptrs;
                     for (size_t aov_index = 0; aov_index < aovs().size(); ++aov_index)
                     {
                         UnfilteredAOV* aov = dynamic_cast<UnfilteredAOV*>(aovs().get_by_index(aov_index));
                         if (aov == nullptr)
                             continue;
 
-                        const string aov_name = aov->get_name();
+                        const std::string aov_name = aov->get_name();
 
                         // Search layer index in the file.
                         size_t subimage_index(~0);
                         for (size_t prop_index = 0; prop_index < checkpoint_props.size(); ++prop_index)
                         {
-                            if (get<0>(checkpoint_props[prop_index]) == aov_name)
+                            if (std::get<0>(checkpoint_props[prop_index]) == aov_name)
                             {
                                 subimage_index = prop_index;
                                 break;
@@ -946,10 +945,10 @@ void Frame::save_checkpoint(
     const size_t shading_channel_count = pixels_weight_buffer.properties().m_channel_count;
 
     // Create channel names.
-    vector<string> shading_channel_names;
-    vector<const char *> shading_channel_names_cstr;
+    std::vector<std::string> shading_channel_names;
+    std::vector<const char *> shading_channel_names_cstr;
     {
-        static const string channel_name_prefix = "channel_";
+        static const std::string channel_name_prefix = "channel_";
         for (size_t i = 0; i < shading_channel_count; ++i)
         {
             shading_channel_names.push_back(channel_name_prefix + pad_left(to_string(i + 1), '0', 4));
@@ -1036,7 +1035,7 @@ namespace
         stopwatch.start();
 
         bf::path bf_file_path(file_path);
-        string extension = lower_case(bf_file_path.extension().string());
+        std::string extension = lower_case(bf_file_path.extension().string());
 
         if (!has_extension(bf_file_path))
         {
@@ -1050,7 +1049,7 @@ namespace
         {
             const bool is_linear_format = is_linear_image_file_format(bf_file_path);
 
-            unique_ptr<Image> transformed_image;
+            std::unique_ptr<Image> transformed_image;
             if (!is_linear_format && image.properties().m_channel_count == 4)
             {
                 transformed_image.reset(new Image(image));
@@ -1079,7 +1078,7 @@ namespace
 
             create_parent_directories(bf_file_path);
 
-            const string filename = bf_file_path.string();
+            const std::string filename = bf_file_path.string();
             GenericImageFileWriter writer(filename.c_str());
 
             writer.append_image(transformed_image.get());
@@ -1090,7 +1089,7 @@ namespace
 
             writer.write();
         }
-        catch (const exception& e)
+        catch (const std::exception& e)
         {
             RENDERER_LOG_ERROR(
                 "failed to write image file %s for frame \"%s\": %s.",
@@ -1151,7 +1150,7 @@ bool Frame::write_aov_images(const char* file_path) const
         return true;
 
     bf::path bf_file_path(file_path);
-    const string extension = lower_case(bf_file_path.extension().string());
+    const std::string extension = lower_case(bf_file_path.extension().string());
 
     if (extension != ".exr")
     {
@@ -1166,17 +1165,17 @@ bool Frame::write_aov_images(const char* file_path) const
     }
 
     const bf::path directory = bf_file_path.parent_path();
-    const string base_file_name = bf_file_path.stem().string();
+    const std::string base_file_name = bf_file_path.stem().string();
 
     bool success = true;
 
     for (const AOV& aov : impl->m_aovs)
     {
         // Compute AOV image file path.
-        const string aov_name = aov.get_name();
-        const string safe_aov_name = make_safe_filename(aov_name);
-        const string aov_file_name = base_file_name + "." + safe_aov_name + ".exr";
-        const string aov_file_path = (directory / aov_file_name).string();
+        const std::string aov_name = aov.get_name();
+        const std::string safe_aov_name = make_safe_filename(aov_name);
+        const std::string aov_file_name = base_file_name + "." + safe_aov_name + ".exr";
+        const std::string aov_file_path = (directory / aov_file_name).string();
 
         // Write AOV image.
         ImageAttributes image_attributes = ImageAttributes::create_default_attributes();
@@ -1193,7 +1192,7 @@ bool Frame::write_main_and_aov_images() const
 
     // Write main image.
     {
-        const string file_path = get_parameters().get_optional<string>("output_filename");
+        const std::string file_path = get_parameters().get_optional<std::string>("output_filename");
         if (!file_path.empty())
         {
             if (!write_main_image(file_path.c_str()))
@@ -1204,10 +1203,10 @@ bool Frame::write_main_and_aov_images() const
     // Write AOV images.
     for (const AOV& aov : impl->m_aovs)
     {
-        bf::path bf_file_path = aov.get_parameters().get_optional<string>("output_filename");
+        bf::path bf_file_path = aov.get_parameters().get_optional<std::string>("output_filename");
         if (!bf_file_path.empty())
         {
-            const string extension = lower_case(bf_file_path.extension().string());
+            const std::string extension = lower_case(bf_file_path.extension().string());
             if (extension != ".exr")
             {
                 if (has_extension(bf_file_path))
@@ -1239,7 +1238,7 @@ void Frame::write_main_and_aov_images_to_multipart_exr(const char* file_path) co
     add_chromaticities_attributes(image_attributes);
     image_attributes.insert("color_space", "linear");
 
-    vector<Image> images;
+    std::vector<Image> images;
 
     create_parent_directories(file_path);
 
@@ -1259,7 +1258,7 @@ void Frame::write_main_and_aov_images_to_multipart_exr(const char* file_path) co
 
     for (const AOV& aov : impl->m_aovs)
     {
-        const string aov_name = aov.get_name();
+        const std::string aov_name = aov.get_name();
         const Image& image = aov.get_image();
 
         if (aov.has_color_data())
@@ -1292,10 +1291,10 @@ bool Frame::archive(
     assert(directory);
 
     // Construct the name of the image file.
-    const string filename = "autosave." + get_time_stamp_string() + ".exr";
+    const std::string filename = "autosave." + get_time_stamp_string() + ".exr";
 
     // Construct the path to the image file.
-    const string file_path = (bf::path(directory) / filename).string();
+    const std::string file_path = (bf::path(directory) / filename).string();
 
     // Return the path to the image file.
     if (output_path)
@@ -1349,7 +1348,7 @@ void Frame::extract_parameters()
     {
         const char* DefaultFilterName = "blackman-harris";
 
-        impl->m_filter_name = m_params.get_optional<string>("filter", DefaultFilterName);
+        impl->m_filter_name = m_params.get_optional<std::string>("filter", DefaultFilterName);
         impl->m_filter_radius = m_params.get_optional<float>("filter_size", 1.5f);
 
         if (impl->m_filter_name == "box")
@@ -1399,7 +1398,7 @@ void Frame::extract_parameters()
 
     // Retrieve denoiser parameters.
     {
-        const string denoise_mode = m_params.get_optional<string>("denoiser", "off");
+        const std::string denoise_mode = m_params.get_optional<std::string>("denoiser", "off");
 
         if (denoise_mode == "off")
             impl->m_denoising_mode = DenoisingMode::Off;
@@ -1427,14 +1426,14 @@ void Frame::extract_parameters()
         // Check if the checkpoint create path is valid.
         if (impl->m_checkpoint_create)
         {
-            string path = m_params.get_optional<string>("checkpoint_create_path", "");
+            std::string path = m_params.get_optional<std::string>("checkpoint_create_path", "");
             const bool use_default_path = path.empty();
             if (use_default_path)
-                path = m_params.get_required<string>("output_path");
+                path = m_params.get_required<std::string>("output_path");
 
             bf::path bf_path(path.c_str());
 
-            const string extension = lower_case(bf_path.extension().string());
+            const std::string extension = lower_case(bf_path.extension().string());
 
             if (extension != ".exr")
             {
@@ -1448,7 +1447,7 @@ void Frame::extract_parameters()
                 if (use_default_path && !ends_with(path, ".checkpoint.exr"))
                 {
                     const bf::path directory = bf_path.parent_path();
-                    const string base_file_name = bf_path.stem().string();
+                    const std::string base_file_name = bf_path.stem().string();
                     path = (directory / (base_file_name + ".checkpoint.exr")).string();
                 }
 
@@ -1463,14 +1462,14 @@ void Frame::extract_parameters()
         // Check if the checkpoint resume path is valid.
         if (impl->m_checkpoint_resume)
         {
-            string path = m_params.get_optional<string>("checkpoint_resume_path", "");
+            std::string path = m_params.get_optional<std::string>("checkpoint_resume_path", "");
             const bool use_default_path = path == "";
             if (use_default_path)
-                path = m_params.get_required<string>("output_path");
+                path = m_params.get_required<std::string>("output_path");
 
             bf::path bf_path(path.c_str());
 
-            const string extension = lower_case(bf_path.extension().string());
+            const std::string extension = lower_case(bf_path.extension().string());
 
             if (extension != ".exr")
             {
@@ -1484,7 +1483,7 @@ void Frame::extract_parameters()
                 if (use_default_path && !ends_with(path, ".checkpoint.exr"))
                 {
                     const bf::path directory = bf_path.parent_path();
-                    const string base_file_name = bf_path.stem().string();
+                    const std::string base_file_name = bf_path.stem().string();
                     path = (directory / (base_file_name + ".checkpoint.exr")).string();
                 }
 
@@ -1494,7 +1493,7 @@ void Frame::extract_parameters()
     }
 
     // Retrieve reference image path parameters.
-    impl->m_ref_image_path = m_params.get_optional<string>("reference_image", "");
+    impl->m_ref_image_path = m_params.get_optional<std::string>("reference_image", "");
 }
 
 AOVContainer& Frame::internal_aovs() const

--- a/src/appleseed/renderer/modeling/input/colorsource.cpp
+++ b/src/appleseed/renderer/modeling/input/colorsource.cpp
@@ -45,7 +45,6 @@
 #include <cassert>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/input/inputarray.cpp
+++ b/src/appleseed/renderer/modeling/input/inputarray.cpp
@@ -48,7 +48,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -82,11 +81,11 @@ namespace
 
     struct Input
     {
-        string          m_name;
+        std::string     m_name;
         InputFormat     m_format;
         InputType       m_type;
         bool            m_has_default_value;
-        string          m_default_value;
+        std::string     m_default_value;
         Source*         m_source;
         Entity*         m_entity;
 
@@ -328,7 +327,7 @@ namespace
         }
     };
 
-    typedef vector<Input> InputVector;
+    typedef std::vector<Input> InputVector;
 }
 
 struct InputArray::Impl

--- a/src/appleseed/renderer/modeling/input/inputbinder.cpp
+++ b/src/appleseed/renderer/modeling/input/inputbinder.cpp
@@ -71,7 +71,6 @@
 #include <utility>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -192,12 +191,12 @@ InputBinder::ReferencedEntity InputBinder::find_referenced_entity(
 {
     const ParamArray& entity_params = entity.get_parameters();
 
-    string param_value;
+    std::string param_value;
 
     if (entity_params.strings().exist(input.name()))
     {
         // A value is assigned to this input, retrieve it.
-        param_value = entity_params.get<string>(input.name());
+        param_value = entity_params.get<std::string>(input.name());
     }
     else if (input.type() == InputTypeOptional)
     {
@@ -284,7 +283,7 @@ void InputBinder::collect_assembly_symbols(
     build_assembly_symbol_table(assembly, symbols);
 
     // Store the symbol table of the assembly.
-    m_assembly_symbols.insert(make_pair(&assembly, symbols));
+    m_assembly_symbols.insert(std::make_pair(&assembly, symbols));
 
     // Recurse into child assemblies.
     for (const auto& child_assembly : assembly.assemblies())
@@ -492,17 +491,17 @@ void InputBinder::bind_entity_inputs(
     const char*                     entity_type,
     ConnectableEntity&              entity)
 {
-    const string entity_path(entity.get_path().c_str());
+    const std::string entity_path(entity.get_path().c_str());
     const ParamArray& entity_params = entity.get_parameters();
 
     for (auto& input : entity.get_inputs())
     {
-        string param_value;
+        std::string param_value;
 
         if (entity_params.strings().exist(input.name()))
         {
             // A value is assigned to this input, retrieve it.
-            param_value = entity_params.get<string>(input.name());
+            param_value = entity_params.get<std::string>(input.name());
         }
         else if (input.type() == InputTypeOptional)
         {
@@ -698,7 +697,7 @@ bool InputBinder::try_bind_assembly_entity_to_input(
 }
 
 bool InputBinder::try_bind_scalar_to_input(
-    const string&                   param_value,
+    const std::string&              param_value,
     InputArray::iterator&           input) const
 {
     try
@@ -742,7 +741,7 @@ void InputBinder::bind_texture_instance_to_input(
                 assembly_uid,
                 *texture_instance));
     }
-    catch (const exception& e)
+    catch (const std::exception& e)
     {
         RENDERER_LOG_ERROR(
             "while binding inputs of %s \"%s\", failed to bind \"%s\" to input \"%s\" (%s).",

--- a/src/appleseed/renderer/modeling/input/texturesource.cpp
+++ b/src/appleseed/renderer/modeling/input/texturesource.cpp
@@ -45,7 +45,6 @@
 #include <cassert>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/light/directionallight.cpp
+++ b/src/appleseed/renderer/modeling/light/directionallight.cpp
@@ -56,7 +56,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class ShadingContext; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/light/maxomnilight.cpp
+++ b/src/appleseed/renderer/modeling/light/maxomnilight.cpp
@@ -53,7 +53,6 @@ namespace renderer      { class Project; }
 namespace renderer      { class ShadingContext; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/light/maxspotlight.cpp
+++ b/src/appleseed/renderer/modeling/light/maxspotlight.cpp
@@ -57,7 +57,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/light/pointlight.cpp
+++ b/src/appleseed/renderer/modeling/light/pointlight.cpp
@@ -52,7 +52,6 @@ namespace renderer      { class Project; }
 namespace renderer      { class ShadingContext; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/light/spotlight.cpp
+++ b/src/appleseed/renderer/modeling/light/spotlight.cpp
@@ -57,7 +57,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/light/sunlight.cpp
+++ b/src/appleseed/renderer/modeling/light/sunlight.cpp
@@ -62,7 +62,6 @@ namespace renderer      { class Assembly; }
 namespace renderer      { class ShadingContext; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/material/disneymaterial.cpp
+++ b/src/appleseed/renderer/modeling/material/disneymaterial.cpp
@@ -55,7 +55,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -75,7 +74,7 @@ namespace
             const Dictionary&       params,
             const bool              is_vector)
           : m_param_name(name)
-          , m_expr(params.get<string>(name))
+          , m_expr(params.get<std::string>(name))
           , m_is_vector(is_vector)
           , m_is_constant(false)
           , m_texture_is_srgb(true)
@@ -94,12 +93,12 @@ namespace
         {
         }
 
-        string& expression()
+        std::string& expression()
         {
             return m_expr;
         }
 
-        const string& expression() const
+        const std::string& expression() const
         {
             return m_expr;
         }
@@ -127,8 +126,8 @@ namespace
 
             // Case of a simple texture lookup of the form texture("path/to/texture", $u, $v).
             {
-                const string expression = trim_both(m_expression.getExpr(), " \r\n");
-                vector<string> tokens;
+                const std::string expression = trim_both(m_expression.getExpr(), " \r\n");
+                std::vector<std::string> tokens;
                 tokenize(expression, "()", tokens);
 
                 if (tokens.size() != 2)
@@ -137,7 +136,7 @@ namespace
                 if (trim_both(tokens[0]) != "texture")
                     return true;
 
-                const string inner_content = tokens[1];
+                const std::string inner_content = tokens[1];
                 tokens.clear();
                 tokenize(inner_content, ",", tokens);
 
@@ -185,10 +184,10 @@ namespace
                         &color[0]))
                 {
                     // Failed to find or open the texture.
-                    const string message = texture_system.geterror();
+                    const std::string message = texture_system.geterror();
                     if (!message.empty())
                     {
-                        const string modified_message = prefix_all_lines(trim_both(message), "oiio: ");
+                        const std::string modified_message = prefix_all_lines(trim_both(message), "oiio: ");
                         RENDERER_LOG_ERROR("%s", modified_message.c_str());
                     }
                     return Color3f(1.0f, 0.0f, 1.0f);
@@ -209,7 +208,7 @@ namespace
 
       private:
         const char*                 m_param_name;
-        string                      m_expr;
+        std::string                 m_expr;
         bool                        m_is_vector;
         bool                        m_is_constant;
         Color3d                     m_constant_value;
@@ -252,7 +251,7 @@ struct DisneyMaterialLayer::Impl
     {
     }
 
-    const string            m_name;
+    const std::string       m_name;
     const int               m_layer_number;
     DisneyLayerParam        m_mask;
     DisneyLayerParam        m_base_color;
@@ -548,11 +547,11 @@ Dictionary DisneyMaterialLayer::get_default_values()
     for (size_t i = 0; i < input_metadata.size(); ++i)
     {
         const Dictionary& im = input_metadata[i];
-        const string input_name = im.get<string>("name");
+        const std::string input_name = im.get<std::string>("name");
 
         if (im.strings().exist("default"))
         {
-            const string input_value = im.get<string>("default");
+            const std::string input_value = im.get<std::string>("default");
             values.insert(input_name, input_value);
         }
     }
@@ -572,12 +571,12 @@ namespace
 
 struct DisneyMaterial::Impl
 {
-    typedef vector<DisneyMaterialLayer> DisneyMaterialLayerContainer;
+    typedef std::vector<DisneyMaterialLayer> DisneyMaterialLayerContainer;
 
     static const size_t MaxThreadCount = 256;
 
     DisneyMaterialLayerContainer                m_layers;
-    unique_ptr<DisneyLayeredBRDF>               m_brdf;
+    std::unique_ptr<DisneyLayeredBRDF>          m_brdf;
     mutable TLS<DisneyMaterialLayerContainer*>  m_per_thread_layers;
 
     explicit Impl(const DisneyMaterial* parent)
@@ -656,7 +655,7 @@ void DisneyMaterial::update_asset_paths(const StringDictionary& mappings)
     SeExprFilePathExtractor::MappingCollection mappings_;
 
     for (const_each<StringDictionary> i = mappings; i; ++i)
-        mappings_.insert(make_pair(i->key(), i->value()));
+        mappings_.insert(std::make_pair(i->key(), i->value()));
 
     for (each<DictionaryDictionary> layer_it = m_params.dictionaries(); layer_it; ++layer_it)
     {
@@ -714,7 +713,7 @@ void DisneyMaterial::add_layer(Dictionary layer_values)
     // Assign a name to the layer if there isn't one already.
     if (!layer_values.strings().exist("layer_name"))
     {
-        const string layer_name = make_unique_name("layer", impl->m_layers);
+        const std::string layer_name = make_unique_name("layer", impl->m_layers);
         layer_values.insert("layer_name", layer_name);
     }
 
@@ -728,7 +727,7 @@ void DisneyMaterial::add_layer(Dictionary layer_values)
     }
 
     // Insert the layer into the material.
-    const string& layer_name = layer_values.get<string>("layer_name");
+    const std::string& layer_name = layer_values.get<std::string>("layer_name");
     m_params.insert(layer_name, layer_values);
 }
 
@@ -753,14 +752,14 @@ const DisneyMaterialLayer& DisneyMaterial::get_layer(
 
     assert(thread_index < Impl::MaxThreadCount);
 
-    vector<DisneyMaterialLayer>* layers =
+    std::vector<DisneyMaterialLayer>* layers =
         impl->m_per_thread_layers[thread_index];
 
     if (layers == nullptr)
     {
-        layers = new vector<DisneyMaterialLayer>(impl->m_layers);
+        layers = new std::vector<DisneyMaterialLayer>(impl->m_layers);
 
-        for (const_each<vector<DisneyMaterialLayer>> it = *layers; it; ++it)
+        for (const_each<std::vector<DisneyMaterialLayer>> it = *layers; it; ++it)
         {
             APPLESEED_UNUSED const bool ok = it->prepare_expressions();
             assert(ok);

--- a/src/appleseed/renderer/modeling/material/material.cpp
+++ b/src/appleseed/renderer/modeling/material/material.cpp
@@ -59,7 +59,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -249,8 +248,8 @@ IBasisModifier* Material::create_basis_modifier(const MessageContext& context) c
     }
 
     // Retrieve the displacement method.
-    const string displacement_method =
-        m_params.get_required<string>(
+    const std::string displacement_method =
+        m_params.get_required<std::string>(
             "displacement_method",
             "bump",
             make_vector("bump", "normal"),
@@ -266,7 +265,7 @@ IBasisModifier* Material::create_basis_modifier(const MessageContext& context) c
     else
     {
         const NormalMappingModifier::UpVector up_vector =
-            m_params.get_optional<string>("normal_map_up", "z", make_vector("y", "z"), context) == "y"
+            m_params.get_optional<std::string>("normal_map_up", "z", make_vector("y", "z"), context) == "y"
                 ? NormalMappingModifier::UpVectorY
                 : NormalMappingModifier::UpVectorZ;
         return new NormalMappingModifier(displacement_source, up_vector);

--- a/src/appleseed/renderer/modeling/object/curveobject.cpp
+++ b/src/appleseed/renderer/modeling/object/curveobject.cpp
@@ -44,7 +44,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -60,11 +59,11 @@ namespace
 
 struct CurveObject::Impl
 {
-    CurveBasis          m_basis;
-    size_t              m_curve_count;
-    vector<Curve1Type>  m_curves1;
-    vector<Curve3Type>  m_curves3;
-    vector<string>      m_material_slots;
+    CurveBasis               m_basis;
+    size_t                   m_curve_count;
+    std::vector<Curve1Type>  m_curves1;
+    std::vector<Curve3Type>  m_curves3;
+    std::vector<std::string> m_material_slots;
 
     Impl()
     {
@@ -231,7 +230,7 @@ void CurveObject::collect_asset_paths(StringArray& paths) const
 {
     if (m_params.strings().exist("filepath"))
     {
-        const string filepath = m_params.get<string>("filepath");
+        const std::string filepath = m_params.get<std::string>("filepath");
         if (!starts_with(filepath, "builtin:"))
             paths.push_back(filepath.c_str());
     }
@@ -241,7 +240,7 @@ void CurveObject::update_asset_paths(const StringDictionary& mappings)
 {
     if (m_params.strings().exist("filepath"))
     {
-        const string filepath = m_params.get<string>("filepath");
+        const std::string filepath = m_params.get<std::string>("filepath");
         if (!starts_with(filepath, "builtin:"))
             m_params.set("filepath", mappings.get(filepath.c_str()));
     }

--- a/src/appleseed/renderer/modeling/object/curveobjectreader.cpp
+++ b/src/appleseed/renderer/modeling/object/curveobjectreader.cpp
@@ -66,7 +66,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace renderer
@@ -84,7 +83,7 @@ namespace
       public:
         CurveObjectBuilder(
             const ParamArray& params,
-            const string& name)
+            const std::string& name)
           : m_params(params)
           , m_name(name)
           , m_split_count(0)
@@ -275,16 +274,16 @@ namespace
         }
 
       private:
-        const ParamArray    m_params;
-        const string        m_name;
-        CurveObject*        m_object;
-        size_t              m_split_count;
+        const ParamArray         m_params;
+        const std::string        m_name;
+        CurveObject*             m_object;
+        size_t                   m_split_count;
 
         // Curve attributes and statistics.
-        vector<GVector3>    m_vertices;
-        vector<GScalar>     m_widths;
-        vector<GScalar>     m_opacities;
-        vector<Color3f>     m_colors;
+        std::vector<GVector3>    m_vertices;
+        std::vector<GScalar>     m_widths;
+        std::vector<GScalar>     m_opacities;
+        std::vector<Color3f>     m_colors;
 
         // Global statistics.
         size_t              m_total_vertex_count;
@@ -348,7 +347,7 @@ auto_release_ptr<CurveObject> CurveObjectReader::read(
 {
     CurveObjectBuilder builder(params, name);
 
-    const string filepath = params.get<string>("filepath");
+    const std::string filepath = params.get<std::string>("filepath");
 
     if (filepath == "builtin:hairball")
         return builder.create_hair_ball();
@@ -381,7 +380,7 @@ auto_release_ptr<CurveObject> CurveObjectReader::read(
     {
         reader.read(builder);
     }
-    catch (const exception& e)
+    catch (const std::exception& e)
     {
         RENDERER_LOG_ERROR("failed to load curve file %s: %s.", filepath.c_str(), e.what());
         return auto_release_ptr<CurveObject>(nullptr);

--- a/src/appleseed/renderer/modeling/object/curveobjectwriter.cpp
+++ b/src/appleseed/renderer/modeling/object/curveobjectwriter.cpp
@@ -53,7 +53,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -120,12 +119,12 @@ namespace
         const CurveObject&  m_object;
 
         // Curve parameters for writing.
-        size_t              m_curve_count;
-        vector<size_t>      m_vertex_counts;
-        vector<GVector3>    m_vertices;
-        vector<GScalar>     m_widths;
-        vector<GScalar>     m_opacities;
-        vector<Color3f>     m_colors;
+        size_t                   m_curve_count;
+        std::vector<size_t>      m_vertex_counts;
+        std::vector<GVector3>    m_vertices;
+        std::vector<GScalar>     m_widths;
+        std::vector<GScalar>     m_opacities;
+        std::vector<Color3f>     m_colors;
 
         // Global stats.
         size_t              m_total_vertex_count;
@@ -235,7 +234,7 @@ bool CurveObjectWriter::write(
     {
         writer.write(walker);
     }
-    catch (const exception& e)
+    catch (const std::exception& e)
     {
         RENDERER_LOG_ERROR("failed to write curve file %s: %s.", filepath, e.what());
         return false;

--- a/src/appleseed/renderer/modeling/object/diskobject.cpp
+++ b/src/appleseed/renderer/modeling/object/diskobject.cpp
@@ -44,7 +44,6 @@
 #include "foundation/utility/string.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/object/meshobject.cpp
+++ b/src/appleseed/renderer/modeling/object/meshobject.cpp
@@ -48,7 +48,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -65,7 +64,7 @@ namespace
 struct MeshObject::Impl
 {
     StaticTriangleTess          m_tess;
-    vector<string>              m_material_slots;
+    std::vector<std::string>    m_material_slots;
 };
 
 MeshObject::MeshObject(

--- a/src/appleseed/renderer/modeling/object/meshobjectoperations.cpp
+++ b/src/appleseed/renderer/modeling/object/meshobjectoperations.cpp
@@ -45,7 +45,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -57,7 +56,7 @@ void compute_smooth_vertex_normals_base_pose(MeshObject& object)
     const size_t vertex_count = object.get_vertex_count();
     const size_t triangle_count = object.get_triangle_count();
 
-    vector<GVector3> normals(vertex_count, GVector3(0.0));
+    std::vector<GVector3> normals(vertex_count, GVector3(0.0));
 
     for (size_t i = 0; i < triangle_count; ++i)
     {
@@ -87,7 +86,7 @@ void compute_smooth_vertex_normals_pose(MeshObject& object, const size_t motion_
     const size_t vertex_count = object.get_vertex_count();
     const size_t triangle_count = object.get_triangle_count();
 
-    vector<GVector3> normals(vertex_count, GVector3(0.0));
+    std::vector<GVector3> normals(vertex_count, GVector3(0.0));
 
     for (size_t i = 0; i < triangle_count; ++i)
     {
@@ -123,7 +122,7 @@ void compute_smooth_vertex_tangents_base_pose(MeshObject& object)
     const size_t vertex_count = object.get_vertex_count();
     const size_t triangle_count = object.get_triangle_count();
 
-    vector<GVector3> tangents(vertex_count, GVector3(0.0));
+    std::vector<GVector3> tangents(vertex_count, GVector3(0.0));
 
     for (size_t i = 0; i < triangle_count; ++i)
     {
@@ -174,7 +173,7 @@ void compute_smooth_vertex_tangents_pose(MeshObject& object, const size_t motion
     const size_t vertex_count = object.get_vertex_count();
     const size_t triangle_count = object.get_triangle_count();
 
-    vector<GVector3> tangents(vertex_count, GVector3(0.0));
+    std::vector<GVector3> tangents(vertex_count, GVector3(0.0));
 
     for (size_t i = 0; i < triangle_count; ++i)
     {

--- a/src/appleseed/renderer/modeling/object/meshobjectprimitives.cpp
+++ b/src/appleseed/renderer/modeling/object/meshobjectprimitives.cpp
@@ -47,7 +47,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -61,7 +60,7 @@ namespace
     class ParametricGrid
     {
       public:
-        static unique_ptr<ParametricGrid> create(const size_t res_u, const size_t res_v, const ParamArray& params)
+        static std::unique_ptr<ParametricGrid> create(const size_t res_u, const size_t res_v, const ParamArray& params)
         {
             const float width = params.get_optional<float>("width", 1.0f);
             const float height = params.get_optional<float>("height", 1.0f);
@@ -69,10 +68,10 @@ namespace
             if (width <= 0.0f || height <= 0.0f)
             {
                 RENDERER_LOG_ERROR("width and height must be greater than zero.");
-                return unique_ptr<ParametricGrid>();
+                return std::unique_ptr<ParametricGrid>();
             }
 
-            return unique_ptr<ParametricGrid>(new ParametricGrid(width, height));
+            return std::unique_ptr<ParametricGrid>(new ParametricGrid(width, height));
         }
 
         const Transformf& transform() const
@@ -160,17 +159,17 @@ namespace
     class ParametricDisk
     {
       public:
-        static unique_ptr<ParametricDisk> create(const size_t res_u, const size_t res_v, const ParamArray& params)
+        static std::unique_ptr<ParametricDisk> create(const size_t res_u, const size_t res_v, const ParamArray& params)
         {
             const float radius = params.get_optional<float>("radius", 1.0f);
 
             if (radius <= 0.0f)
             {
                 RENDERER_LOG_ERROR("radius must be greater than zero.");
-                return unique_ptr<ParametricDisk>();
+                return std::unique_ptr<ParametricDisk>();
             }
 
-            return unique_ptr<ParametricDisk>(new ParametricDisk(radius));
+            return std::unique_ptr<ParametricDisk>(new ParametricDisk(radius));
         }
 
         const Transformf& transform() const
@@ -248,17 +247,17 @@ namespace
     class ParametricSphere
     {
       public:
-        static unique_ptr<ParametricSphere> create(const size_t res_u, const size_t res_v, const ParamArray& params)
+        static std::unique_ptr<ParametricSphere> create(const size_t res_u, const size_t res_v, const ParamArray& params)
         {
             const float radius = params.get_optional<float>("radius", 1.0f);
 
             if (radius <= 0.0f)
             {
                 RENDERER_LOG_ERROR("radius must be greater than zero.");
-                return unique_ptr<ParametricSphere>();
+                return std::unique_ptr<ParametricSphere>();
             }
 
-            return unique_ptr<ParametricSphere>(new ParametricSphere(res_u, radius));
+            return std::unique_ptr<ParametricSphere>(new ParametricSphere(res_u, radius));
         }
 
         const Transformf& transform() const
@@ -312,7 +311,7 @@ namespace
     class ParametricTorus
     {
       public:
-        static unique_ptr<ParametricTorus> create(const size_t res_u, const size_t res_v, const ParamArray& params)
+        static std::unique_ptr<ParametricTorus> create(const size_t res_u, const size_t res_v, const ParamArray& params)
         {
             const float major_radius = params.get_optional<float>("major_radius", 1.0f);
             const float minor_radius = params.get_optional<float>("minor_radius", 0.2f);
@@ -320,10 +319,10 @@ namespace
             if (major_radius <= 0.0f || minor_radius <= 0.0f)
             {
                 RENDERER_LOG_ERROR("torus radii must be greater than zero.");
-                return unique_ptr<ParametricTorus>();
+                return std::unique_ptr<ParametricTorus>();
             }
 
-            return unique_ptr<ParametricTorus>(new ParametricTorus(res_u, res_v, major_radius, minor_radius));
+            return std::unique_ptr<ParametricTorus>(new ParametricTorus(res_u, res_v, major_radius, minor_radius));
         }
 
         const Transformf& transform() const
@@ -466,7 +465,7 @@ namespace
             return auto_release_ptr<MeshObject>();
         }
 
-        unique_ptr<ParametricSurface> surface = ParametricSurface::create(res_u, res_v, params);
+        std::unique_ptr<ParametricSurface> surface = ParametricSurface::create(res_u, res_v, params);
 
         if (surface.get() == nullptr)
             return auto_release_ptr<MeshObject>();

--- a/src/appleseed/renderer/modeling/object/meshobjectreader.cpp
+++ b/src/appleseed/renderer/modeling/object/meshobjectreader.cpp
@@ -69,7 +69,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -91,11 +90,11 @@ namespace
       : public IMeshBuilder
     {
       public:
-        typedef vector<MeshObject*> MeshObjectVector;
+        typedef std::vector<MeshObject*> MeshObjectVector;
 
         MeshObjectBuilder(
             const ParamArray&   params,
-            const string&       base_object_name)
+            const std::string&  base_object_name)
           : m_params(params)
           , m_ignore_vertex_normals(m_params.get_optional<bool>("ignore_vertex_normals"))
           , m_base_object_name(base_object_name)
@@ -127,7 +126,7 @@ namespace
         void begin_mesh(const char* mesh_name) override
         {
             // Construct the object name.
-            const string object_name = m_base_object_name + "." + make_unique_mesh_name(mesh_name);
+            const std::string object_name = m_base_object_name + "." + make_unique_mesh_name(mesh_name);
 
             // Create an empty mesh object.
             m_objects.push_back(
@@ -292,37 +291,37 @@ namespace
         }
 
       private:
-        const ParamArray        m_params;
-        const bool              m_ignore_vertex_normals;
-        const string            m_base_object_name;
+        const ParamArray                  m_params;
+        const bool                        m_ignore_vertex_normals;
+        const std::string                 m_base_object_name;
 
-        MeshObjectVector        m_objects;
+        MeshObjectVector                  m_objects;
 
         // Support data for untitled meshes.
-        size_t                  m_untitled_mesh_counter;
-        map<string, size_t>     m_mesh_counters;
+        size_t                            m_untitled_mesh_counter;
+        std::map<std::string, size_t>     m_mesh_counters;
 
         // Face definition.
-        size_t                  m_vertex_count;
-        vector<uint32>          m_face_vertices;
-        vector<uint32>          m_face_normals;
-        vector<uint32>          m_face_tex_coords;
-        uint32                  m_face_material;
+        size_t                            m_vertex_count;
+        std::vector<uint32>               m_face_vertices;
+        std::vector<uint32>               m_face_normals;
+        std::vector<uint32>               m_face_tex_coords;
+        uint32                            m_face_material;
 
         // Support data for face triangulation.
-        Triangulator<double>    m_triangulator;
-        vector<Vector3d>        m_polygon;
-        vector<size_t>          m_triangles;
+        Triangulator<double>              m_triangulator;
+        std::vector<Vector3d>             m_polygon;
+        std::vector<size_t>               m_triangles;
 
         // Mesh statistics.
-        size_t                  m_normal_count;
-        size_t                  m_face_count;
-        size_t                  m_triangulation_error_count;
-        size_t                  m_null_normal_vector_count;
+        size_t                            m_normal_count;
+        size_t                            m_face_count;
+        size_t                            m_triangulation_error_count;
+        size_t                            m_null_normal_vector_count;
 
         // Global statistics.
-        size_t                  m_total_vertex_count;
-        size_t                  m_total_triangle_count;
+        size_t                            m_total_vertex_count;
+        size_t                            m_total_triangle_count;
 
         void reset_mesh_stats()
         {
@@ -332,7 +331,7 @@ namespace
             m_null_normal_vector_count = 0;
         }
 
-        string make_unique_mesh_name(string mesh_name)
+        std::string make_unique_mesh_name(std::string mesh_name)
         {
             if (mesh_name.empty())
                 mesh_name = to_string(m_untitled_mesh_counter++);
@@ -402,7 +401,7 @@ namespace
     {
         GenericMeshFileReader reader(filename);
 
-        const string obj_parsing_mode = params.get_optional<string>("obj_parsing_mode", "fast");
+        const std::string obj_parsing_mode = params.get_optional<std::string>("obj_parsing_mode", "fast");
 
         if (obj_parsing_mode == "fast")
         {
@@ -454,7 +453,7 @@ namespace
 
             return false;
         }
-        catch (const exception& e)
+        catch (const std::exception& e)
         {
             RENDERER_LOG_ERROR(
                 "failed to load mesh file %s: %s.",
@@ -579,12 +578,12 @@ namespace
 
     struct MeshObjectKeyFrame
     {
-        double  m_key;
-        string  m_filename;
+        double       m_key;
+        std::string  m_filename;
 
         MeshObjectKeyFrame() {}
 
-        MeshObjectKeyFrame(const double key, const string& filename)
+        MeshObjectKeyFrame(const double key, const std::string& filename)
           : m_key(key)
           , m_filename(filename)
         {
@@ -668,13 +667,13 @@ namespace
 
     void unshare_normals(MeshObject& object)
     {
-        vector<GVector3> old_normals(object.get_vertex_normal_count());
+        std::vector<GVector3> old_normals(object.get_vertex_normal_count());
         for (size_t i = 0, e = object.get_vertex_normal_count(); i < e; ++i)
             old_normals[i] = object.get_vertex_normal(i);
 
         const size_t triangle_count = object.get_triangle_count();
 
-        vector<Triangle> old_triangles(triangle_count);
+        std::vector<Triangle> old_triangles(triangle_count);
         for (size_t i = 0, e = triangle_count; i < e; ++i)
             old_triangles[i] = object.get_triangle(i);
 
@@ -705,13 +704,13 @@ namespace
     {
         assert(filenames.size() >= 2);
 
-        vector<MeshObjectKeyFrame> key_frames;
+        std::vector<MeshObjectKeyFrame> key_frames;
         key_frames.reserve(filenames.size());
 
         for (const_each<StringDictionary> i = filenames; i; ++i)
         {
             const double key = from_string<double>(i->key());
-            const string filename = i->value<string>();
+            const std::string filename = i->value<std::string>();
             key_frames.emplace_back(key, filename);
         }
 
@@ -735,7 +734,7 @@ namespace
 
         for (size_t i = 1; i < key_frames.size(); ++i)
         {
-            const string& filename = key_frames[i].m_filename;
+            const std::string& filename = key_frames[i].m_filename;
 
             MeshObjectArray poses;
 
@@ -832,7 +831,7 @@ bool MeshObjectReader::read(
 
         // Single-pose object.
         if (!read_mesh_object(
-                search_paths.qualify(params.strings().get<string>("filename")).c_str(),
+                search_paths.qualify(params.strings().get<std::string>("filename")).c_str(),
                 base_object_name,
                 completed_params,
                 objects))

--- a/src/appleseed/renderer/modeling/object/meshobjectwriter.cpp
+++ b/src/appleseed/renderer/modeling/object/meshobjectwriter.cpp
@@ -51,7 +51,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -163,7 +162,7 @@ namespace
 
       private:
         const MeshObject&   m_object;
-        const string        m_object_name;
+        const std::string   m_object_name;
     };
 }
 
@@ -183,7 +182,7 @@ bool MeshObjectWriter::write(
         MeshObjectWalker walker(object, object_name);
         writer.write(walker);
     }
-    catch (const exception& e)
+    catch (const std::exception& e)
     {
         RENDERER_LOG_ERROR(
             "failed to write mesh file %s: %s.",

--- a/src/appleseed/renderer/modeling/object/sphereobject.cpp
+++ b/src/appleseed/renderer/modeling/object/sphereobject.cpp
@@ -44,7 +44,6 @@
 #include "foundation/utility/string.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/postprocessingstage/colormappostprocessingstage.cpp
+++ b/src/appleseed/renderer/modeling/postprocessingstage/colormappostprocessingstage.cpp
@@ -70,7 +70,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -132,8 +131,8 @@ namespace
         {
             const OnFrameBeginMessageContext context("post-processing stage", this);
 
-            const string color_map =
-                m_params.get_optional<string>(
+            const std::string color_map =
+                m_params.get_optional<std::string>(
                     "color_map",
                     "inferno",
                     make_vector("inferno", "jet", "magma", "plasma", "viridis", "custom"),
@@ -153,8 +152,8 @@ namespace
             {
                 assert(color_map == "custom");
 
-                const string color_map_filepath =
-                    m_params.get_optional<string>("color_map_file_path", "", context);
+                const std::string color_map_filepath =
+                    m_params.get_optional<std::string>("color_map_file_path", "", context);
 
                 if (color_map_filepath.empty())
                 {
@@ -168,7 +167,7 @@ namespace
                         to_string(
                             project.search_paths().qualify(color_map_filepath)));
                 }
-                catch (const exception& e)
+                catch (const std::exception& e)
                 {
                     RENDERER_LOG_ERROR("%s%s", context.get(), e.what());
                     return false;
@@ -266,7 +265,7 @@ namespace
             }
         };
 
-        typedef vector<Segment> SegmentVector;
+        typedef std::vector<Segment> SegmentVector;
 
         ColorMap            m_color_map;
         bool                m_auto_range;
@@ -277,10 +276,10 @@ namespace
         bool                m_render_isolines;
         float               m_line_thickness;
 
-        void set_palette_from_image_file(const string& file_path)
+        void set_palette_from_image_file(const std::string& file_path)
         {
             GenericImageFileReader reader;
-            unique_ptr<Image> image(reader.read(file_path.c_str()));
+            std::unique_ptr<Image> image(reader.read(file_path.c_str()));
 
             if (!is_linear_image_file_format(file_path))
                 convert_srgb_to_linear_rgb(*image);
@@ -356,7 +355,7 @@ namespace
 
                 const float lum =
                     fit<size_t, float>(i, 0, m_legend_bar_ticks - 1, max_luminance, min_luminance);
-                const string label = to_string(lum);
+                const std::string label = to_string(lum);
 
                 const float label_width =
                     TextRenderer::compute_string_width(LabelFont, LabelFontHeight, label.c_str());

--- a/src/appleseed/renderer/modeling/postprocessingstage/postprocessingstage.cpp
+++ b/src/appleseed/renderer/modeling/postprocessingstage/postprocessingstage.cpp
@@ -34,7 +34,6 @@
 #include "renderer/utility/paramarray.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/postprocessingstage/renderstamppostprocessingstage.cpp
+++ b/src/appleseed/renderer/modeling/postprocessingstage/renderstamppostprocessingstage.cpp
@@ -63,7 +63,6 @@
 
 using namespace foundation;
 using namespace OIIO;
-using namespace std;
 
 namespace renderer
 {
@@ -72,7 +71,7 @@ namespace
 {
     const char* Model = "render_stamp_post_processing_stage";
 
-    const string DefaultFormatString = "appleseed {lib-version} | Time: {render-time}";
+    const std::string DefaultFormatString = "appleseed {lib-version} | Time: {render-time}";
     const float DefaultScaleFactor = 1.0f;
     const float MinScaleFactor = 0.1f;
     const float MaxScaleFactor = 20.0f;
@@ -130,7 +129,7 @@ namespace
             const double render_time = render_info.get_optional<double>("render_time", 0.0);
 
             // Compute the final string.
-            string text = m_format_string;
+            std::string text = m_format_string;
             text = replace(text, "{lib-name}", Appleseed::get_lib_name());
             text = replace(text, "{lib-version}", Appleseed::get_lib_version());
             text = replace(text, "{lib-cpu-features}", Appleseed::get_lib_cpu_features());
@@ -178,7 +177,7 @@ namespace
             const float filter_width = fit(m_scale_factor, MinScaleFactor, MaxScaleFactor, 2.75f, 4.5f);
             ImageBufAlgo::resize(scaled_unpremult_icon, unpremult_icon, "mitchell", filter_width, roi);
             ImageBufAlgo::premult(scaled_premult_icon, scaled_unpremult_icon, ROI::All());
-            unique_ptr<float[]> pixels(new float[roi.width() * roi.height() * roi.nchannels()]);
+            std::unique_ptr<float[]> pixels(new float[roi.width() * roi.height() * roi.nchannels()]);
             scaled_premult_icon.get_pixels(ROI::All(), TypeDesc::TypeFloat, pixels.get());
 
             // Blit the appleseed logo.
@@ -205,9 +204,9 @@ namespace
         }
 
       private:
-        string   m_format_string;
-        float    m_scale_factor;
-        ImageBuf m_icon;
+        std::string   m_format_string;
+        float         m_scale_factor;
+        ImageBuf      m_icon;
     };
 }
 

--- a/src/appleseed/renderer/modeling/project-builtin/cornellboxproject.cpp
+++ b/src/appleseed/renderer/modeling/project-builtin/cornellboxproject.cpp
@@ -69,7 +69,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/project/assethandler.cpp
+++ b/src/appleseed/renderer/modeling/project/assethandler.cpp
@@ -56,7 +56,6 @@
 using namespace boost;
 using namespace boost::filesystem;
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -67,7 +66,7 @@ namespace renderer
 
 namespace
 {
-    string convert_to_posix(string path)
+    std::string convert_to_posix(std::string path)
     {
         replace(path.begin(), path.end(), '\\', '/');
         return path;
@@ -98,8 +97,8 @@ namespace
     // The resources pointed to by p1 and p2 must exist on the filesystem.
     bool is_extension_of(const path& p1, const path& p2)
     {
-        const string r1 = canonical(p1).string();
-        const string r2 = canonical(p2).string();
+        const std::string r1 = canonical(p1).string();
+        const std::string r2 = canonical(p2).string();
         return starts_with(r1, r2);
     }
 
@@ -133,8 +132,8 @@ bool AssetHandler::handle_assets() const
     m_project.collect_asset_paths(paths);
 
     // Remove duplicates.
-    vector<string> unique_paths = array_vector<vector<string>>(paths);
-    sort(unique_paths.begin(), unique_paths.end());
+    std::vector<std::string> unique_paths = array_vector<std::vector<std::string>>(paths);
+    std::sort(unique_paths.begin(), unique_paths.end());
     unique_paths.erase(
         unique(unique_paths.begin(), unique_paths.end()),
         unique_paths.end());
@@ -144,7 +143,7 @@ bool AssetHandler::handle_assets() const
 
     for (size_t i = 0, e = unique_paths.size(); i < e; ++i)
     {
-        string asset_path = unique_paths[i];
+        std::string asset_path = unique_paths[i];
         assert(!asset_path.empty());
 
         // Handle this asset.
@@ -168,7 +167,7 @@ bool AssetHandler::handle_assets() const
     return true;
 }
 
-bool AssetHandler::handle_asset(string& asset_path) const
+bool AssetHandler::handle_asset(std::string& asset_path) const
 {
     // Let's first get rid of the case where the asset path is absolute.
     if (path(asset_path).is_absolute())
@@ -219,7 +218,7 @@ bool AssetHandler::handle_asset(string& asset_path) const
     }
 }
 
-bool AssetHandler::handle_absolute_asset(string& asset_path) const
+bool AssetHandler::handle_absolute_asset(std::string& asset_path) const
 {
     switch (m_mode)
     {
@@ -233,7 +232,7 @@ bool AssetHandler::handle_absolute_asset(string& asset_path) const
     }
 }
 
-bool AssetHandler::make_absolute_asset_path(string& asset_path) const
+bool AssetHandler::make_absolute_asset_path(std::string& asset_path) const
 {
     // Make sure the asset path is qualified and canonized.
     path absolute_asset_path =
@@ -246,7 +245,7 @@ bool AssetHandler::make_absolute_asset_path(string& asset_path) const
     return true;
 }
 
-bool AssetHandler::copy_absolute_asset(string& asset_path) const
+bool AssetHandler::copy_absolute_asset(std::string& asset_path) const
 {
     const path old_absolute_asset_path(asset_path);
     const path asset_filename = old_absolute_asset_path.filename();
@@ -268,7 +267,7 @@ bool AssetHandler::copy_absolute_asset(string& asset_path) const
     return true;
 }
 
-bool AssetHandler::copy_relative_asset(string& asset_path) const
+bool AssetHandler::copy_relative_asset(std::string& asset_path) const
 {
     // Copy the asset file only if the destination differs from the source.
     if (m_project_old_root_dir != m_project_new_root_dir)

--- a/src/appleseed/renderer/modeling/project/configuration.cpp
+++ b/src/appleseed/renderer/modeling/project/configuration.cpp
@@ -50,7 +50,6 @@
 #include <cstring>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/project/project.cpp
+++ b/src/appleseed/renderer/modeling/project/project.cpp
@@ -68,7 +68,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -114,7 +113,7 @@ struct Project::Impl
 
     // Project metadata.
     size_t                              m_format_revision;
-    string                              m_path;
+    std::string                         m_path;
     SearchPaths                         m_search_paths;
 
     // Scene description.
@@ -125,7 +124,7 @@ struct Project::Impl
 
     // Project-specific components.
     LightPathRecorder                   m_light_path_recorder;
-    unique_ptr<TraceContext>            m_trace_context;
+    std::unique_ptr<TraceContext>       m_trace_context;
 
     explicit Impl(const Project& project)
       : m_format_revision(ProjectFormatRevision)
@@ -441,7 +440,7 @@ namespace
     {
         typedef typename EntityFactoryRegistrarType::EntityType EntityType;
 
-        const string entry_point_name =
+        const std::string entry_point_name =
             format("appleseed_create_{0}_factory", EntityTraits<EntityType>::get_entity_type_name());
 
         plugin_store.register_plugin_handler(

--- a/src/appleseed/renderer/modeling/project/projectfilereader.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilereader.cpp
@@ -147,7 +147,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 using namespace xercesc;
 namespace bf = boost::filesystem;
 
@@ -170,7 +169,7 @@ namespace
     {
       public:
         ErrorLoggerAndCounter(
-            const string&   input_filepath,
+            const std::string&   input_filepath,
             EventCounters&  event_counters)
           : ErrorLogger(global_logger(), input_filepath)
           , m_event_counters(event_counters)
@@ -252,7 +251,7 @@ namespace
 
     template <typename T>
     T get_scalar(
-        const string&       text,
+        const std::string&  text,
         ParseContext&       context)
     {
         try
@@ -268,7 +267,7 @@ namespace
     }
 
     Vector3d get_vector3(
-        const string&       text,
+        const std::string&  text,
         ParseContext&       context)
     {
         Vector3d vec;
@@ -304,7 +303,7 @@ namespace
 
     template <typename Vec>
     void get_vector(
-        const string&       text,
+        const std::string&  text,
         Vec&                values,
         ParseContext&       context)
     {
@@ -323,9 +322,9 @@ namespace
     template <typename Entity, typename EntityFactoryRegistrar>
     auto_release_ptr<Entity> create_entity(
         const EntityFactoryRegistrar&   registrar,
-        const string&                   type,
-        const string&                   model,
-        const string&                   name,
+        const std::string&              type,
+        const std::string&              model,
+        const std::string&              name,
         const ParamArray&               params,
         ParseContext&                   context)
     {
@@ -452,7 +451,7 @@ namespace
             const XMLCh* const  chars,
             const XMLSize_t     length) override
         {
-            const string inner_value = transcode(chars);
+            const std::string inner_value = transcode(chars);
             if (!m_value.empty() && !inner_value.empty())
             {
                 RENDERER_LOG_ERROR(
@@ -465,20 +464,20 @@ namespace
             }
         }
 
-        const string& get_name() const
+        const std::string& get_name() const
         {
             return m_name;
         }
 
-        const string& get_value() const
+        const std::string& get_value() const
         {
             return m_value;
         }
 
       private:
         ParseContext&   m_context;
-        string          m_name;
-        string          m_value;
+        std::string     m_name;
+        std::string     m_value;
     };
 
 
@@ -522,7 +521,7 @@ namespace
             m_name = get_value(attrs, "name");
         }
 
-        const string& get_name() const
+        const std::string& get_name() const
         {
             return m_name;
         }
@@ -533,7 +532,7 @@ namespace
         }
 
       private:
-        string m_name;
+        std::string m_name;
     };
 
 
@@ -678,9 +677,9 @@ namespace
         }
 
       private:
-        ParseContext&   m_context;
-        Matrix4d        m_matrix;
-        vector<double>  m_values;
+        ParseContext&        m_context;
+        Matrix4d             m_matrix;
+        std::vector<double>  m_values;
     };
 
 
@@ -946,7 +945,7 @@ namespace
         }
 
       private:
-        typedef map<float, Transformd> TransformMap;
+        typedef std::map<float, Transformd> TransformMap;
 
         TransformMap m_transforms;
 
@@ -1089,7 +1088,7 @@ namespace
       private:
         ParseContext&                   m_context;
         auto_release_ptr<ColorEntity>   m_color_entity;
-        string                          m_name;
+        std::string                     m_name;
         ColorValueArray                 m_values;
         ColorValueArray                 m_alpha;
     };
@@ -1104,7 +1103,7 @@ namespace
       : public Base
     {
       public:
-        EntityElementHandler(const string& entity_type, ParseContext& context)
+        EntityElementHandler(const std::string& entity_type, ParseContext& context)
           : m_context(context)
           , m_entity_type(entity_type)
         {
@@ -1141,10 +1140,10 @@ namespace
 
       protected:
         ParseContext&                   m_context;
-        const string                    m_entity_type;
+        const std::string               m_entity_type;
         auto_release_ptr<Entity>        m_entity;
-        string                          m_name;
-        string                          m_model;
+        std::string                     m_name;
+        std::string                     m_model;
     };
 
 
@@ -1216,8 +1215,8 @@ namespace
         const TextureFactoryRegistrar   m_texture_factory_registrar;
         ParseContext&                   m_context;
         auto_release_ptr<Texture>       m_texture;
-        string                          m_name;
-        string                          m_model;
+        std::string                     m_name;
+        std::string                     m_model;
     };
 
 
@@ -1279,8 +1278,8 @@ namespace
 
         ParseContext&                       m_context;
         auto_release_ptr<TextureInstance>   m_texture_instance;
-        string                              m_name;
-        string                              m_texture;
+        std::string                         m_name;
+        std::string                         m_texture;
     };
 
 
@@ -1406,8 +1405,8 @@ namespace
       private:
         ParseContext&                       m_context;
         auto_release_ptr<Environment>       m_environment;
-        string                              m_name;
-        string                              m_model;
+        std::string                         m_name;
+        std::string                         m_model;
     };
 
 
@@ -1527,7 +1526,7 @@ namespace
       : public ParametrizedElementHandler
     {
       public:
-        typedef vector<Object*> ObjectVector;
+        typedef std::vector<Object*> ObjectVector;
 
         explicit ObjectElementHandler(ParseContext& context)
           : m_context(context)
@@ -1609,8 +1608,8 @@ namespace
       private:
         ParseContext&   m_context;
         ObjectVector    m_objects;
-        string          m_name;
-        string          m_model;
+        std::string     m_name;
+        std::string     m_model;
     };
 
 
@@ -1643,26 +1642,26 @@ namespace
             }
         }
 
-        const string& get_material_slot() const
+        const std::string& get_material_slot() const
         {
             return m_slot;
         }
 
-        const string& get_material_side() const
+        const std::string& get_material_side() const
         {
             return m_side;
         }
 
-        const string& get_material_name() const
+        const std::string& get_material_name() const
         {
             return m_material;
         }
 
       private:
         ParseContext&           m_context;
-        string                  m_slot;
-        string                  m_side;
-        string                  m_material;
+        std::string             m_slot;
+        std::string             m_side;
+        std::string             m_material;
     };
 
 
@@ -1715,9 +1714,9 @@ namespace
                     AssignMaterialElementHandler* assign_mat_handler =
                         static_cast<AssignMaterialElementHandler*>(handler);
 
-                    const string& material_slot = assign_mat_handler->get_material_slot();
-                    const string& material_side = assign_mat_handler->get_material_side();
-                    const string& material_name = assign_mat_handler->get_material_name();
+                    const std::string& material_slot = assign_mat_handler->get_material_slot();
+                    const std::string& material_side = assign_mat_handler->get_material_side();
+                    const std::string& material_name = assign_mat_handler->get_material_name();
 
                     if (material_side == "front")
                         m_front_material_mappings.insert(material_slot, material_name);
@@ -1748,8 +1747,8 @@ namespace
         auto_release_ptr<ObjectInstance>    m_object_instance;
         StringDictionary                    m_front_material_mappings;
         StringDictionary                    m_back_material_mappings;
-        string                              m_name;
-        string                              m_object;
+        std::string                         m_name;
+        std::string                         m_object;
     };
 
 
@@ -1797,8 +1796,8 @@ namespace
         typedef TransformSequenceElementHandler<ParametrizedElementHandler> Base;
 
         auto_release_ptr<AssemblyInstance>  m_assembly_instance;
-        string                              m_name;
-        string                              m_assembly;
+        std::string                         m_name;
+        std::string                         m_assembly;
     };
 
 
@@ -1821,13 +1820,13 @@ namespace
             m_code = trim_both(transcode(chars));
         }
 
-        const string& get_code() const
+        const std::string& get_code() const
         {
             return m_code;
         }
 
       private:
-        string  m_code;
+        std::string  m_code;
     };
 
 
@@ -1871,22 +1870,22 @@ namespace
             }
         }
 
-        const string& get_type() const
+        const std::string& get_type() const
         {
             return m_type;
         }
 
-        const string& get_name() const
+        const std::string& get_name() const
         {
             return m_name;
         }
 
-        const string& get_layer() const
+        const std::string& get_layer() const
         {
             return m_layer;
         }
 
-        const string& get_code() const
+        const std::string& get_code() const
         {
             return m_code;
         }
@@ -1897,10 +1896,10 @@ namespace
         }
 
       private:
-        string  m_type;
-        string  m_name;
-        string  m_layer;
-        string  m_code;
+        std::string  m_type;
+        std::string  m_name;
+        std::string  m_layer;
+        std::string  m_code;
     };
 
 
@@ -1924,31 +1923,31 @@ namespace
             m_dst_param = get_value(attrs, "dst_param");
         }
 
-        const string& src_layer()
+        const std::string& src_layer()
         {
             return m_src_layer;
         }
 
-        const string& src_param()
+        const std::string& src_param()
         {
             return m_src_param;
         }
 
-        const string& dst_layer()
+        const std::string& dst_layer()
         {
             return m_dst_layer;
         }
 
-        const string& dst_param()
+        const std::string& dst_param()
         {
             return m_dst_param;
         }
 
       private:
-        string m_src_layer;
-        string m_src_param;
-        string m_dst_layer;
-        string m_dst_param;
+        std::string m_src_layer;
+        std::string m_src_param;
+        std::string m_dst_layer;
+        std::string m_dst_param;
     };
 
 
@@ -2021,7 +2020,7 @@ namespace
         }
 
       private:
-        string                          m_name;
+        std::string                     m_name;
         auto_release_ptr<ShaderGroup>   m_shader_group;
     };
 
@@ -2246,8 +2245,8 @@ namespace
 
       private:
         auto_release_ptr<Assembly>  m_assembly;
-        string                      m_name;
-        string                      m_model;
+        std::string                 m_name;
+        std::string                 m_model;
         AssemblyContainer           m_assemblies;
         AssemblyInstanceContainer   m_assembly_instances;
         BSDFContainer               m_bsdfs;
@@ -2471,7 +2470,7 @@ namespace
       protected:
         ParseContext&           m_context;
         auto_release_ptr<AOV>   m_aov;
-        string                  m_model;
+        std::string             m_model;
     };
 
 
@@ -2699,7 +2698,7 @@ namespace
       private:
         ParseContext&                   m_context;
         auto_release_ptr<Frame>         m_frame;
-        string                          m_name;
+        std::string                     m_name;
         AOVContainer                    m_aovs;
         PostProcessingStageContainer    m_post_processing_stages;
     };
@@ -2800,8 +2799,8 @@ namespace
       private:
         ParseContext&                   m_context;
         auto_release_ptr<Configuration> m_configuration;
-        string                          m_name;
-        string                          m_base_name;
+        std::string                     m_name;
+        std::string                     m_base_name;
     };
 
 
@@ -2862,13 +2861,13 @@ namespace
             m_path = trim_both(transcode(chars));
         }
 
-        const string& get_path() const
+        const std::string& get_path() const
         {
             return m_path;
         }
 
       private:
-        string          m_path;
+        std::string          m_path;
     };
 
 
@@ -2899,7 +2898,7 @@ namespace
 
                     SearchPathElementHandler* path_handler =
                         static_cast<SearchPathElementHandler*>(handler);
-                    const string& path = path_handler->get_path();
+                    const std::string& path = path_handler->get_path();
                     if (!path.empty())
                         m_context.get_project().search_paths().push_back_explicit_path(path);
                 }
@@ -2941,7 +2940,7 @@ namespace
 
       private:
         ParseContext&   m_context;
-        string          m_name;
+        std::string     m_name;
     };
 
 
@@ -3074,10 +3073,10 @@ namespace
             register_factory_helper<ValuesElementHandler>("values", ElementValues);
             register_factory_helper<VolumeElementHandler>("volume", ElementVolume);
 
-            unique_ptr<IElementHandlerFactory<ProjectElementID>> factory(
+            std::unique_ptr<IElementHandlerFactory<ProjectElementID>> factory(
                 new ProjectElementHandlerFactory(m_context));
 
-            register_factory("project", ElementProject, move(factory));
+            register_factory("project", ElementProject, std::move(factory));
         }
 
       private:
@@ -3093,9 +3092,9 @@ namespace
             {
             }
 
-            unique_ptr<ElementHandlerType> create() override
+            std::unique_ptr<ElementHandlerType> create() override
             {
-                return unique_ptr<ElementHandlerType>(new ProjectElementHandler(m_context));
+                return std::unique_ptr<ElementHandlerType>(new ProjectElementHandler(m_context));
             }
         };
 
@@ -3110,16 +3109,16 @@ namespace
             {
             }
 
-            unique_ptr<ElementHandlerType> create() override
+            std::unique_ptr<ElementHandlerType> create() override
             {
-                return unique_ptr<ElementHandlerType>(new ElementHandler(m_context));
+                return std::unique_ptr<ElementHandlerType>(new ElementHandler(m_context));
             }
         };
 
         template <typename ElementHandler>
-        void register_factory_helper(const string& name, const ProjectElementID id)
+        void register_factory_helper(const std::string& name, const ProjectElementID id)
         {
-            unique_ptr<IElementHandlerFactory<ProjectElementID>> factory(
+            std::unique_ptr<IElementHandlerFactory<ProjectElementID>> factory(
                 new GenericElementHandlerFactory<ElementHandler>(m_context));
 
             register_factory(name, id, move(factory));
@@ -3129,9 +3128,9 @@ namespace
 
 namespace
 {
-    bool is_builtin_project(const string& project_filepath, string& project_name)
+    bool is_builtin_project(const std::string& project_filepath, std::string& project_name)
     {
-        const string BuiltInPrefix = "builtin:";
+        const std::string BuiltInPrefix = "builtin:";
 
         if (starts_with(project_filepath, BuiltInPrefix))
         {
@@ -3145,17 +3144,17 @@ namespace
     // Return the name of the single .appleseed file inside a given archive file.
     // If there are zero or more than one .appleseed file inside the archive, an
     // empty string is returned (i.e. the archive is not a valid packed project).
-    string get_project_filename_from_archive(const char* project_filepath)
+    std::string get_project_filename_from_archive(const char* project_filepath)
     {
-        const vector<string> files =
+        const std::vector<std::string> files =
             get_filenames_with_extension_from_zip(project_filepath, ".appleseed");
 
-        return files.size() == 1 ? files[0] : string();
+        return files.size() == 1 ? files[0] : std::string();
     }
 
-    string unpack_project(
-        const string& project_filepath,
-        const string& project_name,
+    std::string unpack_project(
+        const std::string& project_filepath,
+        const std::string& project_name,
         const bf::path& unpacked_project_directory)
     {
         if (bf::exists(unpacked_project_directory))
@@ -3175,15 +3174,15 @@ auto_release_ptr<Project> ProjectFileReader::read(
     assert(project_filepath);
 
     // Handle built-in projects.
-    string project_name;
+    std::string project_name;
     if (is_builtin_project(project_filepath, project_name))
         return load_builtin(project_name.c_str());
 
     // Handle packed projects.
-    string actual_project_filepath;
+    std::string actual_project_filepath;
     if (is_zip_file(project_filepath))
     {
-        const string project_filename = get_project_filename_from_archive(project_filepath);
+        const std::string project_filename = get_project_filename_from_archive(project_filepath);
         if (project_filename.empty())
         {
             RENDERER_LOG_ERROR(
@@ -3192,7 +3191,7 @@ auto_release_ptr<Project> ProjectFileReader::read(
             return auto_release_ptr<Project>(nullptr);
         }
 
-        const string unpacked_project_directory =
+        const std::string unpacked_project_directory =
             bf::path(project_filepath).replace_extension(".unpacked").string();
 
         RENDERER_LOG_INFO(
@@ -3254,10 +3253,10 @@ auto_release_ptr<Assembly> ProjectFileReader::read_archive(
     assert(archive_filepath);
 
     // Handle packed archives.
-    string actual_archive_filepath;
+    std::string actual_archive_filepath;
     if (is_zip_file(archive_filepath))
     {
-        const string archive_name = get_project_filename_from_archive(archive_filepath);
+        const std::string archive_name = get_project_filename_from_archive(archive_filepath);
         if (archive_name.empty())
         {
             RENDERER_LOG_ERROR(
@@ -3266,7 +3265,7 @@ auto_release_ptr<Assembly> ProjectFileReader::read_archive(
             return auto_release_ptr<Assembly>(nullptr);
         }
 
-        const string unpacked_archive_directory =
+        const std::string unpacked_archive_directory =
             bf::path(archive_filepath).replace_extension(".unpacked").string();
 
         actual_archive_filepath =
@@ -3381,20 +3380,20 @@ auto_release_ptr<Project> ProjectFileReader::load_project_file(
     }
 
     // Create the error handler.
-    unique_ptr<ErrorLogger> error_handler(
+    std::unique_ptr<ErrorLogger> error_handler(
         new ErrorLoggerAndCounter(
             project_filepath,
             event_counters));
 
     // Create the content handler.
     ParseContext context(project.ref(), options, event_counters);
-    unique_ptr<ContentHandler> content_handler(
+    std::unique_ptr<ContentHandler> content_handler(
         new ContentHandler(
             project.get(),
             context));
 
     // Create the parser.
-    unique_ptr<SAX2XMLReader> parser(XMLReaderFactory::createXMLReader());
+    std::unique_ptr<SAX2XMLReader> parser(XMLReaderFactory::createXMLReader());
     parser->setFeature(XMLUni::fgSAX2CoreNameSpaces, true);         // perform namespace processing
 
     if (!(options & OmitProjectSchemaValidation))

--- a/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
@@ -98,7 +98,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -522,8 +521,8 @@ namespace
 
                 ParamArray& params = bsdf.get_parameters();
 
-                const string mdf = params.get_optional<string>("mdf", "");
-                const string mdf_param = params.get_optional<string>("mdf_parameter", "");
+                const std::string mdf = params.get_optional<std::string>("mdf", "");
+                const std::string mdf_param = params.get_optional<std::string>("mdf_parameter", "");
 
                 if (mdf_param.empty())
                     continue;
@@ -599,7 +598,7 @@ namespace
             }
         }
 
-        static bool try_parse_scalar(const string& s, float& value)
+        static bool try_parse_scalar(const std::string& s, float& value)
         {
             try
             {
@@ -612,7 +611,7 @@ namespace
             }
         }
 
-        static ColorEntity* find_color_entity(const Assembly& assembly, const string& name)
+        static ColorEntity* find_color_entity(const Assembly& assembly, const std::string& name)
         {
             for (each<ColorContainer> i = assembly.colors(); i; ++i)
             {
@@ -631,7 +630,7 @@ namespace
             return find_color_entity(*parent_scene, name);
         }
 
-        static ColorEntity* find_color_entity(const Scene& scene, const string& name)
+        static ColorEntity* find_color_entity(const Scene& scene, const std::string& name)
         {
             for (each<ColorContainer> i = scene.colors(); i; ++i)
             {
@@ -642,7 +641,7 @@ namespace
             return nullptr;
         }
 
-        static bool mdf_param_to_glossiness(const string& mdf, const float mdf_param, float& glossiness)
+        static bool mdf_param_to_glossiness(const std::string& mdf, const float mdf_param, float& glossiness)
         {
             if (mdf == "blinn")
             {
@@ -718,18 +717,18 @@ namespace
 
             if (object && object->get_material_slot_count() == 1)
             {
-                const string slot_name = object->get_material_slot(0);
+                const std::string slot_name = object->get_material_slot(0);
 
                 rebuild_material_mappings(object_instance.get_front_material_mappings(), slot_name);
                 rebuild_material_mappings(object_instance.get_back_material_mappings(), slot_name);
             }
         }
 
-        static void rebuild_material_mappings(StringDictionary& mappings, const string& slot_name)
+        static void rebuild_material_mappings(StringDictionary& mappings, const std::string& slot_name)
         {
             if (!mappings.empty())
             {
-                const string material_name = mappings.begin().value();
+                const std::string material_name = mappings.begin().value();
 
                 mappings.clear();
                 mappings.insert(slot_name, material_name);
@@ -812,23 +811,23 @@ namespace
       private:
         struct MaterialInfo
         {
-            bool        m_updated;
-            Material*   m_material;
-            BSDF*       m_bsdf;
-            string      m_bsdf_reflectance;
-            string      m_bsdf_reflectance_multiplier;
-            string      m_bsdf_transmittance;
-            string      m_bsdf_transmittance_multiplier;
-            string      m_bsdf_fresnel_multiplier;
-            float       m_bsdf_from_ior;
-            float       m_bsdf_to_ior;
-            string      m_bssrdf;
-            string      m_edf;
-            string      m_alpha_map;
-            string      m_displacement_map;
-            string      m_displacement_method;
-            string      m_bump_amplitude;
-            string      m_normal_map_up;
+            bool          m_updated;
+            Material*     m_material;
+            BSDF*         m_bsdf;
+            std::string   m_bsdf_reflectance;
+            std::string   m_bsdf_reflectance_multiplier;
+            std::string   m_bsdf_transmittance;
+            std::string   m_bsdf_transmittance_multiplier;
+            std::string   m_bsdf_fresnel_multiplier;
+            float         m_bsdf_from_ior;
+            float         m_bsdf_to_ior;
+            std::string   m_bssrdf;
+            std::string   m_edf;
+            std::string   m_alpha_map;
+            std::string   m_displacement_map;
+            std::string   m_displacement_method;
+            std::string   m_bump_amplitude;
+            std::string   m_normal_map_up;
         };
 
         static void visit(AssemblyContainer& assemblies)
@@ -845,15 +844,15 @@ namespace
 
         static void update(Assembly& assembly)
         {
-            vector<MaterialInfo> materials;
+            std::vector<MaterialInfo> materials;
             collect_refractive_materials(assembly, materials);
 
-            for (each<vector<MaterialInfo>> i = materials; i; ++i)
+            for (each<std::vector<MaterialInfo>> i = materials; i; ++i)
             {
                 if (i->m_updated)
                     continue;
 
-                for (each<vector<MaterialInfo>> j = succ(i); j; ++j)
+                for (each<std::vector<MaterialInfo>> j = succ(i); j; ++j)
                 {
                     if (j->m_updated)
                         continue;
@@ -878,7 +877,7 @@ namespace
                         assembly.bsdfs().insert(bsdf_owner);
 
                         // Rename mat1.
-                        const string old_mat1_name = mat1.m_material->get_name();
+                        const std::string old_mat1_name = mat1.m_material->get_name();
                         cleanup_entity_name(*mat1.m_material);
                         update_material_mappings(
                             assembly.object_instances(),
@@ -920,7 +919,7 @@ namespace
             }
         }
 
-        static void collect_refractive_materials(Assembly& assembly, vector<MaterialInfo>& materials)
+        static void collect_refractive_materials(Assembly& assembly, std::vector<MaterialInfo>& materials)
         {
             for (each<MaterialContainer> i = assembly.materials(); i; ++i)
             {
@@ -934,7 +933,7 @@ namespace
                 if (!material_params.strings().exist("bsdf"))
                     continue;
 
-                const string bsdf_name = material_params.get<string>("bsdf");
+                const std::string bsdf_name = material_params.get<std::string>("bsdf");
                 BSDF* bsdf = assembly.bsdfs().get_by_name(bsdf_name.c_str());
 
                 if (bsdf == nullptr)
@@ -957,20 +956,20 @@ namespace
                 info.m_updated = false;
                 info.m_material = &material;
                 info.m_bsdf = bsdf;
-                info.m_bsdf_reflectance = bsdf_params.get<string>("reflectance");
-                info.m_bsdf_reflectance_multiplier = bsdf_params.get_optional<string>("reflectance_multiplier", "1.0");
-                info.m_bsdf_transmittance = bsdf_params.get<string>("transmittance");
-                info.m_bsdf_transmittance_multiplier = bsdf_params.get_optional<string>("transmittance_multiplier", "1.0");
-                info.m_bsdf_fresnel_multiplier = bsdf_params.get_optional<string>("fresnel_multiplier", "1.0");
+                info.m_bsdf_reflectance = bsdf_params.get<std::string>("reflectance");
+                info.m_bsdf_reflectance_multiplier = bsdf_params.get_optional<std::string>("reflectance_multiplier", "1.0");
+                info.m_bsdf_transmittance = bsdf_params.get<std::string>("transmittance");
+                info.m_bsdf_transmittance_multiplier = bsdf_params.get_optional<std::string>("transmittance_multiplier", "1.0");
+                info.m_bsdf_fresnel_multiplier = bsdf_params.get_optional<std::string>("fresnel_multiplier", "1.0");
                 info.m_bsdf_from_ior = bsdf_params.get<float>("from_ior");
                 info.m_bsdf_to_ior = bsdf_params.get<float>("to_ior");
-                info.m_bssrdf = material_params.get_optional<string>("bssrdf", "");
-                info.m_edf = material_params.get_optional<string>("edf", "");
-                info.m_alpha_map = material_params.get_optional<string>("alpha_map", "");
-                info.m_displacement_map = material_params.get_optional<string>("displacement_map", "");
-                info.m_displacement_method = material_params.get_optional<string>("displacement_method", "");
-                info.m_bump_amplitude = material_params.get_optional<string>("bump_amplitude", "");
-                info.m_normal_map_up = material_params.get_optional<string>("normal_map_up", "");
+                info.m_bssrdf = material_params.get_optional<std::string>("bssrdf", "");
+                info.m_edf = material_params.get_optional<std::string>("edf", "");
+                info.m_alpha_map = material_params.get_optional<std::string>("alpha_map", "");
+                info.m_displacement_map = material_params.get_optional<std::string>("displacement_map", "");
+                info.m_displacement_method = material_params.get_optional<std::string>("displacement_method", "");
+                info.m_bump_amplitude = material_params.get_optional<std::string>("bump_amplitude", "");
+                info.m_normal_map_up = material_params.get_optional<std::string>("normal_map_up", "");
 
                 materials.push_back(info);
             }
@@ -999,7 +998,7 @@ namespace
 
         static void cleanup_entity_name(Entity& entity)
         {
-            string name = entity.get_name();
+            std::string name = entity.get_name();
             name = replace(name, "_front_", "");
             name = replace(name, "_front", "");
             name = replace(name, "front_", "");
@@ -1425,7 +1424,7 @@ namespace
         {
             ParamArray& params = configuration.get_parameters();
 
-            if (params.get_optional<string>("lighting_engine") == "drt")
+            if (params.get_optional<std::string>("lighting_engine") == "drt")
             {
                 // The project was using DRT: switch to PT.
                 params.insert_path("lighting_engine", "pt");
@@ -1815,7 +1814,7 @@ namespace
                 // There cannot be any other post-processing stage at this point.
                 assert(frame.post_processing_stages().empty());
 
-                const string format_string = params.get_optional<string>("render_stamp_format");
+                const std::string format_string = params.get_optional<std::string>("render_stamp_format");
                 frame.post_processing_stages().insert(
                     RenderStampPostProcessingStageFactory().create(
                         "render_stamp",
@@ -1966,7 +1965,7 @@ namespace
                     ParamArray& params = stage.get_parameters();
                     if (params.strings().exist("format_string"))
                     {
-                        string format_string = params.get<string>("format_string");
+                        std::string format_string = params.get<std::string>("format_string");
                         format_string = replace(format_string, "{lib-variant}", "{lib-cpu-features}");
                         params.set("format_string", format_string);
                     }
@@ -2004,7 +2003,7 @@ namespace
             const char* DefaultFilterName = "blackman-harris";
 
             ParamArray& params = frame.get_parameters();
-            const string filter_name = params.get_optional<string>("filter", DefaultFilterName);
+            const std::string filter_name = params.get_optional<std::string>("filter", DefaultFilterName);
 
             const bool update_filter =
                 filter_name == "mitchell" ||
@@ -2111,7 +2110,7 @@ namespace
                         const uint64 max_samples = pfr.strings().get<uint64>("max_samples");
                         pfr.strings().remove("max_samples");
 
-                        if (max_samples < numeric_limits<uint64>::max())
+                        if (max_samples < std::numeric_limits<uint64>::max())
                         {
                             Frame* frame = m_project.get_frame();
                             if (frame)
@@ -2160,7 +2159,7 @@ namespace
 
             if (params.strings().exist("mdf"))
             {
-                const string mdf = params.strings().get<string>("mdf");
+                const std::string mdf = params.strings().get<std::string>("mdf");
                 params.strings().remove("mdf");
                 if (mdf != "ggx")
                 {

--- a/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilewriter.cpp
@@ -100,7 +100,6 @@
 
 using namespace boost;
 using namespace foundation;
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace renderer
@@ -159,19 +158,19 @@ namespace
 
         // Return a lexicographically-sorted vector of references to entities.
         template <typename Collection>
-        vector<std::reference_wrapper<const typename Collection::value_type>> sorted(const Collection& collection)
+        std::vector<std::reference_wrapper<const typename Collection::value_type>> sorted(const Collection& collection)
         {
             return sorted_impl<const typename Collection::value_type>(collection.begin(), collection.end());
         }
         template <typename Collection>
-        vector<std::reference_wrapper<typename Collection::value_type>> sorted(Collection& collection)
+        std::vector<std::reference_wrapper<typename Collection::value_type>> sorted(Collection& collection)
         {
             return sorted_impl<typename Collection::value_type>(collection.begin(), collection.end());
         }
         template <typename ValueType, typename Iterator>
-        vector<std::reference_wrapper<ValueType>> sorted_impl(Iterator input_begin, Iterator input_end)
+        std::vector<std::reference_wrapper<ValueType>> sorted_impl(Iterator input_begin, Iterator input_end)
         {
-            vector<std::reference_wrapper<ValueType>> result;
+            std::vector<std::reference_wrapper<ValueType>> result;
             result.reserve(std::distance(input_begin, input_end));
 
             for (Iterator it = input_begin; it != input_end; ++it)
@@ -416,9 +415,9 @@ namespace
 
         // Write an <assign_material> element.
         void write_assign_material(
-            const string&               slot,
-            const string&               side,
-            const string&               name)
+            const std::string&               slot,
+            const std::string&               side,
+            const std::string&               name)
         {
             XMLElement element("assign_material", m_file, m_indenter);
             element.add_attribute("slot", slot);
@@ -432,10 +431,10 @@ namespace
             const ObjectInstance::Side  side,
             const StringDictionary&     material_mappings)
         {
-            const string side_string = side == ObjectInstance::FrontSide ? "front" : "back";
+            const std::string side_string = side == ObjectInstance::FrontSide ? "front" : "back";
 
             for (const_each<StringDictionary> i = material_mappings; i; ++i)
-                write_assign_material(i->key(), side_string, i->value<string>());
+                write_assign_material(i->key(), side_string, i->value<std::string>());
         }
 
         // Write a <bsdf> element.
@@ -606,7 +605,7 @@ namespace
         // Write a collection of <object> elements.
         void write_object_collection(ObjectContainer& objects)
         {
-            set<string> groups;
+            std::set<std::string> groups;
 
             for (Object& object : sorted(objects))
             {
@@ -619,7 +618,7 @@ namespace
         }
 
         // Write a mesh object.
-        void write_mesh_object(MeshObject& object, set<string>& groups)
+        void write_mesh_object(MeshObject& object, std::set<std::string>& groups)
         {
             ParamArray& params = object.get_parameters();
 
@@ -637,7 +636,7 @@ namespace
             if (params.strings().exist("__base_object_name"))
             {
                 // This object belongs to a group of objects.
-                const string group_name = params.get<string>("__base_object_name");
+                const std::string group_name = params.get<std::string>("__base_object_name");
                 if (groups.find(group_name) == groups.end())
                 {
                     // This is the first time we encounter this group of objects.
@@ -662,11 +661,11 @@ namespace
         }
 
         // Object name mapping established by do_write_orphan_mesh_object().
-        typedef map<string, string> ObjectNameMapping;
+        typedef std::map<std::string, std::string> ObjectNameMapping;
         ObjectNameMapping m_object_name_mapping;
 
         // Get the new name of an object, given its old name.
-        string translate_object_name(const string& old_name) const
+        std::string translate_object_name(const std::string& old_name) const
         {
             const ObjectNameMapping::const_iterator i = m_object_name_mapping.find(old_name);
             return i == m_object_name_mapping.end() ? old_name : i->second;
@@ -676,13 +675,13 @@ namespace
         void write_orphan_mesh_object(const MeshObject& object)
         {
             // Construct the name of the mesh file.
-            const string object_name = object.get_name();
-            const string filename = object_name + ".binarymesh";
+            const std::string object_name = object.get_name();
+            const std::string filename = object_name + ".binarymesh";
 
             if (!(m_options & ProjectFileWriter::OmitWritingGeometryFiles))
             {
                 // Write the mesh file to disk.
-                const string filepath = (m_project_new_root_dir / filename).string();
+                const std::string filepath = (m_project_new_root_dir / filename).string();
                 MeshObjectWriter::write(object, object_name.c_str(), filepath.c_str());
             }
 
@@ -708,13 +707,13 @@ namespace
 
             if (!params.strings().exist("filepath"))
             {
-                const string object_name = object.get_name();
-                const string filename = object_name + ".binarycurve";
+                const std::string object_name = object.get_name();
+                const std::string filename = object_name + ".binarycurve";
 
                 if (!(m_options & ProjectFileWriter::OmitWritingGeometryFiles))
                 {
                     // Write the curve file to disk.
-                    const string filepath = (m_project_new_root_dir / filename).string();
+                    const std::string filepath = (m_project_new_root_dir / filename).string();
                     CurveObjectWriter::write(object, filepath.c_str());
                 }
 
@@ -981,7 +980,7 @@ bool ProjectFileWriter::write_plain_project_file(
         // Write any optional comments.
         if (extra_comments)
         {
-            vector<string> lines;
+            std::vector<std::string> lines;
             split(extra_comments, "\n", lines);
 
             for (const auto& line : lines)

--- a/src/appleseed/renderer/modeling/project/projecttracker.cpp
+++ b/src/appleseed/renderer/modeling/project/projecttracker.cpp
@@ -63,7 +63,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -128,11 +127,11 @@ struct ProjectTracker::Impl
         EntityMap*      m_map;              // or this is, but never both
     };
 
-    typedef vector<IncomingRef> IncomingRefVec;
-    typedef vector<OutgoingRef> OutgoingRefVec;
+    typedef std::vector<IncomingRef> IncomingRefVec;
+    typedef std::vector<OutgoingRef> OutgoingRefVec;
 
-    typedef map<Entity*, IncomingRefVec> IncomingRefs;
-    typedef map<Entity*, OutgoingRefVec> OutgoingRefs;
+    typedef std::map<Entity*, IncomingRefVec> IncomingRefs;
+    typedef std::map<Entity*, OutgoingRefVec> OutgoingRefs;
 
     Project&            m_project;
     InputBinder         m_input_binder;
@@ -243,7 +242,7 @@ struct ProjectTracker::Impl
 
     void collect_relations_from_entity(ObjectInstance& object_instance)
     {
-        set<string> material_names;
+        std::set<std::string> material_names;
 
         for (const auto& kv : object_instance.get_front_material_mappings())
             material_names.insert(kv.value());
@@ -330,15 +329,15 @@ struct ProjectTracker::Impl
 
     void print_incoming_references(Logger& logger) const
     {
-        typedef pair<Entity*, IncomingRefVec> IncomingRefItem;
+        typedef std::pair<Entity*, IncomingRefVec> IncomingRefItem;
 
-        vector<IncomingRefItem> sorted_incoming_refs;
+        std::vector<IncomingRefItem> sorted_incoming_refs;
         sorted_incoming_refs.reserve(m_incoming_refs.size());
 
         for (const auto& kv : m_incoming_refs)
             sorted_incoming_refs.emplace_back(kv.first, kv.second);
 
-        sort(
+        std::sort(
             sorted_incoming_refs.begin(),
             sorted_incoming_refs.end(),
             [](const IncomingRefItem& lhs, const IncomingRefItem& rhs)
@@ -377,15 +376,15 @@ struct ProjectTracker::Impl
 
     void print_outgoing_references(Logger& logger) const
     {
-        typedef pair<Entity*, OutgoingRefVec> OutgoingRefItem;
+        typedef std::pair<Entity*, OutgoingRefVec> OutgoingRefItem;
 
-        vector<OutgoingRefItem> sorted_outgoing_refs;
+        std::vector<OutgoingRefItem> sorted_outgoing_refs;
         sorted_outgoing_refs.reserve(m_outgoing_refs.size());
 
         for (const auto& kv : m_outgoing_refs)
             sorted_outgoing_refs.emplace_back(kv.first, kv.second);
 
-        sort(
+        std::sort(
             sorted_outgoing_refs.begin(),
             sorted_outgoing_refs.end(),
             [](const OutgoingRefItem& lhs, const OutgoingRefItem& rhs)
@@ -480,7 +479,7 @@ struct ProjectTracker::Impl
     {
         typedef typename EntityCollection::value_type EntityType;
 
-        vector<EntityType*> to_remove;
+        std::vector<EntityType*> to_remove;
 
         for (auto& entity : entities)
         {

--- a/src/appleseed/renderer/modeling/scene/archiveassembly.cpp
+++ b/src/appleseed/renderer/modeling/scene/archiveassembly.cpp
@@ -50,7 +50,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -103,8 +102,8 @@ bool ArchiveAssembly::do_expand_contents(
     {
         // Establish and store the qualified path to the archive project.
         const SearchPaths& search_paths = project.search_paths();
-        const string filepath =
-            to_string(search_paths.qualify(m_params.get_required<string>("filename", "")));
+        const std::string filepath =
+            to_string(search_paths.qualify(m_params.get_required<std::string>("filename", "")));
 
         ProjectFileReader reader;
         auto_release_ptr<Assembly> assembly =

--- a/src/appleseed/renderer/modeling/scene/assembly.cpp
+++ b/src/appleseed/renderer/modeling/scene/assembly.cpp
@@ -55,7 +55,6 @@
 #include "foundation/utility/job/abortswitch.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -299,7 +298,7 @@ bool Assembly::on_frame_begin(
         const ObjectInstance* object_instance = object_instances().get_by_index(i);
         const Object& object = object_instance->get_object();
         if (dynamic_cast<const ProceduralObject*>(&object) != nullptr)
-            m_render_data.m_procedural_object_instances.push_back(make_pair(object_instance, i));
+            m_render_data.m_procedural_object_instances.push_back(std::make_pair(object_instance, i));
     }
     m_has_render_data = true;
 

--- a/src/appleseed/renderer/modeling/scene/assemblyinstance.cpp
+++ b/src/appleseed/renderer/modeling/scene/assemblyinstance.cpp
@@ -42,7 +42,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -63,7 +62,7 @@ UniqueID AssemblyInstance::get_class_uid()
 
 struct AssemblyInstance::Impl
 {
-    string m_assembly_name;
+    std::string m_assembly_name;
 };
 
 AssemblyInstance::AssemblyInstance(

--- a/src/appleseed/renderer/modeling/scene/containers.cpp
+++ b/src/appleseed/renderer/modeling/scene/containers.cpp
@@ -34,7 +34,6 @@
 #include "foundation/utility/api/apistring.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -45,7 +44,7 @@ namespace renderer
 
 namespace
 {
-    string build_message(
+    std::string build_message(
         const char*     entity_name,
         const Entity*   context)
     {
@@ -66,7 +65,7 @@ ExceptionUnknownEntity::ExceptionUnknownEntity(
 {
 }
 
-const string& ExceptionUnknownEntity::get_context_path() const
+const std::string& ExceptionUnknownEntity::get_context_path() const
 {
     return m_context_path;
 }

--- a/src/appleseed/renderer/modeling/scene/objectinstance.cpp
+++ b/src/appleseed/renderer/modeling/scene/objectinstance.cpp
@@ -54,7 +54,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -134,7 +133,7 @@ struct ObjectInstance::Impl
 {
     // Order of data members impacts performance, preserve it.
     Transformd              m_transform;
-    string                  m_object_name;
+    std::string             m_object_name;
     StringDictionary        m_front_material_mappings;
     StringDictionary        m_back_material_mappings;
     OIIO::ustring           m_sss_set_identifier;
@@ -166,8 +165,8 @@ ObjectInstance::ObjectInstance(
     m_medium_priority = params.get_optional<int8>("medium_priority", 0);
 
     // Retrieve ray bias method.
-    const string ray_bias_method =
-        params.get_optional<string>(
+    const std::string ray_bias_method =
+        params.get_optional<std::string>(
             "ray_bias_method",
             "none",
             make_vector("none", "normal", "incoming_direction", "outgoing_direction"),

--- a/src/appleseed/renderer/modeling/scene/scene.cpp
+++ b/src/appleseed/renderer/modeling/scene/scene.cpp
@@ -63,7 +63,6 @@
 #include <set>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -175,7 +174,7 @@ namespace
 {
     bool assembly_instances_use_alpha_mapping(
         const AssemblyInstanceContainer&  assembly_instances,
-        set<UniqueID>&                    visited_assemblies)
+        std::set<UniqueID>&               visited_assemblies)
     {
         // Regarding transparency in the Tracer,
         // we only care about camera and shadow rays.
@@ -221,7 +220,7 @@ namespace
 
     bool assembly_instances_has_participating_media(
         const AssemblyInstanceContainer&  assembly_instances,
-        set<UniqueID>&                    visited_assemblies)
+        std::set<UniqueID>&               visited_assemblies)
     {
         // Regarding participating media in the Tracer,
         // we only care about camera and shadow rays.
@@ -268,13 +267,13 @@ namespace
 
 bool Scene::uses_alpha_mapping() const
 {
-    set<UniqueID> visited_assemblies;
+    std::set<UniqueID> visited_assemblies;
     return assembly_instances_use_alpha_mapping(assembly_instances(), visited_assemblies);
 }
 
 bool Scene::has_participating_media() const
 {
-    set<UniqueID> visited_assemblies;
+    std::set<UniqueID> visited_assemblies;
     return assembly_instances_has_participating_media(assembly_instances(), visited_assemblies);
 }
 

--- a/src/appleseed/renderer/modeling/scene/textureinstance.cpp
+++ b/src/appleseed/renderer/modeling/scene/textureinstance.cpp
@@ -50,7 +50,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -73,7 +72,7 @@ struct TextureInstance::Impl
 {
     // Order of data members impacts performance, preserve it.
     Transformf              m_transform;
-    string                  m_texture_name;
+    std::string             m_texture_name;
 };
 
 TextureInstance::TextureInstance(
@@ -95,22 +94,22 @@ TextureInstance::TextureInstance(
     const EntityDefMessageContext context("texture instance", this);
 
     // Retrieve the texture addressing mode.
-    const string addressing_mode =
-        m_params.get_optional<string>("addressing_mode", "wrap", make_vector("clamp", "wrap"), context);
+    const std::string addressing_mode =
+        m_params.get_optional<std::string>("addressing_mode", "wrap", make_vector("clamp", "wrap"), context);
     if (addressing_mode == "clamp")
         m_addressing_mode = TextureAddressingClamp;
     else m_addressing_mode = TextureAddressingWrap;
 
     // Retrieve the texture filtering mode.
-    const string filtering_mode =
-        m_params.get_optional<string>("filtering_mode", "bilinear", make_vector("nearest", "bilinear"), context);
+    const std::string filtering_mode =
+        m_params.get_optional<std::string>("filtering_mode", "bilinear", make_vector("nearest", "bilinear"), context);
     if (filtering_mode == "nearest")
         m_filtering_mode = TextureFilteringNearest;
     else m_filtering_mode = TextureFilteringBilinear;
 
     // Retrieve the texture alpha mode.
-    const string alpha_mode =
-        m_params.get_optional<string>("alpha_mode", "alpha_channel", make_vector("alpha_channel", "luminance", "detect"), context);
+    const std::string alpha_mode =
+        m_params.get_optional<std::string>("alpha_mode", "alpha_channel", make_vector("alpha_channel", "luminance", "detect"), context);
     if (alpha_mode == "alpha_channel")
         m_alpha_mode = TextureAlphaModeAlphaChannel;
     else if (alpha_mode == "luminance")

--- a/src/appleseed/renderer/modeling/shadergroup/shader.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shader.cpp
@@ -47,7 +47,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -63,12 +62,12 @@ namespace
 
 struct Shader::Impl
 {
-    string                  m_type;
-    string                  m_shader;
+    std::string             m_type;
+    std::string             m_shader;
     ShaderParamContainer    m_params;
 
-    string                  m_source_code;
-    string                  m_byte_code;
+    std::string             m_source_code;
+    std::string             m_byte_code;
 
     Impl(
         const char*         type,
@@ -96,7 +95,7 @@ struct Shader::Impl
 
                 case OSLParamTypeColorArray:
                   {
-                      vector<float> values;
+                      std::vector<float> values;
                       parser.parse_float3_array(values);
                       m_params.insert(ShaderParam::create_color_array_param(i.it().key(), values));
                   }
@@ -111,7 +110,7 @@ struct Shader::Impl
 
                 case OSLParamTypeFloatArray:
                   {
-                      vector<float> values;
+                      std::vector<float> values;
                       parser.parse_float_array(values);
                       m_params.insert(ShaderParam::create_float_array_param(i.it().key(), values));
                   }
@@ -126,7 +125,7 @@ struct Shader::Impl
 
                 case OSLParamTypeIntArray:
                   {
-                      vector<int> values;
+                      std::vector<int> values;
                       parser.parse_int_array(values);
                       m_params.insert(ShaderParam::create_int_array_param(i.it().key(), values));
                   }
@@ -142,7 +141,7 @@ struct Shader::Impl
 
                   case OSLParamTypeMatrixArray:
                     {
-                        vector<float> values;
+                        std::vector<float> values;
                         parser.parse_matrix_array(values);
                         m_params.insert(ShaderParam::create_matrix_array_param(i.it().key(), values));
                     }
@@ -158,7 +157,7 @@ struct Shader::Impl
 
                 case OSLParamTypeNormalArray:
                   {
-                      vector<float> values;
+                      std::vector<float> values;
                       parser.parse_float3_array(values);
                       m_params.insert(ShaderParam::create_normal_array_param(i.it().key(), values));
                   }
@@ -174,7 +173,7 @@ struct Shader::Impl
 
                 case OSLParamTypePointArray:
                   {
-                      vector<float> values;
+                      std::vector<float> values;
                       parser.parse_float3_array(values);
                       m_params.insert(ShaderParam::create_point_array_param(i.it().key(), values));
                   }
@@ -199,7 +198,7 @@ struct Shader::Impl
 
                 case OSLParamTypeVectorArray:
                   {
-                      vector<float> values;
+                      std::vector<float> values;
                       parser.parse_float3_array(values);
                       m_params.insert(ShaderParam::create_vector_array_param(i.it().key(), values));
                   }

--- a/src/appleseed/renderer/modeling/shadergroup/shadercompiler.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shadercompiler.cpp
@@ -45,7 +45,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -73,10 +72,10 @@ struct ShaderCompiler::Impl
         delete m_error_handler;
     }
 
-    string              m_stdosl_path;
-    OSL::OSLCompiler*   m_compiler;
-    OIIOErrorHandler*   m_error_handler;
-    vector<string>      m_options;
+    std::string               m_stdosl_path;
+    OSL::OSLCompiler*         m_compiler;
+    OIIOErrorHandler*         m_error_handler;
+    std::vector<std::string>  m_options;
 };
 
 ShaderCompiler::ShaderCompiler(const char* stdosl_path)
@@ -108,7 +107,7 @@ bool ShaderCompiler::compile_buffer(
     const char* source_code,
     APIString&  result) const
 {
-    string buffer;
+    std::string buffer;
     const bool ok = impl->m_compiler->compile_buffer(
         source_code,
         buffer,

--- a/src/appleseed/renderer/modeling/shadergroup/shaderconnection.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderconnection.cpp
@@ -40,7 +40,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -56,10 +55,10 @@ namespace
 
 struct ShaderConnection::Impl
 {
-    string m_src_layer;
-    string m_src_param;
-    string m_dst_layer;
-    string m_dst_param;
+    std::string m_src_layer;
+    std::string m_src_param;
+    std::string m_dst_layer;
+    std::string m_dst_param;
 };
 
 ShaderConnection::ShaderConnection(
@@ -75,8 +74,8 @@ ShaderConnection::ShaderConnection(
     impl->m_dst_layer = dst_layer;
     impl->m_dst_param = dst_param;
 
-    const string entity_name =
-        string(get_src_layer()) + ":" + get_src_param() + "->" + get_dst_layer() + ":" + get_dst_param();
+    const std::string entity_name =
+        std::string(get_src_layer()) + ":" + get_src_param() + "->" + get_dst_layer() + ":" + get_dst_param();
 
     set_name(entity_name.c_str());
 }

--- a/src/appleseed/renderer/modeling/shadergroup/shadergroup.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shadergroup.cpp
@@ -51,7 +51,6 @@
 #include <utility>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -87,7 +86,7 @@ namespace
 
 struct ShaderGroup::Impl
 {
-    typedef pair<const AssemblyInstance*, const ObjectInstance*> SurfaceAreaKey;
+    typedef std::pair<const AssemblyInstance*, const ObjectInstance*> SurfaceAreaKey;
     typedef boost::unordered_map<SurfaceAreaKey, float>          SurfaceAreaMap;
 
     ShaderContainer             m_shaders;
@@ -258,7 +257,7 @@ bool ShaderGroup::create_optimized_osl_shader_group(
 
         return true;
     }
-    catch (const exception& e)
+    catch (const std::exception& e)
     {
         RENDERER_LOG_ERROR("failed to setup shader group \"%s\": %s.", get_path().c_str(), e.what());
         return false;

--- a/src/appleseed/renderer/modeling/shadergroup/shaderparam.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderparam.cpp
@@ -42,7 +42,6 @@
 #include <sstream>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -58,13 +57,13 @@ namespace
 
 struct ShaderParam::Impl
 {
-    OSL::TypeDesc   m_type_desc;
-    int             m_int_value;
-    float           m_float_value[16];
-    string          m_string_storage;
-    const char*     m_string_value;
-    vector<float>   m_float_array_value;
-    vector<int>     m_int_array_value;
+    OSL::TypeDesc        m_type_desc;
+    int                  m_int_value;
+    float                m_float_value[16];
+    std::string          m_string_storage;
+    const char*          m_string_value;
+    std::vector<float>   m_float_array_value;
+    std::vector<int>     m_int_array_value;
 };
 
 ShaderParam::ShaderParam(const char* name)
@@ -99,9 +98,9 @@ const void* ShaderParam::get_value() const
     return &impl->m_float_value;
 }
 
-string ShaderParam::get_value_as_string() const
+std::string ShaderParam::get_value_as_string() const
 {
-    stringstream ss;
+    std::stringstream ss;
 
     if (!impl->m_float_array_value.empty())
     {

--- a/src/appleseed/renderer/modeling/shadergroup/shaderparamparser.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderparamparser.cpp
@@ -33,7 +33,6 @@
 #include <cassert>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -42,7 +41,7 @@ namespace renderer
 // ShaderParamParser class implementation.
 //
 
-ShaderParamParser::ShaderParamParser(const string& s)
+ShaderParamParser::ShaderParamParser(const std::string& s)
   : m_original_string(s)
 {
     tokenize(s, Blanks, m_tokens);
@@ -50,7 +49,7 @@ ShaderParamParser::ShaderParamParser(const string& s)
     m_tok_it = m_tokens.begin();
     m_tok_end = m_tokens.end();
 
-    const string tok(*m_tok_it);
+    const std::string tok(*m_tok_it);
 
     if (tok == "color")
         m_param_type = OSLParamTypeColor;
@@ -126,12 +125,12 @@ void ShaderParamParser::parse_matrix_array(std::vector<float>& values)
         throw ExceptionOSLParamParseError();
 }
 
-string ShaderParamParser::parse_string_value()
+std::string ShaderParamParser::parse_string_value()
 {
     assert(param_type() == OSLParamTypeString);
 
     // Remove the string prefix and trim whitespace.
-    string val(m_original_string, 6, string::npos);
+    std::string val(m_original_string, 6, std::string::npos);
     return trim_both(val);
 }
 

--- a/src/appleseed/renderer/modeling/shadergroup/shaderquery.cpp
+++ b/src/appleseed/renderer/modeling/shadergroup/shaderquery.cpp
@@ -49,7 +49,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/surfaceshader/aosurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/aosurfaceshader.cpp
@@ -51,7 +51,6 @@ namespace renderer  { class ShadingComponents; }
 namespace renderer  { class ShadingPoint; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -75,7 +74,7 @@ namespace
           , m_samples(m_params.get_required<size_t>("samples", 16))
           , m_max_distance(m_params.get_required<double>("max_distance", 1.0))
         {
-            const string sampling_method = m_params.get_required<string>("sampling_method", "uniform");
+            const std::string sampling_method = m_params.get_required<std::string>("sampling_method", "uniform");
 
             if (sampling_method == "uniform")
                 m_sampling_method = UniformSampling;

--- a/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
@@ -53,7 +53,6 @@ namespace renderer  { class PixelContext; }
 namespace renderer  { class ShadingComponents; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -79,7 +78,7 @@ namespace
             m_inputs.declare("color_multiplier", InputFormatFloat, "1.0");
             m_inputs.declare("alpha_multiplier", InputFormatFloat, "1.0");
 
-            const string alpha_source = m_params.get_optional<string>("alpha_source", "color");
+            const std::string alpha_source = m_params.get_optional<std::string>("alpha_source", "color");
             if (alpha_source == "color")
                 m_alpha_source = AlphaSourceColor;
             else if (alpha_source == "material")

--- a/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
@@ -72,7 +72,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -154,7 +153,7 @@ struct DiagnosticSurfaceShader::Impl
     explicit Impl(const ParamArray& params)
     {
         // Retrieve shading mode.
-        const string mode_string = params.get_required<string>("mode", "coverage");
+        const std::string mode_string = params.get_required<std::string>("mode", "coverage");
         const KeyValuePair<const char*, ShadingMode>* mode_pair =
             lookup_kvpair_array(ShadingModeValues, ShadingModeCount, mode_string);
         if (mode_pair != nullptr)

--- a/src/appleseed/renderer/modeling/surfaceshader/nprsurfaceshaderhelper.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/nprsurfaceshaderhelper.cpp
@@ -49,7 +49,6 @@
 #include <limits>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -179,7 +178,7 @@ Color4f NPRSurfaceShaderHelper::evaluate_npr_contour(
     ShadingRay ray;
     ray.m_org = original_ray.m_org;
     ray.m_tmin = original_ray.m_tmin;
-    ray.m_tmax = numeric_limits<double>::max();
+    ray.m_tmax = std::numeric_limits<double>::max();
     ray.m_time = original_ray.m_time;
     ray.m_flags = VisibilityFlags::ProbeRay;
     ray.m_depth = original_ray.m_depth;

--- a/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
@@ -57,7 +57,6 @@ namespace renderer  { class PixelContext; }
 namespace renderer  { class Project; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/modeling/texture/disktexture2d.cpp
+++ b/src/appleseed/renderer/modeling/texture/disktexture2d.cpp
@@ -57,7 +57,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -84,11 +83,11 @@ namespace
             const EntityDefMessageContext context("texture", this);
 
             // Establish and store the qualified path to the texture file.
-            m_filepath = to_string(search_paths.qualify(m_params.get_required<string>("filename", "")));
+            m_filepath = to_string(search_paths.qualify(m_params.get_required<std::string>("filename", "")));
 
             // Retrieve the color space.
-            const string color_space =
-                m_params.get_required<string>(
+            const std::string color_space =
+                m_params.get_required<std::string>(
                     "color_space",
                     "linear_rgb",
                     make_vector("linear_rgb", "srgb", "ciexyz"),
@@ -175,7 +174,7 @@ namespace
         }
 
       private:
-        string                              m_filepath;
+        std::string                         m_filepath;
         ColorSpace                          m_color_space;
 
         mutable boost::mutex                m_mutex;

--- a/src/appleseed/renderer/modeling/texture/memorytexture2d.cpp
+++ b/src/appleseed/renderer/modeling/texture/memorytexture2d.cpp
@@ -55,7 +55,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -170,17 +169,17 @@ namespace
             }
         };
 
-        unique_ptr<DummyTexture>    m_dummy_texture;
-        auto_release_ptr<Image>     m_image;
-        ColorSpace                  m_color_space;
+        std::unique_ptr<DummyTexture>    m_dummy_texture;
+        auto_release_ptr<Image>          m_image;
+        ColorSpace                       m_color_space;
 
         void extract_parameters()
         {
             const EntityDefMessageContext context("texture", this);
 
             // Retrieve the color space.
-            const string color_space =
-                m_params.get_required<string>(
+            const std::string color_space =
+                m_params.get_required<std::string>(
                     "color_space",
                     "linear_rgb",
                     make_vector("linear_rgb", "srgb", "ciexyz"),


### PR DESCRIPTION
This PR part of a series.
Fixes #2641 for appleseed/renderer/modeling.

See also: #2689, #2690, #2692, #2693, #2694