### PR TITLE
Remove 'using namespace std' from appleseed/renderer, part 2

### DIFF
--- a/src/appleseed/renderer/device/cpu/cpurenderdevice.cpp
+++ b/src/appleseed/renderer/device/cpu/cpurenderdevice.cpp
@@ -51,7 +51,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -116,8 +115,8 @@ CPURenderDevice::~CPURenderDevice()
     m_shading_system->release();
     delete m_renderer_services;
 
-    const string stats = m_texture_system->getstats();
-    const string modified_stats = prefix_all_lines(trim_both(stats), "oiio: ");
+    const std::string stats = m_texture_system->getstats();
+    const std::string modified_stats = prefix_all_lines(trim_both(stats), "oiio: ");
     RENDERER_LOG_DEBUG("%s", modified_stats.c_str());
 
     RENDERER_LOG_DEBUG("destroying oiio texture system...");
@@ -134,7 +133,7 @@ bool CPURenderDevice::initialize(
     IAbortSwitch&           abort_switch)
 {
     // Construct a search paths string from the project's search paths.
-    const string project_search_paths =
+    const std::string project_search_paths =
         to_string(get_project().search_paths().to_string_reversed(SearchPaths::osl_path_separator()));
 
     // Initialize OIIO.
@@ -150,7 +149,7 @@ bool CPURenderDevice::initialize(
     m_texture_system->attribute("max_memory_MB", texture_cache_size_mb);
 
     // Set OIIO search paths.
-    string prev_oiio_search_path;
+    std::string prev_oiio_search_path;
     m_texture_system->getattribute("searchpath", prev_oiio_search_path);
     if (prev_oiio_search_path != project_search_paths)
     {
@@ -176,7 +175,7 @@ bool CPURenderDevice::initialize(
             *m_shading_system));
 
     // Set OSL search paths.
-    string prev_osl_search_paths;
+    std::string prev_osl_search_paths;
     m_shading_system->getattribute("searchpath:shader", prev_osl_search_paths);
     if (prev_osl_search_paths != project_search_paths)
     {

--- a/src/appleseed/renderer/device/renderdevicebase.cpp
+++ b/src/appleseed/renderer/device/renderdevicebase.cpp
@@ -39,8 +39,6 @@
 // Standard headers.
 #include <string>
 
-using namespace std;
-
 namespace renderer
 {
 
@@ -69,7 +67,7 @@ const ParamArray& RenderDeviceBase::get_params() const
 
 bool RenderDeviceBase::is_progressive_render() const
 {
-    return get_params().get<string>("frame_renderer") == "progressive";
+    return get_params().get<std::string>("frame_renderer") == "progressive";
 }
 
 IRendererController* RenderDeviceBase::get_frame_renderer_controller()

--- a/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
+++ b/src/appleseed/renderer/kernel/aov/aovaccumulator.cpp
@@ -44,7 +44,6 @@
 #include <cstring>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/aov/imagestack.cpp
+++ b/src/appleseed/renderer/kernel/aov/imagestack.cpp
@@ -43,7 +43,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -57,11 +56,11 @@ struct ImageStack::Impl
 
     struct NamedImage
     {
-        string              m_name;
+        std::string         m_name;
         Image*              m_image;
     };
 
-    vector<NamedImage>      m_images;
+    std::vector<NamedImage> m_images;
 };
 
 ImageStack::ImageStack(

--- a/src/appleseed/renderer/kernel/denoising/denoiser.cpp
+++ b/src/appleseed/renderer/kernel/denoising/denoiser.cpp
@@ -52,7 +52,6 @@
 
 using namespace bcd;
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -184,7 +183,7 @@ namespace
         DenoiserOutputs outputs;
         outputs.m_pDenoisedColors = &dst;
 
-        unique_ptr<IDenoiser> denoiser;
+        std::unique_ptr<IDenoiser> denoiser;
 
         if (options.m_num_scales > 1)
             denoiser.reset(new MultiscaleDenoiser(static_cast<int>(options.m_num_scales)));

--- a/src/appleseed/renderer/kernel/intersection/assemblytree.cpp
+++ b/src/appleseed/renderer/kernel/intersection/assemblytree.cpp
@@ -69,7 +69,6 @@
 #include <utility>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -106,7 +105,7 @@ size_t AssemblyTree::get_memory_size() const
         - sizeof(*static_cast<const TreeType*>(this))
         + sizeof(*this)
         + m_items.capacity() * sizeof(AssemblyInstance*)
-        + m_assembly_versions.size() * sizeof(pair<UniqueID, VersionID>);
+        + m_assembly_versions.size() * sizeof(std::pair<UniqueID, VersionID>);
 }
 
 void AssemblyTree::collect_assembly_instances(
@@ -190,7 +189,7 @@ void AssemblyTree::rebuild_assembly_tree()
 
     if (!m_items.empty())
     {
-        const vector<size_t>& ordering = partitioner.get_item_ordering();
+        const std::vector<size_t>& ordering = partitioner.get_item_ordering();
         assert(m_items.size() == ordering.size());
 
         // Reorder the items according to the tree ordering.
@@ -316,7 +315,7 @@ void AssemblyTree::collect_unique_assemblies(AssemblyVector& assemblies) const
 
 void AssemblyTree::delete_unused_child_trees(const AssemblyVector& assemblies)
 {
-    set<UniqueID> assembly_uids;
+    std::set<UniqueID> assembly_uids;
 
     for (const_each<AssemblyVector> i = assemblies; i; ++i)
         assembly_uids.insert((*i)->get_uid());
@@ -405,7 +404,7 @@ void AssemblyTree::create_triangle_tree(const Assembly& assembly)
                 assembly.object_instances().begin(),
                 assembly.object_instances().end());
 
-        unique_ptr<ILazyFactory<TriangleTree>> triangle_tree_factory(
+        std::unique_ptr<ILazyFactory<TriangleTree>> triangle_tree_factory(
             new TriangleTreeFactory(
                 TriangleTree::Arguments(
                     m_scene,
@@ -413,11 +412,11 @@ void AssemblyTree::create_triangle_tree(const Assembly& assembly)
                     assembly_bbox,
                     assembly)));
 
-        tree = new Lazy<TriangleTree>(move(triangle_tree_factory));
+        tree = new Lazy<TriangleTree>(std::move(triangle_tree_factory));
         m_triangle_tree_repository.insert(hash, tree);
     }
 
-    m_triangle_trees.insert(make_pair(assembly.get_uid(), tree));
+    m_triangle_trees.insert(std::make_pair(assembly.get_uid(), tree));
 }
 
 void AssemblyTree::create_curve_tree(const Assembly& assembly)
@@ -433,7 +432,7 @@ void AssemblyTree::create_curve_tree(const Assembly& assembly)
                 assembly.object_instances().begin(),
                 assembly.object_instances().end());
 
-        unique_ptr<ILazyFactory<CurveTree>> curve_tree_factory(
+        std::unique_ptr<ILazyFactory<CurveTree>> curve_tree_factory(
             new CurveTreeFactory(
                 CurveTree::Arguments(
                     m_scene,
@@ -441,11 +440,11 @@ void AssemblyTree::create_curve_tree(const Assembly& assembly)
                     assembly_bbox,
                     assembly)));
 
-        tree = new Lazy<CurveTree>(move(curve_tree_factory));
+        tree = new Lazy<CurveTree>(std::move(curve_tree_factory));
         m_curve_tree_repository.insert(hash, tree);
     }
 
-    m_curve_trees.insert(make_pair(assembly.get_uid(), tree));
+    m_curve_trees.insert(std::make_pair(assembly.get_uid(), tree));
 }
 
 #ifdef APPLESEED_WITH_EMBREE
@@ -471,7 +470,7 @@ void AssemblyTree::create_embree_scene(const Assembly& assembly)
 
     if (scene == nullptr)
     {
-        unique_ptr<ILazyFactory<EmbreeScene>> embree_scene_factory(
+        std::unique_ptr<ILazyFactory<EmbreeScene>> embree_scene_factory(
             new EmbreeSceneFactory(
                 EmbreeScene::Arguments(
                     m_scene.get_embree_device(),
@@ -482,7 +481,7 @@ void AssemblyTree::create_embree_scene(const Assembly& assembly)
         m_embree_scene_repository.insert(hash, scene);
     }
 
-    m_embree_scenes.insert(make_pair(assembly.get_uid(), scene));
+    m_embree_scenes.insert(std::make_pair(assembly.get_uid(), scene));
 }
 
 void AssemblyTree::delete_embree_scene(const UniqueID assembly_id)

--- a/src/appleseed/renderer/kernel/intersection/curvetree.cpp
+++ b/src/appleseed/renderer/kernel/intersection/curvetree.cpp
@@ -60,7 +60,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -89,7 +88,7 @@ CurveTree::CurveTree(const Arguments& arguments)
     const MessageContext message_context(
         format("while building curve tree for assembly \"{0}\"", m_arguments.m_assembly.get_path()));
     const ParamArray& params = m_arguments.m_assembly.get_parameters().child("acceleration_structure");
-    const string algorithm = params.get_optional<string>("algorithm", "bvh", make_vector("bvh", "sbvh"), message_context);
+    const std::string algorithm = params.get_optional<std::string>("algorithm", "bvh", make_vector("bvh", "sbvh"), message_context);
     const double time = params.get_optional<double>("time", 0.5);
 
     // Start stopwatch.
@@ -111,7 +110,7 @@ CurveTree::CurveTree(const Arguments& arguments)
             statistics).to_string().c_str());
 }
 
-void CurveTree::collect_curves(vector<GAABB3>& curve_bboxes)
+void CurveTree::collect_curves(std::vector<GAABB3>& curve_bboxes)
 {
     const ObjectInstanceContainer& object_instances = m_arguments.m_assembly.object_instances();
 
@@ -186,7 +185,7 @@ void CurveTree::build_bvh(
         "collecting geometry for curve tree #" FMT_UNIQUE_ID " from assembly \"%s\"...",
         m_arguments.m_curve_tree_uid,
         m_arguments.m_assembly.get_path().c_str());
-    vector<GAABB3> curve_bboxes;
+    std::vector<GAABB3> curve_bboxes;
     collect_curves(curve_bboxes);
 
     // Print statistics about the input geometry.
@@ -197,7 +196,7 @@ void CurveTree::build_bvh(
         plural(m_curve_keys.size(), "curve").c_str());
 
     // Create the partitioner.
-    typedef bvh::SAHPartitioner<vector<GAABB3>> Partitioner;
+    typedef bvh::SAHPartitioner<std::vector<GAABB3>> Partitioner;
     Partitioner partitioner(
         curve_bboxes,
         CurveTreeDefaultMaxLeafSize,
@@ -218,23 +217,23 @@ void CurveTree::build_bvh(
     // Reorder the curve keys based on the nodes ordering.
     if (!m_curves1.empty() || !m_curves3.empty())
     {
-        const vector<size_t>& ordering = partitioner.get_item_ordering();
+        const std::vector<size_t>& ordering = partitioner.get_item_ordering();
         reorder_curve_keys(ordering);
         reorder_curves(ordering);
         reorder_curve_keys_in_leaf_nodes();
     }
 }
 
-void CurveTree::reorder_curve_keys(const vector<size_t>& ordering)
+void CurveTree::reorder_curve_keys(const std::vector<size_t>& ordering)
 {
-    vector<CurveKey> temp_keys(m_curve_keys.size());
+    std::vector<CurveKey> temp_keys(m_curve_keys.size());
     small_item_reorder(&m_curve_keys[0], &temp_keys[0], &ordering[0], ordering.size());
 }
 
-void CurveTree::reorder_curves(const vector<size_t>& ordering)
+void CurveTree::reorder_curves(const std::vector<size_t>& ordering)
 {
-    vector<Curve1Type> new_curves1(m_curves1.size());
-    vector<Curve3Type> new_curves3(m_curves3.size());
+    std::vector<Curve1Type> new_curves1(m_curves1.size());
+    std::vector<Curve3Type> new_curves3(m_curves3.size());
 
     size_t curve1_index = 0;
     size_t curve3_index = 0;
@@ -276,8 +275,8 @@ void CurveTree::reorder_curve_keys_in_leaf_nodes()
         const size_t item_count = m_nodes[i].get_item_count();
 
         // Collect the curve keys for this leaf node.
-        vector<CurveKey> curve1_keys;
-        vector<CurveKey> curve3_keys;
+        std::vector<CurveKey> curve1_keys;
+        std::vector<CurveKey> curve3_keys;
         for (size_t j = 0; j < item_count; ++j)
         {
             const CurveKey& key = m_curve_keys[item_index + j];
@@ -312,9 +311,9 @@ CurveTreeFactory::CurveTreeFactory(const CurveTree::Arguments& arguments)
 {
 }
 
-unique_ptr<CurveTree> CurveTreeFactory::create()
+std::unique_ptr<CurveTree> CurveTreeFactory::create()
 {
-    return unique_ptr<CurveTree>(new CurveTree(m_arguments));
+    return std::unique_ptr<CurveTree>(new CurveTree(m_arguments));
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/kernel/intersection/embreescene.cpp
+++ b/src/appleseed/renderer/kernel/intersection/embreescene.cpp
@@ -54,7 +54,6 @@
 
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 namespace renderer
 {
@@ -279,7 +278,7 @@ EmbreeScene::EmbreeScene(const EmbreeScene::Arguments& arguments)
         RTCGeometry geometry_handle;
 
         // Set per instance data.
-        unique_ptr<EmbreeGeometryData> geometry_data(new EmbreeGeometryData());
+        std::unique_ptr<EmbreeGeometryData> geometry_data(new EmbreeGeometryData());
         geometry_data->m_object_instance_idx = instance_idx;
         geometry_data->m_vis_flags = object_instance->get_vis_flags();
 
@@ -508,9 +507,9 @@ EmbreeSceneFactory::EmbreeSceneFactory(const EmbreeScene::Arguments& arguments)
 {
 }
 
-unique_ptr<EmbreeScene> EmbreeSceneFactory::create()
+std::unique_ptr<EmbreeScene> EmbreeSceneFactory::create()
 {
-    return unique_ptr<EmbreeScene>(new EmbreeScene(m_arguments));
+    return std::unique_ptr<EmbreeScene>(new EmbreeScene(m_arguments));
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/kernel/intersection/intersectionfilter.cpp
+++ b/src/appleseed/renderer/kernel/intersection/intersectionfilter.cpp
@@ -48,7 +48,6 @@
 #include <memory>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -62,7 +61,7 @@ namespace
         return tess.m_primitives.size();
     }
 
-    void copy_uv_coordinates(const StaticTriangleTess& tess, vector<Vector2f>& uv)
+    void copy_uv_coordinates(const StaticTriangleTess& tess, std::vector<Vector2f>& uv)
     {
         for (const_each<StaticTriangleTess::PrimitiveArray> i = tess.m_primitives; i; ++i)
         {
@@ -85,7 +84,7 @@ namespace
         }
     }
 
-    void copy_uv_coordinates(Object& object, vector<Vector2f>& uv)
+    void copy_uv_coordinates(Object& object, std::vector<Vector2f>& uv)
     {
         const MeshObject& mesh = static_cast<const MeshObject&>(object);
         const StaticTriangleTess& tess = mesh.get_static_triangle_tess();
@@ -159,7 +158,7 @@ void IntersectionFilter::do_update(
 
     // Build the alpha mask.
     double transparency;
-    unique_ptr<AlphaMask> alpha_mask(
+    std::unique_ptr<AlphaMask> alpha_mask(
         create_alpha_mask(
             alpha_map,
             texture_cache,

--- a/src/appleseed/renderer/kernel/intersection/intersector.cpp
+++ b/src/appleseed/renderer/kernel/intersection/intersector.cpp
@@ -53,7 +53,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -477,18 +476,18 @@ namespace
         uint64  m_total_ray_count;
 
         RayCountStatisticsEntry(
-            const string&   name,
-            const uint64    ray_count,
-            const uint64    total_ray_count)
+            const std::string&   name,
+            const uint64         ray_count,
+            const uint64         total_ray_count)
           : Entry(name)
           , m_ray_count(ray_count)
           , m_total_ray_count(total_ray_count)
         {
         }
 
-        unique_ptr<Entry> clone() const override
+        std::unique_ptr<Entry> clone() const override
         {
-            return unique_ptr<Entry>(new RayCountStatisticsEntry(*this));
+            return std::unique_ptr<Entry>(new RayCountStatisticsEntry(*this));
         }
 
         void merge(const Entry* other) override
@@ -500,7 +499,7 @@ namespace
             m_total_ray_count += typed_other->m_total_ray_count;
         }
 
-        string to_string() const override
+        std::string to_string() const override
         {
             return pretty_uint(m_ray_count) + " (" + pretty_percent(m_ray_count, m_total_ray_count) + ")";
         }
@@ -514,13 +513,13 @@ StatisticsVector Intersector::get_statistics() const
     Statistics intersection_stats;
     intersection_stats.insert("total rays", total_ray_count);
     intersection_stats.insert(
-        unique_ptr<RayCountStatisticsEntry>(
+        std::unique_ptr<RayCountStatisticsEntry>(
             new RayCountStatisticsEntry(
                 "shading rays",
                 m_shading_ray_count,
                 total_ray_count)));
     intersection_stats.insert(
-        unique_ptr<RayCountStatisticsEntry>(
+        std::unique_ptr<RayCountStatisticsEntry>(
             new RayCountStatisticsEntry(
                 "probe rays",
                 m_probe_ray_count,

--- a/src/appleseed/renderer/kernel/intersection/triangleencoder.cpp
+++ b/src/appleseed/renderer/kernel/intersection/triangleencoder.cpp
@@ -39,16 +39,15 @@
 #include "foundation/utility/memory.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
 
 size_t TriangleEncoder::compute_size(
-    const vector<TriangleVertexInfo>&   triangle_vertex_infos,
-    const vector<size_t>&               triangle_indices,
-    const size_t                        item_begin,
-    const size_t                        item_count)
+    const std::vector<TriangleVertexInfo>&   triangle_vertex_infos,
+    const std::vector<size_t>&               triangle_indices,
+    const size_t                             item_begin,
+    const size_t                             item_count)
 {
     size_t size = 0;
 
@@ -69,12 +68,12 @@ size_t TriangleEncoder::compute_size(
 }
 
 void TriangleEncoder::encode(
-    const vector<TriangleVertexInfo>&   triangle_vertex_infos,
-    const vector<GVector3>&             triangle_vertices,
-    const vector<size_t>&               triangle_indices,
-    const size_t                        item_begin,
-    const size_t                        item_count,
-    MemoryWriter&                       writer)
+    const std::vector<TriangleVertexInfo>&   triangle_vertex_infos,
+    const std::vector<GVector3>&             triangle_vertices,
+    const std::vector<size_t>&               triangle_indices,
+    const size_t                             item_begin,
+    const size_t                             item_count,
+    MemoryWriter&                            writer)
 {
     for (size_t i = 0; i < item_count; ++i)
     {

--- a/src/appleseed/renderer/kernel/intersection/triangleitemhandler.cpp
+++ b/src/appleseed/renderer/kernel/intersection/triangleitemhandler.cpp
@@ -44,15 +44,14 @@
 #include <limits>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
 
 TriangleItemHandler::TriangleItemHandler(
-    const vector<TriangleVertexInfo>&   triangle_vertex_infos,
-    const vector<GVector3>&             triangle_vertices,
-    const vector<AABB3d>&               triangle_bboxes)
+    const std::vector<TriangleVertexInfo>&   triangle_vertex_infos,
+    const std::vector<GVector3>&             triangle_vertices,
+    const std::vector<AABB3d>&               triangle_bboxes)
   : m_triangle_vertex_infos(triangle_vertex_infos)
   , m_triangle_vertices(triangle_vertices)
   , m_triangle_bboxes(triangle_bboxes)
@@ -102,10 +101,10 @@ AABB3d TriangleItemHandler::clip(
     const int v2_ge_min = v2d >= slab_min ? 1 : 0;
     const int v2_le_max = v2d <= slab_max ? 1 : 0;
 
-    __m128d bbox_min_xy = _mm_set1_pd(+numeric_limits<double>::max());
-    __m128d bbox_min_zz = _mm_set1_pd(+numeric_limits<double>::max());
-    __m128d bbox_max_xy = _mm_set1_pd(-numeric_limits<double>::max());
-    __m128d bbox_max_zz = _mm_set1_pd(-numeric_limits<double>::max());
+    __m128d bbox_min_xy = _mm_set1_pd(+std::numeric_limits<double>::max());
+    __m128d bbox_min_zz = _mm_set1_pd(+std::numeric_limits<double>::max());
+    __m128d bbox_max_xy = _mm_set1_pd(-std::numeric_limits<double>::max());
+    __m128d bbox_max_zz = _mm_set1_pd(-std::numeric_limits<double>::max());
 
     const __m128d v0_xy = _mm_load_pd(&v0.x);
     const __m128d v0_zz = _mm_set1_pd(v0.z);

--- a/src/appleseed/renderer/kernel/intersection/triangletree.cpp
+++ b/src/appleseed/renderer/kernel/intersection/triangletree.cpp
@@ -78,7 +78,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -104,16 +103,16 @@ namespace
 
     template <typename AABBType>
     void collect_static_triangles(
-        const GAABB3&                   tree_bbox,
-        const ObjectInstance&           object_instance,
-        const size_t                    object_instance_index,
-        const StaticTriangleTess&       tess,
-        const bool                      save_memory,
-        vector<TriangleKey>*            triangle_keys,
-        vector<TriangleVertexInfo>*     triangle_vertex_infos,
-        vector<GVector3>*               triangle_vertices,
-        vector<AABBType>*               triangle_bboxes,
-        size_t&                         triangle_vertex_count)
+        const GAABB3&                        tree_bbox,
+        const ObjectInstance&                object_instance,
+        const size_t                         object_instance_index,
+        const StaticTriangleTess&            tess,
+        const bool                           save_memory,
+        std::vector<TriangleKey>*            triangle_keys,
+        std::vector<TriangleVertexInfo>*     triangle_vertex_infos,
+        std::vector<GVector3>*               triangle_vertices,
+        std::vector<AABBType>*               triangle_bboxes,
+        size_t&                              triangle_vertex_count)
     {
         const Transformd& transform = object_instance.get_transform();
         const size_t triangle_count = tess.m_primitives.size();
@@ -198,17 +197,17 @@ namespace
 
     template <typename AABBType>
     void collect_moving_triangles(
-        const GAABB3&                   tree_bbox,
-        const ObjectInstance&           object_instance,
-        const size_t                    object_instance_index,
-        const StaticTriangleTess&       tess,
-        const double                    time,
-        const bool                      save_memory,
-        vector<TriangleKey>*            triangle_keys,
-        vector<TriangleVertexInfo>*     triangle_vertex_infos,
-        vector<GVector3>*               triangle_vertices,
-        vector<AABBType>*               triangle_bboxes,
-        size_t&                         triangle_vertex_count)
+        const GAABB3&                        tree_bbox,
+        const ObjectInstance&                object_instance,
+        const size_t                         object_instance_index,
+        const StaticTriangleTess&            tess,
+        const double                         time,
+        const bool                           save_memory,
+        std::vector<TriangleKey>*            triangle_keys,
+        std::vector<TriangleVertexInfo>*     triangle_vertex_infos,
+        std::vector<GVector3>*               triangle_vertices,
+        std::vector<AABBType>*               triangle_bboxes,
+        size_t&                              triangle_vertex_count)
     {
         const Transformd& transform = object_instance.get_transform();
         const size_t motion_segment_count = tess.get_motion_segment_count();
@@ -223,7 +222,7 @@ namespace
             increase_capacity(triangle_bboxes, triangle_count);
         }
 
-        vector<GAABB3> tri_pose_bboxes(motion_segment_count + 1);
+        std::vector<GAABB3> tri_pose_bboxes(motion_segment_count + 1);
 
         for (size_t i = 0; i < triangle_count; ++i)
         {
@@ -316,13 +315,13 @@ namespace
 
     template <typename AABBType>
     void collect_triangles(
-        const TriangleTree::Arguments&  arguments,
-        const double                    time,
-        const bool                      save_memory,
-        vector<TriangleKey>*            triangle_keys,
-        vector<TriangleVertexInfo>*     triangle_vertex_infos,
-        vector<GVector3>*               triangle_vertices,
-        vector<AABBType>*               triangle_bboxes)
+        const TriangleTree::Arguments&       arguments,
+        const double                         time,
+        const bool                           save_memory,
+        std::vector<TriangleKey>*            triangle_keys,
+        std::vector<TriangleVertexInfo>*     triangle_vertex_infos,
+        std::vector<GVector3>*               triangle_vertices,
+        std::vector<AABBType>*               triangle_bboxes)
     {
         assert_empty(triangle_keys);
         assert_empty(triangle_vertex_infos);
@@ -402,7 +401,7 @@ TriangleTree::TriangleTree(const Arguments& arguments)
     const MessageContext message_context(
         format("while building triangle tree for assembly \"{0}\"", m_arguments.m_assembly.get_path()));
     const ParamArray& params = m_arguments.m_assembly.get_parameters().child("acceleration_structure");
-    const string algorithm = params.get_optional<string>("algorithm", "bvh", make_vector("bvh", "sbvh"), message_context);
+    const std::string algorithm = params.get_optional<std::string>("algorithm", "bvh", make_vector("bvh", "sbvh"), message_context);
     const double time = params.get_optional<double>("time", 0.5);
     const bool save_memory = params.get_optional<bool>("save_temporary_memory", false);
 
@@ -480,7 +479,7 @@ namespace
 
     #define RENDERER_LOG_VECTOR_STATS(vec) print_vector_stats(#vec, vec)
 
-    size_t count_static_triangles(const vector<TriangleVertexInfo>& info)
+    size_t count_static_triangles(const std::vector<TriangleVertexInfo>& info)
     {
         size_t count = 0;
 
@@ -508,9 +507,9 @@ void TriangleTree::build_bvh(
         m_arguments.m_triangle_tree_uid,
         m_arguments.m_assembly.get_path().c_str());
     stopwatch.start();
-    vector<TriangleKey> triangle_keys;
-    vector<TriangleVertexInfo> triangle_vertex_infos;
-    vector<GAABB3> triangle_bboxes;
+    std::vector<TriangleKey> triangle_keys;
+    std::vector<TriangleVertexInfo> triangle_vertex_infos;
+    std::vector<GAABB3> triangle_bboxes;
     collect_triangles(
         m_arguments,
         time,
@@ -540,7 +539,7 @@ void TriangleTree::build_bvh(
     const GScalar triangle_intersection_cost = params.get_optional<GScalar>("triangle_intersection_cost", TriangleTreeDefaultTriangleIntersectionCost);
 
     // Create the partitioner.
-    typedef bvh::SAHPartitioner<vector<GAABB3>> Partitioner;
+    typedef bvh::SAHPartitioner<std::vector<GAABB3>> Partitioner;
     Partitioner partitioner(
         triangle_bboxes,
         max_leaf_size,
@@ -564,7 +563,7 @@ void TriangleTree::build_bvh(
     clear_release_memory(triangle_bboxes);
 
     // Collect triangle vertices.
-    vector<GVector3> triangle_vertices;
+    std::vector<GVector3> triangle_vertices;
     collect_triangles<GAABB3>(
         m_arguments,
         time,
@@ -609,10 +608,10 @@ void TriangleTree::build_sbvh(
         "collecting geometry for triangle tree #" FMT_UNIQUE_ID " from assembly \"%s\"...",
         m_arguments.m_triangle_tree_uid,
         m_arguments.m_assembly.get_path().c_str());
-    vector<TriangleKey> triangle_keys;
-    vector<TriangleVertexInfo> triangle_vertex_infos;
-    vector<GVector3> triangle_vertices;
-    vector<AABB3d> triangle_bboxes;
+    std::vector<TriangleKey> triangle_keys;
+    std::vector<TriangleVertexInfo> triangle_vertex_infos;
+    std::vector<GVector3> triangle_vertices;
+    std::vector<AABB3d> triangle_bboxes;
     stopwatch.start();
     collect_triangles(
         m_arguments,
@@ -644,7 +643,7 @@ void TriangleTree::build_sbvh(
     const GScalar triangle_intersection_cost = params.get_optional<GScalar>("triangle_intersection_cost", TriangleTreeDefaultTriangleIntersectionCost);
 
     // Create the partitioner.
-    typedef bvh::SBVHPartitioner<TriangleItemHandler, vector<AABB3d>> Partitioner;
+    typedef bvh::SBVHPartitioner<TriangleItemHandler, std::vector<AABB3d>> Partitioner;
     TriangleItemHandler triangle_handler(
         triangle_vertex_infos,
         triangle_vertices,
@@ -752,24 +751,24 @@ namespace
 #endif
 }
 
-vector<GAABB3> TriangleTree::compute_motion_bboxes(
-    const vector<size_t>&               triangle_indices,
-    const vector<TriangleVertexInfo>&   triangle_vertex_infos,
-    const vector<GVector3>&             triangle_vertices,
+std::vector<GAABB3> TriangleTree::compute_motion_bboxes(
+    const std::vector<size_t>&               triangle_indices,
+    const std::vector<TriangleVertexInfo>&   triangle_vertex_infos,
+    const std::vector<GVector3>&             triangle_vertices,
     const size_t                        node_index)
 {
     NodeType& node = m_nodes[node_index];
 
     if (node.is_interior())
     {
-        const vector<GAABB3> left_bboxes =
+        const std::vector<GAABB3> left_bboxes =
             compute_motion_bboxes(
                 triangle_indices,
                 triangle_vertex_infos,
                 triangle_vertices,
                 node.get_child_node_index() + 0);
 
-        const vector<GAABB3> right_bboxes =
+        const std::vector<GAABB3> right_bboxes =
             compute_motion_bboxes(
                 triangle_indices,
                 triangle_vertex_infos,
@@ -783,7 +782,7 @@ vector<GAABB3> TriangleTree::compute_motion_bboxes(
         {
             node.set_left_bbox_index(m_node_bboxes.size());
 
-            for (vector<GAABB3>::const_iterator i = left_bboxes.begin(); i != left_bboxes.end(); ++i)
+            for (std::vector<GAABB3>::const_iterator i = left_bboxes.begin(); i != left_bboxes.end(); ++i)
                 m_node_bboxes.push_back(swizzle(AABB3d(*i)));
         }
 
@@ -791,12 +790,12 @@ vector<GAABB3> TriangleTree::compute_motion_bboxes(
         {
             node.set_right_bbox_index(m_node_bboxes.size());
 
-            for (vector<GAABB3>::const_iterator i = right_bboxes.begin(); i != right_bboxes.end(); ++i)
+            for (std::vector<GAABB3>::const_iterator i = right_bboxes.begin(); i != right_bboxes.end(); ++i)
                 m_node_bboxes.push_back(swizzle(AABB3d(*i)));
         }
 
         const size_t bbox_count = max(left_bboxes.size(), right_bboxes.size());
-        vector<GAABB3> bboxes(bbox_count);
+        std::vector<GAABB3> bboxes(bbox_count);
 
         for (size_t i = 0; i < bbox_count; ++i)
         {
@@ -831,7 +830,7 @@ vector<GAABB3> TriangleTree::compute_motion_bboxes(
             base_pose_bbox.insert(triangle_vertices[vertex_info.m_vertex_index + 2]);
         }
 
-        vector<GAABB3> bboxes(max_motion_segment_count + 1);
+        std::vector<GAABB3> bboxes(max_motion_segment_count + 1);
         bboxes[0] = base_pose_bbox;
 
         if (max_motion_segment_count > 0)
@@ -876,11 +875,11 @@ vector<GAABB3> TriangleTree::compute_motion_bboxes(
 }
 
 void TriangleTree::store_triangles(
-    const vector<size_t>&               triangle_indices,
-    const vector<TriangleVertexInfo>&   triangle_vertex_infos,
-    const vector<GVector3>&             triangle_vertices,
-    const vector<TriangleKey>&          triangle_keys,
-    Statistics&                         statistics)
+    const std::vector<size_t>&               triangle_indices,
+    const std::vector<TriangleVertexInfo>&   triangle_vertex_infos,
+    const std::vector<GVector3>&             triangle_vertices,
+    const std::vector<TriangleKey>&          triangle_keys,
+    Statistics&                              statistics)
 {
     const size_t node_count = m_nodes.size();
 
@@ -1078,9 +1077,9 @@ namespace
         return h;
     }
 
-    typedef set<size_t> IndexSet;
-    typedef set<FilterKey> FilterKeySet;
-    typedef map<size_t, const FilterKey*> IndexToFilterKeyMap;
+    typedef std::set<size_t> IndexSet;
+    typedef std::set<FilterKey> FilterKeySet;
+    typedef std::map<size_t, const FilterKey*> IndexToFilterKeyMap;
 
     // Collect the set of object instances contained in an assembly.
     void collect_object_instances(
@@ -1160,7 +1159,7 @@ namespace
             }
 
             // Create an intersection filter for this key.
-            unique_ptr<IntersectionFilter> intersection_filter(
+            std::unique_ptr<IntersectionFilter> intersection_filter(
                 new IntersectionFilter(
                     *filter_key.m_object,
                     filter_key.m_materials,
@@ -1193,7 +1192,7 @@ namespace
         if (repository.empty())
             return;
 
-        set<uint64> hashes;
+        std::set<uint64> hashes;
 
         for (const_each<FilterKeySet> i = filter_keys; i; ++i)
             hashes.insert(hash(*i));
@@ -1216,10 +1215,10 @@ namespace
     }
 
     void map_object_instances_to_intersection_filters(
-        const IndexSet&                     object_instances,
-        const IndexToFilterKeyMap&          object_instances_to_filter_keys,
-        const IntersectionFilterRepository& repository,
-        vector<const IntersectionFilter*>&  filters)
+        const IndexSet&                          object_instances,
+        const IndexToFilterKeyMap&               object_instances_to_filter_keys,
+        const IntersectionFilterRepository&      repository,
+        std::vector<const IntersectionFilter*>&  filters)
     {
         if (!object_instances.empty())
         {
@@ -1301,9 +1300,9 @@ TriangleTreeFactory::TriangleTreeFactory(const TriangleTree::Arguments& argument
 {
 }
 
-unique_ptr<TriangleTree> TriangleTreeFactory::create()
+std::unique_ptr<TriangleTree> TriangleTreeFactory::create()
 {
-    return unique_ptr<TriangleTree>(new TriangleTree(m_arguments));
+    return std::unique_ptr<TriangleTree>(new TriangleTree(m_arguments));
 }
 
 

--- a/src/appleseed/renderer/kernel/intersection/triangletree.cpp
+++ b/src/appleseed/renderer/kernel/intersection/triangletree.cpp
@@ -755,7 +755,7 @@ std::vector<GAABB3> TriangleTree::compute_motion_bboxes(
     const std::vector<size_t>&               triangle_indices,
     const std::vector<TriangleVertexInfo>&   triangle_vertex_infos,
     const std::vector<GVector3>&             triangle_vertices,
-    const size_t                        node_index)
+    const size_t                             node_index)
 {
     NodeType& node = m_nodes[node_index];
 

--- a/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
@@ -44,7 +44,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -90,7 +89,7 @@ BackwardLightSampler::BackwardLightSampler(
   : LightSamplerBase(params)
 {
     // Read which sampling algorithm should be used.
-    m_use_light_tree = params.get_optional<string>("algorithm", "cdf") == "lighttree";
+    m_use_light_tree = params.get_optional<std::string>("algorithm", "cdf") == "lighttree";
 
     RENDERER_LOG_INFO("collecting light emitters...");
 
@@ -170,7 +169,7 @@ BackwardLightSampler::BackwardLightSampler(
         m_light_tree.reset(new LightTree(m_light_tree_lights, m_emitting_shapes));
 
         // Build the light tree.
-        const vector<size_t> tri_index_to_node_index = m_light_tree->build();
+        const std::vector<size_t> tri_index_to_node_index = m_light_tree->build();
         assert(tri_index_to_node_index.size() == m_emitting_shapes.size());
 
         // Associate light tree nodes to emitting shapes.

--- a/src/appleseed/renderer/kernel/lighting/bdpt/bdptlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/bdpt/bdptlightingengine.cpp
@@ -47,7 +47,6 @@
 #include "foundation/utility/statistics.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/lighting/directlightingintegrator.cpp
+++ b/src/appleseed/renderer/kernel/lighting/directlightingintegrator.cpp
@@ -52,7 +52,6 @@
 #include <cmath>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/lighting/forwardlightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/forwardlightsampler.cpp
@@ -45,7 +45,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/lighting/lightpathrecorder.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lightpathrecorder.cpp
@@ -57,7 +57,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -66,10 +65,10 @@ APPLESEED_DEFINE_APIARRAY(LightPathArray);
 
 struct LightPathRecorder::Impl
 {
-    const Project&                      m_project;
+    const Project&                                m_project;
 
-    boost::mutex                        m_mutex;
-    vector<unique_ptr<LightPathStream>> m_streams;
+    boost::mutex                                  m_mutex;
+    std::vector<std::unique_ptr<LightPathStream>> m_streams;
 
     // One entry in the index = one pixel in the frame.
     struct IndexEntry
@@ -78,9 +77,9 @@ struct LightPathRecorder::Impl
         size_t  m_end_path;             // index of one path past the last one
     };
 
-    size_t                              m_render_width;
-    size_t                              m_render_height;
-    vector<IndexEntry>                  m_index;
+    size_t                                   m_render_width;
+    size_t                                   m_render_height;
+    std::vector<IndexEntry>                  m_index;
 
     explicit Impl(const Project& project)
       : m_project(project)
@@ -129,7 +128,7 @@ LightPathStream* LightPathRecorder::create_stream()
     boost::mutex::scoped_lock lock(impl->m_mutex);
 
     auto stream = new LightPathStream(impl->m_project);
-    impl->m_streams.push_back(unique_ptr<LightPathStream>(stream));
+    impl->m_streams.push_back(std::unique_ptr<LightPathStream>(stream));
 
     return stream;
 }
@@ -329,7 +328,7 @@ bool LightPathRecorder::write(const char* filename) const
         };
 
         // Initialize index.
-        vector<StoredIndexEntry> stored_index(impl->m_render_width * impl->m_render_height);
+        std::vector<StoredIndexEntry> stored_index(impl->m_render_width * impl->m_render_height);
         for (auto& index_entry : stored_index)
         {
             index_entry.m_start_offset = ~uint64(0);
@@ -349,8 +348,8 @@ bool LightPathRecorder::write(const char* filename) const
         }
 
         // Collect entity names and build (entity name -> name index) dictionary.
-        vector<string> entity_names;
-        map<const Entity*, uint16> entity_name_to_index;
+        std::vector<std::string> entity_names;
+        std::map<const Entity*, uint16> entity_name_to_index;
         for (const auto& vertex : stream->m_vertices)
         {
             if (entity_name_to_index.find(vertex.m_entity) == entity_name_to_index.end())
@@ -358,7 +357,7 @@ bool LightPathRecorder::write(const char* filename) const
                 // Insert a new (entity name -> name index) entry into the dictionary.
                 assert(entity_names.size() < 65536);
                 entity_name_to_index.insert(
-                    make_pair(
+                    std::make_pair(
                         vertex.m_entity,
                         static_cast<uint16>(entity_names.size())));
 

--- a/src/appleseed/renderer/kernel/lighting/lightsamplerbase.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lightsamplerbase.cpp
@@ -47,7 +47,6 @@
 #include "foundation/utility/containers/dictionary.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/lighting/lighttree.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttree.cpp
@@ -53,7 +53,6 @@
 #include <limits>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -63,8 +62,8 @@ namespace renderer
 //
 
 LightTree::LightTree(
-    const vector<NonPhysicalLightInfo>&      non_physical_lights,
-    const vector<EmittingShape>&             emitting_shapes)
+    const std::vector<NonPhysicalLightInfo>&      non_physical_lights,
+    const std::vector<EmittingShape>&             emitting_shapes)
   : m_non_physical_lights(non_physical_lights)
   , m_emitting_shapes(emitting_shapes)
   , m_tree_depth(0)
@@ -72,7 +71,7 @@ LightTree::LightTree(
 {
 }
 
-vector<size_t> LightTree::build()
+std::vector<size_t> LightTree::build()
 {
     AABBVector light_bboxes;
 
@@ -125,7 +124,7 @@ vector<size_t> LightTree::build()
     {
         m_is_built = true;
 
-        const vector<size_t>& ordering = partitioner.get_item_ordering();
+        const std::vector<size_t>& ordering = partitioner.get_item_ordering();
         assert(m_items.size() == ordering.size());
 
         // Reorder items according to the tree ordering.
@@ -212,7 +211,7 @@ float LightTree::recursive_node_update(
             // we can't compute the max_contribution easily (ex: textured lights)
             // In such cases, we can use a default importance value of 1.0 to avoid
             // infinite importance values in the light tree nodes.
-            if (max_contribution == numeric_limits<float>::max())
+            if (max_contribution == std::numeric_limits<float>::max())
                 importance = 1.0f;
             else
                 importance = max_contribution * edf->get_uncached_importance_multiplier();
@@ -440,9 +439,9 @@ void LightTree::child_node_probabilites(
 }
 
 void LightTree::draw_tree_structure(
-    const string&       filename_base,
-    const AABB3d&       root_bbox,
-    const bool          separate_by_levels) const
+    const std::string&       filename_base,
+    const AABB3d&            root_bbox,
+    const bool               separate_by_levels) const
 {
     // todo: add a possibility to shift each level of bboxes along the z-axis.
 

--- a/src/appleseed/renderer/kernel/lighting/materialsamplers.cpp
+++ b/src/appleseed/renderer/kernel/lighting/materialsamplers.cpp
@@ -39,7 +39,6 @@
 #include "renderer/modeling/volume/volume.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/pt/ptlightingengine.cpp
@@ -75,7 +75,6 @@ namespace renderer  { class PixelContext; }
 namespace renderer  { class TextureCache; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmlightingengine.cpp
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmlightingengine.cpp
@@ -69,7 +69,6 @@ namespace renderer  { class PixelContext; }
 namespace renderer  { class TextureCache; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmparameters.cpp
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmparameters.cpp
@@ -43,7 +43,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -65,8 +64,8 @@ namespace
         const char*         name,
         const char*         default_value)
     {
-        const string value =
-            params.get_optional<string>(
+        const std::string value =
+            params.get_optional<std::string>(
                 name,
                 default_value,
                 make_vector("mono", "poly"));
@@ -82,8 +81,8 @@ namespace
         const char*         name,
         const char*         default_value)
     {
-        const string value =
-            params.get_optional<string>(
+        const std::string value =
+            params.get_optional<std::string>(
                 name,
                 default_value,
                 make_vector("sppm", "rt", "off"));

--- a/src/appleseed/renderer/kernel/lighting/sppm/sppmpasscallback.cpp
+++ b/src/appleseed/renderer/kernel/lighting/sppm/sppmpasscallback.cpp
@@ -50,7 +50,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/rendering/debug/blanktilerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/debug/blanktilerenderer.cpp
@@ -48,7 +48,6 @@
 namespace foundation    { class IAbortSwitch; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/rendering/debug/debugsamplerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/debug/debugsamplerenderer.cpp
@@ -47,7 +47,6 @@
 namespace renderer  { class PixelContext; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/rendering/debug/debugtilerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/debug/debugtilerenderer.cpp
@@ -48,7 +48,6 @@
 namespace foundation    { class IAbortSwitch; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/rendering/final/adaptivetilerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/final/adaptivetilerenderer.cpp
@@ -78,7 +78,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -339,7 +338,7 @@ namespace
             // Create the buffer into which we will accumulate every second samples.
             // If rendering multiple passes, the permanent buffer factory will return
             // the same buffer so we must create a new one.
-            unique_ptr<ShadingResultFrameBuffer> second_framebuffer(
+            std::unique_ptr<ShadingResultFrameBuffer> second_framebuffer(
                 new ShadingResultFrameBuffer(
                     tile.get_width(),
                     tile.get_height(),
@@ -353,8 +352,8 @@ namespace
             const size_t tile_pixel_count = framebuffer->get_width() * framebuffer->get_height();
 
             // Blocks rendering.
-            deque<PixelBlock> rendering_blocks;
-            vector<PixelBlock> finished_blocks;
+            std::deque<PixelBlock> rendering_blocks;
+            std::vector<PixelBlock> finished_blocks;
 
             // Initially split blocks so that no block is larger than `BlockMaxAllowedSize`.
             create_rendering_blocks(rendering_blocks, tile_bbox, framebuffer->get_crop_window());
@@ -367,7 +366,7 @@ namespace
                         ? min(m_params.m_min_samples, m_params.m_max_samples)
                         : m_params.m_min_samples;
 
-                deque<PixelBlock> blocks = rendering_blocks;
+                std::deque<PixelBlock> blocks = rendering_blocks;
                 rendering_blocks.clear();
 
                 while (!blocks.empty())
@@ -555,7 +554,7 @@ namespace
             average_noise_level /= tile_pixel_count;
 
             // Print final statistics about this tile.
-            const string converged_pixels_string = pretty_percent(tile_converged_pixel_count, tile_pixel_count, 0);
+            const std::string converged_pixels_string = pretty_percent(tile_converged_pixel_count, tile_pixel_count, 0);
             Statistics stats;
             stats.insert(
                 "pixels",
@@ -714,11 +713,11 @@ namespace
         }
 
         void create_rendering_blocks(
-            deque<PixelBlock>&                  rendering_blocks,
-            const AABB2i&                       tile_bbox,
-            const AABB2u&                       frame_bbox)
+            std::deque<PixelBlock>&                  rendering_blocks,
+            const AABB2i&                            tile_bbox,
+            const AABB2u&                            frame_bbox)
         {
-            deque<PixelBlock> initial_blocks(1, PixelBlock(tile_bbox));
+            std::deque<PixelBlock> initial_blocks(1, PixelBlock(tile_bbox));
 
             while (!initial_blocks.empty())
             {
@@ -885,9 +884,9 @@ namespace
 
         // Split the given block in two.
         void split_pixel_block(
-            const PixelBlock&                   pb,
-            deque<PixelBlock>&                  blocks,
-            const int                           splitting_point) const
+            const PixelBlock&                        pb,
+            std::deque<PixelBlock>&                  blocks,
+            const int                                splitting_point) const
         {
             AABB2i f_half = pb.m_surface, s_half = pb.m_surface;
 

--- a/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
@@ -69,7 +69,6 @@ namespace renderer { class IRendererController; }
 
 using namespace boost;
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -263,8 +262,8 @@ namespace
 
             static TileJobFactory::TileOrdering get_tile_ordering(const ParamArray& params)
             {
-                const string tile_ordering =
-                    params.get_optional<string>("tile_ordering", "spiral");
+                const std::string tile_ordering =
+                    params.get_optional<std::string>("tile_ordering", "spiral");
 
                 if (tile_ordering == "linear")
                 {
@@ -302,8 +301,8 @@ namespace
             PassManagerFunc(
                 const Frame&                        frame,
                 IShadingResultFrameBufferFactory*   framebuffer_factory,
-                vector<ITileRenderer*>&             tile_renderers,
-                vector<ITileCallback*>&             tile_callbacks,
+                std::vector<ITileRenderer*>&        tile_renderers,
+                std::vector<ITileCallback*>&        tile_callbacks,
                 IPassCallback*                      pass_callback,
                 const Spectrum::Mode                spectrum_mode,
                 const TileJobFactory::TileOrdering  tile_ordering,
@@ -432,8 +431,8 @@ namespace
           private:
             const Frame&                            m_frame;
             IShadingResultFrameBufferFactory*       m_framebuffer_factory;
-            vector<ITileRenderer*>&                 m_tile_renderers;
-            vector<ITileCallback*>&                 m_tile_callbacks;
+            std::vector<ITileRenderer*>&            m_tile_renderers;
+            std::vector<ITileCallback*>&            m_tile_callbacks;
             IPassCallback*                          m_pass_callback;
             const Spectrum::Mode                    m_spectrum_mode;
             const TileJobFactory::TileOrdering      m_tile_ordering;
@@ -479,19 +478,19 @@ namespace
         const Parameters                        m_params;
 
         JobQueue                                m_job_queue;
-        unique_ptr<JobManager>                  m_job_manager;
+        std::unique_ptr<JobManager>             m_job_manager;
         AbortSwitch                             m_abort_switch;
 
         IShadingResultFrameBufferFactory*       m_framebuffer_factory;
-        vector<ITileRenderer*>                  m_tile_renderers;   // tile renderers, one per thread
-        vector<ITileCallback*>                  m_tile_callbacks;   // tile callbacks, none or one per thread
+        std::vector<ITileRenderer*>             m_tile_renderers;   // tile renderers, one per thread
+        std::vector<ITileCallback*>             m_tile_callbacks;   // tile callbacks, none or one per thread
         IPassCallback*                          m_pass_callback;
 
         TileJobFactory                          m_tile_job_factory;
 
         bool                                    m_is_rendering;
-        unique_ptr<PassManagerFunc>             m_pass_manager_func;
-        unique_ptr<boost::thread>               m_pass_manager_thread;
+        std::unique_ptr<PassManagerFunc>        m_pass_manager_func;
+        std::unique_ptr<boost::thread>          m_pass_manager_thread;
 
         void print_tile_renderers_stats() const
         {

--- a/src/appleseed/renderer/kernel/rendering/generic/genericsamplegenerator.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericsamplegenerator.cpp
@@ -59,7 +59,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericsamplerenderer.cpp
@@ -70,7 +70,6 @@
 namespace renderer  { class PixelContext; }
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/rendering/generic/generictilerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/generictilerenderer.cpp
@@ -69,7 +69,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -234,7 +233,7 @@ namespace
         auto_release_ptr<IPixelRenderer>    m_pixel_renderer;
         AOVAccumulatorContainer             m_aov_accumulators;
         IShadingResultFrameBufferFactory*   m_framebuffer_factory;
-        vector<Vector<int16, 2>>            m_pixel_ordering;
+        std::vector<Vector<int16, 2>>       m_pixel_ordering;
 
         void compute_pixel_ordering(const Frame& frame)
         {
@@ -245,7 +244,7 @@ namespace
             const size_t pixel_count = tile_width * tile_height;
 
             // Generate the pixel ordering inside the tile.
-            vector<size_t> ordering;
+            std::vector<size_t> ordering;
             ordering.reserve(pixel_count);
             hilbert_ordering(ordering, tile_width, tile_height);
             assert(ordering.size() == pixel_count);

--- a/src/appleseed/renderer/kernel/rendering/generic/tilejob.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/tilejob.cpp
@@ -45,7 +45,6 @@
 #include <exception>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -148,7 +147,7 @@ void TileJob::execute(const size_t thread_index)
             m_pass_hash,
             m_abort_switch);
     }
-    catch (const exception&)
+    catch (const std::exception&)
     {
         // Call the post-render tile callback.
         if (tile_callback)

--- a/src/appleseed/renderer/kernel/rendering/generic/tilejobfactory.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/tilejobfactory.cpp
@@ -43,7 +43,6 @@
 #include <cassert>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -66,7 +65,7 @@ void TileJobFactory::create(
     const CanvasProperties& props = frame.image().properties();
 
     // Generate tiles ordering.
-    vector<size_t> tiles;
+    std::vector<size_t> tiles;
     generate_tile_ordering(props, tile_ordering, tiles);
 
     // Make sure the right number of tiles was created.
@@ -99,7 +98,7 @@ void TileJobFactory::create(
 void TileJobFactory::generate_tile_ordering(
     const CanvasProperties&             frame_properties,
     const TileOrdering                  tile_ordering,
-    vector<size_t>&                     tiles)
+    std::vector<size_t>&                tiles)
 {
     switch (tile_ordering)
     {

--- a/src/appleseed/renderer/kernel/rendering/globalsampleaccumulationbuffer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/globalsampleaccumulationbuffer.cpp
@@ -46,7 +46,6 @@
 #include "boost/chrono/duration.hpp"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/rendering/localsampleaccumulationbuffer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/localsampleaccumulationbuffer.cpp
@@ -55,7 +55,6 @@
 
 using namespace boost;
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
@@ -70,7 +70,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -117,7 +116,7 @@ struct MasterRenderer::Impl
     SerialRendererController*           m_serial_renderer_controller;
     ITileCallbackFactory*               m_serial_tile_callback_factory;
 
-    unique_ptr<IRenderDevice>           m_render_device;
+    std::unique_ptr<IRenderDevice>      m_render_device;
 
     Stopwatch<DefaultWallclockTimer>    m_stopwatch;
 
@@ -184,7 +183,7 @@ struct MasterRenderer::Impl
             return result;
 
         // Update the render device if needed.
-        const string device_name = get_render_device(m_params);
+        const std::string device_name = get_render_device(m_params);
         if (device_name == "cpu")
         {
             if (dynamic_cast<const CPURenderDevice*>(m_render_device.get()) == nullptr)
@@ -240,14 +239,14 @@ struct MasterRenderer::Impl
             result.m_post_processing_time = m_stopwatch.get_seconds();
             render_info.insert("post_processing_time", result.m_post_processing_time);
         }
-        catch (const bad_alloc&)
+        catch (const std::bad_alloc&)
         {
             renderer_controller.on_rendering_abort();
             RENDERER_LOG_ERROR("rendering failed (ran out of memory).");
             result.m_status = RenderingResult::Failed;
         }
 #ifdef NDEBUG
-        catch (const exception& e)
+        catch (const std::exception& e)
         {
             renderer_controller.on_rendering_abort();
             RENDERER_LOG_ERROR("rendering failed (%s).", e.what());
@@ -497,13 +496,13 @@ struct MasterRenderer::Impl
             return;
 
         // Collect post-processing stages.
-        vector<PostProcessingStage*> ordered_stages;
+        std::vector<PostProcessingStage*> ordered_stages;
         ordered_stages.reserve(frame->post_processing_stages().size());
         for (auto& stage : frame->post_processing_stages())
             ordered_stages.push_back(&stage);
 
         // Sort post-processing stages in increasing order.
-        sort(
+        std::sort(
             ordered_stages.begin(),
             ordered_stages.end(),
             [](PostProcessingStage* lhs, PostProcessingStage* rhs)

--- a/src/appleseed/renderer/kernel/rendering/oiioerrorhandler.cpp
+++ b/src/appleseed/renderer/kernel/rendering/oiioerrorhandler.cpp
@@ -36,7 +36,6 @@
 #include "foundation/utility/string.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -50,9 +49,9 @@ OIIOErrorHandler::OIIOErrorHandler()
 	verbosity(VERBOSE);
 }
 
-void OIIOErrorHandler::operator()(int errcode, const string& msg)
+void OIIOErrorHandler::operator()(int errcode, const std::string& msg)
 {
-    const string modified_msg = prefix_all_lines(trim_both(msg), "osl: ");
+    const std::string modified_msg = prefix_all_lines(trim_both(msg), "osl: ");
 
     switch (errcode & ErrorCodeMask)
     {

--- a/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/progressive/progressiveframerenderer.cpp
@@ -79,7 +79,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace renderer
@@ -105,7 +104,7 @@ namespace
           : m_project(project)
           , m_params(params)
           , m_sample_counter(
-                m_params.m_max_average_spp < numeric_limits<uint64>::max()
+                m_params.m_max_average_spp < std::numeric_limits<uint64>::max()
                     ? m_params.m_max_average_spp * project.get_frame()->get_crop_window().volume()
                     : m_params.m_max_average_spp)
           , m_ref_image_avg_lum(0.0)
@@ -206,10 +205,10 @@ namespace
                 get_spectrum_mode_name(m_params.m_spectrum_mode).c_str(),
                 get_sampling_context_mode_name(m_params.m_sampling_mode).c_str(),
                 pretty_uint(m_params.m_thread_count).c_str(),
-                m_params.m_max_average_spp == numeric_limits<uint64>::max()
+                m_params.m_max_average_spp == std::numeric_limits<uint64>::max()
                     ? "unlimited"
                     : pretty_uint(m_params.m_max_average_spp).c_str(),
-                m_params.m_time_limit == numeric_limits<double>::max()
+                m_params.m_time_limit == std::numeric_limits<double>::max()
                     ? "unlimited"
                     : pretty_time(m_params.m_time_limit).c_str(),
                 m_params.m_max_fps,
@@ -386,8 +385,8 @@ namespace
               : m_spectrum_mode(get_spectrum_mode(params))
               , m_sampling_mode(get_sampling_context_mode(params))
               , m_thread_count(get_rendering_thread_count(params))
-              , m_max_average_spp(params.get_optional<uint64>("max_average_spp", numeric_limits<uint64>::max()))
-              , m_time_limit(params.get_optional<double>("time_limit", numeric_limits<double>::max()))
+              , m_max_average_spp(params.get_optional<uint64>("max_average_spp", std::numeric_limits<uint64>::max()))
+              , m_time_limit(params.get_optional<double>("time_limit", std::numeric_limits<double>::max()))
               , m_max_fps(params.get_optional<double>("max_fps", 30.0))
               , m_perf_stats(params.get_optional<bool>("performance_statistics", false))
               , m_luminance_stats(params.get_optional<bool>("luminance_statistics", false))
@@ -553,7 +552,7 @@ namespace
             {
                 if (!m_sample_count_records.empty())
                 {
-                    const string filepath =
+                    const std::string filepath =
                         (bf::path(m_project.search_paths().get_root_path().c_str()) / "sample_count.gnuplot").string();
                     RENDERER_LOG_DEBUG("writing %s...", filepath.c_str());
 
@@ -569,7 +568,7 @@ namespace
 
                 if (!m_rmsd_records.empty())
                 {
-                    const string filepath =
+                    const std::string filepath =
                         (bf::path(m_project.search_paths().get_root_path().c_str()) / "rms_deviation.gnuplot").string();
                     RENDERER_LOG_DEBUG("writing %s...", filepath.c_str());
 
@@ -629,8 +628,8 @@ namespace
 
             double                          m_rcp_pixel_count;
             SampleCountHistory<128>         m_sample_count_history;
-            vector<Vector2d>                m_sample_count_records;     // total sample count over time
-            vector<Vector2d>                m_rmsd_records;             // RMS deviation over time
+            std::vector<Vector2d>           m_sample_count_records;     // total sample count over time
+            std::vector<Vector2d>           m_rmsd_records;             // RMS deviation over time
 
             void record_and_print_perf_stats(const double time)
             {
@@ -657,7 +656,7 @@ namespace
                 // Develop the accumulation buffer to the frame.
                 m_buffer.develop_to_frame(*m_project.get_frame(), m_abort_switch);
 
-                string output;
+                std::string output;
 
                 if (m_luminance_stats)
                 {
@@ -692,33 +691,33 @@ namespace
         // Progressive frame renderer implementation details.
         //
 
-        const Project&                          m_project;
-        const Parameters                        m_params;
-        SampleCounter                           m_sample_counter;
+        const Project&                               m_project;
+        const Parameters                             m_params;
+        SampleCounter                                m_sample_counter;
 
-        unique_ptr<SampleAccumulationBuffer>    m_buffer;
+        std::unique_ptr<SampleAccumulationBuffer>    m_buffer;
 
-        JobQueue                                m_job_queue;
-        unique_ptr<JobManager>                  m_job_manager;
-        AbortSwitch                             m_abort_switch;
+        JobQueue                                     m_job_queue;
+        std::unique_ptr<JobManager>                  m_job_manager;
+        AbortSwitch                                  m_abort_switch;
 
-        typedef vector<ISampleGenerator*> SampleGeneratorVector;
-        SampleGeneratorVector                   m_sample_generators;
+        typedef std::vector<ISampleGenerator*>       SampleGeneratorVector;
+        SampleGeneratorVector                        m_sample_generators;
 
-        typedef vector<SampleGeneratorJob*> SampleGeneratorJobVector;
-        SampleGeneratorJobVector                m_sample_generator_jobs;
+        typedef std::vector<SampleGeneratorJob*>     SampleGeneratorJobVector;
+        SampleGeneratorJobVector                     m_sample_generator_jobs;
 
-        auto_release_ptr<ITileCallback>         m_tile_callback;
+        auto_release_ptr<ITileCallback>              m_tile_callback;
 
-        unique_ptr<DisplayFunc>                 m_display_func;
-        unique_ptr<boost::thread>               m_display_thread;
-        AbortSwitch                             m_display_thread_abort_switch;
+        std::unique_ptr<DisplayFunc>                 m_display_func;
+        std::unique_ptr<boost::thread>               m_display_thread;
+        AbortSwitch                                  m_display_thread_abort_switch;
 
-        double                                  m_ref_image_avg_lum;
-        unique_ptr<StatisticsFunc>              m_statistics_func;
-        unique_ptr<boost::thread>               m_statistics_thread;
+        double                                       m_ref_image_avg_lum;
+        std::unique_ptr<StatisticsFunc>              m_statistics_func;
+        std::unique_ptr<boost::thread>               m_statistics_thread;
 
-        TimedRendererController                 m_renderer_controller;
+        TimedRendererController                      m_renderer_controller;
 
         void print_sample_generators_stats() const
         {

--- a/src/appleseed/renderer/kernel/rendering/progressive/samplecounter.cpp
+++ b/src/appleseed/renderer/kernel/rendering/progressive/samplecounter.cpp
@@ -35,7 +35,6 @@
 #include <cassert>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -63,7 +62,7 @@ uint64 SampleCounter::reserve(const uint64 n)
         uint64 current = m_sample_count;
         assert(current <= m_max_sample_count);
 
-        const uint64 reserved = min(n, m_max_sample_count - current);
+        const uint64 reserved = std::min(n, m_max_sample_count - current);
         if (m_sample_count.compare_exchange_weak(current, current + reserved))
             return reserved;
     }

--- a/src/appleseed/renderer/kernel/rendering/progressive/samplegeneratorjob.cpp
+++ b/src/appleseed/renderer/kernel/rendering/progressive/samplegeneratorjob.cpp
@@ -48,7 +48,6 @@
 #include <cmath>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/rendering/renderercomponents.cpp
+++ b/src/appleseed/renderer/kernel/rendering/renderercomponents.cpp
@@ -66,7 +66,6 @@
 
 using namespace foundation;
 using namespace OIIO;
-using namespace std;
 
 namespace renderer
 {
@@ -175,7 +174,7 @@ bool RendererComponents::on_frame_begin(
 
 bool RendererComponents::create_lighting_engine_factory()
 {
-    const string name = m_params.get_required<string>("lighting_engine", "pt");
+    const std::string name = m_params.get_required<std::string>("lighting_engine", "pt");
 
     if (name.empty())
     {
@@ -258,7 +257,7 @@ bool RendererComponents::create_lighting_engine_factory()
 
 bool RendererComponents::create_sample_renderer_factory()
 {
-    const string name = m_params.get_required<string>("sample_renderer", "generic");
+    const std::string name = m_params.get_required<std::string>("sample_renderer", "generic");
 
     if (name.empty())
     {
@@ -300,7 +299,7 @@ bool RendererComponents::create_sample_renderer_factory()
 
 bool RendererComponents::create_sample_generator_factory()
 {
-    const string name = m_params.get_optional<string>("sample_generator", "");
+    const std::string name = m_params.get_optional<std::string>("sample_generator", "");
 
     if (name.empty())
     {
@@ -353,7 +352,7 @@ bool RendererComponents::create_sample_generator_factory()
 
 bool RendererComponents::create_pixel_renderer_factory()
 {
-    const string name = m_params.get_optional<string>("pixel_renderer", "");
+    const std::string name = m_params.get_optional<std::string>("pixel_renderer", "");
 
     if (name.empty())
     {
@@ -384,7 +383,7 @@ bool RendererComponents::create_pixel_renderer_factory()
         }
 
         ParamArray tex_sampler_params = get_child_and_inherit_globals(m_params, "texture_controlled_pixel_renderer");
-        const string tex_path = tex_sampler_params.get_optional<string>("file_path", "");
+        const std::string tex_path = tex_sampler_params.get_optional<std::string>("file_path", "");
 
         if (tex_path.empty())
         {
@@ -420,7 +419,7 @@ bool RendererComponents::create_pixel_renderer_factory()
 
 bool RendererComponents::create_shading_result_framebuffer_factory()
 {
-    const string name = m_params.get_optional<string>("shading_result_framebuffer", "ephemeral");
+    const std::string name = m_params.get_optional<std::string>("shading_result_framebuffer", "ephemeral");
 
     if (name.empty())
     {
@@ -449,7 +448,7 @@ bool RendererComponents::create_shading_result_framebuffer_factory()
 
 bool RendererComponents::create_tile_renderer_factory()
 {
-    const string name = m_params.get_optional<string>("tile_renderer", "");
+    const std::string name = m_params.get_optional<std::string>("tile_renderer", "");
 
     if (name.empty())
     {
@@ -522,7 +521,7 @@ bool RendererComponents::create_tile_renderer_factory()
 
 bool RendererComponents::create_frame_renderer_factory()
 {
-    const string name = m_params.get_required<string>("frame_renderer", "generic");
+    const std::string name = m_params.get_required<std::string>("frame_renderer", "generic");
 
     if (name.empty())
     {

--- a/src/appleseed/renderer/kernel/rendering/rendererservices.cpp
+++ b/src/appleseed/renderer/kernel/rendering/rendererservices.cpp
@@ -50,7 +50,6 @@
 #include <limits>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -814,7 +813,7 @@ IMPLEMENT_ATTR_GETTER(camera_clip)
     if (type == g_float_array2_typedesc)
     {
         reinterpret_cast<float*>(val)[0] = 0.0f;
-        reinterpret_cast<float*>(val)[1] = numeric_limits<float>::max();
+        reinterpret_cast<float*>(val)[1] = std::numeric_limits<float>::max();
 
         if (derivs)
             clear_derivatives(type, val);
@@ -844,7 +843,7 @@ IMPLEMENT_ATTR_GETTER(camera_clip_far)
 {
     if (type == OIIO::TypeDesc::TypeFloat)
     {
-        reinterpret_cast<float*>(val)[0] = numeric_limits<float>::max();
+        reinterpret_cast<float*>(val)[0] = std::numeric_limits<float>::max();
 
         if (derivs)
             clear_derivatives(type, val);

--- a/src/appleseed/renderer/kernel/rendering/scenepicker.cpp
+++ b/src/appleseed/renderer/kernel/rendering/scenepicker.cpp
@@ -58,7 +58,6 @@
 #include <limits>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -99,7 +98,7 @@ ScenePicker::PickingResult ScenePicker::pick(const Vector2d& ndc) const
 
     result.m_hit = false;
     result.m_primitive_type = ShadingPoint::PrimitiveNone;
-    result.m_distance = numeric_limits<double>::max();
+    result.m_distance = std::numeric_limits<double>::max();
 
     result.m_bary = Vector2f(0.0);
     result.m_uv = Vector2f(0.0);

--- a/src/appleseed/renderer/kernel/rendering/shadingresultframebuffer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/shadingresultframebuffer.cpp
@@ -43,7 +43,6 @@
 #include <cassert>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/rendering/tilecallbackcollection.cpp
+++ b/src/appleseed/renderer/kernel/rendering/tilecallbackcollection.cpp
@@ -34,7 +34,6 @@
 #include <list>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -45,7 +44,7 @@ namespace
       : public ITileCallback
     {
       public:
-        explicit TileCallbackCollection(list<ITileCallbackFactory*> factories)
+        explicit TileCallbackCollection(std::list<ITileCallbackFactory*> factories)
         {
             for (auto i : factories)
                 m_callbacks.push_back(i->create());
@@ -94,7 +93,7 @@ namespace
         }
 
       private:
-        list<ITileCallback*> m_callbacks;
+        std::list<ITileCallback*> m_callbacks;
     };
 }
 
@@ -105,7 +104,7 @@ namespace
 
 struct TileCallbackCollectionFactory::Impl
 {
-    typedef list<ITileCallbackFactory*> TileCallbackFactoryContainer;
+    typedef std::list<ITileCallbackFactory*> TileCallbackFactoryContainer;
 
     TileCallbackFactoryContainer m_factories;
 };

--- a/src/appleseed/renderer/kernel/shading/closures.cpp
+++ b/src/appleseed/renderer/kernel/shading/closures.cpp
@@ -73,7 +73,6 @@
 
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 using OSL::TypeDesc;
 
@@ -1348,7 +1347,7 @@ namespace
             }
             else
             {
-                string msg = "unknown subsurface profile: ";
+                std::string msg = "unknown subsurface profile: ";
                 msg += p->profile.c_str();
                 throw ExceptionOSLRuntimeError(msg.c_str());
             }

--- a/src/appleseed/renderer/kernel/shading/fastambientocclusion.cpp
+++ b/src/appleseed/renderer/kernel/shading/fastambientocclusion.cpp
@@ -58,7 +58,6 @@
 #include <cassert>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -93,7 +92,7 @@ AOVoxelTree::AOVoxelTree(
     tree_stats.print(global_logger());
 }
 
-void AOVoxelTree::dump_solid_leaves_to_disk(const string& filename) const
+void AOVoxelTree::dump_solid_leaves_to_disk(const std::string& filename) const
 {
     RENDERER_LOG_INFO(
         "writing ambient occlusion voxel tree file %s...",
@@ -113,7 +112,7 @@ void AOVoxelTree::dump_solid_leaves_to_disk(const string& filename) const
     }
 }
 
-void AOVoxelTree::dump_tree_to_disk(const string& filename) const
+void AOVoxelTree::dump_tree_to_disk(const std::string& filename) const
 {
     RENDERER_LOG_INFO(
         "writing ambient occlusion voxel tree file %s...",

--- a/src/appleseed/renderer/kernel/shading/shadingengine.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingengine.cpp
@@ -56,7 +56,6 @@
 #include "foundation/utility/containers/dictionary.h"
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
@@ -53,7 +53,6 @@
 #include <utility>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/texturing/texturestore.cpp
+++ b/src/appleseed/renderer/kernel/texturing/texturestore.cpp
@@ -52,7 +52,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/kernel/volume/volume.cpp
+++ b/src/appleseed/renderer/kernel/volume/volume.cpp
@@ -40,7 +40,6 @@
 #include <utility>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -117,7 +116,7 @@ namespace
     }
 }
 
-unique_ptr<VoxelGrid> read_fluid_file(
+std::unique_ptr<VoxelGrid> read_fluid_file(
     const char*         filename,
     FluidChannels&      channels)
 {
@@ -126,21 +125,21 @@ unique_ptr<VoxelGrid> read_fluid_file(
     FILE* file = fopen(filename, "rb");
 
     if (file == nullptr)
-        return unique_ptr<VoxelGrid>(nullptr);
+        return std::unique_ptr<VoxelGrid>(nullptr);
 
     // Read the file header.
     FluidFileHeader header;
     if (fread(&header, sizeof(FluidFileHeader), 1, file) < 1)
     {
         fclose(file);
-        return unique_ptr<VoxelGrid>(nullptr);
+        return std::unique_ptr<VoxelGrid>(nullptr);
     }
 
     // Check the validity of the file header.
     if (header.m_id != CC32('F', 'L', 'D', '3'))
     {
         fclose(file);
-        return unique_ptr<VoxelGrid>(nullptr);
+        return std::unique_ptr<VoxelGrid>(nullptr);
     }
 
     const size_t voxel_count = header.m_xres * header.m_yres * header.m_zres;
@@ -188,7 +187,7 @@ unique_ptr<VoxelGrid> read_fluid_file(
         channel_count += 3;
     }
 
-    unique_ptr<VoxelGrid> grid(
+    std::unique_ptr<VoxelGrid> grid(
         new VoxelGrid(
             header.m_xres,
             header.m_yres,
@@ -278,7 +277,7 @@ unique_ptr<VoxelGrid> read_fluid_file(
 
     fclose(file);
 
-    return read == needed ? move(grid) : unique_ptr<VoxelGrid>(nullptr);
+    return read == needed ? move(grid) : std::unique_ptr<VoxelGrid>(nullptr);
 }
 
 void write_voxel_grid(

--- a/src/appleseed/renderer/meta/tests/test_containers.cpp
+++ b/src/appleseed/renderer/meta/tests/test_containers.cpp
@@ -41,7 +41,6 @@
 
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 TEST_SUITE(Renderer_Modeling_Scene_Containers)
 {
@@ -51,7 +50,7 @@ TEST_SUITE(Renderer_Modeling_Scene_Containers)
     {
         DummyEntityVector entities;
 
-        const string result = make_unique_name("assembly", entities);
+        const std::string result = make_unique_name("assembly", entities);
 
         EXPECT_EQ("assembly1", result);
     }
@@ -62,7 +61,7 @@ TEST_SUITE(Renderer_Modeling_Scene_Containers)
         entities.insert(auto_release_ptr<DummyEntity>(new DummyEntity("assembly3")));
         entities.insert(auto_release_ptr<DummyEntity>(new DummyEntity("assembly1")));
 
-        const string result = make_unique_name("assembly", entities);
+        const std::string result = make_unique_name("assembly", entities);
 
         EXPECT_EQ("assembly4", result);
     }
@@ -72,7 +71,7 @@ TEST_SUITE(Renderer_Modeling_Scene_Containers)
         DummyEntityVector entities;
         entities.insert(auto_release_ptr<DummyEntity>(new DummyEntity("assembly-5")));
 
-        const string result = make_unique_name("assembly", entities);
+        const std::string result = make_unique_name("assembly", entities);
 
         EXPECT_EQ("assembly1", result);
     }
@@ -82,7 +81,7 @@ TEST_SUITE(Renderer_Modeling_Scene_Containers)
         DummyEntityVector entities;
         entities.insert(auto_release_ptr<DummyEntity>(new DummyEntity("object")));
 
-        const string result = make_unique_name("assembly", entities);
+        const std::string result = make_unique_name("assembly", entities);
 
         EXPECT_EQ("assembly1", result);
     }
@@ -92,7 +91,7 @@ TEST_SUITE(Renderer_Modeling_Scene_Containers)
         DummyEntityVector entities;
         entities.insert(auto_release_ptr<DummyEntity>(new DummyEntity("assembly_instance")));
 
-        const string result = make_unique_name("assembly", entities);
+        const std::string result = make_unique_name("assembly", entities);
 
         EXPECT_EQ("assembly1", result);
     }

--- a/src/appleseed/renderer/meta/tests/test_environmentedf.cpp
+++ b/src/appleseed/renderer/meta/tests/test_environmentedf.cpp
@@ -83,7 +83,6 @@
 
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 TEST_SUITE(Renderer_Modeling_EnvironmentEDF)
 {
@@ -155,7 +154,7 @@ TEST_SUITE(Renderer_Modeling_EnvironmentEDF)
 
       private:
         const CanvasProperties  m_props;
-        unique_ptr<Tile>        m_tile;
+        std::unique_ptr<Tile>   m_tile;
 
         void create_horizontal_gradient()
         {

--- a/src/appleseed/renderer/meta/tests/test_imagetools.cpp
+++ b/src/appleseed/renderer/meta/tests/test_imagetools.cpp
@@ -49,7 +49,6 @@
 #include <utility>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(ImageTools)
 {
@@ -63,7 +62,7 @@ TEST_SUITE(ImageTools)
         const size_t W = 256;
         const size_t H = 256;
 
-        unique_ptr<Image> output(new Image(W, H, 32, 32, 3, PixelFormatFloat));
+        std::unique_ptr<Image> output(new Image(W, H, 32, 32, 3, PixelFormatFloat));
 
         MersenneTwister rng;
 
@@ -198,14 +197,14 @@ TEST_SUITE(ImageTools)
         }
     };
 
-    unique_ptr<Image> apply(const Image& image, const IOnePixelOp& op)
+    std::unique_ptr<Image> apply(const Image& image, const IOnePixelOp& op)
     {
         const CanvasProperties& props = image.properties();
 
         if (props.m_channel_count != 4)
             throw ExceptionUnsupportedChannelCount();
 
-        unique_ptr<Image> output(new Image(props));
+        std::unique_ptr<Image> output(new Image(props));
 
         for (size_t y = 0; y < props.m_canvas_height; ++y)
         {
@@ -225,7 +224,7 @@ TEST_SUITE(ImageTools)
         return output;
     }
 
-    unique_ptr<Image> apply(const Image& lhs, const Image& rhs, const ITwoPixelOp& op)
+    std::unique_ptr<Image> apply(const Image& lhs, const Image& rhs, const ITwoPixelOp& op)
     {
         const CanvasProperties& lhs_props = lhs.properties();
         const CanvasProperties& rhs_props = rhs.properties();
@@ -238,7 +237,7 @@ TEST_SUITE(ImageTools)
         if (lhs_props.m_channel_count != 4)
             throw ExceptionUnsupportedChannelCount();
 
-        unique_ptr<Image> output(new Image(lhs));
+        std::unique_ptr<Image> output(new Image(lhs));
 
         for (size_t y = 0; y < lhs_props.m_canvas_height; ++y)
         {

--- a/src/appleseed/renderer/meta/tests/test_inputarray.cpp
+++ b/src/appleseed/renderer/meta/tests/test_inputarray.cpp
@@ -39,7 +39,6 @@
 #include <string>
 
 using namespace renderer;
-using namespace std;
 
 TEST_SUITE(Renderer_Modeling_Input_InputArray)
 {
@@ -50,7 +49,7 @@ TEST_SUITE(Renderer_Modeling_Input_InputArray)
 
         const InputArray::const_iterator i = inputs.find("x");
 
-        EXPECT_EQ("x", string(i.name()));
+        EXPECT_EQ("x", std::string(i.name()));
     }
 
     TEST_CASE(Find_GivenNameOfNonExistingInput_ReturnsEndIterator)

--- a/src/appleseed/renderer/meta/tests/test_localsampleaccumulationbuffer.cpp
+++ b/src/appleseed/renderer/meta/tests/test_localsampleaccumulationbuffer.cpp
@@ -45,7 +45,6 @@
 
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 TEST_SUITE(Renderer_Kernel_Rendering_LocalSampleAccumulationBuffer)
 {

--- a/src/appleseed/renderer/meta/tests/test_paramarray.cpp
+++ b/src/appleseed/renderer/meta/tests/test_paramarray.cpp
@@ -39,7 +39,6 @@
 
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 TEST_SUITE(Renderer_Utility_ParamArray)
 {
@@ -50,7 +49,7 @@ TEST_SUITE(Renderer_Utility_ParamArray)
 
         const char* value = params.strings().get("x");
 
-        EXPECT_EQ("42", string(value));
+        EXPECT_EQ("42", std::string(value));
     }
 
     TEST_CASE(InsertPath_GivenParentNameAndItemName_InsertsItem)
@@ -60,7 +59,7 @@ TEST_SUITE(Renderer_Utility_ParamArray)
 
         const char* value = params.dictionaries().get("parent").strings().get("x");
 
-        EXPECT_EQ("42", string(value));
+        EXPECT_EQ("42", std::string(value));
     }
 
     TEST_CASE(ExistPath_GivenNameOfExistingItem_ReturnsTrue)
@@ -110,7 +109,7 @@ TEST_SUITE(Renderer_Utility_ParamArray)
 
         const char* value = params.get_path("x");
 
-        EXPECT_EQ("42", string(value));
+        EXPECT_EQ("42", std::string(value));
     }
 
     TEST_CASE(GetPath_GivenParentNameAndItemName_ReturnsItemValue)
@@ -120,7 +119,7 @@ TEST_SUITE(Renderer_Utility_ParamArray)
 
         const char* value = params.get_path("parent.x");
 
-        EXPECT_EQ("42", string(value));
+        EXPECT_EQ("42", std::string(value));
     }
 
     TEST_CASE(GetPath_GivenInvalidItemName_ThrowsExceptionDictionaryKeyNotFound)

--- a/src/appleseed/renderer/meta/tests/test_pixelsampler.cpp
+++ b/src/appleseed/renderer/meta/tests/test_pixelsampler.cpp
@@ -40,7 +40,6 @@
 
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 TEST_SUITE(Renderer_Kernel_Rendering_Final_PixelSampler)
 {

--- a/src/appleseed/renderer/meta/tests/test_projectfilewriter.cpp
+++ b/src/appleseed/renderer/meta/tests/test_projectfilewriter.cpp
@@ -56,7 +56,6 @@ using namespace boost;
 using namespace boost::filesystem;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 TEST_SUITE(Renderer_Modeling_Project_ProjectFileWriter)
 {
@@ -171,14 +170,14 @@ TEST_SUITE(Renderer_Modeling_Project_ProjectFileWriter)
 
         // Check the search paths.
         EXPECT_EQ(2, m_project->search_paths().get_explicit_path_count());
-        EXPECT_EQ(string("subdirectory"), m_project->search_paths().get_explicit_path(0));
+        EXPECT_EQ(std::string("subdirectory"), m_project->search_paths().get_explicit_path(0));
         EXPECT_EQ(canonical(m_input_directory / "setup/alternate/subdirectory").string(), m_project->search_paths().get_explicit_path(1));
 
         // Check the asset paths.
-        EXPECT_EQ(string("asset1.obj"),                                        get_mesh_object_filename("asset1"));
-        EXPECT_EQ(string("asset2.obj"),                                        get_mesh_object_filename("asset2"));
-        EXPECT_EQ(string("asset3.obj"),                                        get_mesh_object_filename("asset3"));
-        EXPECT_EQ(string("subdirectory/asset4.obj"),                           get_mesh_object_filename("asset4"));
+        EXPECT_EQ(std::string("asset1.obj"),                                   get_mesh_object_filename("asset1"));
+        EXPECT_EQ(std::string("asset2.obj"),                                   get_mesh_object_filename("asset2"));
+        EXPECT_EQ(std::string("asset3.obj"),                                   get_mesh_object_filename("asset3"));
+        EXPECT_EQ(std::string("subdirectory/asset4.obj"),                      get_mesh_object_filename("asset4"));
         EXPECT_EQ(canonical(project_directory / "asset5.obj"),                 get_mesh_object_filename("asset5"));
         EXPECT_EQ(canonical(m_input_directory / "setup/alternate/asset6.obj"), get_mesh_object_filename("asset6"));
         EXPECT_EQ(canonical(m_input_directory / "setup/alternate/asset7.obj"), get_mesh_object_filename("asset7"));
@@ -217,16 +216,16 @@ TEST_SUITE(Renderer_Modeling_Project_ProjectFileWriter)
 
         // Check the search paths.
         EXPECT_EQ(1, m_project->search_paths().get_explicit_path_count());
-        EXPECT_EQ(string("subdirectory"), m_project->search_paths().get_explicit_path(0));
+        EXPECT_EQ(std::string("subdirectory"), m_project->search_paths().get_explicit_path(0));
 
         // Check the asset paths.
-        EXPECT_EQ(string("asset1.obj"),              get_mesh_object_filename("asset1"));
-        EXPECT_EQ(string("asset2.obj"),              get_mesh_object_filename("asset2"));
-        EXPECT_EQ(string("assets/asset3.obj"),       get_mesh_object_filename("asset3"));
-        EXPECT_EQ(string("subdirectory/asset4.obj"), get_mesh_object_filename("asset4"));
-        EXPECT_EQ(string("assets/asset5.obj"),       get_mesh_object_filename("asset5"));
-        EXPECT_EQ(string("assets/asset6.obj"),       get_mesh_object_filename("asset6"));
-        EXPECT_EQ(string("assets/asset7.obj"),       get_mesh_object_filename("asset7"));
+        EXPECT_EQ(std::string("asset1.obj"),              get_mesh_object_filename("asset1"));
+        EXPECT_EQ(std::string("asset2.obj"),              get_mesh_object_filename("asset2"));
+        EXPECT_EQ(std::string("assets/asset3.obj"),       get_mesh_object_filename("asset3"));
+        EXPECT_EQ(std::string("subdirectory/asset4.obj"), get_mesh_object_filename("asset4"));
+        EXPECT_EQ(std::string("assets/asset5.obj"),       get_mesh_object_filename("asset5"));
+        EXPECT_EQ(std::string("assets/asset6.obj"),       get_mesh_object_filename("asset6"));
+        EXPECT_EQ(std::string("assets/asset7.obj"),       get_mesh_object_filename("asset7"));
     }
 
     TEST_CASE_F(Write_MeshObjectWithMultivaluedFilenameParameter_DoesNotAddAnotherFilenameParameter, Fixture)
@@ -267,7 +266,7 @@ TEST_SUITE(Renderer_Modeling_Project_ProjectFileWriter)
         ASSERT_TRUE(success);
         EXPECT_TRUE(exists(m_output_directory / "curve_object.binarycurve"));
         EXPECT_EQ(
-            string("curve_object.binarycurve"),
+            std::string("curve_object.binarycurve"),
             get_assembly()->objects().get_by_name("curve_object")->get_parameters().get("filepath"));
     }
 
@@ -287,7 +286,7 @@ TEST_SUITE(Renderer_Modeling_Project_ProjectFileWriter)
         ASSERT_TRUE(success);
         EXPECT_FALSE(exists(m_output_directory / "curve_object.binarycurve"));
         EXPECT_EQ(
-            string("curve_object.binarycurve"),
+            std::string("curve_object.binarycurve"),
             get_assembly()->objects().get_by_name("curve_object")->get_parameters().get("filepath"));
     }
 

--- a/src/appleseed/renderer/meta/tests/test_samplegeneratorjob.cpp
+++ b/src/appleseed/renderer/meta/tests/test_samplegeneratorjob.cpp
@@ -41,7 +41,6 @@
 
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 TEST_SUITE(Renderer_Kernel_Rendering_Progressive_SampleGeneratorJob)
 {
@@ -49,7 +48,7 @@ TEST_SUITE(Renderer_Kernel_Rendering_Progressive_SampleGeneratorJob)
     {
         const uint64 N = 1500000;
 
-        vector<Vector2d> points;
+        std::vector<Vector2d> points;
         points.reserve(N);
 
         for (uint64 x = 0; x < N; x += 100)

--- a/src/appleseed/renderer/meta/tests/test_sss.cpp
+++ b/src/appleseed/renderer/meta/tests/test_sss.cpp
@@ -68,7 +68,6 @@
 
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
 {
@@ -386,7 +385,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         const ComputeRdBetterDipole better_rd_fun(Eta);
 
         const size_t PointCount = 1000;
-        vector<Vector2d> std_points, better_points;
+        std::vector<Vector2d> std_points, better_points;
 
         for (size_t i = 0; i < PointCount; ++i)
         {
@@ -429,7 +428,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         auto_release_ptr<Project> project(ProjectFactory::create("project"));
 
         const ComputeRdStandardDipole rd_fun(1.0f);
-        vector<Vector2d> ai_points, ni_points;
+        std::vector<Vector2d> ai_points, ni_points;
 
         for (size_t i = 0; i < PointCount; ++i)
         {
@@ -477,7 +476,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         auto_release_ptr<Project> project(ProjectFactory::create("project"));
 
         const ComputeRdBetterDipole rd_fun(1.0f);
-        vector<Vector2d> ai_points, ni_points;
+        std::vector<Vector2d> ai_points, ni_points;
 
         for (size_t i = 0; i < PointCount; ++i)
         {
@@ -634,8 +633,8 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         //
 
         const size_t SampleCount = 1000;
-        vector<Vector2d> points_low_albedo;
-        vector<Vector2d> points_high_albedo;
+        std::vector<Vector2d> points_low_albedo;
+        std::vector<Vector2d> points_high_albedo;
 
         GnuplotFile plotfile;
         plotfile.set_title("Approximations for diffusion length");
@@ -671,9 +670,9 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         const size_t MaxIterations = 50;
         size_t transmitted_count_classical = 0;
         size_t transmitted_count_dwivedi = 0;
-        vector<size_t> iterations_hist_classical(MaxIterations, 0);
-        vector<size_t> iterations_hist_dwivedi(MaxIterations, 0);
-        vector<Vector2d> points;
+        std::vector<size_t> iterations_hist_classical(MaxIterations, 0);
+        std::vector<size_t> iterations_hist_dwivedi(MaxIterations, 0);
+        std::vector<Vector2d> points;
 
         GnuplotFile plotfile;
         plotfile.set_title("Histogram of randomwalk iterations");
@@ -768,7 +767,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         plotfile.set_yrange(0.0, 6.0);
 
         const size_t N = 1000;
-        vector<Vector2d> points;
+        std::vector<Vector2d> points;
 
         for (size_t i = 0; i < N; ++i)
         {
@@ -791,7 +790,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         plotfile.set_yrange(0.0, 20.0);
 
         const size_t N = 1000;
-        vector<Vector2d> points;
+        std::vector<Vector2d> points;
 
         for (size_t i = 0; i < N; ++i)
         {
@@ -820,7 +819,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
             const float s = normalized_diffusion_s_mfp(a);
 
             const size_t N = 1000;
-            vector<Vector2d> points;
+            std::vector<Vector2d> points;
 
             for (size_t j = 0; j < N; ++j)
             {
@@ -868,7 +867,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
             const float s = normalized_diffusion_s_dmfp(a);
 
             const size_t N = 1000;
-            vector<Vector2d> points;
+            std::vector<Vector2d> points;
 
             for (size_t j = 0; j < N; ++j)
             {
@@ -910,7 +909,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         plotfile.set_yrange(0.0, 1.0);
 
         const size_t N = 1000;
-        vector<Vector2d> points;
+        std::vector<Vector2d> points;
 
         for (size_t i = 0; i < N; ++i)
         {
@@ -1006,7 +1005,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         auto_release_ptr<Project> project(ProjectFactory::create("project"));
 
         const size_t N = 200;
-        vector<Vector2d> points;
+        std::vector<Vector2d> points;
         MersenneTwister rng;
 
         for (size_t i = 0; i < N; ++i)
@@ -1075,7 +1074,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         auto_release_ptr<Project> project(ProjectFactory::create("project"));
 
         const size_t N = 200;
-        vector<Vector2d> points;
+        std::vector<Vector2d> points;
         MersenneTwister rng;
 
         for (size_t i = 0; i < N; ++i)
@@ -1154,7 +1153,7 @@ TEST_SUITE(Renderer_Modeling_BSSRDF_SSS)
         bssrdf_eval.set_values_from_sigmas(sigma_a, sigma_s);
 
         const size_t N = 1000;
-        vector<Vector2d> points;
+        std::vector<Vector2d> points;
 
         for (size_t i = 0; i < N; ++i)
         {

--- a/src/appleseed/renderer/meta/tests/test_volume.cpp
+++ b/src/appleseed/renderer/meta/tests/test_volume.cpp
@@ -65,7 +65,6 @@
 
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 TEST_SUITE(Renderer_Modeling_Volume)
 {
@@ -78,16 +77,16 @@ TEST_SUITE(Renderer_Modeling_Volume)
         // Number of samples for plots.
         static const size_t NumberOfSamplesPlot = 100;
 
-        TextureStore                    m_texture_store;
-        TextureCache                    m_texture_cache;
-        shared_ptr<OIIOTextureSystem>   m_texture_system;
-        RendererServices                m_renderer_services;
-        shared_ptr<OSLShadingSystem>    m_shading_system;
-        Intersector                     m_intersector;
-        Arena                           m_arena;
-        OSLShaderGroupExec              m_sg_exec;
-        Tracer                          m_tracer;
-        ShadingContext                  m_shading_context;
+        TextureStore                         m_texture_store;
+        TextureCache                         m_texture_cache;
+        std::shared_ptr<OIIOTextureSystem>   m_texture_system;
+        RendererServices                     m_renderer_services;
+        std::shared_ptr<OSLShadingSystem>    m_shading_system;
+        Intersector                          m_intersector;
+        Arena                                m_arena;
+        OSLShaderGroupExec                   m_sg_exec;
+        Tracer                               m_tracer;
+        ShadingContext                       m_shading_context;
 
         explicit VolumeTestSceneContext(TestSceneBase& base)
           : TestSceneContext(base)
@@ -192,7 +191,7 @@ TEST_SUITE(Renderer_Modeling_Volume)
             return bias.x / NumberOfSamples;
         }
 
-        vector<Vector2f> generate_samples_for_plot(const Volume& volume)
+        std::vector<Vector2f> generate_samples_for_plot(const Volume& volume)
         {
             ShadingRay shading_ray;
             shading_ray.m_org = Vector3d(0.0f, 0.0f, 0.0f);
@@ -204,7 +203,7 @@ TEST_SUITE(Renderer_Modeling_Volume)
             SamplingContext::RNGType rng;
             SamplingContext sampling_context(rng, SamplingContext::RNGMode);
 
-            vector<Vector2f> points;
+            std::vector<Vector2f> points;
             points.reserve(NumberOfSamples);
             for (size_t i = 0; i < NumberOfSamplesPlot; ++i)
             {
@@ -340,7 +339,7 @@ TEST_SUITE(Renderer_Modeling_Volume)
             test_scene.m_scene.assemblies().insert(assembly);
 
             VolumeTestSceneContext context(test_scene);
-            const vector<Vector2f> points = context.generate_samples_for_plot(volume_ref);
+            const std::vector<Vector2f> points = context.generate_samples_for_plot(volume_ref);
 
             plotfile
                 .new_plot()

--- a/src/appleseed/renderer/utility/messagecontext.cpp
+++ b/src/appleseed/renderer/utility/messagecontext.cpp
@@ -37,8 +37,6 @@
 #include "foundation/utility/api/apistring.h"
 #include "foundation/utility/string.h"
 
-using namespace std;
-
 namespace renderer
 {
 
@@ -48,7 +46,7 @@ namespace renderer
 
 struct MessageContext::Impl
 {
-    string m_message;
+    std::string m_message;
 };
 
 MessageContext::MessageContext()

--- a/src/appleseed/renderer/utility/oiiomaketexture.cpp
+++ b/src/appleseed/renderer/utility/oiiomaketexture.cpp
@@ -41,7 +41,6 @@
 
 using namespace foundation;
 using namespace OIIO;
-using namespace std;
 
 namespace renderer
 {
@@ -53,7 +52,7 @@ bool oiio_make_texture(
     const char* out_depth,
     APIString&  error_msg)
 {
-    std::unordered_map<string, TypeDesc> out_depth_map;
+    std::unordered_map<std::string, TypeDesc> out_depth_map;
     out_depth_map["sint8"] = TypeDesc::INT8;
     out_depth_map["uint8"] = TypeDesc::UINT8;
     out_depth_map["uint16"] = TypeDesc::UINT16;
@@ -77,7 +76,7 @@ bool oiio_make_texture(
 
     const ImageBufAlgo::MakeTextureMode mode = ImageBufAlgo::MakeTxTexture;
 
-    stringstream s;
+    std::stringstream s;
     const bool success = ImageBufAlgo::make_texture(mode, in_filename, out_filename, spec, &s);
 
     if (!success)

--- a/src/appleseed/renderer/utility/paramarray.cpp
+++ b/src/appleseed/renderer/utility/paramarray.cpp
@@ -35,7 +35,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -76,7 +75,7 @@ ParamArray& ParamArray::insert_path(const char* path, const char* value)
     assert(path);
     assert(value);
 
-    vector<string> parts;
+    std::vector<std::string> parts;
     tokenize(path, PartSeparator, parts);
 
     assert(!parts.empty());
@@ -85,7 +84,7 @@ ParamArray& ParamArray::insert_path(const char* path, const char* value)
 
     for (size_t i = 0; i < parts.size() - 1; ++i)
     {
-        const string& part = parts[i];
+        const std::string& part = parts[i];
 
         if (!leaf->dictionaries().exist(part))
             leaf->insert(part, Dictionary());
@@ -102,7 +101,7 @@ bool ParamArray::exist_path(const char* path) const
 {
     assert(path);
 
-    vector<string> parts;
+    std::vector<std::string> parts;
     tokenize(path, PartSeparator, parts);
 
     assert(!parts.empty());
@@ -124,7 +123,7 @@ const char* ParamArray::get_path(const char* path) const
 {
     assert(path);
 
-    vector<string> parts;
+    std::vector<std::string> parts;
     tokenize(path, PartSeparator, parts);
 
     assert(!parts.empty());
@@ -141,7 +140,7 @@ ParamArray& ParamArray::remove_path(const char* path)
 {
     assert(path);
 
-    vector<string> parts;
+    std::vector<std::string> parts;
     tokenize(path, PartSeparator, parts);
 
     assert(!parts.empty());

--- a/src/appleseed/renderer/utility/plugin.cpp
+++ b/src/appleseed/renderer/utility/plugin.cpp
@@ -37,7 +37,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -48,8 +47,8 @@ namespace renderer
 
 struct Plugin::Impl
 {
-    const string                m_filepath;
-    unique_ptr<SharedLibrary>   m_shared_library;
+    const std::string                m_filepath;
+    std::unique_ptr<SharedLibrary>   m_shared_library;
 
     explicit Impl(const char* filepath)
       : m_filepath(filepath)

--- a/src/appleseed/renderer/utility/pluginstore.cpp
+++ b/src/appleseed/renderer/utility/pluginstore.cpp
@@ -51,7 +51,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace bf = boost::filesystem;
 
@@ -61,13 +60,13 @@ namespace renderer
 struct PluginStore::Impl
 {
     typedef PluginStore::PluginHandlerType PluginHandlerType;
-    typedef map<string, PluginHandlerType> PluginHandlerMap;
+    typedef std::map<std::string, PluginHandlerType> PluginHandlerMap;
 
     struct PluginDeleter;
-    typedef unique_ptr<Plugin, PluginDeleter> PluginUniquePtr;
+    typedef std::unique_ptr<Plugin, PluginDeleter> PluginUniquePtr;
 
-    typedef map<string, PluginUniquePtr> PluginMap;
-    typedef map<Plugin*, PluginMap::const_iterator> PluginInverseMap;
+    typedef std::map<std::string, PluginUniquePtr> PluginMap;
+    typedef std::map<Plugin*, PluginMap::const_iterator> PluginInverseMap;
 
     struct PluginDeleter
     {
@@ -145,7 +144,7 @@ struct PluginStore::Impl
             // Invoke plugin handlers.
             for (const auto& plugin_handler_item : m_plugin_handlers)
             {
-                const string& entry_point_name = plugin_handler_item.first;
+                const std::string& entry_point_name = plugin_handler_item.first;
                 const PluginHandlerType& plugin_handler = plugin_handler_item.second;
 
                 // If the plugin exposes the expected entry point then pass it to the plugin handler.

--- a/src/appleseed/renderer/utility/projectpoints.cpp
+++ b/src/appleseed/renderer/utility/projectpoints.cpp
@@ -44,7 +44,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -71,7 +70,7 @@ ProjectPoints::ProjectPoints(
 {
     auto_release_ptr<Scene> scene = SceneFactory::create();
 
-    const string camera_name = camera->get_name();
+    const std::string camera_name = camera->get_name();
     scene->cameras().insert(camera);
 
     impl->m_project = ProjectFactory::create("project_points");

--- a/src/appleseed/renderer/utility/settingsparsing.cpp
+++ b/src/appleseed/renderer/utility/settingsparsing.cpp
@@ -43,18 +43,17 @@
 #include <algorithm>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
 
-string get_render_device(const ParamArray& params)
+std::string get_render_device(const ParamArray& params)
 {
     std::vector<std::string> devices;
     devices.emplace_back("cpu");
 
-    const string device =
-        params.get_optional<string>(
+    const std::string device =
+        params.get_optional<std::string>(
             "device",
             "cpu",
             devices);
@@ -64,8 +63,8 @@ string get_render_device(const ParamArray& params)
 
 Spectrum::Mode get_spectrum_mode(const ParamArray& params)
 {
-    const string spectrum_mode =
-        params.get_required<string>(
+    const std::string spectrum_mode =
+        params.get_required<std::string>(
             "spectrum_mode",
             "rgb",
             make_vector("rgb", "spectral"));
@@ -87,7 +86,7 @@ Spectrum::Mode get_spectrum_mode(const ParamArray& params)
 #endif
 }
 
-string get_spectrum_mode_name(const Spectrum::Mode mode)
+std::string get_spectrum_mode_name(const Spectrum::Mode mode)
 {
 #ifdef APPLESEED_WITH_SPECTRAL_SUPPORT
     switch (mode)
@@ -103,8 +102,8 @@ string get_spectrum_mode_name(const Spectrum::Mode mode)
 
 SamplingContext::Mode get_sampling_context_mode(const ParamArray& params)
 {
-    const string sampling_mode =
-        params.get_required<string>(
+    const std::string sampling_mode =
+        params.get_required<std::string>(
             "sampling_mode",
             "qmc",
             make_vector("rng", "qmc"));
@@ -115,7 +114,7 @@ SamplingContext::Mode get_sampling_context_mode(const ParamArray& params)
             : SamplingContext::QMCMode;
 }
 
-string get_sampling_context_mode_name(const SamplingContext::Mode mode)
+std::string get_sampling_context_mode_name(const SamplingContext::Mode mode)
 {
     switch (mode)
     {
@@ -134,7 +133,7 @@ size_t get_rendering_thread_count(const ParamArray& params)
     if (!params.strings().exist(ThreadCountParameterName))
         return core_count;
 
-    const string thread_count_str = params.strings().get<string>(ThreadCountParameterName);
+    const std::string thread_count_str = params.strings().get<std::string>(ThreadCountParameterName);
 
     if (thread_count_str == "auto")
         return core_count;

--- a/src/appleseed/renderer/utility/testutils.cpp
+++ b/src/appleseed/renderer/utility/testutils.cpp
@@ -45,7 +45,6 @@
 #include <cassert>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {

--- a/src/appleseed/renderer/utility/transformsequence.cpp
+++ b/src/appleseed/renderer/utility/transformsequence.cpp
@@ -43,7 +43,6 @@
 #include <cstring>
 
 using namespace foundation;
-using namespace std;
 
 namespace renderer
 {
@@ -90,8 +89,8 @@ TransformSequence& TransformSequence::operator=(TransformSequence&& rhs) APPLESE
 {
     m_capacity = rhs.m_capacity;
     m_size = rhs.m_size;
-    swap(m_keys, rhs.m_keys);
-    swap(m_interpolators, rhs.m_interpolators);
+    std::swap(m_keys, rhs.m_keys);
+    std::swap(m_interpolators, rhs.m_interpolators);
     m_can_swap_handedness = rhs.m_can_swap_handedness;
     m_all_swap_handedness = rhs.m_all_swap_handedness;
     rhs.clear();
@@ -212,7 +211,7 @@ bool TransformSequence::prepare()
 
     if (m_size > 1)
     {
-        sort(m_keys, m_keys + m_size);
+        std::sort(m_keys, m_keys + m_size);
 
         m_interpolators = new TransformInterpolatord[m_size - 1];
 


### PR DESCRIPTION
This PR part of a series.
Fixes #2641 for appleseed/renderer/device, kernel, meta and utility.

See also: #2689, #2690, #2691, #2693, #2694