### PR TITLE
Remove 'using namespace std' from appleseed/foundation

### DIFF
--- a/src/appleseed/foundation/array/array.cpp
+++ b/src/appleseed/foundation/array/array.cpp
@@ -32,8 +32,6 @@
 // appleseed.foundation headers.
 #include "foundation/utility/otherwise.h"
 
-using namespace std;
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/array/keyframedarray.cpp
+++ b/src/appleseed/foundation/array/keyframedarray.cpp
@@ -34,8 +34,6 @@
 #include <cassert>
 #include <utility>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -66,7 +64,7 @@ KeyFramedArray::KeyFramedArray(Array&& first_key, const size_t num_keys)
     for (size_t i = 1; i < num_keys; ++i)
         m_keys[i] = Array(first_key.type(), first_key.size());
 
-    m_keys[0] = move(first_key);
+    m_keys[0] = std::move(first_key);
 }
 
 KeyFramedArray::~KeyFramedArray()
@@ -78,7 +76,7 @@ KeyFramedArray::KeyFramedArray(const KeyFramedArray& rhs)
 {
     m_key_count = rhs.m_key_count;
     m_keys = new Array[m_key_count];
-    copy(rhs.begin(), rhs.end(), begin());
+    std::copy(rhs.begin(), rhs.end(), begin());
 }
 
 KeyFramedArray::KeyFramedArray(KeyFramedArray&& rhs) APPLESEED_NOEXCEPT
@@ -92,14 +90,14 @@ KeyFramedArray::KeyFramedArray(KeyFramedArray&& rhs) APPLESEED_NOEXCEPT
 KeyFramedArray& KeyFramedArray::operator=(const KeyFramedArray& rhs)
 {
     KeyFramedArray tmp(rhs);
-    swap(*this, tmp);
+    std::swap(*this, tmp);
     return *this;
 }
 
 KeyFramedArray& KeyFramedArray::operator=(KeyFramedArray&& rhs) APPLESEED_NOEXCEPT
 {
-    KeyFramedArray tmp(move(rhs));
-    swap(m_keys, tmp.m_keys);
+    KeyFramedArray tmp(std::move(rhs));
+    std::swap(m_keys, tmp.m_keys);
     m_key_count = tmp.m_key_count;
     return *this;
 }
@@ -113,7 +111,7 @@ ArrayType KeyFramedArray::type() const
 void KeyFramedArray::resize(const size_t size, const size_t keys)
 {
     KeyFramedArray tmp(Array(type(), size), keys);
-    swap(*this, tmp);
+    std::swap(*this, tmp);
 }
 
 const Array* KeyFramedArray::begin() const
@@ -146,8 +144,8 @@ void KeyFramedArray::set_key_count(const size_t keys)
 {
     assert(keys > 0);
     assert(!is_moved());
-    KeyFramedArray tmp(move(m_keys[0]), keys);
-    swap(*this, tmp);
+    KeyFramedArray tmp(std::move(m_keys[0]), keys);
+    std::swap(*this, tmp);
 }
 
 const Array& KeyFramedArray::get_key(const size_t i) const
@@ -195,7 +193,7 @@ bool KeyFramedArray::all_keyframes_equal() const
     if (m_key_count > 1)
     {
         // Check that the keyframes are not empty.
-        if (all_of(begin(), end(), [](const Array& x) { return x.empty(); }))
+        if (std::all_of(begin(), end(), [](const Array& x) { return x.empty(); }))
             return true;
 
         // Check that all the keyframe values are equal to the first.
@@ -217,7 +215,7 @@ bool KeyFramedArray::operator==(const KeyFramedArray& rhs) const
     if (m_key_count != rhs.m_key_count)
         return false;
 
-    return equal(begin(), end(), rhs.begin());
+    return std::equal(begin(), end(), rhs.begin());
 }
 
 bool KeyFramedArray::operator!=(const KeyFramedArray& rhs) const

--- a/src/appleseed/foundation/array/meshalgorithm.cpp
+++ b/src/appleseed/foundation/array/meshalgorithm.cpp
@@ -36,8 +36,6 @@
 // Standard headers.
 #include <algorithm>
 
-using namespace std;
-
 namespace foundation
 {
 namespace

--- a/src/appleseed/foundation/core/appleseed.cpp
+++ b/src/appleseed/foundation/core/appleseed.cpp
@@ -38,8 +38,6 @@
 #include <sstream>
 #include <string>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -95,11 +93,11 @@ namespace
 {
     struct LibCPUFeaturesString
     {
-        string m_value;
+        std::string m_value;
 
         LibCPUFeaturesString()
         {
-            stringstream sstr;
+            std::stringstream sstr;
 
 #ifdef APPLESEED_USE_SSE
             sstr << "SSE SSE2 ";
@@ -136,11 +134,11 @@ namespace
 {
     struct SyntheticVersionString
     {
-        string m_value;
+        std::string m_value;
 
         SyntheticVersionString()
         {
-            stringstream sstr;
+            std::stringstream sstr;
 
             sstr << Appleseed::get_lib_name();
             sstr << " version ";

--- a/src/appleseed/foundation/cuda/cudadevice.cpp
+++ b/src/appleseed/foundation/cuda/cudadevice.cpp
@@ -37,8 +37,6 @@
 #include <cassert>
 #include <vector>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -79,8 +77,8 @@ CUDADevice::CUDADevice(const CUdevice device_number)
 
 struct CUDADeviceList::Impl
 {
-    vector<CUDADevice>         m_devices;
-    mutable vector<CUcontext>  m_contexts;
+    std::vector<CUDADevice>         m_devices;
+    mutable std::vector<CUcontext>  m_contexts;
 
     Impl()
     {

--- a/src/appleseed/foundation/cuda/exception.cpp
+++ b/src/appleseed/foundation/cuda/exception.cpp
@@ -32,8 +32,6 @@
 // Standard headers.
 #include <string>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -43,7 +41,7 @@ namespace foundation
 
 ExceptionCUDAError::ExceptionCUDAError(const CUresult error)
 {
-    string err;
+    std::string err;
     const char* error_string;
 
     if (cuGetErrorString(error, &error_string) == CUDA_SUCCESS)

--- a/src/appleseed/foundation/cuda/module.cpp
+++ b/src/appleseed/foundation/cuda/module.cpp
@@ -36,8 +36,6 @@
 #include <algorithm>
 #include <cassert>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -65,8 +63,8 @@ CUDAModule::~CUDAModule()
 
 CUDAModule& CUDAModule::operator=(CUDAModule&& rhs)
 {
-    CUDAModule tmp(move(rhs));
-    swap(m_module, tmp.m_module);
+    CUDAModule tmp(std::move(rhs));
+    std::swap(m_module, tmp.m_module);
     return *this;
 }
 

--- a/src/appleseed/foundation/curve/binarycurvefilereader.cpp
+++ b/src/appleseed/foundation/curve/binarycurvefilereader.cpp
@@ -41,8 +41,6 @@
 #include <cstring>
 #include <memory>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -50,7 +48,7 @@ namespace foundation
 // BinaryCurveFileReader class implementation.
 //
 
-BinaryCurveFileReader::BinaryCurveFileReader(const string& filename)
+BinaryCurveFileReader::BinaryCurveFileReader(const std::string& filename)
   : m_filename(filename)
 {
 }
@@ -70,7 +68,7 @@ void BinaryCurveFileReader::read(ICurveBuilder& builder)
     uint16 version;
     checked_read(file, version);
 
-    unique_ptr<ReaderAdapter> reader;
+    std::unique_ptr<ReaderAdapter> reader;
 
     switch (version)
     {

--- a/src/appleseed/foundation/curve/binarycurvefilewriter.cpp
+++ b/src/appleseed/foundation/curve/binarycurvefilewriter.cpp
@@ -37,8 +37,6 @@
 // Standard headers.
 #include <cstring>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -46,7 +44,7 @@ namespace foundation
 // BinaryCurveFileWriter class implementation.
 //
 
-BinaryCurveFileWriter::BinaryCurveFileWriter(const string& filename)
+BinaryCurveFileWriter::BinaryCurveFileWriter(const std::string& filename)
   : m_filename(filename)
   , m_writer(m_file, 256 * 1024)
 {

--- a/src/appleseed/foundation/curve/genericcurvefilereader.cpp
+++ b/src/appleseed/foundation/curve/genericcurvefilereader.cpp
@@ -41,7 +41,6 @@
 // Standard headers.
 #include <string>
 
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace foundation
@@ -49,7 +48,7 @@ namespace foundation
 
 struct GenericCurveFileReader::Impl
 {
-    string  m_filename;
+    std::string  m_filename;
     float   m_radius;
     size_t  m_degree;
 };
@@ -70,7 +69,7 @@ GenericCurveFileReader::~GenericCurveFileReader()
 void GenericCurveFileReader::read(ICurveBuilder& builder)
 {
     const bf::path filepath(impl->m_filename);
-    const string extension = lower_case(filepath.extension().string());
+    const std::string extension = lower_case(filepath.extension().string());
 
     if (extension == ".binarycurve")
     {

--- a/src/appleseed/foundation/curve/genericcurvefilereader.cpp
+++ b/src/appleseed/foundation/curve/genericcurvefilereader.cpp
@@ -49,8 +49,8 @@ namespace foundation
 struct GenericCurveFileReader::Impl
 {
     std::string  m_filename;
-    float   m_radius;
-    size_t  m_degree;
+    float        m_radius;
+    size_t       m_degree;
 };
 
 GenericCurveFileReader::GenericCurveFileReader(const char* filename, const float radius, const size_t degree)

--- a/src/appleseed/foundation/curve/genericcurvefilewriter.cpp
+++ b/src/appleseed/foundation/curve/genericcurvefilewriter.cpp
@@ -40,7 +40,6 @@
 // Standard headers.
 #include <string>
 
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace foundation
@@ -49,7 +48,7 @@ namespace foundation
 GenericCurveFileWriter::GenericCurveFileWriter(const char* filename)
 {
     const bf::path filepath(filename);
-    const string extension = lower_case(filepath.extension().string());
+    const std::string extension = lower_case(filepath.extension().string());
 
     if (extension == ".binarycurve")
         m_writer = new BinaryCurveFileWriter(filename);

--- a/src/appleseed/foundation/curve/mitshairfilereader.cpp
+++ b/src/appleseed/foundation/curve/mitshairfilereader.cpp
@@ -45,8 +45,6 @@
 #include <cstring>
 #include <memory>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -54,7 +52,7 @@ namespace foundation
 // MitsHairFileReader class implementation.
 //
 
-MitsHairFileReader::MitsHairFileReader(const string& filename, const float radius, const size_t degree)
+MitsHairFileReader::MitsHairFileReader(const std::string& filename, const float radius, const size_t degree)
   : m_filename(filename)
   , m_radius(radius)
   , m_degree(degree)
@@ -73,7 +71,7 @@ void MitsHairFileReader::read(ICurveBuilder& builder)
 
     read_and_check_signature(file);
 
-    unique_ptr<ReaderAdapter> reader;
+    std::unique_ptr<ReaderAdapter> reader;
     reader.reset(new PassthroughReaderAdapter(file));
     read_curves(*reader.get(), builder);
 }
@@ -107,7 +105,7 @@ void MitsHairFileReader::read_curves(ReaderAdapter& reader, ICurveBuilder& build
         builder.begin_curve_object(static_cast<CurveBasis>(m_degree));
         builder.begin_curve();
 
-        vector<Vector3f> vertices, new_vertices;
+        std::vector<Vector3f> vertices, new_vertices;
 
         for (uint32 c = 0; c < vertex_count; ++c)
         {

--- a/src/appleseed/foundation/image/analysis.cpp
+++ b/src/appleseed/foundation/image/analysis.cpp
@@ -43,8 +43,6 @@
 #include <cmath>
 #include <cstddef>
 
-using namespace std;
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/image/colormap.cpp
+++ b/src/appleseed/foundation/image/colormap.cpp
@@ -39,8 +39,6 @@
 #include <cassert>
 #include <limits>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -99,8 +97,8 @@ void ColorMap::find_min_max_red_channel(
     float&          min_value,
     float&          max_value)
 {
-    min_value = +numeric_limits<float>::max();
-    max_value = -numeric_limits<float>::max();
+    min_value = +std::numeric_limits<float>::max();
+    max_value = -std::numeric_limits<float>::max();
 
     for_each_pixel(image, crop_window, [&min_value, &max_value](const Color3f& color)
     {
@@ -127,8 +125,8 @@ void ColorMap::find_min_max_relative_luminance(
     float&          min_luminance,
     float&          max_luminance)
 {
-    min_luminance = +numeric_limits<float>::max();
-    max_luminance = -numeric_limits<float>::max();
+    min_luminance = +std::numeric_limits<float>::max();
+    max_luminance = -std::numeric_limits<float>::max();
 
     for_each_pixel(image, crop_window, [&min_luminance, &max_luminance](const Color3f& color)
     {

--- a/src/appleseed/foundation/image/conversion.cpp
+++ b/src/appleseed/foundation/image/conversion.cpp
@@ -40,7 +40,6 @@
 #include <cassert>
 #include <cstddef>
 
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace foundation
@@ -48,7 +47,7 @@ namespace foundation
 
 bool is_linear_image_file_format(const bf::path& path)
 {
-    const string extension = lower_case(path.extension().string());
+    const std::string extension = lower_case(path.extension().string());
 
     return
         extension == ".exr"  ||

--- a/src/appleseed/foundation/image/drawing.cpp
+++ b/src/appleseed/foundation/image/drawing.cpp
@@ -37,8 +37,6 @@
 // Standard headers.
 #include <algorithm>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -56,10 +54,10 @@ void Drawing::draw_filled_rect(
     const int w = static_cast<int>(props.m_canvas_width);
     const int h = static_cast<int>(props.m_canvas_height);
 
-    const size_t x0 = static_cast<size_t>(max(from.x, 0));
-    const size_t y0 = static_cast<size_t>(max(from.y, 0));
-    const size_t x1 = static_cast<size_t>(min(to.x, w - 1));
-    const size_t y1 = static_cast<size_t>(min(to.y, h - 1));
+    const size_t x0 = static_cast<size_t>(std::max(from.x, 0));
+    const size_t y0 = static_cast<size_t>(std::max(from.y, 0));
+    const size_t x1 = static_cast<size_t>(std::min(to.x, w - 1));
+    const size_t y1 = static_cast<size_t>(std::min(to.y, h - 1));
 
     const Color4f color_premult = color.premultiplied();
 

--- a/src/appleseed/foundation/image/genericimagefilereader.cpp
+++ b/src/appleseed/foundation/image/genericimagefilereader.cpp
@@ -40,8 +40,6 @@
 #include <cstddef>
 #include <memory>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -62,7 +60,7 @@ Image* GenericImageFileReader::read(
     if (image_attributes)
         reader.read_image_attributes(*image_attributes);
 
-    unique_ptr<Image> image(
+    std::unique_ptr<Image> image(
         new Image(
             props.m_canvas_width,
             props.m_canvas_height,
@@ -75,7 +73,7 @@ Image* GenericImageFileReader::read(
     {
         for (size_t tile_x = 0; tile_x < props.m_tile_count_x; ++tile_x)
         {
-            unique_ptr<Tile> tile(reader.read_tile(tile_x, tile_y));
+            std::unique_ptr<Tile> tile(reader.read_tile(tile_x, tile_y));
             image->set_tile(tile_x, tile_y, tile.release());
         }
     }

--- a/src/appleseed/foundation/image/genericprogressiveimagefilereader.cpp
+++ b/src/appleseed/foundation/image/genericprogressiveimagefilereader.cpp
@@ -53,8 +53,6 @@
 #include <memory>
 #include <string>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -65,7 +63,7 @@ namespace foundation
 struct GenericProgressiveImageFileReader::Impl
 {
     Logger*                                 m_logger;
-    string                                  m_filename;
+    std::string                             m_filename;
 
 #if OIIO_VERSION < 20000
     OIIO::ImageInput*                       m_input;
@@ -264,10 +262,10 @@ Tile* GenericProgressiveImageFileReader::read_tile(
 
     // Compute tile's dimensions.
     const size_t tile_width = impl->m_is_tiled
-        ? min(impl->m_props.m_tile_width, impl->m_props.m_canvas_width - (tile_x * impl->m_props.m_tile_width))
+        ? std::min(impl->m_props.m_tile_width, impl->m_props.m_canvas_width - (tile_x * impl->m_props.m_tile_width))
         : impl->m_props.m_canvas_width;
     const size_t tile_height = impl->m_is_tiled
-        ? min(impl->m_props.m_tile_height, impl->m_props.m_canvas_height - (tile_y * impl->m_props.m_tile_height))
+        ? std::min(impl->m_props.m_tile_height, impl->m_props.m_canvas_height - (tile_y * impl->m_props.m_tile_height))
         : impl->m_props.m_canvas_height;
 
     // Create the tile.
@@ -311,8 +309,8 @@ void GenericProgressiveImageFileReader::read_tile(
 
         const size_t origin_x = tile_x * impl->m_props.m_tile_width;
         const size_t origin_y = tile_y * impl->m_props.m_tile_height;
-        const size_t tile_width = min(impl->m_props.m_tile_width, impl->m_props.m_canvas_width - origin_x);
-        const size_t tile_height = min(impl->m_props.m_tile_height, impl->m_props.m_canvas_height - origin_y);
+        const size_t tile_width = std::min(impl->m_props.m_tile_width, impl->m_props.m_canvas_width - origin_x);
+        const size_t tile_height = std::min(impl->m_props.m_tile_height, impl->m_props.m_canvas_height - origin_y);
 
         if (tile_width == impl->m_props.m_tile_width && tile_height == impl->m_props.m_tile_height)
         {
@@ -333,7 +331,7 @@ void GenericProgressiveImageFileReader::read_tile(
             assert(output_tile->get_width() == tile_width);
             assert(output_tile->get_height() == tile_height);
 
-            unique_ptr<Tile> source_tile(
+            std::unique_ptr<Tile> source_tile(
                 new Tile(
                     impl->m_props.m_tile_width,
                     impl->m_props.m_tile_height,

--- a/src/appleseed/foundation/image/image.cpp
+++ b/src/appleseed/foundation/image/image.cpp
@@ -38,8 +38,6 @@
 #include <cassert>
 #include <cstring>
 
-using namespace std;
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/image/nativedrawing.cpp
+++ b/src/appleseed/foundation/image/nativedrawing.cpp
@@ -38,8 +38,6 @@
 #include <cassert>
 #include <cstring>
 
-using namespace std;
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/image/text/textrenderer.cpp
+++ b/src/appleseed/foundation/image/text/textrenderer.cpp
@@ -43,8 +43,6 @@
 #include <cstddef>
 #include <vector>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -124,7 +122,7 @@ float TextRenderer::compute_string_width(
         }
     }
 
-    return max(width, max_width);
+    return std::max(width, max_width);
 }
     
 float TextRenderer::compute_string_height(
@@ -247,7 +245,7 @@ void TextRenderer::draw_string(
     const float baseline = ascent * scale;
 
     // Bitmap inside which glyphs will be rendered.
-    vector<uint8> glyph_bitmap(32 * 32, 0);
+    std::vector<uint8> glyph_bitmap(32 * 32, 0);
 
     float x = origin_x;
     float y = origin_y;

--- a/src/appleseed/foundation/image/tile.cpp
+++ b/src/appleseed/foundation/image/tile.cpp
@@ -30,8 +30,6 @@
 // Interface header.
 #include "tile.h"
 
-using namespace std;
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/math/filtersamplingtable.cpp
+++ b/src/appleseed/foundation/math/filtersamplingtable.cpp
@@ -35,8 +35,6 @@
 // Standard headers.
 #include <algorithm>
 
-using namespace std;
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/math/half.cpp
+++ b/src/appleseed/foundation/math/half.cpp
@@ -32,8 +32,6 @@
 // Standard headers.
 #include <cmath>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -8353,7 +8351,7 @@ uint16 Half::float_to_half_except(const uint32 i)
         u.i = i;
 
         return static_cast<uint16>(
-            s | static_cast<int>(abs(u.f) * 1.6777216e7 + 0.5));
+            s | static_cast<int>(std::abs(u.f) * 1.6777216e7 + 0.5));
     }
 
     if (e == 0x23c00)

--- a/src/appleseed/foundation/math/microfacet.cpp
+++ b/src/appleseed/foundation/math/microfacet.cpp
@@ -37,8 +37,6 @@
 #include <cassert>
 #include <cmath>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -138,7 +136,7 @@ float BlinnMDF::G(
     const float         alpha_x,
     const float         alpha_y)
 {
-    return min(
+    return std::min(
         G1(wi, m, alpha_x, alpha_y),
         G1(wo, m, alpha_x, alpha_y));
 }
@@ -153,7 +151,7 @@ float BlinnMDF::G1(
     if (cos_vm == 0.0f)
         return 0.0f;
 
-    return min(1.0f, 2.0f * abs(m.y * v.y / cos_vm));
+    return std::min(1.0f, 2.0f * abs(m.y * v.y / cos_vm));
 }
 
 Vector3f BlinnMDF::sample(
@@ -163,7 +161,7 @@ Vector3f BlinnMDF::sample(
     const float         alpha_y)
 {
     const float cos_theta = pow(1.0f - s[0], 1.0f / (alpha_x + 2.0f));
-    const float sin_theta = sqrt(max(0.0f, 1.0f - square(cos_theta)));
+    const float sin_theta = sqrt(std::max(0.0f, 1.0f - square(cos_theta)));
 
     float cos_phi, sin_phi;
     sample_phi(s[1], cos_phi, sin_phi);
@@ -195,7 +193,7 @@ float BeckmannMDF::D(
         return 0.0f;
 
     const float cos_theta_2 = square(cos_theta);
-    const float sin_theta = sqrt(max(0.0f, 1.0f - cos_theta_2));
+    const float sin_theta = sqrt(std::max(0.0f, 1.0f - cos_theta_2));
     const float cos_theta_4 = square(cos_theta_2);
     const float tan_theta_2 = (1.0f - cos_theta_2) / cos_theta_2;
 
@@ -237,7 +235,7 @@ float BeckmannMDF::lambda(
     if (cos_theta == 0.0f)
         return 0.0f;
 
-    const float sin_theta = sqrt(max(0.0f, 1.0f - square(cos_theta)));
+    const float sin_theta = sqrt(std::max(0.0f, 1.0f - square(cos_theta)));
 
     // Normal incidence. No shadowing.
     if (sin_theta == 0.0f)
@@ -321,7 +319,7 @@ Vector2f BeckmannMDF::sample_slope(
         return slope;
     }
 
-    const float ct = max(cos_theta, threshold);
+    const float ct = std::max(cos_theta, threshold);
     const float tan_theta = sqrt(1.0f - square(ct)) / ct;
     const float cot_theta = 1.0f / tan_theta;
 
@@ -386,7 +384,7 @@ float GGXMDF::D(
         return square(alpha_x) * RcpPi<float>();
 
     const float cos_theta_2 = square(cos_theta);
-    const float sin_theta = sqrt(max(0.0f, 1.0f - cos_theta_2));
+    const float sin_theta = sqrt(std::max(0.0f, 1.0f - cos_theta_2));
     const float cos_theta_4 = square(cos_theta_2);
     const float tan_theta_2 = (1.0f - cos_theta_2) / cos_theta_2;
 
@@ -430,7 +428,7 @@ float GGXMDF::lambda(
         return 0.0f;
 
     const float cos_theta_2 = square(cos_theta);
-    const float sin_theta = sqrt(max(0.0f, 1.0f - cos_theta_2));
+    const float sin_theta = sqrt(std::max(0.0f, 1.0f - cos_theta_2));
 
     const float alpha =
         projected_roughness(
@@ -481,12 +479,12 @@ Vector3f GGXMDF::sample(
 
     // Compute normal.
     const Vector3f h =
-        p1 * t1 + p2 * t2 + sqrt(max(0.0f, 1.0f - p1 * p1 - p2 * p2)) * stretched;
+        p1 * t1 + p2 * t2 + sqrt(std::max(0.0f, 1.0f - p1 * p1 - p2 * p2)) * stretched;
 
     // Unstretch and normalize.
     const Vector3f m(
         h.x * alpha_x,
-        max(0.0f, h.y),
+        std::max(0.0f, h.y),
         h.z * alpha_y);
     return normalize(m);
 }
@@ -544,7 +542,7 @@ float GGXMDF::lambda(
         return 0.0f;
 
     const float cos_theta_2 = square(cos_theta);
-    const float sin_theta = sqrt(max(0.0f, 1.0f - cos_theta_2));
+    const float sin_theta = sqrt(std::max(0.0f, 1.0f - cos_theta_2));
 
     const float tan_theta_2 = square(sin_theta) / cos_theta_2;
     const float a2_rcp = square(alpha) * tan_theta_2;
@@ -607,7 +605,7 @@ float WardMDF::G(
     const float         alpha_x,
     const float         alpha_y)
 {
-    return min(
+    return std::min(
         G1(wi, m, alpha_x, alpha_y),
         G1(wo, m, alpha_x, alpha_y));
 }
@@ -628,7 +626,7 @@ float WardMDF::G1(
     if (cos_vm == 0.0f)
         return 0.0f;
 
-    return min(1.0f, 2.0f * abs(m.y * v.y) / cos_vm);
+    return std::min(1.0f, 2.0f * abs(m.y * v.y) / cos_vm);
 }
 
 Vector3f WardMDF::sample(
@@ -701,7 +699,7 @@ float GTR1MDF::lambda(
 
     // [2] section 3.2.
     const float cos_theta_2 = square(cos_theta);
-    const float sin_theta = sqrt(max(0.0f, 1.0f - cos_theta_2));
+    const float sin_theta = sqrt(std::max(0.0f, 1.0f - cos_theta_2));
 
     // Normal incidence. No shadowing.
     if (sin_theta == 0.0f)
@@ -731,7 +729,7 @@ Vector3f GTR1MDF::sample(
     const float a = 1.0f - pow(alpha_2, 1.0f - s[0]);
     const float cos_theta_2 = a / (1.0f - alpha_2);
     const float cos_theta = sqrt(cos_theta_2);
-    const float sin_theta = sqrt(max(0.0f, 1.0f - cos_theta_2));
+    const float sin_theta = sqrt(std::max(0.0f, 1.0f - cos_theta_2));
 
     float cos_phi, sin_phi;
     sample_phi(s[1], cos_phi, sin_phi);
@@ -763,7 +761,7 @@ float StdMDF::D(
         return 0.0;
 
     const float cos_theta_2 = square(cos_theta);
-    const float sin_theta = sqrt(max(0.0f, 1.0f - cos_theta_2));
+    const float sin_theta = sqrt(std::max(0.0f, 1.0f - cos_theta_2));
     const float cos_theta_4 = square(cos_theta_2);
     const float tan_theta_2 = (1.0f - cos_theta_2) / cos_theta_2;
 
@@ -819,7 +817,7 @@ float StdMDF::lambda(
     if (cos_theta == 0.0f)
         return 0.0f;
 
-    const float sin_theta = sqrt(max(0.0f, 1.0f - square(cos_theta)));
+    const float sin_theta = sqrt(std::max(0.0f, 1.0f - square(cos_theta)));
 
     // Normal incidence. No shadowing.
     if (sin_theta == 0.0f)

--- a/src/appleseed/foundation/math/ordering.cpp
+++ b/src/appleseed/foundation/math/ordering.cpp
@@ -48,7 +48,7 @@ namespace foundation
 
 void linear_ordering(
     std::vector<size_t>&     ordering,
-    const size_t        size)
+    const size_t             size)
 {
     assert(ordering.empty());
     assert(size > 0);
@@ -60,8 +60,8 @@ void linear_ordering(
 
 void spiral_ordering(
     std::vector<size_t>&     ordering,
-    const size_t        size_x,
-    const size_t        size_y)
+    const size_t             size_x,
+    const size_t             size_y)
 {
     assert(ordering.empty());
 
@@ -130,12 +130,12 @@ namespace
 {
     void hilbert(
         std::vector<size_t>& ordering,
-        const int       size_x,
-        const int       size_y,
-        Vector2i        point,
-        int             size,
-        const Vector2i& dx,
-        const Vector2i& dy)
+        const int            size_x,
+        const int            size_y,
+        Vector2i             point,
+        int                  size,
+        const Vector2i&      dx,
+        const Vector2i&      dy)
     {
         if (size > 1)
         {
@@ -163,8 +163,8 @@ namespace
 
 void hilbert_ordering(
     std::vector<size_t>&     ordering,
-    const size_t        size_x,
-    const size_t        size_y)
+    const size_t             size_x,
+    const size_t             size_y)
 {
     assert(ordering.empty());
 

--- a/src/appleseed/foundation/math/ordering.cpp
+++ b/src/appleseed/foundation/math/ordering.cpp
@@ -38,7 +38,6 @@
 #include <algorithm>
 
 using namespace foundation;
-using namespace std;
 
 namespace foundation
 {
@@ -48,7 +47,7 @@ namespace foundation
 //
 
 void linear_ordering(
-    vector<size_t>&     ordering,
+    std::vector<size_t>&     ordering,
     const size_t        size)
 {
     assert(ordering.empty());
@@ -60,7 +59,7 @@ void linear_ordering(
 }
 
 void spiral_ordering(
-    vector<size_t>&     ordering,
+    std::vector<size_t>&     ordering,
     const size_t        size_x,
     const size_t        size_y)
 {
@@ -71,7 +70,7 @@ void spiral_ordering(
     const int size = static_cast<int>(size_x * size_y);
     const int tw = static_cast<int>(size_x);
     const int th = static_cast<int>(size_y);
-    const int center = (min(tw, th) - 1) / 2;
+    const int center = (std::min(tw, th) - 1) / 2;
 
     for (int i = 0; i < size; ++i)
     {
@@ -84,7 +83,7 @@ void spiral_ordering(
             ty--;
         }
 
-        const int mintxty = min(tx, ty);
+        const int mintxty = std::min(tx, ty);
         const int txty = tx * ty;
         int x = center;
         int y = center;
@@ -130,7 +129,7 @@ void spiral_ordering(
 namespace
 {
     void hilbert(
-        vector<size_t>& ordering,
+        std::vector<size_t>& ordering,
         const int       size_x,
         const int       size_y,
         Vector2i        point,
@@ -163,7 +162,7 @@ namespace
 }
 
 void hilbert_ordering(
-    vector<size_t>&     ordering,
+    std::vector<size_t>&     ordering,
     const size_t        size_x,
     const size_t        size_y)
 {
@@ -172,7 +171,7 @@ void hilbert_ordering(
     ordering.reserve(size_x * size_y);
 
     // This Hilbert curve generator only works on a square grid whose size is a power of two.
-    const size_t root_size = next_pow2(max(size_x, size_y));
+    const size_t root_size = next_pow2(std::max(size_x, size_y));
 
     hilbert(
         ordering,

--- a/src/appleseed/foundation/math/phasefunction.cpp
+++ b/src/appleseed/foundation/math/phasefunction.cpp
@@ -39,8 +39,6 @@
 #include <cassert>
 #include <cmath>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -97,7 +95,7 @@ float HenyeyPhaseFunction::sample(const Vector3f& outgoing, const Vector2f& s, V
         cosine = 0.5f / m_g * (1.0f + sqr_g - p * p);
     }
 
-    const float sine = sqrt(max(1.0f - cosine * cosine, 0.0f));
+    const float sine = sqrt(std::max(1.0f - cosine * cosine, 0.0f));
     const Vector2f tangent = sample_circle_uniform(s[1]);
     const Basis3f basis(outgoing);
 

--- a/src/appleseed/foundation/math/rng/simdmersennetwister.cpp
+++ b/src/appleseed/foundation/math/rng/simdmersennetwister.cpp
@@ -32,8 +32,6 @@
 // Standard headers.
 #include <cstring>
 
-using namespace std;
-
 /*
     Copyright (c) 2006,2007 Mutsuo Saito, Makoto Matsumoto and Hiroshima
     University.

--- a/src/appleseed/foundation/mesh/binarymeshfilereader.cpp
+++ b/src/appleseed/foundation/mesh/binarymeshfilereader.cpp
@@ -42,8 +42,6 @@
 #include <cstring>
 #include <memory>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -51,7 +49,7 @@ namespace foundation
 // BinaryMeshFileReader class implementation.
 //
 
-BinaryMeshFileReader::BinaryMeshFileReader(const string& filename)
+BinaryMeshFileReader::BinaryMeshFileReader(const std::string& filename)
   : m_filename(filename)
 {
 }
@@ -120,12 +118,12 @@ void BinaryMeshFileReader::read_and_check_signature(BufferedFile& file)
         throw ExceptionIOError("invalid binarymesh format signature");
 }
 
-string BinaryMeshFileReader::read_string(ReaderAdapter& reader)
+std::string BinaryMeshFileReader::read_string(ReaderAdapter& reader)
 {
     uint16 length;
     checked_read(reader, length);
 
-    string s;
+    std::string s;
     s.resize(length);
     checked_read(reader, &s[0], length);
 
@@ -140,7 +138,7 @@ void BinaryMeshFileReader::read_meshes(ReaderAdapter& reader, IMeshBuilder& buil
         while (true)
         {
             // Read the name of the next mesh.
-            string mesh_name;
+            std::string mesh_name;
             try
             {
                 mesh_name = read_string(reader);
@@ -217,7 +215,7 @@ void BinaryMeshFileReader::read_material_slots(ReaderAdapter& reader, IMeshBuild
 
     for (uint16 i = 0; i < count; ++i)
     {
-        const string material_slot = read_string(reader);
+        const std::string material_slot = read_string(reader);
         builder.push_material_slot(material_slot.c_str());
     }
 }

--- a/src/appleseed/foundation/mesh/binarymeshfilewriter.cpp
+++ b/src/appleseed/foundation/mesh/binarymeshfilewriter.cpp
@@ -39,8 +39,6 @@
 // Standard headers.
 #include <cstring>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -54,7 +52,7 @@ namespace
     const uint16 Version = 4;
 }
 
-BinaryMeshFileWriter::BinaryMeshFileWriter(const string& filename)
+BinaryMeshFileWriter::BinaryMeshFileWriter(const std::string& filename)
   : m_filename(filename)
   , m_writer(m_file, 256 * 1024)
 {

--- a/src/appleseed/foundation/mesh/genericmeshfilereader.cpp
+++ b/src/appleseed/foundation/mesh/genericmeshfilereader.cpp
@@ -42,7 +42,6 @@
 // Standard headers.
 #include <string>
 
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace foundation
@@ -50,8 +49,8 @@ namespace foundation
 
 struct GenericMeshFileReader::Impl
 {
-    string  m_filename;
-    int     m_obj_options;
+    std::string  m_filename;
+    int          m_obj_options;
 };
 
 GenericMeshFileReader::GenericMeshFileReader(const char* filename)
@@ -79,7 +78,7 @@ void GenericMeshFileReader::set_obj_options(const int obj_options)
 void GenericMeshFileReader::read(IMeshBuilder& builder)
 {
     const bf::path filepath(impl->m_filename);
-    const string extension = lower_case(filepath.extension().string());
+    const std::string extension = lower_case(filepath.extension().string());
 
     if (extension == ".obj")
     {

--- a/src/appleseed/foundation/mesh/genericmeshfilewriter.cpp
+++ b/src/appleseed/foundation/mesh/genericmeshfilewriter.cpp
@@ -42,7 +42,6 @@
 // Standard headers.
 #include <string>
 
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace foundation
@@ -51,7 +50,7 @@ namespace foundation
 GenericMeshFileWriter::GenericMeshFileWriter(const char* filename)
 {
     const bf::path filepath(filename);
-    const string extension = lower_case(filepath.extension().string());
+    const std::string extension = lower_case(filepath.extension().string());
 
     if (extension == ".obj")
         m_writer = new OBJMeshFileWriter(filename);

--- a/src/appleseed/foundation/mesh/objmeshfilereader.cpp
+++ b/src/appleseed/foundation/mesh/objmeshfilereader.cpp
@@ -43,8 +43,6 @@
 #include <utility>
 #include <vector>
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -59,30 +57,30 @@ namespace
 
 struct OBJMeshFileReader::Impl
 {
-    const int               m_options;
-    IMeshBuilder&           m_builder;
-    OBJMeshFileLexer        m_lexer;
+    const int                         m_options;
+    IMeshBuilder&                     m_builder;
+    OBJMeshFileLexer                  m_lexer;
 
     // Current state.
-    bool                    m_inside_mesh_def;              // currently inside a mesh definition?
-    string                  m_current_mesh_name;            // name of the current mesh
-    map<string, size_t>     m_material_slots;               // material slots for the current mesh
-    size_t                  m_current_material_slot_index;  // index of the current material slot
+    bool                              m_inside_mesh_def;              // currently inside a mesh definition?
+    std::string                       m_current_mesh_name;            // name of the current mesh
+    std::map<std::string, size_t>     m_material_slots;               // material slots for the current mesh
+    size_t                            m_current_material_slot_index;  // index of the current material slot
 
     // Features defined in the file.
-    vector<Vector3d>        m_vertices;
-    vector<Vector2d>        m_tex_coords;
-    vector<Vector3d>        m_normals;
+    std::vector<Vector3d>             m_vertices;
+    std::vector<Vector2d>             m_tex_coords;
+    std::vector<Vector3d>             m_normals;
 
     // Mappings between internal indices and mesh indices.
-    vector<size_t>          m_vertex_index_mapping;
-    vector<size_t>          m_tex_coord_index_mapping;
-    vector<size_t>          m_normal_index_mapping;
+    std::vector<size_t>               m_vertex_index_mapping;
+    std::vector<size_t>               m_tex_coord_index_mapping;
+    std::vector<size_t>               m_normal_index_mapping;
 
     // Temporary vectors for collecting indices while parsing face statements.
-    vector<size_t>          m_face_vertex_indices;
-    vector<size_t>          m_face_tex_coord_indices;
-    vector<size_t>          m_face_normal_indices;
+    std::vector<size_t>               m_face_vertex_indices;
+    std::vector<size_t>               m_face_tex_coord_indices;
+    std::vector<size_t>               m_face_normal_indices;
 
     // Constructor.
     Impl(
@@ -408,8 +406,8 @@ struct OBJMeshFileReader::Impl
     }
 
     static void translate_indices(
-        vector<size_t>&         indices,
-        const vector<size_t>&   mapping)
+        std::vector<size_t>&         indices,
+        const std::vector<size_t>&   mapping)
     {
         const size_t count = indices.size();
 
@@ -420,7 +418,7 @@ struct OBJMeshFileReader::Impl
     void parse_o_g_statement()
     {
         // Retrieve the name of the upcoming mesh.
-        const string upcoming_mesh_name = parse_compound_identifier();
+        const std::string upcoming_mesh_name = parse_compound_identifier();
 
         // Start a new mesh only if the name of the object or group actually changes.
         if (upcoming_mesh_name != m_current_mesh_name)
@@ -440,9 +438,9 @@ struct OBJMeshFileReader::Impl
         }
     }
 
-    string parse_compound_identifier()
+    std::string parse_compound_identifier()
     {
-        string identifier;
+        std::string identifier;
 
         m_lexer.eat_blanks();
 
@@ -524,10 +522,10 @@ struct OBJMeshFileReader::Impl
         ensure_mesh_def();
 
         // Retrieve the name of the material slot.
-        const string material_slot_name = parse_compound_identifier();
+        const std::string material_slot_name = parse_compound_identifier();
 
         // Check whether this material slot has already been defined for this mesh.
-        const map<string, size_t>::const_iterator& it =
+        const std::map<std::string, size_t>::const_iterator& it =
             m_material_slots.find(material_slot_name);
 
         if (it != m_material_slots.end())
@@ -539,7 +537,7 @@ struct OBJMeshFileReader::Impl
         {
             // It hasn't: insert it into the mesh and make it the active material slot.
             m_current_material_slot_index = m_builder.push_material_slot(material_slot_name.c_str());
-            m_material_slots.insert(make_pair(material_slot_name, m_current_material_slot_index));
+            m_material_slots.insert(std::make_pair(material_slot_name, m_current_material_slot_index));
         }
     }
 
@@ -559,8 +557,8 @@ struct OBJMeshFileReader::Impl
 };
 
 OBJMeshFileReader::OBJMeshFileReader(
-    const string&   filename,
-    const int       options)
+    const std::string&   filename,
+    const int            options)
   : m_filename(filename)
   , m_options(options)
 {

--- a/src/appleseed/foundation/mesh/objmeshfilewriter.cpp
+++ b/src/appleseed/foundation/mesh/objmeshfilewriter.cpp
@@ -38,8 +38,6 @@
 #include "foundation/utility/otherwise.h"
 #include "foundation/utility/string.h"
 
-using namespace std;
-
 namespace foundation
 {
 
@@ -47,7 +45,7 @@ namespace foundation
 // OBJMeshFileWriter class implementation.
 //
 
-OBJMeshFileWriter::OBJMeshFileWriter(const string& filename)
+OBJMeshFileWriter::OBJMeshFileWriter(const std::string& filename)
   : m_filename(filename)
   , m_file(nullptr)
   , m_base_vertex_index(1)

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_cache.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_cache.cpp
@@ -38,7 +38,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 BENCHMARK_SUITE(Foundation_Utility_Cache_LRUCache)
 {

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_cdf.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_cdf.cpp
@@ -38,7 +38,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 BENCHMARK_SUITE(Foundation_Math_CDF)
 {

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_fastmath.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_fastmath.cpp
@@ -40,7 +40,6 @@
 #include <cstring>
 
 using namespace foundation;
-using namespace std;
 
 BENCHMARK_SUITE(Foundation_Math_FastMath)
 {

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_half.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_half.cpp
@@ -48,7 +48,7 @@ BENCHMARK_SUITE(Foundation_Math_Half)
     struct FloatToHalfFixture
     {
         std::vector<float> m_input;
-        std::vector<Half> m_output;
+        std::vector<Half>  m_output;
 
         FloatToHalfFixture()
         {
@@ -136,7 +136,7 @@ BENCHMARK_SUITE(Foundation_Math_Half)
     template <size_t Size>
     struct HalfToFloatFixture
     {
-        std::vector<Half> m_input;
+        std::vector<Half>  m_input;
         std::vector<float> m_output;
 
         HalfToFloatFixture()

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_half.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_half.cpp
@@ -37,7 +37,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 BENCHMARK_SUITE(Foundation_Math_Half)
 {
@@ -48,8 +47,8 @@ BENCHMARK_SUITE(Foundation_Math_Half)
     template <size_t Size>
     struct FloatToHalfFixture
     {
-        vector<float> m_input;
-        vector<Half> m_output;
+        std::vector<float> m_input;
+        std::vector<Half> m_output;
 
         FloatToHalfFixture()
         {
@@ -137,8 +136,8 @@ BENCHMARK_SUITE(Foundation_Math_Half)
     template <size_t Size>
     struct HalfToFloatFixture
     {
-        vector<Half> m_input;
-        vector<float> m_output;
+        std::vector<Half> m_input;
+        std::vector<float> m_output;
 
         HalfToFloatFixture()
         {

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_imageimportancesampler.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_imageimportancesampler.cpp
@@ -40,7 +40,6 @@
 #include <memory>
 
 using namespace foundation;
-using namespace std;
 
 BENCHMARK_SUITE(Foundation_Math_Sampling_ImageImportanceSampler)
 {
@@ -48,7 +47,7 @@ BENCHMARK_SUITE(Foundation_Math_Sampling_ImageImportanceSampler)
     {
         typedef ImageImportanceSampler<ImageSampler::Payload, float> ImportanceSamplerType;
 
-        unique_ptr<ImportanceSamplerType>   m_importance_sampler;
+        std::unique_ptr<ImportanceSamplerType>   m_importance_sampler;
         Xorshift32                          m_rng;
 
         Vector2u                            m_texel_coords_sum;
@@ -59,7 +58,7 @@ BENCHMARK_SUITE(Foundation_Math_Sampling_ImageImportanceSampler)
           , m_texel_prob_sum(0.0f)
         {
             GenericImageFileReader reader;
-            unique_ptr<Image> image(reader.read("unit tests/inputs/test_imageimportancesampler_doge2.exr"));
+            std::unique_ptr<Image> image(reader.read("unit tests/inputs/test_imageimportancesampler_doge2.exr"));
 
             const size_t width = image->properties().m_canvas_width;
             const size_t height = image->properties().m_canvas_height;

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_imageimportancesampler.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_imageimportancesampler.cpp
@@ -48,10 +48,10 @@ BENCHMARK_SUITE(Foundation_Math_Sampling_ImageImportanceSampler)
         typedef ImageImportanceSampler<ImageSampler::Payload, float> ImportanceSamplerType;
 
         std::unique_ptr<ImportanceSamplerType>   m_importance_sampler;
-        Xorshift32                          m_rng;
+        Xorshift32                               m_rng;
 
-        Vector2u                            m_texel_coords_sum;
-        float                               m_texel_prob_sum;
+        Vector2u                                 m_texel_coords_sum;
+        float                                    m_texel_prob_sum;
 
         Fixture()
           : m_texel_coords_sum(0, 0)

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_intersection.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_intersection.cpp
@@ -45,7 +45,6 @@
 #include <limits>
 
 using namespace foundation;
-using namespace std;
 
 namespace
 {
@@ -158,7 +157,7 @@ BENCHMARK_SUITE(Foundation_Math_Intersection_RayAABB)
         for (size_t i = 0; i < RayCount; ++i)
         {
             m_ray[i].m_tmin = 0.0f;
-            m_ray[i].m_tmax = numeric_limits<float>::max();
+            m_ray[i].m_tmax = std::numeric_limits<float>::max();
 
             m_hit ^= clip(m_ray[i], m_ray_info[i], m_aabb);
         }
@@ -169,7 +168,7 @@ BENCHMARK_SUITE(Foundation_Math_Intersection_RayAABB)
         for (size_t i = 0; i < RayCount; ++i)
         {
             m_ray[i].m_tmin = 0.0;
-            m_ray[i].m_tmax = numeric_limits<double>::max();
+            m_ray[i].m_tmax = std::numeric_limits<double>::max();
 
             m_hit ^= clip(m_ray[i], m_ray_info[i], m_aabb);
         }

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_job.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_job.cpp
@@ -36,7 +36,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 BENCHMARK_SUITE(Foundation_Utility_Job)
 {

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_knn.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_knn.cpp
@@ -50,7 +50,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 BENCHMARK_SUITE(Foundation_Math_Knn_Answer)
 {
@@ -97,7 +96,7 @@ BENCHMARK_SUITE(Foundation_Math_Knn_Query)
 {
     namespace
     {
-        bool load_points_from_disk(const char* filename, vector<Vector3f>& points)
+        bool load_points_from_disk(const char* filename, std::vector<Vector3f>& points)
         {
             assert(filename);
             assert(points.empty());
@@ -131,10 +130,10 @@ BENCHMARK_SUITE(Foundation_Math_Knn_Query)
     class FixtureBase
     {
       protected:
-        vector<Vector3f>    m_points;
-        vector<Vector3f>    m_query_points;
+        std::vector<Vector3f>    m_points;
+        std::vector<Vector3f>    m_query_points;
 
-        FixtureBase(const string& name)
+        FixtureBase(const std::string& name)
           : m_answer(AnswerSize)
           , m_accumulator(0)
         {
@@ -194,7 +193,7 @@ BENCHMARK_SUITE(Foundation_Math_Knn_Query)
         knn::QueryStatistics                m_query_stats;
 #endif
 
-        void configure_logger(const string& name)
+        void configure_logger(const std::string& name)
         {
             m_log_target.reset(create_file_log_target());
             m_log_target->open(("unit benchmarks/outputs/test_knn_" + name + "_stats.txt").c_str());

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_permutation.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_permutation.cpp
@@ -38,7 +38,6 @@
 #include <cstring>
 
 using namespace foundation;
-using namespace std;
 
 BENCHMARK_SUITE(Foundation_Math_Permutation)
 {

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_poolallocator.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_poolallocator.cpp
@@ -37,7 +37,6 @@
 #include <memory>
 
 using namespace foundation;
-using namespace std;
 
 BENCHMARK_SUITE(Foundation_Utility_PoolAllocator)
 {
@@ -77,7 +76,7 @@ BENCHMARK_SUITE(Foundation_Utility_PoolAllocator)
         }
     };
 
-    typedef allocator<uint32> DefaultAllocator;
+    typedef std::allocator<uint32> DefaultAllocator;
     typedef PoolAllocator<uint32, N> PoolAllocator;
 
     BENCHMARK_CASE_F(RepeatedAllocation_PoolAllocator, Fixture<PoolAllocator>)

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_samesign.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_samesign.cpp
@@ -44,7 +44,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 BENCHMARK_SUITE(SameSign)
 {

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_sampling.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_sampling.cpp
@@ -40,7 +40,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace
 {

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_string.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_string.cpp
@@ -35,7 +35,6 @@
 #include <cstdlib>
 
 using namespace foundation;
-using namespace std;
 
 BENCHMARK_SUITE(Foundation_Utility_String)
 {

--- a/src/appleseed/foundation/meta/tests/test_array.cpp
+++ b/src/appleseed/foundation/meta/tests/test_array.cpp
@@ -36,7 +36,6 @@
 #include <utility>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Array_Array)
 {
@@ -76,7 +75,7 @@ TEST_SUITE(Foundation_Array_Array)
         xref.assign(items, items + countof(items));
 
         Array y(x);
-        Array z(move(y));
+        Array z(std::move(y));
 
         EXPECT_TRUE(y.is_moved());
         EXPECT_TRUE(x == z);

--- a/src/appleseed/foundation/meta/tests/test_arrayalgorithm.cpp
+++ b/src/appleseed/foundation/meta/tests/test_arrayalgorithm.cpp
@@ -33,7 +33,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Array_Algorithm)
 {
@@ -78,7 +77,7 @@ TEST_SUITE(Foundation_Array_Algorithm)
         const ArrayView<uint16> src_view(src);
         const ArrayView<uint8> dst_view(array);
 
-        EXPECT_TRUE(equal(src_view.begin(), src_view.end(), dst_view.begin()));
+        EXPECT_TRUE(std::equal(src_view.begin(), src_view.end(), dst_view.begin()));
     }
 
     TEST_CASE(ConvertToSmallestType32to8)
@@ -95,7 +94,7 @@ TEST_SUITE(Foundation_Array_Algorithm)
         const ArrayView<uint32> src_view(src);
         const ArrayView<uint8> dst_view(array);
 
-        EXPECT_TRUE(equal(src_view.begin(), src_view.end(), dst_view.begin()));
+        EXPECT_TRUE(std::equal(src_view.begin(), src_view.end(), dst_view.begin()));
     }
 
     TEST_CASE(ConvertToSmallestType32to16)
@@ -112,7 +111,7 @@ TEST_SUITE(Foundation_Array_Algorithm)
         const ArrayView<uint32> src_view(src);
         const ArrayView<uint16> dst_view(array);
 
-        EXPECT_TRUE(equal(src_view.begin(), src_view.end(), dst_view.begin()));
+        EXPECT_TRUE(std::equal(src_view.begin(), src_view.end(), dst_view.begin()));
     }
 
     TEST_CASE(ConvertToSmallestType32NoOp)
@@ -129,6 +128,6 @@ TEST_SUITE(Foundation_Array_Algorithm)
         const ArrayView<uint32> src_view(src);
         const ArrayView<uint32> dst_view(array);
 
-        EXPECT_TRUE(equal(src_view.begin(), src_view.end(), dst_view.begin()));
+        EXPECT_TRUE(std::equal(src_view.begin(), src_view.end(), dst_view.begin()));
     }
 }

--- a/src/appleseed/foundation/meta/tests/test_arrayapplyvisitor.cpp
+++ b/src/appleseed/foundation/meta/tests/test_arrayapplyvisitor.cpp
@@ -36,7 +36,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Array_ApplyVisitor)
 {
@@ -66,7 +65,7 @@ TEST_SUITE(Foundation_Array_ApplyVisitor)
         }
 
       private:
-        vector<size_t> m_applies;
+        std::vector<size_t> m_applies;
     };
 
     TEST_CASE(ApplyConst)

--- a/src/appleseed/foundation/meta/tests/test_beziercurve.cpp
+++ b/src/appleseed/foundation/meta/tests/test_beziercurve.cpp
@@ -45,7 +45,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_BezierCurveIntersector)
 {
@@ -101,7 +100,7 @@ TEST_SUITE(Foundation_Math_BezierCurveIntersector)
                     // Draw the curve.
                     MatrixType curve_transform;
                     make_curve_projection_transform(curve_transform, ray);
-                    ValueType u, v, t = numeric_limits<ValueType>::max();
+                    ValueType u, v, t = std::numeric_limits<ValueType>::max();
                     if (textured)
                     {
                         if (BezierCurveIntersectorType::intersect(curve, ray, curve_transform, u, v, t))
@@ -600,7 +599,7 @@ TEST_SUITE(Foundation_Math_BezierCurveIntersector)
         // of control points. See http://stackoverflow.com/a/3516110/393756 for details.
         //
 
-        vector<Vector3f> new_points;
+        std::vector<Vector3f> new_points;
 
         for (size_t i = 0; i < countof(ControlPoints); ++i)
         {
@@ -613,7 +612,7 @@ TEST_SUITE(Foundation_Math_BezierCurveIntersector)
             }
         }
 
-        vector<BezierCurve3f> curves;
+        std::vector<BezierCurve3f> curves;
 
         for (size_t i = 0, e = new_points.size(); i + 3 < e; i += 3)
             curves.emplace_back(&new_points[i], 0.05f, 1.0f, Color3f(0.2f, 0.0f, 0.7f));
@@ -636,7 +635,7 @@ TEST_SUITE(Foundation_Math_BezierCurveIntersector)
         Matrix4f xfm_matrix;
         make_curve_projection_transform(xfm_matrix, ray);
 
-        float u, v, t = numeric_limits<float>::max();
+        float u, v, t = std::numeric_limits<float>::max();
         const bool hit = BezierCurveIntersector<BezierCurve1f>::intersect(Curves[0], ray, xfm_matrix, u, v, t);
 
         ASSERT_TRUE(hit);
@@ -655,7 +654,7 @@ TEST_SUITE(Foundation_Math_BezierCurveIntersector)
         Matrix4f xfm_matrix;
         make_curve_projection_transform(xfm_matrix, ray);
 
-        float u, v, t = numeric_limits<float>::max();
+        float u, v, t = std::numeric_limits<float>::max();
         const bool hit = BezierCurveIntersector<BezierCurve1f>::intersect(Curves[0], ray, xfm_matrix, u, v, t);
 
         ASSERT_TRUE(hit);
@@ -674,7 +673,7 @@ TEST_SUITE(Foundation_Math_BezierCurveIntersector)
         Matrix4f xfm_matrix;
         make_curve_projection_transform(xfm_matrix, ray);
 
-        float u, v, t = numeric_limits<float>::max();
+        float u, v, t = std::numeric_limits<float>::max();
         const bool hit = BezierCurveIntersector<BezierCurve1f>::intersect(Curves[0], ray, xfm_matrix, u, v, t);
 
         ASSERT_TRUE(hit);
@@ -693,7 +692,7 @@ TEST_SUITE(Foundation_Math_BezierCurveIntersector)
         Matrix4f xfm_matrix;
         make_curve_projection_transform(xfm_matrix, ray);
 
-        float u, v, t = numeric_limits<float>::max();
+        float u, v, t = std::numeric_limits<float>::max();
         const bool hit = BezierCurveIntersector<BezierCurve1f>::intersect(Curve, ray, xfm_matrix, u, v, t);
 
         ASSERT_TRUE(hit);

--- a/src/appleseed/foundation/meta/tests/test_boost_datetime.cpp
+++ b/src/appleseed/foundation/meta/tests/test_boost_datetime.cpp
@@ -41,7 +41,6 @@
 
 using namespace boost;
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Boost_DateTime)
 {
@@ -49,14 +48,14 @@ TEST_SUITE(Boost_DateTime)
     {
         using namespace gregorian;
 
-        const string result = to_string(date(2010, Jun, 22));
+        const std::string result = to_string(date(2010, Jun, 22));
 
         EXPECT_EQ("2010-Jun-22", result);
     }
 
     TEST_CASE(TimeDurationToString)
     {
-        const string result = to_string(posix_time::time_duration(17, 45, 31));
+        const std::string result = to_string(posix_time::time_duration(17, 45, 31));
 
         EXPECT_EQ("17:45:31", result);
     }

--- a/src/appleseed/foundation/meta/tests/test_boost_path.cpp
+++ b/src/appleseed/foundation/meta/tests/test_boost_path.cpp
@@ -36,7 +36,6 @@
 // Standard headers.
 #include <string>
 
-using namespace std;
 namespace bf = boost::filesystem;
 
 TEST_SUITE(Boost_Path)
@@ -62,12 +61,12 @@ TEST_SUITE(Boost_Path)
 
     TEST_CASE(String_GivenPathWithSlashes)
     {
-        const string s = bf::path("dir/file.txt").string();
+        const std::string s = bf::path("dir/file.txt").string();
     }
 
     TEST_CASE(String_GivenPathWithBackSlashes)
     {
-        const string s = bf::path("dir\\file.txt").string();
+        const std::string s = bf::path("dir\\file.txt").string();
     }
 
     TEST_CASE(Native_GivenPathWithSlashes)
@@ -82,21 +81,21 @@ TEST_SUITE(Boost_Path)
 
     TEST_CASE(GenericString_GivenPathWithSlashes)
     {
-        const string s = bf::path("dir/file.txt").generic_string();
+        const std::string s = bf::path("dir/file.txt").generic_string();
     }
 
     TEST_CASE(GenericString_GivenPathWithBackSlashes)
     {
-        const string s = bf::path("dir\\file.txt").generic_string();
+        const std::string s = bf::path("dir\\file.txt").generic_string();
     }
 
     TEST_CASE(MakePreferred_GivenPathWithSlashes)
     {
-        const string s = bf::path("dir/file.txt").make_preferred().string();
+        const std::string s = bf::path("dir/file.txt").make_preferred().string();
     }
 
     TEST_CASE(MakePreferred_GivenPathWithBackSlashes)
     {
-        const string s = bf::path("dir\\file.txt").make_preferred().string();
+        const std::string s = bf::path("dir\\file.txt").make_preferred().string();
     }
 }

--- a/src/appleseed/foundation/meta/tests/test_bsp.cpp
+++ b/src/appleseed/foundation/meta/tests/test_bsp.cpp
@@ -46,7 +46,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_BSP_Node)
 {
@@ -145,7 +144,7 @@ TEST_SUITE(Foundation_Math_BSP_Intersector)
         }
 
       private:
-        vector<AABB3d>  m_boxes;
+        std::vector<AABB3d>  m_boxes;
     };
 
     struct LeafFactory
@@ -225,7 +224,7 @@ TEST_SUITE(Foundation_Math_BSP_Intersector)
       public:
         LeafVisitor()
           : m_visited_leaf_count(0)
-          , m_closest_hit(numeric_limits<double>::max())
+          , m_closest_hit(std::numeric_limits<double>::max())
         {
         }
 
@@ -276,7 +275,7 @@ TEST_SUITE(Foundation_Math_BSP_Intersector)
 
         Fixture()
         {
-            unique_ptr<Leaf> root_leaf(new Leaf());
+            std::unique_ptr<Leaf> root_leaf(new Leaf());
             root_leaf->insert(AABB3d(Vector3d(-1.0, -0.5, -0.2), Vector3d(0.0, 0.5, 0.2)));
             root_leaf->insert(AABB3d(Vector3d(0.0, -0.5, -0.7), Vector3d(1.0, 0.5, 0.7)));
 
@@ -284,7 +283,7 @@ TEST_SUITE(Foundation_Math_BSP_Intersector)
             LeafFactory leaf_factory;
             LeafSplitter leaf_splitter;
 
-            builder.build(m_tree, move(root_leaf), leaf_factory, leaf_splitter);
+            builder.build(m_tree, std::move(root_leaf), leaf_factory, leaf_splitter);
         }
     };
 

--- a/src/appleseed/foundation/meta/tests/test_bufferedfile.cpp
+++ b/src/appleseed/foundation/meta/tests/test_bufferedfile.cpp
@@ -37,13 +37,12 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_BufferedFile)
 {
     const char* Filename = "unit tests/outputs/test_bufferedfile.tmp";
     const size_t BufferSize = 4;
-    const string DataString = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const std::string DataString = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
     TEST_CASE(InitialStateIsCorrect)
     {
@@ -135,7 +134,7 @@ TEST_SUITE(Foundation_Utility_BufferedFile)
 
         char buf[100];
         EXPECT_EQ(DataString.size(), file.read(buf, DataString.size()));
-        EXPECT_EQ(DataString, string(buf, DataString.size()));
+        EXPECT_EQ(DataString, std::string(buf, DataString.size()));
         EXPECT_EQ(DataString.size(), file.tell());
     }
 
@@ -186,7 +185,7 @@ TEST_SUITE(Foundation_Utility_BufferedFile)
 
         char buf[100];
         EXPECT_EQ(DataString.size(), file.read(buf, DataString.size()));
-        EXPECT_EQ(DataString, string(buf, DataString.size()));
+        EXPECT_EQ(DataString, std::string(buf, DataString.size()));
         EXPECT_EQ(DataString.size(), file.tell());
     }
 
@@ -218,7 +217,7 @@ TEST_SUITE(Foundation_Utility_BufferedFile)
         m_file.read(buf, 6);
         EXPECT_TRUE(m_file.seek(4, BufferedFile::SeekFromCurrent));
         EXPECT_EQ(8, m_file.read(buf, 8));
-        EXPECT_EQ("KLMNOPQR", string(buf, 8));
+        EXPECT_EQ("KLMNOPQR", std::string(buf, 8));
     }
 
     TEST_CASE_F(TestSeekingBackwardWhileReading, FileReadingFixture)
@@ -227,7 +226,7 @@ TEST_SUITE(Foundation_Utility_BufferedFile)
         m_file.read(buf, 6);
         EXPECT_TRUE(m_file.seek(-4, BufferedFile::SeekFromCurrent));
         EXPECT_EQ(8, m_file.read(buf, 8));
-        EXPECT_EQ("CDEFGHIJ", string(buf, 8));
+        EXPECT_EQ("CDEFGHIJ", std::string(buf, 8));
     }
 
     TEST_CASE_F(TestSeekingFromBeginningWhileReading, FileReadingFixture)
@@ -236,7 +235,7 @@ TEST_SUITE(Foundation_Utility_BufferedFile)
         m_file.read(buf, 8);
         EXPECT_TRUE(m_file.seek(2, BufferedFile::SeekFromBeginning));
         EXPECT_EQ(8, m_file.read(buf, 8));
-        EXPECT_EQ("CDEFGHIJ", string(buf, 8));
+        EXPECT_EQ("CDEFGHIJ", std::string(buf, 8));
     }
 
     TEST_CASE_F(TestSeekingFromEndWhileReading, FileReadingFixture)
@@ -245,7 +244,7 @@ TEST_SUITE(Foundation_Utility_BufferedFile)
         m_file.read(buf, 8);
         EXPECT_TRUE(m_file.seek(-8, BufferedFile::SeekFromEnd));
         EXPECT_EQ(8, m_file.read(buf, 8));
-        EXPECT_EQ("STUVWXYZ", string(buf, 8));
+        EXPECT_EQ("STUVWXYZ", std::string(buf, 8));
     }
 
     TEST_CASE(TestSeekingBackwardInsideBufferWhileWriting)

--- a/src/appleseed/foundation/meta/tests/test_bvh.cpp
+++ b/src/appleseed/foundation/meta/tests/test_bvh.cpp
@@ -41,7 +41,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_BVH_Node)
 {
@@ -105,7 +104,7 @@ TEST_SUITE(Foundation_Math_BVH_SpatialBuilder)
     TEST_CASE(InstantiateSpatialBuilderAndSBVHPartitioner)
     {
         typedef AlignedVector<bvh::Node<AABB3d>> NodeVector;
-        typedef vector<AABB3d> AABBVector;
+        typedef std::vector<AABB3d> AABBVector;
 
         typedef bvh::Tree<NodeVector> Tree;
         typedef bvh::SBVHPartitioner<ItemHandler, AABBVector> Partitioner;

--- a/src/appleseed/foundation/meta/tests/test_cache.cpp
+++ b/src/appleseed/foundation/meta/tests/test_cache.cpp
@@ -39,7 +39,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 namespace
 {

--- a/src/appleseed/foundation/meta/tests/test_cdf.cpp
+++ b/src/appleseed/foundation/meta/tests/test_cdf.cpp
@@ -33,7 +33,6 @@
 #include "foundation/utility/test.h"
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_CDF)
 {

--- a/src/appleseed/foundation/meta/tests/test_color.cpp
+++ b/src/appleseed/foundation/meta/tests/test_color.cpp
@@ -41,7 +41,6 @@
 #endif
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Image_Color)
 {

--- a/src/appleseed/foundation/meta/tests/test_colorspace.cpp
+++ b/src/appleseed/foundation/meta/tests/test_colorspace.cpp
@@ -42,7 +42,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Image_ColorSpace)
 {
@@ -550,9 +549,9 @@ TEST_SUITE(Foundation_Image_ColorSpace)
             1.0e-6f);
     }
 
-    vector<Vector2d> zip(const double x[], const double y[], const size_t count)
+    std::vector<Vector2d> zip(const double x[], const double y[], const size_t count)
     {
-        vector<Vector2d> points(count);
+        std::vector<Vector2d> points(count);
 
         for (size_t i = 0; i < count; ++i)
         {

--- a/src/appleseed/foundation/meta/tests/test_commandlineparser.cpp
+++ b/src/appleseed/foundation/meta/tests/test_commandlineparser.cpp
@@ -37,13 +37,12 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_CommandLineParser_ValueOptionHandler)
 {
     TEST_CASE(Parse_GivenMultipleInvocations_AccumulateValues)
     {
-        ValueOptionHandler<string> handler;
+        ValueOptionHandler<std::string> handler;
         handler.set_exact_value_count(1);
         handler.set_flags(OptionHandler::Repeatable);
 

--- a/src/appleseed/foundation/meta/tests/test_copyonwrite.cpp
+++ b/src/appleseed/foundation/meta/tests/test_copyonwrite.cpp
@@ -35,7 +35,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_CopyOnWrite)
 {
@@ -48,8 +47,8 @@ TEST_SUITE(Foundation_Utility_CopyOnWrite)
 
     TEST_CASE(ConstructWithMovableType)
     {
-        vector<int> x(1, 11);
-        CopyOnWrite<vector<int>> cow(move(x));
+        std::vector<int> x(1, 11);
+        CopyOnWrite<std::vector<int>> cow(std::move(x));
         EXPECT_TRUE(cow.unique());
         EXPECT_EQ(11, cow.read()[0]);
     }
@@ -75,7 +74,7 @@ TEST_SUITE(Foundation_Utility_CopyOnWrite)
         CopyOnWrite<int> a(11);
         EXPECT_TRUE(a.unique());
 
-        CopyOnWrite<int> b(move(a));
+        CopyOnWrite<int> b(std::move(a));
         EXPECT_TRUE(a.is_null());
         EXPECT_TRUE(b.unique());
 
@@ -105,7 +104,7 @@ TEST_SUITE(Foundation_Utility_CopyOnWrite)
         EXPECT_TRUE(a.unique());
 
         CopyOnWrite<int> b;
-        b = move(a);
+        b = std::move(a);
         EXPECT_TRUE(a.is_null());
         EXPECT_TRUE(b.unique());
 

--- a/src/appleseed/foundation/meta/tests/test_datetime.cpp
+++ b/src/appleseed/foundation/meta/tests/test_datetime.cpp
@@ -41,7 +41,6 @@
 
 using namespace boost;
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Platform_DateTime)
 {
@@ -63,7 +62,7 @@ TEST_SUITE(Foundation_Platform_DateTime)
         using namespace posix_time;
 
         const ptime time(date(2010, Jun, 22), time_duration(17, 45, 31));
-        const string result = to_string(time);
+        const std::string result = to_string(time);
 
         EXPECT_EQ("20100622T174531", result);
     }

--- a/src/appleseed/foundation/meta/tests/test_dictionary.cpp
+++ b/src/appleseed/foundation/meta/tests/test_dictionary.cpp
@@ -35,7 +35,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_StringDictionary)
 {
@@ -130,7 +129,7 @@ TEST_SUITE(Foundation_Utility_StringDictionary)
 
         EXPECT_EXCEPTION(ExceptionDictionaryKeyNotFound,
         {
-            APPLESEED_UNUSED const int item = sd.get<int>(string("key"));
+            APPLESEED_UNUSED const int item = sd.get<int>(std::string("key"));
         });
     }
 
@@ -149,7 +148,7 @@ TEST_SUITE(Foundation_Utility_StringDictionary)
         StringDictionary sd;
         sd.insert("key", "value");
 
-        sd.remove(string("key"));
+        sd.remove(std::string("key"));
 
         EXPECT_FALSE(sd.exist("key"));
     }
@@ -216,7 +215,7 @@ TEST_SUITE(Foundation_Utility_Dictionary)
 
         Dictionary copy(dic);
 
-        EXPECT_EQ("value", copy.get<string>("key"));
+        EXPECT_EQ("value", copy.get<std::string>("key"));
     }
 
     TEST_CASE(CopyConstructor_GivenSourceDictionaryWithOneDictionaryItem_CopiesDictionaryItem)
@@ -229,7 +228,7 @@ TEST_SUITE(Foundation_Utility_Dictionary)
 
         Dictionary copy(dic);
 
-        EXPECT_EQ("value", copy.dictionary("child").get<string>("key"));
+        EXPECT_EQ("value", copy.dictionary("child").get<std::string>("key"));
     }
 
     TEST_CASE(AssignmentOperator_GivenSourceDictionaryWithOneStringItem_CopiesStringItem)
@@ -240,7 +239,7 @@ TEST_SUITE(Foundation_Utility_Dictionary)
         Dictionary other;
         other = dic;
 
-        EXPECT_EQ("value", other.get<string>("key"));
+        EXPECT_EQ("value", other.get<std::string>("key"));
     }
 
     TEST_CASE(AssignmentOperator_GivenSourceDictionaryWithOneDictionaryItem_CopiesDictionaryItem)
@@ -254,7 +253,7 @@ TEST_SUITE(Foundation_Utility_Dictionary)
         Dictionary other;
         other = dic;
 
-        EXPECT_EQ("value", other.dictionary("child").get<string>("key"));
+        EXPECT_EQ("value", other.dictionary("child").get<std::string>("key"));
     }
 
     TEST_CASE(Clear_GivenDictionaryWithOneStringItem_RemovesItem)
@@ -287,18 +286,18 @@ TEST_SUITE(Foundation_Utility_Dictionary)
 
         EXPECT_EQ(1, dic.size());
         EXPECT_FALSE(dic.empty());
-        EXPECT_EQ("value", dic.get<string>("key"));
+        EXPECT_EQ("value", dic.get<std::string>("key"));
     }
 
     TEST_CASE(Insert_GivenCStringKeyAndStdStringValue_InsertsValue)
     {
         Dictionary dic;
 
-        dic.insert("key", string("value"));
+        dic.insert("key", std::string("value"));
 
         EXPECT_EQ(1, dic.size());
         EXPECT_FALSE(dic.empty());
-        EXPECT_EQ("value", dic.get<string>("key"));
+        EXPECT_EQ("value", dic.get<std::string>("key"));
     }
 
     TEST_CASE(Insert_GivenCStringKeyAndIntegerValue_InsertsValue)
@@ -316,18 +315,18 @@ TEST_SUITE(Foundation_Utility_Dictionary)
     {
         Dictionary dic;
 
-        dic.insert(string("key"), "value");
+        dic.insert(std::string("key"), "value");
 
         EXPECT_EQ(1, dic.size());
         EXPECT_FALSE(dic.empty());
-        EXPECT_EQ("value", dic.get<string>("key"));
+        EXPECT_EQ("value", dic.get<std::string>("key"));
     }
 
     TEST_CASE(Insert_GivenStdStringKeyAndIntegerValue_InsertsValue)
     {
         Dictionary dic;
 
-        dic.insert(string("key"), 42);
+        dic.insert(std::string("key"), 42);
 
         EXPECT_EQ(1, dic.size());
         EXPECT_FALSE(dic.empty());
@@ -368,7 +367,7 @@ TEST_SUITE(Foundation_Utility_Dictionary)
 
         EXPECT_EXCEPTION(ExceptionDictionaryKeyNotFound,
         {
-            APPLESEED_UNUSED const int item = dic.get<int>(string("key"));
+            APPLESEED_UNUSED const int item = dic.get<int>(std::string("key"));
         });
     }
 

--- a/src/appleseed/foundation/meta/tests/test_fastmath.cpp
+++ b/src/appleseed/foundation/meta/tests/test_fastmath.cpp
@@ -124,7 +124,7 @@ TEST_SUITE(Foundation_Math_FastMath)
 
     template <typename T, typename Function>
     void plot_functions(
-        const std::string&           filepath,
+        const std::string&      filepath,
         const FuncDef<Function> functions[],
         const size_t            function_count,
         const T                 low,

--- a/src/appleseed/foundation/meta/tests/test_fastmath.cpp
+++ b/src/appleseed/foundation/meta/tests/test_fastmath.cpp
@@ -46,7 +46,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_FastMath)
 {
@@ -118,14 +117,14 @@ TEST_SUITE(Foundation_Math_FastMath)
     template <typename Function>
     struct FuncDef
     {
-        string      m_title;
-        string      m_color;
-        Function    m_function;
+        std::string      m_title;
+        std::string      m_color;
+        Function         m_function;
     };
 
     template <typename T, typename Function>
     void plot_functions(
-        const string&           filepath,
+        const std::string&           filepath,
         const FuncDef<Function> functions[],
         const size_t            function_count,
         const T                 low,
@@ -136,7 +135,7 @@ TEST_SUITE(Foundation_Math_FastMath)
 
         for (size_t f = 0; f < function_count; ++f)
         {
-            vector<Vector<T, 2>> points(step_count);
+            std::vector<Vector<T, 2>> points(step_count);
 
             for (size_t i = 0; i < step_count; ++i)
             {
@@ -446,7 +445,7 @@ TEST_SUITE(Foundation_Math_FastMath)
     {
         const float error =
             compute_avg_relative_error_scalar<float, float (*)(float)>(
-                log,
+                std::log,
                 fast_log,
                 1.0e-2f,
                 1.0f,
@@ -459,7 +458,7 @@ TEST_SUITE(Foundation_Math_FastMath)
     {
         const float error =
             compute_avg_relative_error_scalar<float, float (*)(float)>(
-                log,
+                std::log,
                 faster_log,
                 1.0e-2f,
                 1.0f,
@@ -498,7 +497,7 @@ TEST_SUITE(Foundation_Math_FastMath)
     {
         const FuncDef<float (*)(float)> functions[] =
         {
-            { "std::log", "black", log },
+            { "std::log", "black", std::log },
             { "foundation::fast_log", "green", fast_log },
             { "foundation::faster_log", "red", faster_log }
         };
@@ -526,7 +525,7 @@ TEST_SUITE(Foundation_Math_FastMath)
     {
         const float error =
             compute_avg_relative_error_scalar<float, float (*)(float)>(
-                exp,
+                std::exp,
                 fast_exp,
                 0.0f,
                 1.0f,
@@ -539,7 +538,7 @@ TEST_SUITE(Foundation_Math_FastMath)
     {
         const float error =
             compute_avg_relative_error_scalar<float, float (*)(float)>(
-                exp,
+                std::exp,
                 faster_exp,
                 0.0f,
                 1.0f,
@@ -578,7 +577,7 @@ TEST_SUITE(Foundation_Math_FastMath)
     {
         const FuncDef<float (*)(float)> functions[] =
         {
-            { "std::exp", "black", exp },
+            { "std::exp", "black", std::exp },
             { "foundation::fast_exp", "green", fast_exp },
             { "foundation::faster_exp", "red", faster_exp }
         };
@@ -634,7 +633,7 @@ TEST_SUITE(Foundation_Math_FastMath)
     {
         const float error =
             compute_avg_relative_error_scalar<float, float (*)(float)>(
-                sqrt,
+                std::sqrt,
                 fast_sqrt,
                 0.0f,
                 1.0f,
@@ -647,7 +646,7 @@ TEST_SUITE(Foundation_Math_FastMath)
     {
         const FuncDef<float (*)(float)> functions[] =
         {
-            { "std::sqrt", "black", sqrt },
+            { "std::sqrt", "black", std::sqrt },
             { "foundation::fast_sqrt", "green", fast_sqrt }
         };
 

--- a/src/appleseed/foundation/meta/tests/test_filtersamplingtable.cpp
+++ b/src/appleseed/foundation/meta/tests/test_filtersamplingtable.cpp
@@ -40,7 +40,6 @@
 #include <fstream>
 
 using namespace foundation;
-using namespace std;
 
 namespace
 {
@@ -51,7 +50,7 @@ namespace
         const size_t    sample_count,
         const char*     filename)
     {
-        ofstream ofs(filename);
+        std::ofstream ofs(filename);
         Xoroshiro128plus rng;
 
         // Generate samples using the table.

--- a/src/appleseed/foundation/meta/tests/test_fresnel.cpp
+++ b/src/appleseed/foundation/meta/tests/test_fresnel.cpp
@@ -45,7 +45,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_Fresnel)
 {
@@ -130,7 +129,7 @@ TEST_SUITE(Foundation_Math_Fresnel)
 
         const double Eta = 1.0 / 1.5;
         const size_t PointCount = 256;
-        vector<Vector2d> reflectance_points, transmittance_points;
+        std::vector<Vector2d> reflectance_points, transmittance_points;
 
         for (size_t i = 0; i < PointCount; ++i)
         {
@@ -175,7 +174,7 @@ TEST_SUITE(Foundation_Math_Fresnel)
 
         const double Eta = 1.0 / 1.5;
         const size_t PointCount = 256;
-        vector<Vector2d> ref_refl_points, schlick_refl_points;
+        std::vector<Vector2d> ref_refl_points, schlick_refl_points;
 
         for (size_t i = 0; i < PointCount; ++i)
         {
@@ -265,7 +264,7 @@ TEST_SUITE(Foundation_Math_Fresnel)
         plotfile.set_ylabel("Fdr");
 
         const size_t PointCount = 256;
-        vector<Vector2d> integral_points, approx_points;
+        std::vector<Vector2d> integral_points, approx_points;
 
         for (size_t i = 0; i < PointCount; ++i)
         {
@@ -363,7 +362,7 @@ TEST_SUITE(Foundation_Math_Fresnel)
         plotfile.set_yrange(0.3, 1.0);
 
         const size_t PointCount = 256;
-        vector<Vector2d> red_points, green_points, blue_points;
+        std::vector<Vector2d> red_points, green_points, blue_points;
 
         for (size_t i = 0; i < PointCount; ++i)
         {
@@ -476,7 +475,7 @@ TEST_SUITE(Foundation_Math_Fresnel)
         static const double edge_tint[3] = {1.0, 0.5, 0.1};
 
         const size_t PointCount = 256;
-        vector<Vector2d> red_points, green_points, blue_points;
+        std::vector<Vector2d> red_points, green_points, blue_points;
 
         for (size_t i = 0; i < PointCount; ++i)
         {

--- a/src/appleseed/foundation/meta/tests/test_genericimagefilewriter.cpp
+++ b/src/appleseed/foundation/meta/tests/test_genericimagefilewriter.cpp
@@ -47,7 +47,6 @@
 #include <memory>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Image_GenericImageFileWriter)
 {
@@ -66,7 +65,7 @@ TEST_SUITE(Foundation_Image_GenericImageFileWriter)
 
         {
             GenericImageFileReader reader;
-            unique_ptr<Image> image(reader.read(ImageFilePath));
+            std::unique_ptr<Image> image(reader.read(ImageFilePath));
 
             for (size_t y = 0; y < 2; ++y)
             {
@@ -107,9 +106,9 @@ TEST_SUITE(Foundation_Image_GenericImageFileWriter)
             ImageAttributes attrs;
 
             GenericImageFileReader reader;
-            unique_ptr<Image> image(reader.read(ImageFilePath, &attrs));
+            std::unique_ptr<Image> image(reader.read(ImageFilePath, &attrs));
 
-            EXPECT_EQ(string("something"), attrs.get<string>("appleseed:test:StringAttr"));
+            EXPECT_EQ(std::string("something"), attrs.get<std::string>("appleseed:test:StringAttr"));
             EXPECT_EQ(47, attrs.get<int>("appleseed:test:StringButIntAttr"));
             EXPECT_EQ(47.5f, attrs.get<float>("appleseed:test:StringButFloatAttr"));
             EXPECT_EQ(32.0f, attrs.get<float>("appleseed:test:FloatAttr"));

--- a/src/appleseed/foundation/meta/tests/test_genericprogressiveimagefilereader.cpp
+++ b/src/appleseed/foundation/meta/tests/test_genericprogressiveimagefilereader.cpp
@@ -35,7 +35,6 @@
 #include <memory>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Image_GenericProgressiveImageFileReader)
 {

--- a/src/appleseed/foundation/meta/tests/test_hash.cpp
+++ b/src/appleseed/foundation/meta/tests/test_hash.cpp
@@ -49,7 +49,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_Hash)
 {
@@ -99,7 +98,7 @@ TEST_SUITE(Foundation_Math_Hash)
 
         void plot_histogram(const char* filename, const char* title) const
         {
-            vector<Vector2d> points;
+            std::vector<Vector2d> points;
             points.reserve(BinCount);
 
             for (size_t i = 0; i < BinCount; ++i)
@@ -242,7 +241,7 @@ TEST_SUITE(Foundation_Math_Hash)
             const size_t    trials,
             Hash            hash)
         {
-            constexpr size_t N = numeric_limits<UInt>::digits;
+            constexpr size_t N = std::numeric_limits<UInt>::digits;
 
             // y = input bit, x = output bit
             size_t counters[N * N];

--- a/src/appleseed/foundation/meta/tests/test_imageimportancesampler.cpp
+++ b/src/appleseed/foundation/meta/tests/test_imageimportancesampler.cpp
@@ -45,7 +45,6 @@
 #include <memory>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_Sampling_ImageImportanceSampler)
 {
@@ -92,7 +91,7 @@ TEST_SUITE(Foundation_Math_Sampling_ImageImportanceSampler)
         const size_t    sample_count)
     {
         GenericImageFileReader reader;
-        unique_ptr<Image> image(reader.read(input_filename));
+        std::unique_ptr<Image> image(reader.read(input_filename));
 
         const size_t width = image->properties().m_canvas_width;
         const size_t height = image->properties().m_canvas_height;
@@ -212,7 +211,7 @@ TEST_SUITE(Foundation_Math_Sampling_ImageImportanceSampler)
         // the CDF to be smaller than 1 while corresponding to items with null importance.
 
         GenericImageFileReader reader;
-        unique_ptr<Image> image(reader.read("unit tests/inputs/test_imageimportancesampler_doge2.exr"));
+        std::unique_ptr<Image> image(reader.read("unit tests/inputs/test_imageimportancesampler_doge2.exr"));
 
         const size_t width = image->properties().m_canvas_width;
         const size_t height = image->properties().m_canvas_height;

--- a/src/appleseed/foundation/meta/tests/test_intersection_rayaabb.cpp
+++ b/src/appleseed/foundation/meta/tests/test_intersection_rayaabb.cpp
@@ -38,7 +38,6 @@
 #include <limits>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_Intersection_RayAABB)
 {
@@ -356,7 +355,7 @@ TEST_SUITE(Foundation_Math_Intersection_RayAABB)
 
         EXPECT_FALSE(hit);
         EXPECT_EQ(0.0, ray.m_tmin);
-        EXPECT_EQ(numeric_limits<double>::max(), ray.m_tmax);
+        EXPECT_EQ(std::numeric_limits<double>::max(), ray.m_tmax);
     }
 
     TEST_CASE(Clip_GivenRayPiercingPosZFaceInTheMiddle_ReturnsTrueAndUpdatesTMinAndTMax)

--- a/src/appleseed/foundation/meta/tests/test_iostreamop.cpp
+++ b/src/appleseed/foundation/meta/tests/test_iostreamop.cpp
@@ -42,13 +42,12 @@
 namespace foundation    { class ExceptionStringConversionError; }
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_IOStreamOp)
 {
     TEST_CASE(ReadFloatArray_GivenEmptyStream_ReturnsEmptyArray)
     {
-        stringstream sstr;
+        std::stringstream sstr;
 
         FloatArray array;
         sstr >> array;
@@ -58,7 +57,7 @@ TEST_SUITE(Foundation_Utility_IOStreamOp)
 
     TEST_CASE(ReadFloatArray_GivenThreeFloatValues_ReturnsValues)
     {
-        stringstream sstr;
+        std::stringstream sstr;
         sstr << "1 -2.2 3e-1";
 
         FloatArray array;
@@ -72,7 +71,7 @@ TEST_SUITE(Foundation_Utility_IOStreamOp)
 
     TEST_CASE(ReadFloatArray_GivenInvalidValue_ThrowsExceptionStringConversionError)
     {
-        stringstream sstr;
+        std::stringstream sstr;
         sstr << "1.1 hello";
 
         FloatArray array;
@@ -85,7 +84,7 @@ TEST_SUITE(Foundation_Utility_IOStreamOp)
 
     TEST_CASE(ReadFloatArray_GivenEmptyStream_DoNotSetFailBitOnStream)
     {
-        stringstream sstr;
+        std::stringstream sstr;
 
         FloatArray array;
         sstr >> array;
@@ -95,7 +94,7 @@ TEST_SUITE(Foundation_Utility_IOStreamOp)
 
     TEST_CASE(ReadFloatArray_GivenThreeFloatValues_DoNotSetFailBitOnStream)
     {
-        stringstream sstr;
+        std::stringstream sstr;
         sstr << "1 -2.2 3e-1";
 
         FloatArray array;
@@ -106,7 +105,7 @@ TEST_SUITE(Foundation_Utility_IOStreamOp)
 
     TEST_CASE(ReadFloatArray_GivenInvalidValue_DoNotSetFailBitOnStream)
     {
-        stringstream sstr;
+        std::stringstream sstr;
         sstr << "1.1 hello";
 
         try
@@ -124,7 +123,7 @@ TEST_SUITE(Foundation_Utility_IOStreamOp)
 
     TEST_CASE(ReadDoubleArray_GivenEmptyStream_ReturnsEmptyArray)
     {
-        stringstream sstr;
+        std::stringstream sstr;
 
         DoubleArray array;
         sstr >> array;
@@ -134,7 +133,7 @@ TEST_SUITE(Foundation_Utility_IOStreamOp)
 
     TEST_CASE(ReadDoubleArray_GivenThreeDoubleValues_ReturnsValues)
     {
-        stringstream sstr;
+        std::stringstream sstr;
         sstr << "1 -2.2 3e-1";
 
         DoubleArray array;
@@ -148,7 +147,7 @@ TEST_SUITE(Foundation_Utility_IOStreamOp)
 
     TEST_CASE(ReadDoubleArray_GivenInvalidValue_ThrowsExceptionStringConversionError)
     {
-        stringstream sstr;
+        std::stringstream sstr;
         sstr << "1.1 hello";
 
         DoubleArray array;
@@ -161,8 +160,8 @@ TEST_SUITE(Foundation_Utility_IOStreamOp)
 
     TEST_CASE(Write3DAABBToStream)
     {
-        stringstream sstr;
-        sstr << fixed << setprecision(1);
+        std::stringstream sstr;
+        sstr << std::fixed << std::setprecision(1);
         sstr << AABB3d(Vector3d(-1.0, -2.0, -3.0), Vector3d(1.0, 2.0, 3.0));
 
         EXPECT_EQ("-1.0 -2.0 -3.0 1.0 2.0 3.0", sstr.str());
@@ -170,7 +169,7 @@ TEST_SUITE(Foundation_Utility_IOStreamOp)
 
     TEST_CASE(Read3DAABBFromStream)
     {
-        stringstream sstr;
+        std::stringstream sstr;
         sstr << "-1.0 -2.0 -3.0 1.0 2.0 3.0";
 
         AABB3d aabb;

--- a/src/appleseed/foundation/meta/tests/test_job.cpp
+++ b/src/appleseed/foundation/meta/tests/test_job.cpp
@@ -46,7 +46,6 @@
 #include <utility>
 
 using namespace foundation;
-using namespace std;
 
 namespace
 {
@@ -410,7 +409,7 @@ TEST_SUITE(Foundation_Utility_Job_WorkerThread)
     {
         void execute(const size_t thread_index) override
         {
-            throw bad_alloc();
+            throw std::bad_alloc();
         }
     };
 

--- a/src/appleseed/foundation/meta/tests/test_keyframedarray.cpp
+++ b/src/appleseed/foundation/meta/tests/test_keyframedarray.cpp
@@ -35,7 +35,6 @@
 #include <utility>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Array_KeyframedArray)
 {
@@ -89,7 +88,7 @@ TEST_SUITE(Foundation_Array_KeyframedArray)
         const float items[] = {1.0f, 5.0f, 7.0f, 11.0f};
         set_keyframes(2, items, items + countof(items), k);
 
-        KeyFramedArray kmoved(move(k));
+        KeyFramedArray kmoved(std::move(k));
         EXPECT_TRUE(k.is_moved());
     }
 

--- a/src/appleseed/foundation/meta/tests/test_knn.cpp
+++ b/src/appleseed/foundation/meta/tests/test_knn.cpp
@@ -47,7 +47,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_Knn_Tree)
 {
@@ -285,7 +284,7 @@ TEST_SUITE(Foundation_Math_Knn_Query)
 
     void generate_random_points(
         MersenneTwister&            rng,
-        vector<Vector3d>&           points,
+        std::vector<Vector3d>&           points,
         const size_t                count)
     {
         assert(points.empty());
@@ -305,7 +304,7 @@ TEST_SUITE(Foundation_Math_Knn_Query)
 
         MersenneTwister rng;
 
-        vector<Vector3d> points;
+        std::vector<Vector3d> points;
         generate_random_points(rng, points, PointCount);
 
         knn::Tree3d tree;
@@ -344,12 +343,12 @@ TEST_SUITE(Foundation_Math_Knn_Query)
 
     struct SortPointByDistancePredicate
     {
-        const vector<Vector3d>&     m_points;
-        const Vector3d&             m_q;
+        const std::vector<Vector3d>&     m_points;
+        const Vector3d&                  m_q;
 
         SortPointByDistancePredicate(
-            const vector<Vector3d>& points,
-            const Vector3d&         q)
+            const std::vector<Vector3d>& points,
+            const Vector3d&              q)
           : m_points(points)
           , m_q(q)
         {
@@ -364,21 +363,21 @@ TEST_SUITE(Foundation_Math_Knn_Query)
     };
 
     void naive_query(
-        const vector<Vector3d>&     points,
-        const Vector3d&             q,
-        vector<size_t>&             indices)
+        const std::vector<Vector3d>&     points,
+        const Vector3d&                  q,
+        std::vector<size_t>&             indices)
     {
         assert(indices.size() == points.size());
 
         SortPointByDistancePredicate pred(points, q);
-        sort(indices.begin(), indices.end(), pred);
+        std::sort(indices.begin(), indices.end(), pred);
     }
 
     bool do_results_match_naive_algorithm(
-        const vector<Vector3d>&     points,
-        const size_t                answer_size,
-        const size_t                query_count,
-        function<Vector3d()>        make_query_point)
+        const std::vector<Vector3d>&     points,
+        const size_t                     answer_size,
+        const size_t                     query_count,
+        std::function<Vector3d()>        make_query_point)
     {
         knn::Tree3d tree;
         knn::Builder3d builder(tree);
@@ -387,7 +386,7 @@ TEST_SUITE(Foundation_Math_Knn_Query)
         knn::Answer<double> answer(answer_size);
         knn::Query3d query(tree, answer);
 
-        vector<size_t> ref_answer(points.size());
+        std::vector<size_t> ref_answer(points.size());
         identity_permutation(ref_answer.size(), &ref_answer[0]);
 
         for (size_t i = 0; i < query_count; ++i)
@@ -420,7 +419,7 @@ TEST_SUITE(Foundation_Math_Knn_Query)
 
         MersenneTwister rng;
 
-        vector<Vector3d> points;
+        std::vector<Vector3d> points;
         generate_random_points(rng, points, PointCount);
 
         auto make_query_point = [&rng]() { return rand_vector1<Vector3d>(rng); };
@@ -435,7 +434,7 @@ TEST_SUITE(Foundation_Math_Knn_Query)
 
         MersenneTwister rng;
 
-        vector<Vector3d> points;
+        std::vector<Vector3d> points;
         generate_random_points(rng, points, PointCount);
 
         points[0] = Vector3d(0.0);
@@ -455,7 +454,7 @@ TEST_SUITE(Foundation_Math_Knn_Query)
 
         MersenneTwister rng;
 
-        vector<Vector3d> points;
+        std::vector<Vector3d> points;
         generate_random_points(rng, points, PointCount);
 
         auto make_query_point = [&rng, &points]() { return points[rand_int1(rng, 0, static_cast<int32>(points.size()) - 1)]; };

--- a/src/appleseed/foundation/meta/tests/test_knn.cpp
+++ b/src/appleseed/foundation/meta/tests/test_knn.cpp
@@ -284,7 +284,7 @@ TEST_SUITE(Foundation_Math_Knn_Query)
 
     void generate_random_points(
         MersenneTwister&            rng,
-        std::vector<Vector3d>&           points,
+        std::vector<Vector3d>&      points,
         const size_t                count)
     {
         assert(points.empty());

--- a/src/appleseed/foundation/meta/tests/test_kvpair.cpp
+++ b/src/appleseed/foundation/meta/tests/test_kvpair.cpp
@@ -35,7 +35,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_KVPair)
 {
@@ -55,7 +54,7 @@ TEST_SUITE(Foundation_Utility_KVPair)
 
         ASSERT_NEQ(0, kvpair);
 
-        EXPECT_EQ(string("Green"), kvpair->m_value);
+        EXPECT_EQ(std::string("Green"), kvpair->m_value);
     }
 
     TEST_CASE(FoundationLookupKVPairArray_GivenKeyOfNonExistingEntry_ReturnsNullPointer)

--- a/src/appleseed/foundation/meta/tests/test_lazy.cpp
+++ b/src/appleseed/foundation/meta/tests/test_lazy.cpp
@@ -36,7 +36,6 @@
 #include <utility>
 
 using namespace foundation;
-using namespace std;
 
 namespace
 {
@@ -61,9 +60,9 @@ namespace
         {
         }
 
-        unique_ptr<Object> create() override
+        std::unique_ptr<Object> create() override
         {
-            return unique_ptr<Object>(new Object(m_value));
+            return std::unique_ptr<Object>(new Object(m_value));
         }
     };
 }
@@ -72,8 +71,8 @@ TEST_SUITE(Foundation_Utility_Lazy_Access)
 {
     TEST_CASE(Get_GivenAccessBoundToNonNullObject_ReturnsNonNullPointer)
     {
-        unique_ptr<ObjectFactory> factory(new SimpleObjectFactory(42));
-        Lazy<Object> object(move(factory));
+        std::unique_ptr<ObjectFactory> factory(new SimpleObjectFactory(42));
+        Lazy<Object> object(std::move(factory));
 
         Access<Object> access(&object);
 
@@ -82,8 +81,8 @@ TEST_SUITE(Foundation_Utility_Lazy_Access)
 
     TEST_CASE(OperatorArrow_GivenAccessBoundToNonNullObject_GivesAccessToObject)
     {
-        unique_ptr<ObjectFactory> factory(new SimpleObjectFactory(42));
-        Lazy<Object> object(move(factory));
+        std::unique_ptr<ObjectFactory> factory(new SimpleObjectFactory(42));
+        Lazy<Object> object(std::move(factory));
 
         Access<Object> access(&object);
 
@@ -92,8 +91,8 @@ TEST_SUITE(Foundation_Utility_Lazy_Access)
 
     TEST_CASE(OperatorStar_GivenAccessBoundToNonNullObject_GivesAccessToObject)
     {
-        unique_ptr<ObjectFactory> factory(new SimpleObjectFactory(42));
-        Lazy<Object> object(move(factory));
+        std::unique_ptr<ObjectFactory> factory(new SimpleObjectFactory(42));
+        Lazy<Object> object(std::move(factory));
 
         Access<Object> access(&object);
 
@@ -102,16 +101,16 @@ TEST_SUITE(Foundation_Utility_Lazy_Access)
 
     struct NullObjectFactory : public ObjectFactory
     {
-        unique_ptr<Object> create() override
+        std::unique_ptr<Object> create() override
         {
-            return unique_ptr<Object>(nullptr);
+            return std::unique_ptr<Object>(nullptr);
         }
     };
 
     TEST_CASE(Get_GivenAccessBoundToNullObject_ReturnsNullPointer)
     {
-        unique_ptr<ObjectFactory> factory(new NullObjectFactory());
-        Lazy<Object> object(move(factory));
+        std::unique_ptr<ObjectFactory> factory(new NullObjectFactory());
+        Lazy<Object> object(std::move(factory));
 
         Access<Object> access(&object);
 

--- a/src/appleseed/foundation/meta/tests/test_makevector.cpp
+++ b/src/appleseed/foundation/meta/tests/test_makevector.cpp
@@ -37,13 +37,12 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_MakeVector)
 {
     TEST_CASE(TestMakeVectorWithSingleIntegerValue)
     {
-        vector<int> expected_vector;
+        std::vector<int> expected_vector;
         expected_vector.push_back(10);
 
         EXPECT_EQ(expected_vector, make_vector(10));
@@ -51,7 +50,7 @@ TEST_SUITE(Foundation_Utility_MakeVector)
 
     TEST_CASE(TestMakeVectorWithMultipleIntegerValues)
     {
-        vector<int> expected_vector;
+        std::vector<int> expected_vector;
         expected_vector.push_back(10);
         expected_vector.push_back(20);
         expected_vector.push_back(30);
@@ -61,7 +60,7 @@ TEST_SUITE(Foundation_Utility_MakeVector)
 
     TEST_CASE(TestMakeVectorWithMultipleStringValues)
     {
-        vector<string> expected_vector;
+        std::vector<std::string> expected_vector;
         expected_vector.emplace_back("hello");
         expected_vector.emplace_back("world");
         expected_vector.emplace_back("bunny");

--- a/src/appleseed/foundation/meta/tests/test_math_filter.cpp
+++ b/src/appleseed/foundation/meta/tests/test_math_filter.cpp
@@ -40,7 +40,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 namespace
 {
@@ -87,14 +86,14 @@ namespace
     }
 
     template <typename Filter2>
-    vector<Vector2d> make_points(const Filter2& filter)
+    std::vector<Vector2d> make_points(const Filter2& filter)
     {
         typedef typename Filter2::ValueType T;
 
         const T r = filter.get_xradius();
 
         const size_t PointCount = 256;
-        vector<Vector2d> points(PointCount);
+        std::vector<Vector2d> points(PointCount);
 
         for (size_t i = 0; i < PointCount; ++i)
         {
@@ -108,9 +107,9 @@ namespace
 
     template <typename Filter2>
     void plot(
-        const string&       filepath,
-        const string&       plot_title,
-        const Filter2&      filter)
+        const std::string&       filepath,
+        const std::string&       plot_title,
+        const Filter2&           filter)
     {
         GnuplotFile plotfile;
         plotfile.set_title(plot_title + ", radius=" + pretty_scalar(filter.get_xradius(), 1));
@@ -120,12 +119,12 @@ namespace
 
     template <typename Filter2T, typename Filter2U>
     void plot(
-        const string&       filepath,
-        const string&       plot_title,
-        const string&       filter1_name,
-        const Filter2T&     filter1,
-        const string&       filter2_name,
-        const Filter2U&     filter2)
+        const std::string&       filepath,
+        const std::string&       plot_title,
+        const std::string&       filter1_name,
+        const Filter2T&          filter1,
+        const std::string&       filter2_name,
+        const Filter2U&          filter2)
     {
         GnuplotFile plotfile;
         plotfile.set_title(plot_title + ", radius=" + pretty_scalar(filter1.get_xradius(), 1));

--- a/src/appleseed/foundation/meta/tests/test_memory.cpp
+++ b/src/appleseed/foundation/meta/tests/test_memory.cpp
@@ -40,7 +40,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_Memory)
 {
@@ -162,7 +161,7 @@ TEST_SUITE(Foundation_Utility_Memory)
 
     TEST_CASE(EnsureMinimumSize_GivenEmptyVector_ResizesVectorByInsertingDefaultValue)
     {
-        vector<int> v;
+        std::vector<int> v;
 
         ensure_minimum_size(v, 2);
 
@@ -171,7 +170,7 @@ TEST_SUITE(Foundation_Utility_Memory)
 
     TEST_CASE(EnsureMinimumSize_GivenEmptyVector_ResizesVectorByInsertingProvidedValue)
     {
-        vector<int> v;
+        std::vector<int> v;
 
         ensure_minimum_size(v, 2, 42);
 
@@ -182,7 +181,7 @@ TEST_SUITE(Foundation_Utility_Memory)
 
     TEST_CASE(EnsureMinimumSize_GivenMinimumSizeSmallerThanCurrentVectorSize_DoesNothing)
     {
-        vector<int> v(12);
+        std::vector<int> v(12);
 
         ensure_minimum_size(v, 3);
 
@@ -191,7 +190,7 @@ TEST_SUITE(Foundation_Utility_Memory)
 
     TEST_CASE(ClearReleaseMemory_GivenVectorWithThousandElements_ClearsVector)
     {
-        vector<int> v(1000);
+        std::vector<int> v(1000);
 
         clear_release_memory(v);
 
@@ -200,7 +199,7 @@ TEST_SUITE(Foundation_Utility_Memory)
 
     TEST_CASE(ClearReleaseMemory_GivenVectorWithThousandElements_ResetsVectorCapacityToDefaultValue)
     {
-        vector<int> v;
+        std::vector<int> v;
         const size_t default_capacity = v.capacity();
 
         v.resize(1000);
@@ -214,7 +213,7 @@ TEST_SUITE(Foundation_Utility_Memory)
     {
         typedef AlignedAllocator<int> Allocator;
 
-        vector<int, AlignedAllocator<int>> v(Allocator(32));
+        std::vector<int, AlignedAllocator<int>> v(Allocator(32));
         const size_t default_capacity = v.capacity();
 
         v.resize(1000);
@@ -226,7 +225,7 @@ TEST_SUITE(Foundation_Utility_Memory)
 
     TEST_CASE(ClearKeepMemory_GivenVectorWithThousandElements_ClearsVector)
     {
-        vector<int> v(1000);
+        std::vector<int> v(1000);
 
         clear_keep_memory(v);
 
@@ -235,7 +234,7 @@ TEST_SUITE(Foundation_Utility_Memory)
 
     TEST_CASE(ClearKeepMemory_GivenVectorWithThousandElements_RetainsVectorCapacity)
     {
-        vector<int> v(1000);
+        std::vector<int> v(1000);
 
         const size_t old_capacity = v.capacity();
 

--- a/src/appleseed/foundation/meta/tests/test_microfacet.cpp
+++ b/src/appleseed/foundation/meta/tests/test_microfacet.cpp
@@ -43,7 +43,6 @@
 #include <limits>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_Microfacet)
 {
@@ -176,10 +175,10 @@ TEST_SUITE(Foundation_Math_Microfacet)
         const float                 angle_step,
         WeakWhiteFurnaceTestResult& result)
     {
-        result.m_min_G1 =  numeric_limits<float>::max();
-        result.m_max_G1 = -numeric_limits<float>::max();
-        result.m_min_result =  numeric_limits<float>::max();
-        result.m_max_result = -numeric_limits<float>::max();
+        result.m_min_G1 =  std::numeric_limits<float>::max();
+        result.m_max_G1 = -std::numeric_limits<float>::max();
+        result.m_min_result =  std::numeric_limits<float>::max();
+        result.m_max_result = -std::numeric_limits<float>::max();
 
         for (size_t i = 0; i < num_runs; ++i)
         {
@@ -188,8 +187,8 @@ TEST_SUITE(Foundation_Math_Microfacet)
             const Vector3f v = sample_hemisphere_uniform(s);
             const float G1 = mdf.G1(v, Vector3f(0.0f, 1.0, 0.0f), alpha_x, alpha_y);
 
-            result.m_min_G1 = min(result.m_min_G1, G1);
-            result.m_max_G1 = max(result.m_max_G1, G1);
+            result.m_min_G1 = std::min(result.m_min_G1, G1);
+            result.m_max_G1 = std::max(result.m_max_G1, G1);
 
             const float cos_thetha_o_4 = abs(4.0f * v.y);
 
@@ -222,8 +221,8 @@ TEST_SUITE(Foundation_Math_Microfacet)
             // Result should be 1.
             integral *= square(angle_step);
 
-            result.m_min_result = min(result.m_min_result, integral);
-            result.m_max_result = max(result.m_max_result, integral);
+            result.m_min_result = std::min(result.m_min_result, integral);
+            result.m_max_result = std::max(result.m_max_result, integral);
         }
     }
 

--- a/src/appleseed/foundation/meta/tests/test_minmax.cpp
+++ b/src/appleseed/foundation/meta/tests/test_minmax.cpp
@@ -44,7 +44,6 @@
 #include <utility>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_MinMax)
 {
@@ -68,18 +67,18 @@ TEST_SUITE(Foundation_Math_MinMax)
         EXPECT_EQ(2, max(2, 1, 0));
     }
 
-    pair<int, int> minmax_pair(const int a, const int b)
+    std::pair<int, int> minmax_pair(const int a, const int b)
     {
         int min, max;
         minmax(a, b, min, max);
-        return make_pair(min, max);
+        return std::make_pair(min, max);
     }
 
-    pair<int, int> minmax_pair(const int a, const int b, const int c)
+    std::pair<int, int> minmax_pair(const int a, const int b, const int c)
     {
         int min, max;
         minmax(a, b, c, min, max);
-        return make_pair(min, max);
+        return std::make_pair(min, max);
     }
 
     TEST_CASE(MinMax_TwoArguments)
@@ -138,7 +137,7 @@ TEST_SUITE(Foundation_Math_MinMax)
 
         const size_t N = countof(Values);
 
-        sort(&Values[0], &Values[N]);
+        std::sort(&Values[0], &Values[N]);
 
         UInt* first = &Values[0];
         UInt* middle = &Values[2];

--- a/src/appleseed/foundation/meta/tests/test_mis.cpp
+++ b/src/appleseed/foundation/meta/tests/test_mis.cpp
@@ -34,7 +34,6 @@
 #include <limits>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_MIS)
 {

--- a/src/appleseed/foundation/meta/tests/test_noise.cpp
+++ b/src/appleseed/foundation/meta/tests/test_noise.cpp
@@ -40,7 +40,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_Noise)
 {

--- a/src/appleseed/foundation/meta/tests/test_objmeshfilereader.cpp
+++ b/src/appleseed/foundation/meta/tests/test_objmeshfilereader.cpp
@@ -40,28 +40,27 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Mesh_OBJMeshFileReader)
 {
     struct Face
     {
-        vector<size_t>      m_vertices;
+        std::vector<size_t>      m_vertices;
     };
 
     struct Mesh
     {
-        string              m_name;
-        vector<Vector3d>    m_vertices;
-        vector<Vector3d>    m_vertex_normals;
-        vector<Vector2d>    m_tex_coords;
-        vector<Face>        m_faces;
+        std::string              m_name;
+        std::vector<Vector3d>    m_vertices;
+        std::vector<Vector3d>    m_vertex_normals;
+        std::vector<Vector2d>    m_tex_coords;
+        std::vector<Face>        m_faces;
     };
 
     struct MeshBuilder
       : public MeshBuilderBase
     {
-        vector<Mesh>        m_meshes;
+        std::vector<Mesh>        m_meshes;
 
         void begin_mesh(const char* name) override
         {

--- a/src/appleseed/foundation/meta/tests/test_objmeshfilewriter.cpp
+++ b/src/appleseed/foundation/meta/tests/test_objmeshfilewriter.cpp
@@ -43,7 +43,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Mesh_OBJMeshFileWriter)
 {
@@ -54,15 +53,15 @@ TEST_SUITE(Foundation_Mesh_OBJMeshFileWriter)
 
     struct Mesh
     {
-        string              m_name;
-        vector<Vector3d>    m_vertices;
-        vector<Face>        m_faces;
+        std::string              m_name;
+        std::vector<Vector3d>    m_vertices;
+        std::vector<Face>        m_faces;
     };
 
     struct MeshBuilder
       : public MeshBuilderBase
     {
-        vector<Mesh> m_meshes;
+        std::vector<Mesh> m_meshes;
 
         void begin_mesh(const char* name) override
         {
@@ -178,7 +177,7 @@ TEST_SUITE(Foundation_Mesh_OBJMeshFileWriter)
         }
     };
 
-    Mesh create_mesh(const string& name)
+    Mesh create_mesh(const std::string& name)
     {
         Mesh mesh;
         mesh.m_name = name;

--- a/src/appleseed/foundation/meta/tests/test_path.cpp
+++ b/src/appleseed/foundation/meta/tests/test_path.cpp
@@ -41,21 +41,20 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 namespace bf = boost::filesystem;
 
 TEST_SUITE(Foundation_Platform_Path)
 {
     TEST_CASE(GetExecutablePath_GivenRunningApplication_ReturnsNonEmptyString)
     {
-        const string executable_path = get_executable_path();
+        const std::string executable_path = get_executable_path();
 
         EXPECT_FALSE(executable_path.empty());
     }
 
     TEST_CASE(GetExecutableDirectory_GivenRunningApplication_ReturnsNonEmptyString)
     {
-        const string executable_dir = get_executable_directory();
+        const std::string executable_dir = get_executable_directory();
 
         EXPECT_FALSE(executable_dir.empty());
     }

--- a/src/appleseed/foundation/meta/tests/test_permutation.cpp
+++ b/src/appleseed/foundation/meta/tests/test_permutation.cpp
@@ -38,7 +38,6 @@
 #include <cstring>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_Permutation)
 {

--- a/src/appleseed/foundation/meta/tests/test_poolallocator.cpp
+++ b/src/appleseed/foundation/meta/tests/test_poolallocator.cpp
@@ -36,7 +36,6 @@
 #include <memory>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_PoolAllocator)
 {
@@ -50,8 +49,8 @@ TEST_SUITE(Foundation_Utility_PoolAllocator)
 
     TEST_CASE(AllocatorsWithDifferentValueTypesAreNotEqual)
     {
-        PoolAllocator<int, 128, allocator<int>> a1;
-        PoolAllocator<unsigned int, 256, allocator<int>> a2;
+        PoolAllocator<int, 128, std::allocator<int>> a1;
+        PoolAllocator<unsigned int, 256, std::allocator<int>> a2;
 
         EXPECT_FALSE(a1 == a2);
         EXPECT_TRUE(a1 != a2);
@@ -69,7 +68,7 @@ TEST_SUITE(Foundation_Utility_PoolAllocator)
     TEST_CASE(AllocatorsWithDifferentFallbackAllocatorsAreNotEqual)
     {
         PoolAllocator<int, 128, PoolAllocator<int, 128>> a1;
-        PoolAllocator<int, 128, allocator<int>> a2;
+        PoolAllocator<int, 128, std::allocator<int>> a2;
 
         EXPECT_FALSE(a1 == a2);
         EXPECT_TRUE(a1 != a2);

--- a/src/appleseed/foundation/meta/tests/test_preprocessor.cpp
+++ b/src/appleseed/foundation/meta/tests/test_preprocessor.cpp
@@ -35,13 +35,12 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_Preprocessor)
 {
     TEST_CASE(Process_GivenEmptyString_ReturnsEmptyString)
     {
-        const string InputText = "";
+        const std::string InputText = "";
 
         Preprocessor preprocessor;
         preprocessor.process(InputText.c_str());
@@ -52,7 +51,7 @@ TEST_SUITE(Foundation_Utility_Preprocessor)
 
     TEST_CASE(Process_GivenPlainString_ReturnsInputString)
     {
-        const string InputText = "hello world";
+        const std::string InputText = "hello world";
 
         Preprocessor preprocessor;
         preprocessor.process(InputText.c_str());
@@ -63,7 +62,7 @@ TEST_SUITE(Foundation_Utility_Preprocessor)
 
     TEST_CASE(Process_GivenPlainMultilineString_ReturnsInputString)
     {
-        const string InputText =
+        const std::string InputText =
             "hello\n"
             "world";
 
@@ -76,7 +75,7 @@ TEST_SUITE(Foundation_Utility_Preprocessor)
 
     TEST_CASE(Process_GivenPlainStringWithLeadingEOL_ReturnsInputString)
     {
-        const string InputText = "\nhello world";
+        const std::string InputText = "\nhello world";
 
         Preprocessor preprocessor;
         preprocessor.process(InputText.c_str());
@@ -87,7 +86,7 @@ TEST_SUITE(Foundation_Utility_Preprocessor)
 
     TEST_CASE(Process_GivenPlainStringWithTrailingEOL_ReturnsInputString)
     {
-        const string InputText = "hello world\n";
+        const std::string InputText = "hello world\n";
 
         Preprocessor preprocessor;
         preprocessor.process(InputText.c_str());
@@ -98,7 +97,7 @@ TEST_SUITE(Foundation_Utility_Preprocessor)
 
     TEST_CASE(Process_GivenStringWithEOLOnly_ReturnsInputString)
     {
-        const string InputText = "\n\n\n";
+        const std::string InputText = "\n\n\n";
 
         Preprocessor preprocessor;
         preprocessor.process(InputText.c_str());
@@ -109,13 +108,13 @@ TEST_SUITE(Foundation_Utility_Preprocessor)
 
     TEST_CASE(Process_IfdefWithUndefinedSymbol_SkipsIfdefSection)
     {
-        const string InputText =
+        const std::string InputText =
             "#ifdef X\n"
             "ignore\n"
             "#endif\n"
             "more\n";
 
-        const string ExpectedText = "more\n";
+        const std::string ExpectedText = "more\n";
 
         Preprocessor preprocessor;
         preprocessor.process(InputText.c_str());
@@ -126,13 +125,13 @@ TEST_SUITE(Foundation_Utility_Preprocessor)
 
     TEST_CASE(Process_IfdefWithPredefinedSymbol_KeepsIfdefSection)
     {
-        const string InputText =
+        const std::string InputText =
             "#ifdef X\n"
             "keep\n"
             "#endif\n"
             "more\n";
 
-        const string ExpectedText =
+        const std::string ExpectedText =
             "keep\n"
             "more\n";
 
@@ -146,14 +145,14 @@ TEST_SUITE(Foundation_Utility_Preprocessor)
 
     TEST_CASE(Process_IfdefWithDefinedSymbol_KeepsIfdefSection)
     {
-        const string InputText =
+        const std::string InputText =
             "#define X\n"
             "#ifdef X\n"
             "keep\n"
             "#endif\n"
             "more\n";
 
-        const string ExpectedText =
+        const std::string ExpectedText =
             "keep\n"
             "more\n";
 
@@ -166,14 +165,14 @@ TEST_SUITE(Foundation_Utility_Preprocessor)
 
     TEST_CASE(Process_IfdefWithValuedSymbol_KeepsIfdefSection)
     {
-        const string InputText =
+        const std::string InputText =
             "#define X 42\n"
             "#ifdef X\n"
             "keep\n"
             "#endif\n"
             "more\n";
 
-        const string ExpectedText =
+        const std::string ExpectedText =
             "keep\n"
             "more\n";
 
@@ -186,13 +185,13 @@ TEST_SUITE(Foundation_Utility_Preprocessor)
 
     TEST_CASE(Process_SymbolDefinitionGuardedByIfDefWithFalseCondition_SymbolIsNotDefined)
     {
-        const string InputText =
+        const std::string InputText =
             "#ifdef X\n"
             "#define Y 42\n"
             "#endif\n"
             "Y";
 
-        const string ExpectedText = "Y";
+        const std::string ExpectedText = "Y";
 
         Preprocessor preprocessor;
         preprocessor.process(InputText.c_str());
@@ -203,19 +202,19 @@ TEST_SUITE(Foundation_Utility_Preprocessor)
 
     TEST_CASE(Process_UnknownKeyword_GeneratesError)
     {
-        const string InputText = "#stuff X Y";
+        const std::string InputText = "#stuff X Y";
 
         Preprocessor preprocessor;
         preprocessor.process(InputText.c_str());
 
         ASSERT_FALSE(preprocessor.succeeded());
-        EXPECT_EQ(string("Unknown directive: #stuff"), preprocessor.get_error_message());
+        EXPECT_EQ(std::string("Unknown directive: #stuff"), preprocessor.get_error_message());
         EXPECT_EQ(1, preprocessor.get_error_location());
     }
 
     TEST_CASE(Process_MissingEndIf_GeneratesError)
     {
-        const string InputText =
+        const std::string InputText =
             "#ifdef X\n"
             "keep\n";
 
@@ -223,18 +222,18 @@ TEST_SUITE(Foundation_Utility_Preprocessor)
         preprocessor.process(InputText.c_str());
 
         ASSERT_FALSE(preprocessor.succeeded());
-        EXPECT_EQ(string("Expected directive: #endif"), preprocessor.get_error_message());
+        EXPECT_EQ(std::string("Expected directive: #endif"), preprocessor.get_error_message());
         EXPECT_EQ(3, preprocessor.get_error_location());
     }
 
     TEST_CASE(Process_GivenSymbolsDefinitions_SubstitutesSymbolsWithValues)
     {
-        const string InputText =
+        const std::string InputText =
             "#define X 42\n"
             "#define Y bun\n"
             "foo X bar X Y Y\n";
 
-        const string ExpectedText =
+        const std::string ExpectedText =
             "foo 42 bar 42 bun bun\n";
 
         Preprocessor preprocessor;
@@ -246,11 +245,11 @@ TEST_SUITE(Foundation_Utility_Preprocessor)
 
     TEST_CASE(Process_GivenSymbolDefinition_OnySubstitutesSymbolsSurroundedByDelimiters)
     {
-        const string InputText =
+        const std::string InputText =
             "#define X 42\n"
             "X fooX\n";
 
-        const string ExpectedText =
+        const std::string ExpectedText =
             "42 fooX\n";
 
         Preprocessor preprocessor;
@@ -262,12 +261,12 @@ TEST_SUITE(Foundation_Utility_Preprocessor)
 
     TEST_CASE(Process_GivenSymbolDefinitionUsingAnotherSymbol_SubstitutesInChain)
     {
-        const string InputText =
+        const std::string InputText =
             "#define X 42\n"
             "#define Y X\n"
             "Y\n";
 
-        const string ExpectedText =
+        const std::string ExpectedText =
             "42\n";
 
         Preprocessor preprocessor;

--- a/src/appleseed/foundation/meta/tests/test_qmc.cpp
+++ b/src/appleseed/foundation/meta/tests/test_qmc.cpp
@@ -54,7 +54,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_QMC)
 {
@@ -216,7 +215,7 @@ TEST_SUITE(Foundation_Math_QMC)
 
     TEST_CASE(Generate2DRandomSequenceImage)
     {
-        vector<Vector2d> points;
+        std::vector<Vector2d> points;
         MersenneTwister rng;
 
         for (size_t i = 0; i < PointCount; ++i)
@@ -231,9 +230,9 @@ TEST_SUITE(Foundation_Math_QMC)
     }
 
     void apply_permutation(
-        const string&   permutation,
-        const size_t    size,
-        size_t          perm[])
+        const std::string&   permutation,
+        const size_t         size,
+        size_t               perm[])
     {
         if (permutation == "identity")
             identity_permutation(size, perm);
@@ -245,10 +244,10 @@ TEST_SUITE(Foundation_Math_QMC)
     }
 
     void generate_halton_sequence_image(
-        const size_t    b0,
-        const size_t    b1,
-        const string&   permutation,
-        const size_t    initial_instance = 0)
+        const size_t         b0,
+        const size_t         b1,
+        const std::string&   permutation,
+        const size_t         initial_instance = 0)
     {
         const size_t bases[2] = { b0, b1 };
 
@@ -256,12 +255,12 @@ TEST_SUITE(Foundation_Math_QMC)
         apply_permutation(permutation, b0, perms);
         apply_permutation(permutation, b1, perms + b0);
 
-        vector<Vector2d> points;
+        std::vector<Vector2d> points;
 
         for (size_t i = 0; i < PointCount; ++i)
             points.push_back(halton_sequence<double, 2>(bases, perms, initial_instance + i));
 
-        const string filename =
+        const std::string filename =
               "unit tests/outputs/test_qmc_halton_" + permutation + "_permuted_"
             + to_string(b0) + "_" + to_string(b1) + "_"
             + (initial_instance > 0 ? to_string(initial_instance) : "")
@@ -300,15 +299,15 @@ TEST_SUITE(Foundation_Math_QMC)
     }
 
     void generate_hammersley_sequence_image(
-        const size_t    b,
-        const string&   permutation)
+        const size_t         b,
+        const std::string&   permutation)
     {
         const size_t bases[1] = { b };
 
         size_t perms[100];
         apply_permutation(permutation, b, perms);
 
-        vector<Vector2d> points;
+        std::vector<Vector2d> points;
 
         for (size_t i = 0; i < PointCount; ++i)
             points.push_back(hammersley_sequence<double, 2>(bases, perms, PointCount, i));
@@ -348,7 +347,7 @@ TEST_SUITE(Foundation_Math_QMC)
     {
         const size_t bases[1] = { b };
 
-        vector<Vector2d> points;
+        std::vector<Vector2d> points;
 
         for (size_t i = 0; i < PointCount; ++i)
             points.push_back(hammersley_zaremba_sequence<double, 2>(bases, PointCount, i));
@@ -386,7 +385,7 @@ TEST_SUITE(Foundation_Math_QMC)
         // is scrambled with a distinct random value: the resulting sample set is
         // indistinguishable from what would be obtained using pure random sampling.
 
-        vector<Vector2d> points;
+        std::vector<Vector2d> points;
         MersenneTwister rng;
 
         for (size_t i = 0; i < PointCount; ++i)
@@ -538,8 +537,8 @@ TEST_SUITE(Foundation_Math_QMC)
         double rng_area = 0.0;
         double qmc_area = 0.0;
 
-        vector<Vector2d> rng_rmsd(SampleCount);
-        vector<Vector2d> qmc_rmsd(SampleCount);
+        std::vector<Vector2d> rng_rmsd(SampleCount);
+        std::vector<Vector2d> qmc_rmsd(SampleCount);
 
         for (size_t i = 0; i < SampleCount; ++i)
         {

--- a/src/appleseed/foundation/meta/tests/test_quaternion.cpp
+++ b/src/appleseed/foundation/meta/tests/test_quaternion.cpp
@@ -49,7 +49,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_Quaternion)
 {
@@ -156,7 +155,7 @@ TEST_SUITE(Foundation_Math_Quaternion)
         const Quaterniond q2 = Quaterniond::make_rotation(Vector3d(0.0, 0.0, 1.0), Pi<double>());
 
         const size_t PointCount = 1000;
-        vector<Vector2d> points;
+        std::vector<Vector2d> points;
 
         for (size_t i = 0; i < PointCount; ++i)
         {

--- a/src/appleseed/foundation/meta/tests/test_registrar.cpp
+++ b/src/appleseed/foundation/meta/tests/test_registrar.cpp
@@ -34,7 +34,6 @@
 #include "foundation/utility/test.h"
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_Registrar)
 {

--- a/src/appleseed/foundation/meta/tests/test_rng.cpp
+++ b/src/appleseed/foundation/meta/tests/test_rng.cpp
@@ -43,7 +43,6 @@
 #include <limits>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_RNG)
 {
@@ -276,7 +275,7 @@ TEST_SUITE(Foundation_Math_RNG)
 
         const float value = rand_float3(rng);
 
-        EXPECT_EQ(numeric_limits<float>::epsilon(), value);
+        EXPECT_EQ(std::numeric_limits<float>::epsilon(), value);
     }
 
     TEST_CASE(RandFloat3_Given0xFFFFFFFF_ReturnsAlmostOne)
@@ -316,7 +315,7 @@ TEST_SUITE(Foundation_Math_RNG)
 
         const double value = rand_double3(rng);
 
-        EXPECT_EQ(numeric_limits<double>::epsilon(), value);
+        EXPECT_EQ(std::numeric_limits<double>::epsilon(), value);
     }
 
     TEST_CASE(RandDouble3_Given0xFFFFFFFF_ReturnsAlmostOne)

--- a/src/appleseed/foundation/meta/tests/test_sampling.cpp
+++ b/src/appleseed/foundation/meta/tests/test_sampling.cpp
@@ -49,7 +49,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_Sampling_QMCSamplingContext)
 {
@@ -141,7 +140,7 @@ TEST_SUITE(Foundation_Math_Sampling_QMCSamplingContext_DirectIlluminationSimulat
     void shade(
         const SamplingContext&      context,
         const size_t                light_sample_count,
-        vector<Vector2d>&           light_samples)
+        std::vector<Vector2d>&           light_samples)
     {
         SamplingContext child_context = context.split(2, light_sample_count);
 
@@ -164,8 +163,8 @@ TEST_SUITE(Foundation_Math_Sampling_QMCSamplingContext_DirectIlluminationSimulat
             pixel_sample_count,
             0);
 
-        vector<Vector2d> pixel_samples;
-        vector<Vector2d> light_samples;
+        std::vector<Vector2d> pixel_samples;
+        std::vector<Vector2d> light_samples;
 
         for (size_t i = 0; i < pixel_sample_count; ++i)
         {
@@ -174,7 +173,7 @@ TEST_SUITE(Foundation_Math_Sampling_QMCSamplingContext_DirectIlluminationSimulat
             shade(sampling_context, light_sample_count, light_samples);
         }
 
-        const string filepath_prefix =
+        const std::string filepath_prefix =
             format("unit tests/outputs/test_sampling_P{0}_L{1}", pixel_sample_count, light_sample_count);
 
         write_point_cloud_image(filepath_prefix + "_pixel_samples.png", pixel_samples);
@@ -267,14 +266,14 @@ TEST_SUITE(Foundation_Math_Sampling_Mappings)
 
     template <typename SamplingFunction>
     void visualize_2d_function_as_image_regular(
-        const string&       filename,
-        SamplingFunction&   sampling_function,
-        const size_t        point_count)
+        const std::string&       filename,
+        SamplingFunction&        sampling_function,
+        const size_t             point_count)
     {
         const size_t grid_size = truncate<size_t>(ceil(sqrt(static_cast<double>(point_count))));
         const double AlmostOne = shift(1.0, -1);
 
-        vector<Vector2d> points;
+        std::vector<Vector2d> points;
         points.reserve(grid_size * grid_size);
 
         for (size_t y = 0; y < grid_size; ++y)
@@ -295,11 +294,11 @@ TEST_SUITE(Foundation_Math_Sampling_Mappings)
 
     template <typename SamplingFunction>
     void visualize_2d_function_as_image_hammersley(
-        const string&       filename,
-        SamplingFunction&   sampling_function,
-        const size_t        point_count)
+        const std::string&       filename,
+        SamplingFunction&        sampling_function,
+        const size_t             point_count)
     {
-        vector<Vector2d> points(point_count);
+        std::vector<Vector2d> points(point_count);
 
         for (size_t i = 0; i < point_count; ++i)
         {
@@ -315,11 +314,11 @@ TEST_SUITE(Foundation_Math_Sampling_Mappings)
 
     template <typename SamplingFunction>
     void visualize_2d_function_as_image_halton(
-        const string&       filename,
-        SamplingFunction&   sampling_function,
-        const size_t        point_count)
+        const std::string&       filename,
+        SamplingFunction&        sampling_function,
+        const size_t             point_count)
     {
-        vector<Vector2d> points(point_count);
+        std::vector<Vector2d> points(point_count);
 
         for (size_t i = 0; i < point_count; ++i)
         {
@@ -335,11 +334,11 @@ TEST_SUITE(Foundation_Math_Sampling_Mappings)
 
     template <typename SamplingFunction>
     void visualize_3d_function_as_vpython_program(
-        const string&       filename,
-        SamplingFunction&   sampling_function,
-        const size_t        point_count)
+        const std::string&       filename,
+        SamplingFunction&        sampling_function,
+        const size_t             point_count)
     {
-        vector<Vector3d> points(point_count);
+        std::vector<Vector3d> points(point_count);
 
         for (size_t i = 0; i < point_count; ++i)
         {

--- a/src/appleseed/foundation/meta/tests/test_sampling.cpp
+++ b/src/appleseed/foundation/meta/tests/test_sampling.cpp
@@ -140,7 +140,7 @@ TEST_SUITE(Foundation_Math_Sampling_QMCSamplingContext_DirectIlluminationSimulat
     void shade(
         const SamplingContext&      context,
         const size_t                light_sample_count,
-        std::vector<Vector2d>&           light_samples)
+        std::vector<Vector2d>&      light_samples)
     {
         SamplingContext child_context = context.split(2, light_sample_count);
 

--- a/src/appleseed/foundation/meta/tests/test_scalar.cpp
+++ b/src/appleseed/foundation/meta/tests/test_scalar.cpp
@@ -37,7 +37,6 @@
 #include <limits>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_Scalar)
 {
@@ -534,12 +533,12 @@ TEST_SUITE(Foundation_Math_Scalar)
 
     TEST_CASE(Feq_ScalarScalar_Overflows)
     {
-        EXPECT_FALSE(feq(0.5 * numeric_limits<double>::max(), 0.1));
+        EXPECT_FALSE(feq(0.5 * std::numeric_limits<double>::max(), 0.1));
     }
 
     TEST_CASE(Feq_ScalarScalar_Underflows)
     {
-        EXPECT_FALSE(feq(2.0 * numeric_limits<double>::min(), 10.0));
+        EXPECT_FALSE(feq(2.0 * std::numeric_limits<double>::min(), 10.0));
     }
 
     TEST_CASE(Fz_Scalar_ReturnsTrue)

--- a/src/appleseed/foundation/meta/tests/test_searchpaths.cpp
+++ b/src/appleseed/foundation/meta/tests/test_searchpaths.cpp
@@ -60,7 +60,7 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
         const SearchPaths search_paths(TestEnvVarName, ';');
 
         const APIString result = search_paths.to_string(';');
-        EXPECT_EQ("", std::to_string(result));
+        EXPECT_EQ("", to_string(result));
     }
 
     TEST_CASE(Constructor_NonEmptyEnvironmentVariable)
@@ -70,7 +70,7 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
         const SearchPaths search_paths(TestEnvVarName, ';');
 
         const APIString result = search_paths.to_string(';');
-        EXPECT_EQ("C:\\Windows\\System32;C:\\Windows;C:\\Program Files", std::to_string(result));
+        EXPECT_EQ("C:\\Windows\\System32;C:\\Windows;C:\\Program Files", to_string(result));
     }
 
     TEST_CASE(ClearExplicitPaths)
@@ -84,7 +84,7 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
         search_paths.clear_explicit_paths();
 
         const APIString result = search_paths.to_string(';');
-        EXPECT_EQ("C:\\Some\\Root\\Path;C:\\Windows\\System32;C:\\Windows;C:\\Program Files", std::to_string(result));
+        EXPECT_EQ("C:\\Some\\Root\\Path;C:\\Windows\\System32;C:\\Windows;C:\\Program Files", to_string(result));
     }
 
     TEST_CASE(ToString)
@@ -96,7 +96,7 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
 
         const APIString result = search_paths.to_string(';');
 
-        EXPECT_EQ("C:\\Windows\\System32;C:\\Windows;C:\\Program Files", std::to_string(result));
+        EXPECT_EQ("C:\\Windows\\System32;C:\\Windows;C:\\Program Files", to_string(result));
     }
 
     TEST_CASE(ToStringReversed)
@@ -108,7 +108,7 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
 
         const APIString result = search_paths.to_string_reversed(';');
 
-        EXPECT_EQ("C:\\Program Files;C:\\Windows;C:\\Windows\\System32", std::to_string(result));
+        EXPECT_EQ("C:\\Program Files;C:\\Windows;C:\\Windows\\System32", to_string(result));
     }
 
 #else

--- a/src/appleseed/foundation/meta/tests/test_searchpaths.cpp
+++ b/src/appleseed/foundation/meta/tests/test_searchpaths.cpp
@@ -37,7 +37,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_SearchPaths)
 {
@@ -61,7 +60,7 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
         const SearchPaths search_paths(TestEnvVarName, ';');
 
         const APIString result = search_paths.to_string(';');
-        EXPECT_EQ("", to_string(result));
+        EXPECT_EQ("", std::to_string(result));
     }
 
     TEST_CASE(Constructor_NonEmptyEnvironmentVariable)
@@ -71,7 +70,7 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
         const SearchPaths search_paths(TestEnvVarName, ';');
 
         const APIString result = search_paths.to_string(';');
-        EXPECT_EQ("C:\\Windows\\System32;C:\\Windows;C:\\Program Files", to_string(result));
+        EXPECT_EQ("C:\\Windows\\System32;C:\\Windows;C:\\Program Files", std::to_string(result));
     }
 
     TEST_CASE(ClearExplicitPaths)
@@ -85,7 +84,7 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
         search_paths.clear_explicit_paths();
 
         const APIString result = search_paths.to_string(';');
-        EXPECT_EQ("C:\\Some\\Root\\Path;C:\\Windows\\System32;C:\\Windows;C:\\Program Files", to_string(result));
+        EXPECT_EQ("C:\\Some\\Root\\Path;C:\\Windows\\System32;C:\\Windows;C:\\Program Files", std::to_string(result));
     }
 
     TEST_CASE(ToString)
@@ -97,7 +96,7 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
 
         const APIString result = search_paths.to_string(';');
 
-        EXPECT_EQ("C:\\Windows\\System32;C:\\Windows;C:\\Program Files", to_string(result));
+        EXPECT_EQ("C:\\Windows\\System32;C:\\Windows;C:\\Program Files", std::to_string(result));
     }
 
     TEST_CASE(ToStringReversed)
@@ -109,7 +108,7 @@ TEST_SUITE(Foundation_Utility_SearchPaths)
 
         const APIString result = search_paths.to_string_reversed(';');
 
-        EXPECT_EQ("C:\\Program Files;C:\\Windows;C:\\Windows\\System32", to_string(result));
+        EXPECT_EQ("C:\\Program Files;C:\\Windows;C:\\Windows\\System32", std::to_string(result));
     }
 
 #else

--- a/src/appleseed/foundation/meta/tests/test_seexpr.cpp
+++ b/src/appleseed/foundation/meta/tests/test_seexpr.cpp
@@ -34,7 +34,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_SeExpr_SeExprFilePathExtractor)
 {
@@ -99,7 +98,7 @@ TEST_SUITE(Foundation_Utility_SeExpr_SeExprFilePathExtractor)
         SeExprFilePathExtractor::MappingCollection mappings;
         mappings["/path/to/file.exr"] = "/bruce/lee.exr";
 
-        const string result =
+        const std::string result =
             extractor.replace_paths("texture(\"/path/to/file.exr\", $u, $v)", mappings);
 
         ASSERT_EQ("texture(\"/bruce/lee.exr\", $u, $v)", result);
@@ -111,7 +110,7 @@ TEST_SUITE(Foundation_Utility_SeExpr_SeExprFilePathExtractor)
         SeExprFilePathExtractor::MappingCollection mappings;
         mappings["/path/to/file.exr"] = "/bruce/lee.exr";
 
-        const string result =
+        const std::string result =
             extractor.replace_paths("texture(\"/path/to/file.exr\", $u, $v) * texture(\"/path/to/file.exr\", $u, $v)", mappings);
 
         ASSERT_EQ("texture(\"/bruce/lee.exr\", $u, $v) * texture(\"/bruce/lee.exr\", $u, $v)", result);

--- a/src/appleseed/foundation/meta/tests/test_settings.cpp
+++ b/src/appleseed/foundation/meta/tests/test_settings.cpp
@@ -38,7 +38,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_SettingsFileReader)
 {
@@ -79,7 +78,7 @@ TEST_SUITE(Foundation_Utility_SettingsFileReader)
         ASSERT_EQ(2, m_dictionary.strings().size());
 
         EXPECT_EQ(42, m_dictionary.get<int>("x"));
-        EXPECT_EQ("foo", m_dictionary.get<string>("y"));
+        EXPECT_EQ("foo", m_dictionary.get<std::string>("y"));
     }
 
     TEST_CASE_F(Read_GivenSettingsFileWithTwoDictionaryParameters_ReturnsDictionaryWithTwoDictionaryParameters, Fixture)
@@ -92,11 +91,11 @@ TEST_SUITE(Foundation_Utility_SettingsFileReader)
 
         const Dictionary& sub1 = m_dictionary.dictionaries().get("sub1");
         EXPECT_EQ(42, sub1.get<int>("x"));
-        EXPECT_EQ("foo", sub1.get<string>("y"));
+        EXPECT_EQ("foo", sub1.get<std::string>("y"));
 
         const Dictionary& sub2 = m_dictionary.dictionaries().get("sub2");
-        EXPECT_EQ("aa", sub2.get<string>("a"));
-        EXPECT_EQ("bb", sub2.get<string>("b"));
+        EXPECT_EQ("aa", sub2.get<std::string>("a"));
+        EXPECT_EQ("bb", sub2.get<std::string>("b"));
     }
 
     TEST_CASE_F(Read_GivenSettingsFileWithNewlinesInParameters_ReturnsDictionaryWithNewlinesInParameters, Fixture)
@@ -107,8 +106,8 @@ TEST_SUITE(Foundation_Utility_SettingsFileReader)
         ASSERT_EQ(2, m_dictionary.strings().size());
         ASSERT_EQ(0, m_dictionary.dictionaries().size());
 
-        EXPECT_EQ("aa", m_dictionary.get<string>("a"));
-        EXPECT_EQ("bb\nbb\nbb", m_dictionary.get<string>("b"));
+        EXPECT_EQ("aa", m_dictionary.get<std::string>("a"));
+        EXPECT_EQ("bb\nbb\nbb", m_dictionary.get<std::string>("b"));
     }
 }
 

--- a/src/appleseed/foundation/meta/tests/test_siphash.cpp
+++ b/src/appleseed/foundation/meta/tests/test_siphash.cpp
@@ -36,7 +36,6 @@
 #include <cstring>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_SipHash)
 {

--- a/src/appleseed/foundation/meta/tests/test_snprintf.cpp
+++ b/src/appleseed/foundation/meta/tests/test_snprintf.cpp
@@ -113,7 +113,7 @@ TEST_SUITE(Foundation_Platform_Snprintf)
         char buf[100];
         const int result = portable_snprintf(buf, sizeof(buf), "%Iu", MaxSizeTValue);
 
-        EXPECT_EQ(MaxSizeTValueString, string(buf));
+        EXPECT_EQ(MaxSizeTValueString, std::string(buf));
     }
 
 #endif

--- a/src/appleseed/foundation/meta/tests/test_snprintf.cpp
+++ b/src/appleseed/foundation/meta/tests/test_snprintf.cpp
@@ -37,7 +37,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Platform_Snprintf)
 {
@@ -101,7 +100,7 @@ TEST_SUITE(Foundation_Platform_Snprintf)
         char buf[100];
         portable_snprintf(buf, sizeof(buf), "%zu", MaxSizeTValue);
 
-        EXPECT_EQ(MaxSizeTValueString, string(buf));
+        EXPECT_EQ(MaxSizeTValueString, std::string(buf));
     }
 
 #ifdef _MSC_VER

--- a/src/appleseed/foundation/meta/tests/test_spline.cpp
+++ b/src/appleseed/foundation/meta/tests/test_spline.cpp
@@ -39,13 +39,12 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_Spline)
 {
-    vector<Vector2d> zip(const double x[], const double y[], const size_t count)
+    std::vector<Vector2d> zip(const double x[], const double y[], const size_t count)
     {
-        vector<Vector2d> points(count);
+        std::vector<Vector2d> points(count);
 
         for (size_t i = 0; i < count; ++i)
         {
@@ -59,7 +58,7 @@ TEST_SUITE(Foundation_Math_Spline)
     TEST_CASE(GeneratePlotFiles)
     {
         // Define knots.
-        vector<double> knot_x, knot_y;
+        std::vector<double> knot_x, knot_y;
         knot_x.push_back(  0.0);  knot_y.push_back(0.0);
         knot_x.push_back( 50.0);  knot_y.push_back(1.0);
         knot_x.push_back(100.0);  knot_y.push_back(0.0);
@@ -68,7 +67,7 @@ TEST_SUITE(Foundation_Math_Spline)
         const size_t N = 1000;
         const double b = knot_x.front();
         const double e = knot_x.back();
-        vector<double> point_x;
+        std::vector<double> point_x;
         for (size_t i = 0; i < N; ++i)
             point_x.push_back(fit<size_t, double>(i, 0, N - 1, b, e));
 
@@ -91,8 +90,8 @@ TEST_SUITE(Foundation_Math_Spline)
 
         // Tension = 0.0
         {
-            vector<double> knot_d(knot_x.size());
-            vector<double> point_y(point_x.size());
+            std::vector<double> knot_d(knot_x.size());
+            std::vector<double> point_y(point_x.size());
 
             compute_cardinal_spline_tangents(
                 knot_x.size(),
@@ -119,8 +118,8 @@ TEST_SUITE(Foundation_Math_Spline)
 
         // Tension = 0.5
         {
-            vector<double> knot_d(knot_x.size());
-            vector<double> point_y(point_x.size());
+            std::vector<double> knot_d(knot_x.size());
+            std::vector<double> point_y(point_x.size());
 
             compute_cardinal_spline_tangents(
                 knot_x.size(),
@@ -147,8 +146,8 @@ TEST_SUITE(Foundation_Math_Spline)
 
         // Tension = 1.0
         {
-            vector<double> knot_d(knot_x.size());
-            vector<double> point_y(point_x.size());
+            std::vector<double> knot_d(knot_x.size());
+            std::vector<double> point_y(point_x.size());
 
             compute_cardinal_spline_tangents(
                 knot_x.size(),

--- a/src/appleseed/foundation/meta/tests/test_stampedptr.cpp
+++ b/src/appleseed/foundation/meta/tests/test_stampedptr.cpp
@@ -35,7 +35,6 @@
 #include <memory>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_StampedPtr)
 {
@@ -53,7 +52,7 @@ TEST_SUITE(Foundation_Utility_StampedPtr)
 
     TEST_CASE(TestWithHeapPointer)
     {
-        const unique_ptr<int> ptr(new int(11));
+        const std::unique_ptr<int> ptr(new int(11));
         const uint16 stamp = 7;
 
         stamped_ptr<const int> x(ptr.get(), stamp);

--- a/src/appleseed/foundation/meta/tests/test_statistics.cpp
+++ b/src/appleseed/foundation/meta/tests/test_statistics.cpp
@@ -38,7 +38,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_Statistics)
 {
@@ -71,7 +70,7 @@ TEST_SUITE(Foundation_Utility_Statistics)
     {
         Statistics stats;
 
-        stats.insert<string>("some value", "bunny");
+        stats.insert<std::string>("some value", "bunny");
 
         EXPECT_EQ("  some value                    bunny", stats.to_string());
     }

--- a/src/appleseed/foundation/meta/tests/test_stlallocatortestbed.cpp
+++ b/src/appleseed/foundation/meta/tests/test_stlallocatortestbed.cpp
@@ -50,7 +50,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(StlAllocatorTestbed)
 {

--- a/src/appleseed/foundation/meta/tests/test_string.cpp
+++ b/src/appleseed/foundation/meta/tests/test_string.cpp
@@ -47,7 +47,6 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Utility_String)
 {
@@ -403,22 +402,22 @@ TEST_SUITE(Foundation_Utility_String)
         EXPECT_TRUE(ends_with("world", "world"));
     }
 
-    vector<string> tokenize_wrapper(
-        const string&   s,
-        const string&   delimiters)
+    std::vector<std::string> tokenize_wrapper(
+        const std::string&   s,
+        const std::string&   delimiters)
     {
-        vector<string> vec;
+        std::vector<std::string> vec;
         tokenize(s, delimiters, vec);
         return vec;
     }
 
     TEST_CASE(TestTokenize)
     {
-        EXPECT_EQ(vector<string>(), tokenize_wrapper("", "\n"));
+        EXPECT_EQ(std::vector<std::string>(), tokenize_wrapper("", "\n"));
 
-        EXPECT_EQ(vector<string>(), tokenize_wrapper("\n", "\n"));
-        EXPECT_EQ(vector<string>(), tokenize_wrapper("\n\n", "\n"));
-        EXPECT_EQ(vector<string>(), tokenize_wrapper("\n\n\n", "\n"));
+        EXPECT_EQ(std::vector<std::string>(), tokenize_wrapper("\n", "\n"));
+        EXPECT_EQ(std::vector<std::string>(), tokenize_wrapper("\n\n", "\n"));
+        EXPECT_EQ(std::vector<std::string>(), tokenize_wrapper("\n\n\n", "\n"));
 
         EXPECT_EQ(make_vector("hello"), tokenize_wrapper("hello", "\n"));
         EXPECT_EQ(make_vector("hello"), tokenize_wrapper("hello\n", "\n"));
@@ -435,11 +434,11 @@ TEST_SUITE(Foundation_Utility_String)
         EXPECT_EQ(make_vector("1", "2", "3"), tokenize_wrapper("  [1, 2 ,3 ] ", ",[] "));
     }
 
-    vector<string> split_wrapper(
-        const string&   s,
-        const string&   delimiters)
+    std::vector<std::string> split_wrapper(
+        const std::string&   s,
+        const std::string&   delimiters)
     {
-        vector<string> vec;
+        std::vector<std::string> vec;
         split(s, delimiters, vec);
         return vec;
     }
@@ -467,77 +466,77 @@ TEST_SUITE(Foundation_Utility_String)
 
     TEST_CASE(Replace_GivenEmptyString_ReturnsEmptyString)
     {
-        const string result = replace("", "aa", "bbb");
+        const std::string result = replace("", "aa", "bbb");
 
         EXPECT_EQ("", result);
     }
 
     TEST_CASE(Replace_GivenNonMatchingString_ReturnsInputString)
     {
-        const string result = replace("xyz", "aa", "bbb");
+        const std::string result = replace("xyz", "aa", "bbb");
 
         EXPECT_EQ("xyz", result);
     }
 
     TEST_CASE(Replace_GivenPartiallyMatchingString_ReturnsInputString)
     {
-        const string result = replace("axyz", "aa", "bbb");
+        const std::string result = replace("axyz", "aa", "bbb");
 
         EXPECT_EQ("axyz", result);
     }
 
     TEST_CASE(Replace_GivenStringWithSingleMatch_ReplacesMatch)
     {
-        const string result = replace("xyaaz", "aa", "bbb");
+        const std::string result = replace("xyaaz", "aa", "bbb");
 
         EXPECT_EQ("xybbbz", result);
     }
 
     TEST_CASE(Replace_GivenStringWithMultipleMatches_ReplacesMatches)
     {
-        const string result = replace("xaayaaz", "aa", "bbb");
+        const std::string result = replace("xaayaaz", "aa", "bbb");
 
         EXPECT_EQ("xbbbybbbz", result);
     }
 
     TEST_CASE(Replace_GivenStringWithMatchAtTheBeginning_ReplacesMatch)
     {
-        const string result = replace("aaxyz", "aa", "bbb");
+        const std::string result = replace("aaxyz", "aa", "bbb");
 
         EXPECT_EQ("bbbxyz", result);
     }
 
     TEST_CASE(Replace_GivenStringWithMatchAtTheEnd_ReplacesMatch)
     {
-        const string result = replace("xyzaa", "aa", "bbb");
+        const std::string result = replace("xyzaa", "aa", "bbb");
 
         EXPECT_EQ("xyzbbb", result);
     }
 
     TEST_CASE(Format_GivenStringWithoutPlaceholders_ReturnsString)
     {
-        const string result = format("hello", "world");
+        const std::string result = format("hello", "world");
 
         EXPECT_EQ("hello", result);
     }
 
     TEST_CASE(Format_GivenStringWithSinglePlaceholder_ReturnsFormattedString)
     {
-        const string result = format("hello {0}", "world");
+        const std::string result = format("hello {0}", "world");
 
         EXPECT_EQ("hello world", result);
     }
 
     TEST_CASE(Format_GivenStringWithSinglePlaceholderRepeatedTwice_ReturnsFormattedString)
     {
-        const string result = format("{0} hello {0}", "yay");
+        const std::string result = format("{0} hello {0}", "yay");
 
         EXPECT_EQ("yay hello yay", result);
     }
 
     TEST_CASE(Format_GivenStringWithFourPlaceholders_ReturnsFormattedString)
     {
-        const string result = format("{3} {2} {1} {0} {1} {2} {3}", "a", "b", "c", "d");
+        const std::string result = format("{3} {2} {1} {0} {1} {2} {3}", "a", "b", "c", "d");
 
         EXPECT_EQ("d c b a b c d", result);
     }
@@ -579,84 +578,84 @@ TEST_SUITE(Foundation_Utility_String)
 
     TEST_CASE(GetNumberedString_GivenEmptyPattern_ReturnsEmptyString)
     {
-        const string result = get_numbered_string("", 12);
+        const std::string result = get_numbered_string("", 12);
 
         EXPECT_EQ("", result);
     }
 
     TEST_CASE(GetNumberedString_GivenPatternWithoutHashes_ReturnsPatternUnmodified)
     {
-        const string result = get_numbered_string("hello", 12);
+        const std::string result = get_numbered_string("hello", 12);
 
         EXPECT_EQ("hello", result);
     }
 
     TEST_CASE(GetNumberedString_GivenPatternWithSingleHashAtTheBeginning_GivenSingleDigitValue_ReplacesHashByValue)
     {
-        const string result = get_numbered_string("#hello", 5);
+        const std::string result = get_numbered_string("#hello", 5);
 
         EXPECT_EQ("5hello", result);
     }
 
     TEST_CASE(GetNumberedString_GivenPatternWithSingleHashInTheMiddle_GivenSingleDigitValue_ReplacesHashByValue)
     {
-        const string result = get_numbered_string("he#llo", 5);
+        const std::string result = get_numbered_string("he#llo", 5);
 
         EXPECT_EQ("he5llo", result);
     }
 
     TEST_CASE(GetNumberedString_GivenPatternWithSingleHashAtTheEnd_GivenSingleDigitValue_ReplacesHashByValue)
     {
-        const string result = get_numbered_string("hello#", 5);
+        const std::string result = get_numbered_string("hello#", 5);
 
         EXPECT_EQ("hello5", result);
     }
 
     TEST_CASE(GetNumberedString_GivenPatternWithThreeHashes_GivenSingleDigitValue_ReplacesHashesByValue)
     {
-        const string result = get_numbered_string("hel###lo", 5);
+        const std::string result = get_numbered_string("hel###lo", 5);
 
         EXPECT_EQ("hel005lo", result);
     }
 
     TEST_CASE(GetNumberedString_GivenPatternWithThreeHashes_GivenTwoDigitsValue_ReplacesHashesByValue)
     {
-        const string result = get_numbered_string("hello###", 12);
+        const std::string result = get_numbered_string("hello###", 12);
 
         EXPECT_EQ("hello012", result);
     }
 
     TEST_CASE(GetNumberedString_GivenPatternWithThreeHashes_GivenFourDigitsValue_ReplacesHashesByValue)
     {
-        const string result = get_numbered_string("hello###", 1234);
+        const std::string result = get_numbered_string("hello###", 1234);
 
         EXPECT_EQ("hello1234", result);
     }
 
     TEST_CASE(ReplaceSpecialXMLCharacters_GivenEmptyString_ReturnsEmptyString)
     {
-        const string result = replace_special_xml_characters("");
+        const std::string result = replace_special_xml_characters("");
 
         EXPECT_EQ("", result);
     }
 
     TEST_CASE(ReplaceSpecialXMLCharacters_GivenStringWithAmpersand_ReplacesAmpersandByEntity)
     {
-        const string result = replace_special_xml_characters("aa&bb");
+        const std::string result = replace_special_xml_characters("aa&bb");
 
         EXPECT_EQ("aa&amp;bb", result);
     }
 
     TEST_CASE(ReplaceSpecialXMLCharacters_GivenStringWithQuoteThenAmpersand_ReplacesQuoteAndAmpersandByEntities)
     {
-        const string result = replace_special_xml_characters("aa\"&bb");
+        const std::string result = replace_special_xml_characters("aa\"&bb");
 
         EXPECT_EQ("aa&quot;&amp;bb", result);
     }
 
     TEST_CASE(ReplaceSpecialXMLCharacters_GivenStringWithXMLEntity_ReplacesAmpersandByEntity)
     {
-        const string result = replace_special_xml_characters("aa&amp;bb");
+        const std::string result = replace_special_xml_characters("aa&amp;bb");
 
         EXPECT_EQ("aa&amp;amp;bb", result);
     }
@@ -783,56 +782,56 @@ TEST_SUITE(Foundation_Utility_String)
 
     TEST_CASE(MakeSafeFilename_GivenSafeFilename_ReturnsFilenameUnchanged)
     {
-        const string result = make_safe_filename("hello-world_42.txt");
+        const std::string result = make_safe_filename("hello-world_42.txt");
 
         EXPECT_EQ("hello-world_42.txt", result);
     }
 
     TEST_CASE(MakeSafeFilename_GivenUnsafeFilename_ReturnsSafeFilename)
     {
-        const string result = make_safe_filename("hello/world !.txt");
+        const std::string result = make_safe_filename("hello/world !.txt");
 
         EXPECT_EQ("hello_world__.txt", result);
     }
 
     TEST_CASE(Capitalize_GivenEmptyString_ReturnsEmptyString)
     {
-        const string result = capitalize("");
+        const std::string result = capitalize("");
 
         EXPECT_EQ("", result);
     }
 
     TEST_CASE(Capitalize_GivenBlankString_ReturnsInputString)
     {
-        const string result = capitalize(" ");
+        const std::string result = capitalize(" ");
 
         EXPECT_EQ(" ", result);
     }
 
     TEST_CASE(Capitalize_GivenSingleWord_ReturnsCapitalizedWord)
     {
-        const string result = capitalize("aB");
+        const std::string result = capitalize("aB");
 
         EXPECT_EQ("Ab", result);
     }
 
     TEST_CASE(Capitalize_GivenTwoWords_ReturnsCapitalizedWords)
     {
-        const string result = capitalize("aB c");
+        const std::string result = capitalize("aB c");
 
         EXPECT_EQ("Ab C", result);
     }
 
     TEST_CASE(Capitalize_GivenSingleWordSurroundedByBlanks_ReturnsInputStringWithCapitalizedWord)
     {
-        const string result = capitalize(" heLLo ");
+        const std::string result = capitalize(" heLLo ");
 
         EXPECT_EQ(" Hello ", result);
     }
 
     TEST_CASE(Capitalize_GivenTwoWordsSurroundedByBlanks_ReturnsInputStringWithCapitalizedWords)
     {
-        const string result = capitalize(" hello CUTE carrot ");
+        const std::string result = capitalize(" hello CUTE carrot ");
 
         EXPECT_EQ(" Hello Cute Carrot ", result);
     }

--- a/src/appleseed/foundation/meta/tests/test_vector.cpp
+++ b/src/appleseed/foundation/meta/tests/test_vector.cpp
@@ -43,7 +43,6 @@
 #include <cmath>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_Vector)
 {

--- a/src/appleseed/foundation/meta/tests/test_voxelgrid.cpp
+++ b/src/appleseed/foundation/meta/tests/test_voxelgrid.cpp
@@ -43,7 +43,6 @@
 #include <cstddef>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Math_VoxelGrid3)
 {
@@ -404,8 +403,8 @@ TEST_SUITE(Foundation_Math_VoxelGrid3)
 
                 const size_t tx0 = truncate<size_t>(fx);
                 const size_t ty0 = truncate<size_t>(fy);
-                const size_t tx1 = min<size_t>(tx0 + 1, SourceWidth - 1);
-                const size_t ty1 = min<size_t>(ty0 + 1, SourceHeight - 1);
+                const size_t tx1 = std::min<size_t>(tx0 + 1, SourceWidth - 1);
+                const size_t ty1 = std::min<size_t>(ty0 + 1, SourceHeight - 1);
 
                 const float wx1 = fx - tx0;
                 const float wy1 = fy - ty0;

--- a/src/appleseed/foundation/meta/tests/test_windows.cpp
+++ b/src/appleseed/foundation/meta/tests/test_windows.cpp
@@ -36,35 +36,34 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Platform_Windows)
 {
     TEST_CASE(GetLastWindowsErrorMessage_LastErrorCodeIsSuccess_MessageIsNotEmpty)
     {
         SetLastError(ERROR_SUCCESS);
-        const string msg = get_last_windows_error_message();
+        const std::string msg = get_last_windows_error_message();
         EXPECT_FALSE(msg.empty());
     }
 
     TEST_CASE(GetLastWindowsErrorMessageWide_LastErrorCodeIsSuccess_MessageIsNotEmpty)
     {
         SetLastError(ERROR_SUCCESS);
-        const wstring msg = get_last_windows_error_message_wide();
+        const std::wstring msg = get_last_windows_error_message_wide();
         EXPECT_FALSE(msg.empty());
     }
 
     TEST_CASE(GetLastWindowsErrorMessage_LastErrorCodeIsFileNotFound_MessageIsNotEmpty)
     {
         SetLastError(ERROR_FILE_NOT_FOUND);
-        const string msg = get_last_windows_error_message();
+        const std::string msg = get_last_windows_error_message();
         EXPECT_FALSE(msg.empty());
     }
 
     TEST_CASE(GetLastWindowsErrorMessageWide_LastErrorCodeIsFileNotFound_MessageIsNotEmpty)
     {
         SetLastError(ERROR_FILE_NOT_FOUND);
-        const wstring msg = get_last_windows_error_message_wide();
+        const std::wstring msg = get_last_windows_error_message_wide();
         EXPECT_FALSE(msg.empty());
     }
 }

--- a/src/appleseed/foundation/meta/tests/test_zip.cpp
+++ b/src/appleseed/foundation/meta/tests/test_zip.cpp
@@ -41,14 +41,13 @@
 #include <vector>
 
 using namespace foundation;
-using namespace std;
 namespace bf = boost::filesystem;
 
 TEST_SUITE(Foundation_Utility_Zip)
 {
     TEST_CASE(Unzip)
     {
-        const string TargetDirectory = "unit tests/outputs/test_zip/";
+        const std::string TargetDirectory = "unit tests/outputs/test_zip/";
 
         try
         {
@@ -59,7 +58,7 @@ TEST_SUITE(Foundation_Utility_Zip)
             EXPECT_TRUE(bf::exists(TargetDirectory));
             EXPECT_FALSE(bf::is_empty(TargetDirectory));
 
-            const string ExpectedFiles[] =
+            const std::string ExpectedFiles[] =
             {
                 "subfolder/a.txt",
                 "subfolder/b.txt",
@@ -67,14 +66,14 @@ TEST_SUITE(Foundation_Utility_Zip)
                 "d.png"
             };
 
-            const set<string> actual_files = recursive_ls(TargetDirectory);
+            const std::set<std::string> actual_files = recursive_ls(TargetDirectory);
 
             for (size_t i = 0; i < countof(ExpectedFiles); ++i)
                 EXPECT_EQ(1, actual_files.count(ExpectedFiles[i]));
 
             bf::remove_all(TargetDirectory);
         }
-        catch (const exception& e)
+        catch (const std::exception& e)
         {
             bf::remove_all(TargetDirectory);
             throw e;
@@ -83,9 +82,9 @@ TEST_SUITE(Foundation_Utility_Zip)
 
     TEST_CASE(ZipUnzipRoundtrip)
     {
-        const string InitialDirectory = "unit tests/inputs/test_zip";
-        const string TargetZip = "unit tests/outputs/test_zip.zip";
-        const string TargetDirectory = "unit tests/outputs/test_zip";
+        const std::string InitialDirectory = "unit tests/inputs/test_zip";
+        const std::string TargetZip = "unit tests/outputs/test_zip.zip";
+        const std::string TargetDirectory = "unit tests/outputs/test_zip";
 
         try
         {
@@ -96,18 +95,18 @@ TEST_SUITE(Foundation_Utility_Zip)
             zip(TargetZip, InitialDirectory);
             unzip(TargetZip, TargetDirectory);
 
-            const set<string> expected_files = recursive_ls(InitialDirectory);
-            const set<string> actual_files = recursive_ls(TargetDirectory);
+            const std::set<std::string> expected_files = recursive_ls(InitialDirectory);
+            const std::set<std::string> actual_files = recursive_ls(TargetDirectory);
 
             ASSERT_EQ(expected_files.size(), actual_files.size());
 
-            for (set<string>::iterator it = actual_files.begin(); it != actual_files.end(); ++it)
+            for (std::set<std::string>::iterator it = actual_files.begin(); it != actual_files.end(); ++it)
                 EXPECT_EQ(1, expected_files.count(*it));
 
             bf::remove(TargetZip);
             bf::remove_all(TargetDirectory);
         }
-        catch (const exception& e)
+        catch (const std::exception& e)
         {
             bf::remove(TargetZip);
             bf::remove_all(TargetDirectory);
@@ -127,7 +126,7 @@ TEST_SUITE(Foundation_Utility_Zip)
 
     TEST_CASE(GetFilenamesWithExtensionFromZip)
     {
-        const vector<string> files =
+        const std::vector<std::string> files =
             get_filenames_with_extension_from_zip(
                 "unit tests/inputs/test_zip_validzipfile.zip",
                 ".txt");

--- a/src/appleseed/foundation/platform/console.cpp
+++ b/src/appleseed/foundation/platform/console.cpp
@@ -41,7 +41,6 @@
 #include <cstdio>
 #include <iostream>
 
-using namespace std;
 
 namespace foundation
 {
@@ -63,7 +62,7 @@ void Console::wait_for_enter_keypress()
 
 void Console::pause()
 {
-    cout << "Press Enter to continue..." << endl;
+    std::cout << "Press Enter to continue..." << std::endl;
     wait_for_enter_keypress();
 }
 

--- a/src/appleseed/foundation/platform/defaulttimers.cpp
+++ b/src/appleseed/foundation/platform/defaulttimers.cpp
@@ -47,8 +47,6 @@
 #include <sys/time.h>
 #endif
 
-using namespace std;
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/platform/path.cpp
+++ b/src/appleseed/foundation/platform/path.cpp
@@ -52,7 +52,6 @@
 #include <unistd.h>
 #endif
 
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace foundation

--- a/src/appleseed/foundation/platform/sharedlibrary.cpp
+++ b/src/appleseed/foundation/platform/sharedlibrary.cpp
@@ -37,7 +37,6 @@
 #include <dlfcn.h>
 #endif
 
-using namespace std;
 
 namespace foundation
 {
@@ -50,7 +49,7 @@ ExceptionCannotLoadSharedLib::ExceptionCannotLoadSharedLib(
     const char* path,
     const char* error_msg)
 {
-    string err("Cannot load shared library ");
+    std::string err("Cannot load shared library ");
     err += path;
     err += ": ";
     err += error_msg;
@@ -66,7 +65,7 @@ ExceptionSharedLibCannotGetSymbol::ExceptionSharedLibCannotGetSymbol(
     const char* symbol_name,
     const char* error_msg)
 {
-    string err("Cannot get symbol ");
+    std::string err("Cannot get symbol ");
     err += symbol_name;
     err += ": ";
     err += error_msg;
@@ -80,7 +79,7 @@ ExceptionSharedLibCannotGetSymbol::ExceptionSharedLibCannotGetSymbol(
 
 ExceptionSharedLibNotFound::ExceptionSharedLibNotFound(const char* error_msg)
 {
-    string err("Cannot find shared library ");
+    std::string err("Cannot find shared library ");
     err += ". Error = ";
     err += error_msg;
     set_what(err.c_str());
@@ -93,7 +92,7 @@ ExceptionSharedLibNotFound::ExceptionSharedLibNotFound(const char* error_msg)
 
 namespace
 {
-    string get_last_error_message()
+    std::string get_last_error_message()
     {
 #ifdef _WIN32
         return get_last_windows_error_message();

--- a/src/appleseed/foundation/platform/sharedlibrary.cpp
+++ b/src/appleseed/foundation/platform/sharedlibrary.cpp
@@ -37,7 +37,6 @@
 #include <dlfcn.h>
 #endif
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/platform/system.cpp
+++ b/src/appleseed/foundation/platform/system.cpp
@@ -106,7 +106,6 @@
 
 #endif
 
-using namespace std;
 
 namespace foundation
 {
@@ -974,7 +973,7 @@ void System::print_information(Logger& logger)
     X86CPUFeatures features;
     detect_x86_cpu_features(features);
 
-    stringstream isabuilder;
+    std::stringstream isabuilder;
     if (features.m_hw_sse) isabuilder << "SSE ";
     if (features.m_hw_sse2) isabuilder << "SSE2 ";
     if (features.m_hw_sse3) isabuilder << "SSE3 ";
@@ -987,12 +986,12 @@ void System::print_information(Logger& logger)
     if (features.m_hw_fma3) isabuilder << "FMA3 ";
     if (features.m_hw_f16c) isabuilder << "F16C ";
 
-    const string isa =
+    const std::string isa =
         isabuilder.str().empty()
             ? "base instruction set"
             : trim_right(isabuilder.str());
 #else
-    const string isa = "base instruction set";
+    const std::string isa = "base instruction set";
 #endif
 
     // Can't use LOG_INFO() here because of the #ifdefs.
@@ -1100,7 +1099,7 @@ namespace
         return (xcr_feature_mask & 0xe6) == 0xe6;
     }
 
-    string get_vendor_string()
+    std::string get_vendor_string()
     {
         char vendor[13];
 
@@ -1126,7 +1125,7 @@ void System::detect_x86_cpu_features(X86CPUFeatures& features)
     memset(&features, 0, sizeof(features));
 
     // CPU vendor.
-    const string vendor = get_vendor_string();
+    const std::string vendor = get_vendor_string();
     features.m_vendor =
         vendor == "GenuineIntel" ? X86CPUFeatures::Vendor::Intel :
         vendor == "AuthenticAMD" ? X86CPUFeatures::Vendor::AMD :

--- a/src/appleseed/foundation/platform/win32stackwalker.cpp
+++ b/src/appleseed/foundation/platform/win32stackwalker.cpp
@@ -662,7 +662,7 @@ private:
     pGMI = (tGMI) GetProcAddress( hPsapi, "GetModuleInformation" );
     if ( (pEPM == NULL) || (pGMFNE == NULL) || (pGMBN == NULL) || (pGMI == NULL) )
     {
-      // we couldn´t find all functions
+      // we couldn't find all functions
       FreeLibrary(hPsapi);
       return FALSE;
     }

--- a/src/appleseed/foundation/platform/windows.cpp
+++ b/src/appleseed/foundation/platform/windows.cpp
@@ -34,7 +34,6 @@
 // Windows headers.
 #include <crtdbg.h>
 
-using namespace std;
 
 namespace foundation
 {

--- a/src/appleseed/foundation/platform/windows.cpp
+++ b/src/appleseed/foundation/platform/windows.cpp
@@ -34,7 +34,6 @@
 // Windows headers.
 #include <crtdbg.h>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/resources/logo/generatelogofiles.cpp
+++ b/src/appleseed/foundation/resources/logo/generatelogofiles.cpp
@@ -49,7 +49,6 @@
 
 namespace bf = boost::filesystem;
 using namespace foundation;
-using namespace std;
 
 TEST_SUITE(Foundation_Resources_Logos)
 {

--- a/src/appleseed/foundation/utility/api/apistring.cpp
+++ b/src/appleseed/foundation/utility/api/apistring.cpp
@@ -33,7 +33,6 @@
 #include <cassert>
 #include <cstring>
 
-using namespace std;
 
 namespace foundation
 {

--- a/src/appleseed/foundation/utility/api/specializedapiarrays.cpp
+++ b/src/appleseed/foundation/utility/api/specializedapiarrays.cpp
@@ -35,7 +35,6 @@
 #include <string>
 #include <vector>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/api/specializedapiarrays.cpp
+++ b/src/appleseed/foundation/utility/api/specializedapiarrays.cpp
@@ -35,7 +35,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 
 namespace foundation
 {
@@ -50,7 +49,7 @@ APPLESEED_DEFINE_APIARRAY(DictionaryArray);
 //
 
 struct StringArray::Impl
-  : public vector<string>
+  : public std::vector<std::string>
 {
 };
 

--- a/src/appleseed/foundation/utility/attributeset.cpp
+++ b/src/appleseed/foundation/utility/attributeset.cpp
@@ -33,7 +33,6 @@
 // Standard headers.
 #include <cstring>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/attributeset.cpp
+++ b/src/appleseed/foundation/utility/attributeset.cpp
@@ -33,7 +33,6 @@
 // Standard headers.
 #include <cstring>
 
-using namespace std;
 
 namespace foundation
 {
@@ -49,9 +48,9 @@ AttributeSet::~AttributeSet()
 }
 
 AttributeSet::ChannelID AttributeSet::create_channel(
-    const string&       name,
-    const NumericTypeID type,
-    const size_t        dimension)
+    const std::string&       name,
+    const NumericTypeID      type,
+    const size_t             dimension)
 {
     assert(dimension > 0);
 

--- a/src/appleseed/foundation/utility/benchmark/benchmarkaggregator.cpp
+++ b/src/appleseed/foundation/utility/benchmark/benchmarkaggregator.cpp
@@ -57,7 +57,6 @@
 #include <vector>
 
 using namespace boost;
-using namespace std;
 using namespace xercesc;
 namespace bf = boost::filesystem;
 
@@ -66,7 +65,7 @@ namespace foundation
 
 namespace
 {
-    Dictionary& push(Dictionary& dictionary, const string& name)
+    Dictionary& push(Dictionary& dictionary, const std::string& name)
     {
         if (!dictionary.dictionaries().exist(name))
             dictionary.dictionaries().insert(name, Dictionary());
@@ -90,7 +89,7 @@ struct BenchmarkAggregator::Impl
 
     const regex         m_filename_regex;
 
-    typedef map<UniqueID, BenchmarkSeries> SeriesMap;
+    typedef std::map<UniqueID, BenchmarkSeries> SeriesMap;
 
     Dictionary          m_benchmarks;
     SeriesMap           m_series;
@@ -117,7 +116,7 @@ struct BenchmarkAggregator::Impl
 
         const DOMNamedNodeMap* attributes = node->getAttributes();
         const DOMNode* config_attribute = attributes->getNamedItem(transcode("configuration").c_str());
-        const string config = transcode(config_attribute->getNodeValue());
+        const std::string config = transcode(config_attribute->getNodeValue());
 
         Dictionary& suites_dic = push(m_benchmarks, config);
 
@@ -143,7 +142,7 @@ struct BenchmarkAggregator::Impl
                 {
                     const DOMNamedNodeMap* attributes = node->getAttributes();
                     const DOMNode* name_attribute = attributes->getNamedItem(transcode("name").c_str());
-                    const string name = transcode(name_attribute->getNodeValue());
+                    const std::string name = transcode(name_attribute->getNodeValue());
 
                     Dictionary& cases_dic = push(suites_dic, name);
 
@@ -172,7 +171,7 @@ struct BenchmarkAggregator::Impl
                 {
                     const DOMNamedNodeMap* attributes = node->getAttributes();
                     const DOMNode* name_attribute = attributes->getNamedItem(transcode("name").c_str());
-                    const string name = transcode(name_attribute->getNodeValue());
+                    const std::string name = transcode(name_attribute->getNodeValue());
 
                     UniqueID series_uid;
 
@@ -219,7 +218,7 @@ struct BenchmarkAggregator::Impl
 
                     if (node->getNodeType() == DOMNode::TEXT_NODE)
                     {
-                        const string text = transcode(node->getTextContent());
+                        const std::string text = transcode(node->getTextContent());
                         const double ticks = from_string<double>(text);
                         series.push_back(BenchmarkDataPoint(date, ticks));
                     }
@@ -259,16 +258,16 @@ bool BenchmarkAggregator::scan_file(const char* path)
     if (!bf::is_regular_file(path))
         return false;
 
-    const string filename = bf::path(path).filename().string();
+    const std::string filename = bf::path(path).filename().string();
 
     smatch match;
 
     if (!regex_match(filename, match, impl->m_filename_regex))
         return false;
 
-    const string date_string = match[1].str();
-    const string time_string = match[2].str();
-    const string iso_string = date_string + "T" + time_string;
+    const std::string date_string = match[1].str();
+    const std::string time_string = match[2].str();
+    const std::string iso_string = date_string + "T" + time_string;
     const posix_time::ptime date = posix_time::from_iso_string(iso_string);
 
     try
@@ -318,7 +317,7 @@ void BenchmarkAggregator::sort_series()
         if (i->second.empty())
             continue;
 
-        sort(&i->second[0], &i->second[0] + i->second.size());
+        std::sort(&i->second[0], &i->second[0] + i->second.size());
     }
 }
 

--- a/src/appleseed/foundation/utility/benchmark/benchmarkresult.cpp
+++ b/src/appleseed/foundation/utility/benchmark/benchmarkresult.cpp
@@ -40,7 +40,6 @@
 #include <cstdarg>
 #include <list>
 
-using namespace std;
 
 namespace foundation
 {
@@ -51,7 +50,7 @@ namespace foundation
 
 struct BenchmarkResult::Impl
 {
-    typedef list<IBenchmarkListener*> BenchmarkListenerContainer;
+    typedef std::list<IBenchmarkListener*> BenchmarkListenerContainer;
 
     BenchmarkListenerContainer  m_listeners;
     size_t                      m_suite_execution_count;

--- a/src/appleseed/foundation/utility/benchmark/benchmarksuite.cpp
+++ b/src/appleseed/foundation/utility/benchmark/benchmarksuite.cpp
@@ -56,7 +56,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 
 namespace foundation
 {
@@ -92,8 +91,8 @@ struct BenchmarkSuite::Impl
     typedef Stopwatch<DefaultProcessorTimer> StopwatchType;
 #endif
 
-    string                          m_name;
-    vector<IBenchmarkCaseFactory*>  m_factories;
+    std::string                          m_name;
+    std::vector<IBenchmarkCaseFactory*>  m_factories;
 
     static double measure_runtime_seconds(
         IBenchmarkCase*         benchmark,
@@ -124,12 +123,12 @@ struct BenchmarkSuite::Impl
         MeasurementFunction&    measurement_function,
         const size_t            measurement_count)
     {
-        double lowest_runtime = numeric_limits<double>::max();
+        double lowest_runtime = std::numeric_limits<double>::max();
 
         for (size_t i = 0; i < measurement_count; ++i)
         {
             const double runtime = measurement_function(benchmark, stopwatch);
-            lowest_runtime = min(lowest_runtime, runtime);
+            lowest_runtime = std::min(lowest_runtime, runtime);
         }
 
         return lowest_runtime;
@@ -153,7 +152,7 @@ struct BenchmarkSuite::Impl
         const double MaxTargetTotalTime = 0.1;          // seconds
         return
             static_cast<size_t>(ceil(
-                min(MaxMeasurementCount * measurement_time, MaxTargetTotalTime) / measurement_time));
+                std::min(MaxMeasurementCount * measurement_time, MaxTargetTotalTime) / measurement_time));
     }
 
     // Measure and return the overhead (in ticks) of running an empty benchmark case.
@@ -161,7 +160,7 @@ struct BenchmarkSuite::Impl
         StopwatchType&          stopwatch,
         const size_t            measurement_count)
     {
-        unique_ptr<IBenchmarkCase> empty_case(new EmptyBenchmarkCase());
+        std::unique_ptr<IBenchmarkCase> empty_case(new EmptyBenchmarkCase());
         return
             measure_runtime(
                 empty_case.get(),
@@ -224,7 +223,7 @@ void BenchmarkSuite::run(
         }
 
         // Instantiate the benchmark case.
-        unique_ptr<IBenchmarkCase> benchmark(factory->create());
+        std::unique_ptr<IBenchmarkCase> benchmark(factory->create());
 
         // Tell the listeners that a benchmark case is about to be executed.
         suite_result.begin_case(*this, *benchmark.get());
@@ -273,7 +272,7 @@ void BenchmarkSuite::run(
                 timing_result);
 
 #ifdef GENERATE_BENCHMARK_PLOTS
-            vector<Vector2d> points;
+            std::vector<Vector2d> points;
 
             const size_t PointCount = 100;
             for (size_t j = 0; j < PointCount; ++j)
@@ -283,13 +282,13 @@ void BenchmarkSuite::run(
                         benchmark.get(),
                         stopwatch,
                         BenchmarkSuite::Impl::measure_runtime_ticks,
-                        max<size_t>(1, measurement_count / PointCount));
+                        std::max<size_t>(1, measurement_count / PointCount));
                 points.emplace_back(
                     static_cast<double>(j),
                     ticks > overhead_ticks ? ticks - overhead_ticks : 0.0);
             }
 
-            const string filepath =
+            const std::string filepath =
                 format("unit benchmarks/plots/{0}_{1}.gnuplot", get_name(), benchmark->get_name());
 
             GnuplotFile plotfile;
@@ -298,7 +297,7 @@ void BenchmarkSuite::run(
 #endif
         }
 #ifdef NDEBUG
-        catch (const exception& e)
+        catch (const std::exception& e)
         {
             if (!is_empty_string(e.what()))
             {

--- a/src/appleseed/foundation/utility/benchmark/benchmarksuiterepository.cpp
+++ b/src/appleseed/foundation/utility/benchmark/benchmarksuiterepository.cpp
@@ -40,7 +40,6 @@
 #include <cstddef>
 #include <vector>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/benchmark/benchmarksuiterepository.cpp
+++ b/src/appleseed/foundation/utility/benchmark/benchmarksuiterepository.cpp
@@ -40,7 +40,6 @@
 #include <cstddef>
 #include <vector>
 
-using namespace std;
 
 namespace foundation
 {
@@ -51,7 +50,7 @@ namespace foundation
 
 struct BenchmarkSuiteRepository::Impl
 {
-    vector<BenchmarkSuite*> m_suites;
+    std::vector<BenchmarkSuite*> m_suites;
 };
 
 BenchmarkSuiteRepository::BenchmarkSuiteRepository()

--- a/src/appleseed/foundation/utility/benchmark/loggerbenchmarklistener.cpp
+++ b/src/appleseed/foundation/utility/benchmark/loggerbenchmarklistener.cpp
@@ -48,16 +48,15 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 
 namespace foundation
 {
 
 namespace
 {
-    string pretty_callrate(
+    std::string pretty_callrate(
         const TimingResult& timing_result,
-        const streamsize    precision = 1)
+        const std::streamsize    precision = 1)
     {
         assert(timing_result.m_ticks > 0.0);
 
@@ -96,7 +95,7 @@ namespace
 
     TEST_SUITE(Foundation_Utility_Benchmark)
     {
-        string pretty_callrate_helper(const double rate)
+        std::string pretty_callrate_helper(const double rate)
         {
             TimingResult result;
             result.m_ticks = 1.0;
@@ -162,11 +161,11 @@ namespace
                 line);
 
             // Split the message into multiple components, one for each line.
-            vector<string> tokens;
+            std::vector<std::string> tokens;
             split(message, "\n", tokens);
 
             // Print the message.
-            for (const_each<vector<string>> i = tokens; i; ++i)
+            for (const_each<std::vector<std::string>> i = tokens; i; ++i)
                 LOG_ERROR(m_logger, "    %s", i->c_str());
         }
 
@@ -177,7 +176,7 @@ namespace
             const size_t            line,
             const TimingResult&     timing_result) override
         {
-            string callrate_string;
+            std::string callrate_string;
 
             if (timing_result.m_ticks > 0.0)
             {

--- a/src/appleseed/foundation/utility/benchmark/loggerbenchmarklistener.cpp
+++ b/src/appleseed/foundation/utility/benchmark/loggerbenchmarklistener.cpp
@@ -48,14 +48,13 @@
 #include <string>
 #include <vector>
 
-
 namespace foundation
 {
 
 namespace
 {
     std::string pretty_callrate(
-        const TimingResult& timing_result,
+        const TimingResult&      timing_result,
         const std::streamsize    precision = 1)
     {
         assert(timing_result.m_ticks > 0.0);

--- a/src/appleseed/foundation/utility/benchmark/xmlfilebenchmarklistener.cpp
+++ b/src/appleseed/foundation/utility/benchmark/xmlfilebenchmarklistener.cpp
@@ -42,7 +42,6 @@
 #include <cassert>
 #include <cstdio>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/benchmark/xmlfilebenchmarklistener.cpp
+++ b/src/appleseed/foundation/utility/benchmark/xmlfilebenchmarklistener.cpp
@@ -42,7 +42,6 @@
 #include <cassert>
 #include <cstdio>
 
-using namespace std;
 
 namespace foundation
 {

--- a/src/appleseed/foundation/utility/bufferedfile.cpp
+++ b/src/appleseed/foundation/utility/bufferedfile.cpp
@@ -41,7 +41,6 @@
 #include <algorithm>
 #include <cstring>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/bufferedfile.cpp
+++ b/src/appleseed/foundation/utility/bufferedfile.cpp
@@ -41,7 +41,6 @@
 #include <algorithm>
 #include <cstring>
 
-using namespace std;
 
 namespace foundation
 {
@@ -72,11 +71,11 @@ BufferedFile::~BufferedFile()
 
 namespace
 {
-    string build_mode_string(
+    std::string build_mode_string(
         const BufferedFile::FileType    type,
         const BufferedFile::FileMode    mode)
     {
-        string s;
+        std::string s;
 
         switch (mode)
         {
@@ -118,7 +117,7 @@ bool BufferedFile::open(
     assert(path);
     assert(buffer_size > 0);
 
-    const string mode_string = build_mode_string(type, mode);
+    const std::string mode_string = build_mode_string(type, mode);
 
     m_file = fopen(path, mode_string.c_str());
 
@@ -229,7 +228,7 @@ size_t BufferedFile::read(
         // Copy the contents of the I/O buffer to the output buffer.
         const size_t left = size - bytes;
         const size_t available = m_buffer_end - m_buffer_index;
-        const size_t count = min(left, available);
+        const size_t count = std::min(left, available);
         memcpy(
             &reinterpret_cast<uint8*>(outbuf)[bytes],
             &m_buffer[m_buffer_index],
@@ -279,7 +278,7 @@ size_t BufferedFile::read_unbuf(
         // Copy the contents of the I/O buffer into the output buffer.
         const size_t left = size - bytes;
         const size_t available = m_buffer_end - m_buffer_index;
-        const size_t count = min(left, available);
+        const size_t count = std::min(left, available);
         memcpy(
             &reinterpret_cast<uint8*>(outbuf)[bytes],
             &m_buffer[m_buffer_index],
@@ -314,7 +313,7 @@ size_t BufferedFile::write(
         // Copy the contents of the input buffer to the I/O buffer.
         const size_t left = size - bytes;
         const size_t available = m_buffer_end - m_buffer_index;
-        const size_t count = min(left, available);
+        const size_t count = std::min(left, available);
         memcpy(
             &m_buffer[m_buffer_index],
             &reinterpret_cast<const uint8*>(inbuf)[bytes],
@@ -362,7 +361,7 @@ size_t BufferedFile::write_unbuf(
         // Copy the contents of the input buffer to the I/O buffer.
         const size_t left = size - bytes;
         const size_t available = m_buffer_end - m_buffer_index;
-        const size_t count = min(left, available);
+        const size_t count = std::min(left, available);
         memcpy(
             &m_buffer[m_buffer_index],
             &reinterpret_cast<const uint8*>(inbuf)[bytes],
@@ -424,7 +423,7 @@ bool BufferedFile::seek(
         {
             assert(origin == SeekFromCurrent);
             const int64 current_index = m_file_index + static_cast<int64>(m_buffer_index);
-            target_index = max<int64>(current_index + offset, 0);
+            target_index = std::max<int64>(current_index + offset, 0);
         }
 
         if (target_index >= m_file_index &&
@@ -520,7 +519,7 @@ size_t CompressedReaderAdapter::read(
                 break;
         }
 
-        const size_t copy = min(size, m_buffer_end - m_buffer_index);
+        const size_t copy = std::min(size, m_buffer_end - m_buffer_index);
         memcpy(outbuf, &m_buffer[m_buffer_index], copy);
 
         outbuf = reinterpret_cast<uint8*>(outbuf) + copy;

--- a/src/appleseed/foundation/utility/cache.cpp
+++ b/src/appleseed/foundation/utility/cache.cpp
@@ -33,7 +33,6 @@
 // appleseed.foundation headers.
 #include "foundation/utility/string.h"
 
-using namespace std;
 
 namespace foundation
 {
@@ -41,18 +40,18 @@ namespace foundation
 namespace cache_impl
 {
     CacheStatisticsEntry::CacheStatisticsEntry(
-        const string&   name,
-        const uint64    hit_count,
-        const uint64    miss_count)
+        const std::string&   name,
+        const uint64         hit_count,
+        const uint64         miss_count)
       : Statistics::Entry(name)
     {
         m_hit_count = hit_count;
         m_miss_count = miss_count;
     }
 
-    unique_ptr<Statistics::Entry> CacheStatisticsEntry::clone() const
+    std::unique_ptr<Statistics::Entry> CacheStatisticsEntry::clone() const
     {
-        return unique_ptr<Entry>(new CacheStatisticsEntry(*this));
+        return std::unique_ptr<Entry>(new CacheStatisticsEntry(*this));
     }
 
     void CacheStatisticsEntry::merge(const Entry* other)
@@ -63,7 +62,7 @@ namespace cache_impl
         m_miss_count += typed_other->m_miss_count;
     }
 
-    string CacheStatisticsEntry::to_string() const
+    std::string CacheStatisticsEntry::to_string() const
     {
         const uint64 accesses = m_hit_count + m_miss_count;
 

--- a/src/appleseed/foundation/utility/cache.cpp
+++ b/src/appleseed/foundation/utility/cache.cpp
@@ -33,7 +33,6 @@
 // appleseed.foundation headers.
 #include "foundation/utility/string.h"
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/commandlineparser/messagelist.cpp
+++ b/src/appleseed/foundation/utility/commandlineparser/messagelist.cpp
@@ -40,7 +40,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 
 namespace foundation
 {
@@ -54,10 +53,10 @@ struct MessageList::Impl
     struct Message
     {
         LogMessage::Category    m_category;
-        string                  m_text;
+        std::string             m_text;
     };
 
-    typedef vector<Message> Messages;
+    typedef std::vector<Message> Messages;
 
     Messages    m_messages;
 };

--- a/src/appleseed/foundation/utility/commandlineparser/messagelist.cpp
+++ b/src/appleseed/foundation/utility/commandlineparser/messagelist.cpp
@@ -40,7 +40,6 @@
 #include <string>
 #include <vector>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/containers/dictionary.cpp
+++ b/src/appleseed/foundation/utility/containers/dictionary.cpp
@@ -37,7 +37,6 @@
 #include <cassert>
 #include <map>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/containers/dictionary.cpp
+++ b/src/appleseed/foundation/utility/containers/dictionary.cpp
@@ -37,13 +37,12 @@
 #include <cassert>
 #include <map>
 
-using namespace std;
 
 namespace foundation
 {
 
-typedef map<string, string> StringMap;
-typedef map<string, Dictionary> DictionaryMap;
+typedef std::map<std::string, std::string> StringMap;
+typedef std::map<std::string, Dictionary> DictionaryMap;
 
 
 //

--- a/src/appleseed/foundation/utility/gnuplotfile.cpp
+++ b/src/appleseed/foundation/utility/gnuplotfile.cpp
@@ -36,7 +36,6 @@
 #include <cstddef>
 #include <iostream>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/gnuplotfile.cpp
+++ b/src/appleseed/foundation/utility/gnuplotfile.cpp
@@ -36,7 +36,6 @@
 #include <cstddef>
 #include <iostream>
 
-using namespace std;
 
 namespace foundation
 {
@@ -55,19 +54,19 @@ GnuplotFile::GnuplotFile()
 {
 }
 
-GnuplotFile& GnuplotFile::set_title(const string& title)
+GnuplotFile& GnuplotFile::set_title(const std::string& title)
 {
     m_title = title;
     return *this;
 }
 
-GnuplotFile& GnuplotFile::set_xlabel(const string& label)
+GnuplotFile& GnuplotFile::set_xlabel(const std::string& label)
 {
     m_xlabel = label;
     return *this;
 }
 
-GnuplotFile& GnuplotFile::set_ylabel(const string& label)
+GnuplotFile& GnuplotFile::set_ylabel(const std::string& label)
 {
     m_ylabel = label;
     return *this;
@@ -105,40 +104,40 @@ GnuplotFile::Plot& GnuplotFile::new_plot()
     return m_plots.back();
 }
 
-bool GnuplotFile::write(const string& filepath) const
+bool GnuplotFile::write(const std::string& filepath) const
 {
-    ofstream file(filepath.c_str());
+    std::ofstream file(filepath.c_str());
 
     if (!file.is_open())
         return false;
 
     if (!m_title.empty())
-        file << "set title \"" << m_title << "\" noenhanced" << endl;
-    else file << "unset title" << endl;
+        file << "set title \"" << m_title << "\" noenhanced" << std::endl;
+    else file << "unset title" << std::endl;
 
     if (!m_xlabel.empty())
-        file << "set xlabel \"" << m_xlabel << "\" noenhanced" << endl;
-    else file << "unset xlabel" << endl;
+        file << "set xlabel \"" << m_xlabel << "\" noenhanced" << std::endl;
+    else file << "unset xlabel" << std::endl;
 
     if (!m_ylabel.empty())
-        file << "set ylabel \"" << m_ylabel << "\" noenhanced" << endl;
-    else file << "unset ylabel" << endl;
+        file << "set ylabel \"" << m_ylabel << "\" noenhanced" << std::endl;
+    else file << "unset ylabel" << std::endl;
 
     if (m_has_xrange)
-        file << "set xrange [" << m_xrange[0] << ":" << m_xrange[1] << "]" << endl;
-    else file << "set autoscale x" << endl;
+        file << "set xrange [" << m_xrange[0] << ":" << m_xrange[1] << "]" << std::endl;
+    else file << "set autoscale x" << std::endl;
 
     if (m_has_yrange)
-        file << "set yrange [" << m_yrange[0] << ":" << m_yrange[1] << "]" << endl;
-    else file << "set autoscale y" << endl;
+        file << "set yrange [" << m_yrange[0] << ":" << m_yrange[1] << "]" << std::endl;
+    else file << "set autoscale y" << std::endl;
 
     if (m_logscale_x)
-        file << "set logscale x" << endl;
-    else file << "unset logscale x" << endl;
+        file << "set logscale x" << std::endl;
+    else file << "unset logscale x" << std::endl;
 
     if (m_logscale_y)
-        file << "set logscale y" << endl;
-    else file << "unset logscale y" << endl;
+        file << "set logscale y" << std::endl;
+    else file << "unset logscale y" << std::endl;
 
     if (!m_plots.empty())
     {
@@ -151,7 +150,7 @@ bool GnuplotFile::write(const string& filepath) const
             m_plots[i].write_decl(file);
         }
 
-        file << endl;
+        file << std::endl;
 
         for (size_t i = 0; i < m_plots.size(); ++i)
             m_plots[i].write_points(file);
@@ -165,13 +164,13 @@ bool GnuplotFile::write(const string& filepath) const
 // GnuplotFile::Plot class implementation.
 //
 
-GnuplotFile::Plot& GnuplotFile::Plot::set_points(const vector<Vector2d>& points)
+GnuplotFile::Plot& GnuplotFile::Plot::set_points(const std::vector<Vector2d>& points)
 {
     m_points = points;
     return *this;
 }
 
-GnuplotFile::Plot& GnuplotFile::Plot::set_points(const vector<Vector2f>& points)
+GnuplotFile::Plot& GnuplotFile::Plot::set_points(const std::vector<Vector2f>& points)
 {
     const size_t n = points.size();
 
@@ -183,31 +182,31 @@ GnuplotFile::Plot& GnuplotFile::Plot::set_points(const vector<Vector2f>& points)
     return *this;
 }
 
-GnuplotFile::Plot& GnuplotFile::Plot::set_title(const string& title)
+GnuplotFile::Plot& GnuplotFile::Plot::set_title(const std::string& title)
 {
     m_title = title;
     return *this;
 }
 
-GnuplotFile::Plot& GnuplotFile::Plot::set_color(const string& color)
+GnuplotFile::Plot& GnuplotFile::Plot::set_color(const std::string& color)
 {
     m_color = color;
     return *this;
 }
 
-GnuplotFile::Plot& GnuplotFile::Plot::set_style(const string& style)
+GnuplotFile::Plot& GnuplotFile::Plot::set_style(const std::string& style)
 {
     m_style = style;
     return *this;
 }
 
-GnuplotFile::Plot& GnuplotFile::Plot::set_smoothing(const string& smoothing)
+GnuplotFile::Plot& GnuplotFile::Plot::set_smoothing(const std::string& smoothing)
 {
     m_smoothing = smoothing;
     return *this;
 }
 
-void GnuplotFile::Plot::write_decl(ofstream& file) const
+void GnuplotFile::Plot::write_decl(std::ofstream& file) const
 {
     file << "\"-\" with ";
 
@@ -224,15 +223,15 @@ void GnuplotFile::Plot::write_decl(ofstream& file) const
     else file << " notitle";
 }
 
-void GnuplotFile::Plot::write_points(ofstream& file) const
+void GnuplotFile::Plot::write_points(std::ofstream& file) const
 {
-    for (const_each<vector<Vector2d>> i = m_points; i; ++i)
+    for (const_each<std::vector<Vector2d>> i = m_points; i; ++i)
     {
         const Vector2d& p = *i;
-        file << "    " << p[0] << " " << p[1] << endl;
+        file << "    " << p[0] << " " << p[1] << std::endl;
     }
 
-    file << "    e" << endl;
+    file << "    e" << std::endl;
 }
 
 }   // namespace foundation

--- a/src/appleseed/foundation/utility/indenter.cpp
+++ b/src/appleseed/foundation/utility/indenter.cpp
@@ -34,16 +34,15 @@
 #include <cassert>
 #include <string>
 
-using namespace std;
 
 namespace foundation
 {
 
 struct Indenter::Impl
 {
-    size_t          m_tab_size;
-    char            m_tab_char;
-    string          m_str;
+    size_t               m_tab_size;
+    char                 m_tab_char;
+    std::string          m_str;
 };
 
 Indenter::Indenter(

--- a/src/appleseed/foundation/utility/indenter.cpp
+++ b/src/appleseed/foundation/utility/indenter.cpp
@@ -34,7 +34,6 @@
 #include <cassert>
 #include <string>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/job/jobmanager.cpp
+++ b/src/appleseed/foundation/utility/job/jobmanager.cpp
@@ -41,7 +41,6 @@
 #include <vector>
 
 using namespace boost;
-using namespace std;
 
 namespace foundation
 {
@@ -52,7 +51,7 @@ namespace foundation
 
 struct JobManager::Impl
 {
-    typedef vector<WorkerThread*> WorkerThreads;
+    typedef std::vector<WorkerThread*> WorkerThreads;
 
     Logger&             m_logger;
     JobQueue&           m_job_queue;

--- a/src/appleseed/foundation/utility/job/jobqueue.cpp
+++ b/src/appleseed/foundation/utility/job/jobqueue.cpp
@@ -43,7 +43,6 @@
 // Standard headers.
 #include <cassert>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/job/jobqueue.cpp
+++ b/src/appleseed/foundation/utility/job/jobqueue.cpp
@@ -43,7 +43,6 @@
 // Standard headers.
 #include <cassert>
 
-using namespace std;
 
 namespace foundation
 {

--- a/src/appleseed/foundation/utility/job/workerthread.cpp
+++ b/src/appleseed/foundation/utility/job/workerthread.cpp
@@ -46,7 +46,6 @@
 #include <new>
 
 using namespace boost;
-using namespace std;
 
 namespace foundation
 {
@@ -209,7 +208,7 @@ bool WorkerThread::execute_job(IJob& job)
     {
         job.execute(m_index);
     }
-    catch (const bad_alloc&)
+    catch (const std::bad_alloc&)
     {
         LOG_ERROR(
             m_logger,

--- a/src/appleseed/foundation/utility/log/consolelogtarget.cpp
+++ b/src/appleseed/foundation/utility/log/consolelogtarget.cpp
@@ -39,7 +39,6 @@
 // Standard headers.
 #include <cstddef>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/log/consolelogtarget.cpp
+++ b/src/appleseed/foundation/utility/log/consolelogtarget.cpp
@@ -39,7 +39,6 @@
 // Standard headers.
 #include <cstddef>
 
-using namespace std;
 
 namespace foundation
 {

--- a/src/appleseed/foundation/utility/log/filelogtarget.cpp
+++ b/src/appleseed/foundation/utility/log/filelogtarget.cpp
@@ -33,7 +33,6 @@
 // Standard headers.
 #include <cassert>
 
-using namespace std;
 
 namespace foundation
 {

--- a/src/appleseed/foundation/utility/log/filelogtarget.cpp
+++ b/src/appleseed/foundation/utility/log/filelogtarget.cpp
@@ -33,7 +33,6 @@
 // Standard headers.
 #include <cassert>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/log/filelogtargetbase.cpp
+++ b/src/appleseed/foundation/utility/log/filelogtargetbase.cpp
@@ -39,7 +39,6 @@
 #include <string>
 #include <vector>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/log/filelogtargetbase.cpp
+++ b/src/appleseed/foundation/utility/log/filelogtargetbase.cpp
@@ -39,7 +39,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 
 namespace foundation
 {
@@ -59,11 +58,11 @@ void FileLogTargetBase::write_message(
     assert(message);
 
     // Split the message into individual lines.
-    vector<string> lines;
+    std::vector<std::string> lines;
     split(message, "\n", lines);
 
     // Emit the lines.
-    for (const_each<vector<string>> i = lines; i; ++i)
+    for (const_each<std::vector<std::string>> i = lines; i; ++i)
         fprintf(file, "%s%s\n", header, i->c_str());
 }
 

--- a/src/appleseed/foundation/utility/log/logger.cpp
+++ b/src/appleseed/foundation/utility/log/logger.cpp
@@ -53,7 +53,6 @@
 #include <vector>
 
 using namespace boost::posix_time;
-using namespace std;
 
 namespace foundation
 {
@@ -72,7 +71,7 @@ namespace
             const LogMessage::Category  category,
             const ptime&                datetime,
             const size_t                thread,
-            const string&               message)
+            const std::string&          message)
           : m_category(LogMessage::get_category_name(category))
           , m_padded_category(LogMessage::get_padded_category_name(category))
           , m_datetime(to_iso_extended_string(datetime) + 'Z')
@@ -82,9 +81,9 @@ namespace
         {
         }
 
-        string evaluate(const string& format) const
+        std::string evaluate(const std::string& format) const
         {
-            string result = format;
+            std::string result = format;
             result = replace(result, "{category}", m_category);
             result = replace(result, "{padded-category}", m_padded_category);
             result = replace(result, "{datetime-utc}", m_datetime);
@@ -95,12 +94,12 @@ namespace
         }
 
       private:
-        const string    m_category;
-        const string    m_padded_category;
-        const string    m_datetime;
-        const string    m_thread;
-        const string    m_process_size;
-        const string    m_message;
+        const std::string    m_category;
+        const std::string    m_padded_category;
+        const std::string    m_datetime;
+        const std::string    m_thread;
+        const std::string    m_process_size;
+        const std::string    m_message;
     };
 
     class Formatter
@@ -123,7 +122,7 @@ namespace
             set_format(category, "{datetime-utc} <{thread}> {process-size} {padded-category} | {message}");
         }
 
-        void set_all_formats(const string& format)
+        void set_all_formats(const std::string& format)
         {
             for (size_t i = 0; i < LogMessage::NumMessageCategories; ++i)
                 set_format(static_cast<LogMessage::Category>(i), format);
@@ -131,29 +130,29 @@ namespace
 
         void set_format(
             const LogMessage::Category  category,
-            const string&               format)
+            const std::string&          format)
         {
-            const string::size_type message_start = format.find("{message}");
+            const std::string::size_type message_start = format.find("{message}");
 
             m_formats[category].m_format = format;
             m_formats[category].m_header_format = format.substr(0, message_start);
             m_formats[category].m_message_format =
-                message_start != string::npos ? format.substr(message_start) :
+                message_start != std::string::npos ? format.substr(message_start) :
                 !format.empty() ? "\n" :
-                string();
+                std::string();
         }
 
-        const string& get_format(const LogMessage::Category category) const
+        const std::string& get_format(const LogMessage::Category category) const
         {
             return m_formats[category].m_format;
         }
 
-        const string& get_header_format(const LogMessage::Category category) const
+        const std::string& get_header_format(const LogMessage::Category category) const
         {
             return m_formats[category].m_header_format;
         }
 
-        const string& get_message_format(const LogMessage::Category category) const
+        const std::string& get_message_format(const LogMessage::Category category) const
         {
             return m_formats[category].m_message_format;
         }
@@ -161,9 +160,9 @@ namespace
       private:
         struct Format
         {
-            string  m_format;
-            string  m_header_format;
-            string  m_message_format;
+            std::string  m_format;
+            std::string  m_header_format;
+            std::string  m_message_format;
         };
 
         Format m_formats[LogMessage::NumMessageCategories];
@@ -191,7 +190,7 @@ namespace
         }
 
       private:
-        typedef map<boost::thread::id, size_t> ThreadIdToIntMap;
+        typedef std::map<boost::thread::id, size_t> ThreadIdToIntMap;
 
         size_t              m_thread_count;
         ThreadIdToIntMap    m_thread_id_to_int;
@@ -205,13 +204,13 @@ namespace
 
 struct Logger::Impl
 {
-    typedef list<ILogTarget*> LogTargetContainer;
+    typedef std::list<ILogTarget*> LogTargetContainer;
 
     boost::mutex            m_mutex;
     bool                    m_enabled;
     LogMessage::Category    m_verbosity_level;
     LogTargetContainer      m_targets;
-    vector<char>            m_message_buffer;
+    std::vector<char>       m_message_buffer;
     ThreadMap               m_thread_map;
     Formatter               m_formatter;
 };
@@ -321,10 +320,10 @@ void Logger::remove_target(ILogTarget* target)
 namespace
 {
     bool write_to_buffer(
-        vector<char>&   buffer,
-        const size_t    max_buffer_size,
-        const char*     format,
-        va_list         argptr)
+        std::vector<char>&   buffer,
+        const size_t         max_buffer_size,
+        const char*          format,
+        va_list              argptr)
     {
         while (true)
         {
@@ -354,7 +353,7 @@ namespace
             if (buffer_size >= max_buffer_size)
                 return false;
 
-            buffer.resize(min(needed_buffer_size, max_buffer_size));
+            buffer.resize(std::min(needed_buffer_size, max_buffer_size));
         }
     }
 }
@@ -390,8 +389,8 @@ void Logger::write(
         // Format the header and message.
         const size_t thread = impl->m_thread_map.thread_id_to_int(boost::this_thread::get_id());
         const FormatEvaluator format_evaluator(effective_category, datetime, thread, &impl->m_message_buffer[0]);
-        const string header = format_evaluator.evaluate(impl->m_formatter.get_header_format(effective_category));
-        string message = format_evaluator.evaluate(impl->m_formatter.get_message_format(effective_category));
+        const std::string header = format_evaluator.evaluate(impl->m_formatter.get_header_format(effective_category));
+        std::string message = format_evaluator.evaluate(impl->m_formatter.get_message_format(effective_category));
 
         // Remove trailing newline characters from the message.
         message = trim_right(message, "\n");

--- a/src/appleseed/foundation/utility/log/logmessage.cpp
+++ b/src/appleseed/foundation/utility/log/logmessage.cpp
@@ -34,7 +34,6 @@
 #include <cassert>
 #include <cstring>
 
-using namespace std;
 
 namespace foundation
 {

--- a/src/appleseed/foundation/utility/log/logmessage.cpp
+++ b/src/appleseed/foundation/utility/log/logmessage.cpp
@@ -34,7 +34,6 @@
 #include <cassert>
 #include <cstring>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/log/openfilelogtarget.cpp
+++ b/src/appleseed/foundation/utility/log/openfilelogtarget.cpp
@@ -38,7 +38,6 @@
 // Standard headers.
 #include <cstddef>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/log/openfilelogtarget.cpp
+++ b/src/appleseed/foundation/utility/log/openfilelogtarget.cpp
@@ -38,7 +38,6 @@
 // Standard headers.
 #include <cstddef>
 
-using namespace std;
 
 namespace foundation
 {

--- a/src/appleseed/foundation/utility/log/stringlogtarget.cpp
+++ b/src/appleseed/foundation/utility/log/stringlogtarget.cpp
@@ -38,14 +38,13 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 
 namespace foundation
 {
 
 struct StringLogTarget::Impl
 {
-    string m_str;
+    std::string m_str;
 };
 
 StringLogTarget::StringLogTarget()
@@ -70,10 +69,10 @@ void StringLogTarget::write(
     const char*                 header,
     const char*                 message)
 {
-    vector<string> lines;
+    std::vector<std::string> lines;
     split(message, "\n", lines);
 
-    for (const_each<vector<string>> i = lines; i; ++i)
+    for (const_each<std::vector<std::string>> i = lines; i; ++i)
     {
         impl->m_str.append(header);
         impl->m_str.append(*i);

--- a/src/appleseed/foundation/utility/log/stringlogtarget.cpp
+++ b/src/appleseed/foundation/utility/log/stringlogtarget.cpp
@@ -38,7 +38,6 @@
 #include <string>
 #include <vector>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/memory.cpp
+++ b/src/appleseed/foundation/utility/memory.cpp
@@ -36,7 +36,6 @@
 // Standard headers.
 #include <cstdlib>
 
-using namespace std;
 
 namespace foundation
 {

--- a/src/appleseed/foundation/utility/memory.cpp
+++ b/src/appleseed/foundation/utility/memory.cpp
@@ -36,7 +36,6 @@
 // Standard headers.
 #include <cstdlib>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/preprocessor.cpp
+++ b/src/appleseed/foundation/utility/preprocessor.cpp
@@ -42,7 +42,6 @@
 #include <string>
 #include <vector>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/preprocessor.cpp
+++ b/src/appleseed/foundation/utility/preprocessor.cpp
@@ -42,7 +42,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 
 namespace foundation
 {
@@ -62,9 +61,9 @@ namespace
     }
 
     bool is_surrounded_by_separators(
-        const string&               s,
-        const string::size_type     begin,
-        const string::size_type     end)
+        const std::string&               s,
+        const std::string::size_type     begin,
+        const std::string::size_type     end)
     {
         const bool separator_on_left = begin == 0 || is_separator(s[begin - 1]);
         const bool separator_on_right = end == s.size() || is_separator(s[end]);
@@ -72,47 +71,47 @@ namespace
         return separator_on_left && separator_on_right;
     }
 
-    bool is_directive(const string& line)
+    bool is_directive(const std::string& line)
     {
-        const string::size_type i = line.find_first_not_of(Blanks);
+        const std::string::size_type i = line.find_first_not_of(Blanks);
 
-        return i != string::npos && line[i] == '#';
+        return i != std::string::npos && line[i] == '#';
     }
 
-    void split_line(const string& line, string& keyword, string& arguments)
+    void split_line(const std::string& line, std::string& keyword, std::string& arguments)
     {
-        string::size_type cursor = line.find_first_not_of(Blanks);
+        std::string::size_type cursor = line.find_first_not_of(Blanks);
 
-        const string::size_type keyword_begin = cursor;
+        const std::string::size_type keyword_begin = cursor;
         cursor = line.find_first_of(Blanks, cursor);
 
         keyword =
-            cursor == string::npos
+            cursor == std::string::npos
                 ? line.substr(keyword_begin)
                 : line.substr(keyword_begin, cursor - keyword_begin);
 
         arguments.clear();
 
-        if (cursor == string::npos)
+        if (cursor == std::string::npos)
             return;
 
         cursor = line.find_first_not_of(Blanks, cursor);
 
-        if (cursor == string::npos)
+        if (cursor == std::string::npos)
             return;
 
-        const string::size_type arguments_begin = cursor;
+        const std::string::size_type arguments_begin = cursor;
 
         cursor = line.find_last_not_of(Blanks);
 
         arguments = line.substr(arguments_begin, cursor - arguments_begin + 1);
     }
 
-    void split_directive(const string& line, string& keyword, string& arguments)
+    void split_directive(const std::string& line, std::string& keyword, std::string& arguments)
     {
-        const string::size_type i = line.find_first_not_of(Blanks);
+        const std::string::size_type i = line.find_first_not_of(Blanks);
 
-        assert(i != string::npos);
+        assert(i != std::string::npos);
         assert(line[i] == '#');
 
         split_line(line.substr(i + 1), keyword, arguments);
@@ -167,7 +166,7 @@ namespace
 
         TEST_CASE(SplitDirective_GivenKeyword_ReturnsKeyword)
         {
-            string keyword, arguments;
+            std::string keyword, arguments;
             split_directive("#keyword", keyword, arguments);
 
             EXPECT_EQ("keyword", keyword);
@@ -175,7 +174,7 @@ namespace
 
         TEST_CASE(SplitDirective_GivenSpacesBeforeHashCharacter_ReturnsKeyword)
         {
-            string keyword, arguments;
+            std::string keyword, arguments;
             split_directive("   #keyword", keyword, arguments);
 
             EXPECT_EQ("keyword", keyword);
@@ -183,7 +182,7 @@ namespace
 
         TEST_CASE(SplitDirective_GivenSpacesAfterHashCharacter_ReturnsKeyword)
         {
-            string keyword, arguments;
+            std::string keyword, arguments;
             split_directive("#   keyword", keyword, arguments);
 
             EXPECT_EQ("keyword", keyword);
@@ -191,7 +190,7 @@ namespace
 
         TEST_CASE(SplitDirective_GivenSpacesBeforeAndAfterHashCharacter_ReturnsKeyword)
         {
-            string keyword, arguments;
+            std::string keyword, arguments;
             split_directive("   #   keyword", keyword, arguments);
 
             EXPECT_EQ("keyword", keyword);
@@ -199,7 +198,7 @@ namespace
 
         TEST_CASE(SplitDirective_GivenSpacesAfterKeyword_ReturnsKeyword)
         {
-            string keyword, arguments;
+            std::string keyword, arguments;
             split_directive("#keyword   ", keyword, arguments);
 
             EXPECT_EQ("keyword", keyword);
@@ -207,7 +206,7 @@ namespace
 
         TEST_CASE(SplitDirective_GivenNoArgument_ReturnsEmptyArguments)
         {
-            string keyword, arguments;
+            std::string keyword, arguments;
             split_directive("#keyword", keyword, arguments);
 
             EXPECT_EQ("", arguments);
@@ -215,7 +214,7 @@ namespace
 
         TEST_CASE(SplitDirective_GivenArguments_ReturnsArguments)
         {
-            string keyword, arguments;
+            std::string keyword, arguments;
             split_directive("#keyword arg1 arg2", keyword, arguments);
 
             EXPECT_EQ("arg1 arg2", arguments);
@@ -223,7 +222,7 @@ namespace
 
         TEST_CASE(SplitDirective_GivenSpacesAfterArguments_ReturnsArguments)
         {
-            string keyword, arguments;
+            std::string keyword, arguments;
             split_directive("#keyword arg1 arg2   ", keyword, arguments);
 
             EXPECT_EQ("arg1 arg2", arguments);
@@ -238,28 +237,28 @@ struct Preprocessor::Impl
     {
         const size_t m_line_number;
 
-        ExceptionParseError(const string& message, const size_t line_number)
+        ExceptionParseError(const std::string& message, const size_t line_number)
           : Exception(message.c_str())
           , m_line_number(line_number)
         {
         }
     };
 
-    bool                    m_succeeded;
-    string                  m_error_message;
-    size_t                  m_error_location;
+    bool                         m_succeeded;
+    std::string                  m_error_message;
+    size_t                       m_error_location;
 
-    typedef map<string, string> SymbolTable;
+    typedef std::map<std::string, std::string> SymbolTable;
 
-    SymbolTable             m_symbols;
+    SymbolTable                  m_symbols;
 
-    vector<string>          m_input_lines;
-    size_t                  m_current_input_line;
+    std::vector<std::string>     m_input_lines;
+    size_t                       m_current_input_line;
 
-    string                  m_result;
-    size_t                  m_current_output_line;
+    std::string                  m_result;
+    size_t                       m_current_output_line;
 
-    void process_text(const string& text)
+    void process_text(const std::string& text)
     {
         assert(m_result.empty());
 
@@ -277,11 +276,11 @@ struct Preprocessor::Impl
     {
         while (!is_end_of_input_text())
         {
-            string line = get_next_input_line();
+            std::string line = get_next_input_line();
 
             if (is_directive(line))
             {
-                string keyword, arguments;
+                std::string keyword, arguments;
                 split_directive(line, keyword, arguments);
                 parse_directive(keyword, arguments);
             }
@@ -292,7 +291,7 @@ struct Preprocessor::Impl
         }
     }
 
-    void parse_directive(const string& keyword, const string& arguments)
+    void parse_directive(const std::string& keyword, const std::string& arguments)
     {
         if (keyword == "define")
         {
@@ -304,13 +303,13 @@ struct Preprocessor::Impl
         }
         else
         {
-            parse_error(string("Unknown directive: #") + keyword);
+            parse_error(std::string("Unknown directive: #") + keyword);
         }
     }
 
-    void parse_define_directive(const string& arguments)
+    void parse_define_directive(const std::string& arguments)
     {
-        string symbol, value;
+        std::string symbol, value;
         split_line(arguments, symbol, value);
 
         substitute_symbols(value);
@@ -318,7 +317,7 @@ struct Preprocessor::Impl
         m_symbols[symbol] = value;
     }
 
-    void parse_ifdef_directive(const string& ifdef_arguments)
+    void parse_ifdef_directive(const std::string& ifdef_arguments)
     {
         const bool condition_value = evaluate_condition(ifdef_arguments);
 
@@ -330,11 +329,11 @@ struct Preprocessor::Impl
                 break;
             }
 
-            string line = get_next_input_line();
+            std::string line = get_next_input_line();
 
             if (is_directive(line))
             {
-                string keyword, arguments;
+                std::string keyword, arguments;
                 split_directive(line, keyword, arguments);
 
                 if (keyword == "endif")
@@ -351,31 +350,31 @@ struct Preprocessor::Impl
         }
     }
 
-    bool evaluate_condition(const string& condition) const
+    bool evaluate_condition(const std::string& condition) const
     {
         return m_symbols.find(condition) != m_symbols.end();
     }
 
-    void process_line(string& line)
+    void process_line(std::string& line)
     {
         substitute_symbols(line);
         emit_line(line);
     }
 
-    void substitute_symbols(string& line) const
+    void substitute_symbols(std::string& line) const
     {
         for (const_each<SymbolTable> i = m_symbols; i; ++i)
             substitute_symbol(line, i->first, i->second);
     }
 
     void substitute_symbol(
-        string&         line,
-        const string&   old_string,
-        const string&   new_string) const
+        std::string&         line,
+        const std::string&   old_string,
+        const std::string&   new_string) const
     {
-        string::size_type pos = line.find(old_string);
+        std::string::size_type pos = line.find(old_string);
 
-        while (pos != string::npos)
+        while (pos != std::string::npos)
         {
             if (is_surrounded_by_separators(line, pos, pos + old_string.size()))
                 line.replace(pos, old_string.size(), new_string);
@@ -384,7 +383,7 @@ struct Preprocessor::Impl
         }
     }
 
-    void parse_error(const string& message)
+    void parse_error(const std::string& message)
     {
         throw ExceptionParseError(message, m_current_input_line);
     }
@@ -394,14 +393,14 @@ struct Preprocessor::Impl
         return m_current_input_line == m_input_lines.size();
     }
 
-    const string& get_next_input_line()
+    const std::string& get_next_input_line()
     {
         assert(m_current_input_line < m_input_lines.size());
 
         return m_input_lines[m_current_input_line++];
     }
 
-    void emit_line(const string& line)
+    void emit_line(const std::string& line)
     {
         if (m_current_output_line > 0)
             m_result += '\n';

--- a/src/appleseed/foundation/utility/searchpaths.cpp
+++ b/src/appleseed/foundation/utility/searchpaths.cpp
@@ -45,7 +45,6 @@
 #include <iterator>
 #include <vector>
 
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace foundation
@@ -71,7 +70,7 @@ const char SearchPaths::osl_path_separator()
 
 struct SearchPaths::Impl
 {
-    typedef vector<string> PathCollection;
+    typedef std::vector<std::string> PathCollection;
 
     bf::path        m_root_path;
     PathCollection  m_environment_paths;
@@ -89,10 +88,10 @@ SearchPaths::SearchPaths(const char* envvar, const char separator)
 {
     if (const char* value = getenv(envvar))
     {
-        vector<string> paths;
-        split(value, string(&separator, 1), paths);
+        std::vector<std::string> paths;
+        split(value, std::string(&separator, 1), paths);
 
-        for (const string& path : paths)
+        for (const std::string& path : paths)
         {
             // Ignore empty paths.
             if (path.empty())
@@ -302,7 +301,7 @@ APIString SearchPaths::do_to_string(const char separator, const bool reversed) c
     if (reversed)
         reverse(paths.begin(), paths.end());
 
-    string paths_str;
+    std::string paths_str;
 
     for (size_t i = 0, e = paths.size(); i < e; ++i)
     {

--- a/src/appleseed/foundation/utility/seexpr.cpp
+++ b/src/appleseed/foundation/utility/seexpr.cpp
@@ -30,7 +30,6 @@
 #include "seexpr.h"
 
 using namespace boost;
-using namespace std;
 
 namespace foundation
 {
@@ -45,16 +44,16 @@ SeExprFilePathExtractor::SeExprFilePathExtractor()
 }
 
 void SeExprFilePathExtractor::extract_paths(
-    const string&               expression,
+    const std::string&          expression,
     PathCollection&             paths) const
 {
-    string::const_iterator start = expression.begin();
-    string::const_iterator end = expression.end();
+    std::string::const_iterator start = expression.begin();
+    std::string::const_iterator end = expression.end();
     smatch matches;
 
     while (regex_search(start, end, matches, m_regex))
     {
-        sub_match<string::const_iterator> submatch = matches["path"];
+        sub_match<std::string::const_iterator> submatch = matches["path"];
         paths.push_back(submatch.str());
         start = submatch.second;
     }
@@ -71,9 +70,9 @@ namespace
         {
         }
 
-        string operator()(const smatch& matches) const
+        std::string operator()(const smatch& matches) const
         {
-            string result = matches["prefix"].str();
+            std::string result = matches["prefix"].str();
             result += m_mappings.find(matches["path"].str())->second;
             result += matches["suffix"].str();
             return result;
@@ -81,8 +80,8 @@ namespace
     };
 }
 
-string SeExprFilePathExtractor::replace_paths(
-    const string&               expression,
+std::string SeExprFilePathExtractor::replace_paths(
+    const std::string&          expression,
     const MappingCollection&    mappings) const
 {
     const Formatter formatter(mappings);

--- a/src/appleseed/foundation/utility/settings/settingsfilereader.cpp
+++ b/src/appleseed/foundation/utility/settings/settingsfilereader.cpp
@@ -44,7 +44,6 @@
 #include <memory>
 #include <string>
 
-using namespace std;
 using namespace xercesc;
 
 namespace foundation
@@ -61,8 +60,8 @@ namespace
     {
         assert(node);
 
-        const basic_string<XMLCh> name_attribute_name = transcode("name");
-        const basic_string<XMLCh> value_attribute_name = transcode("value");
+        const std::basic_string<XMLCh> name_attribute_name = transcode("name");
+        const std::basic_string<XMLCh> value_attribute_name = transcode("value");
 
         node = node->getFirstChild();
 
@@ -70,7 +69,7 @@ namespace
         {
             if (node->getNodeType() == DOMNode::ELEMENT_NODE)
             {
-                const string element_name = transcode(node->getNodeName());
+                const std::string element_name = transcode(node->getNodeName());
 
                 if (element_name == "parameters")
                 {
@@ -121,14 +120,14 @@ bool SettingsFileReader::read(
         return false;
 
     // Create the DOM parser.
-    unique_ptr<XercesDOMParser> parser(new XercesDOMParser());
+    std::unique_ptr<XercesDOMParser> parser(new XercesDOMParser());
     parser->setValidationScheme(XercesDOMParser::Val_Always);
     parser->setDoNamespaces(true);
     parser->setDoSchema(true);
     parser->setExternalNoNamespaceSchemaLocation(schema_filename);
 
     // Create the error handler.
-    unique_ptr<ErrorLogger> error_handler(new ErrorLogger(m_logger, settings_filename));
+    std::unique_ptr<ErrorLogger> error_handler(new ErrorLogger(m_logger, settings_filename));
     parser->setErrorHandler(error_handler.get());
 
     // Parse the settings file.

--- a/src/appleseed/foundation/utility/settings/settingsfilewriter.cpp
+++ b/src/appleseed/foundation/utility/settings/settingsfilewriter.cpp
@@ -37,7 +37,6 @@
 // Standard headers.
 #include <cstdio>
 
-using namespace std;
 
 namespace foundation
 {

--- a/src/appleseed/foundation/utility/settings/settingsfilewriter.cpp
+++ b/src/appleseed/foundation/utility/settings/settingsfilewriter.cpp
@@ -37,7 +37,6 @@
 // Standard headers.
 #include <cstdio>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/statistics.cpp
+++ b/src/appleseed/foundation/utility/statistics.cpp
@@ -33,7 +33,6 @@
 // appleseed.foundation headers.
 #include "foundation/utility/foreach.h"
 
-using namespace std;
 
 namespace foundation
 {
@@ -95,25 +94,25 @@ void Statistics::merge(const Statistics& other)
     }
 }
 
-string Statistics::to_string(const size_t max_header_length) const
+std::string Statistics::to_string(const size_t max_header_length) const
 {
     if (m_entries.empty())
         return "  no statistics";
 
-    stringstream sstr;
+    std::stringstream sstr;
 
     for (const_each<EntryVector> i = m_entries; i; ++i)
     {
         const Entry* entry = *i;
 
         if (i.it() > m_entries.begin())
-            sstr << endl;
+            sstr << std::endl;
 
         sstr << "  ";
 
         if (entry->m_name.size() > max_header_length)
             sstr << entry->m_name.substr(0, max_header_length);
-        else sstr << entry->m_name << string(max_header_length - entry->m_name.size(), ' ');
+        else sstr << entry->m_name << std::string(max_header_length - entry->m_name.size(), ' ');
 
         sstr << entry->to_string();
     }
@@ -146,14 +145,14 @@ Statistics::ExceptionTypeMismatch::ExceptionTypeMismatch(const char* name)
 // Statistics::Entry class implementation.
 //
 
-Statistics::Entry::Entry(const string& name)
+Statistics::Entry::Entry(const std::string& name)
   : m_name(name)
 {
 }
 
 Statistics::Entry::Entry(
-    const string&               name,
-    const string&               unit)
+    const std::string&          name,
+    const std::string&          unit)
   : m_name(name)
   , m_unit(unit)
 {
@@ -165,17 +164,17 @@ Statistics::Entry::Entry(
 //
 
 Statistics::IntegerEntry::IntegerEntry(
-    const string&               name,
-    const string&               unit,
+    const std::string&          name,
+    const std::string&          unit,
     const int64                 value)
   : Entry(name, unit)
   , m_value(value)
 {
 }
 
-unique_ptr<Statistics::Entry> Statistics::IntegerEntry::clone() const
+std::unique_ptr<Statistics::Entry> Statistics::IntegerEntry::clone() const
 {
-    return unique_ptr<Entry>(new IntegerEntry(*this));
+    return std::unique_ptr<Entry>(new IntegerEntry(*this));
 }
 
 void Statistics::IntegerEntry::merge(const Entry* other)
@@ -183,7 +182,7 @@ void Statistics::IntegerEntry::merge(const Entry* other)
     m_value += cast<IntegerEntry>(other)->m_value;
 }
 
-string Statistics::IntegerEntry::to_string() const
+std::string Statistics::IntegerEntry::to_string() const
 {
     return pretty_int(m_value);
 }
@@ -194,17 +193,17 @@ string Statistics::IntegerEntry::to_string() const
 //
 
 Statistics::UnsignedIntegerEntry::UnsignedIntegerEntry(
-    const string&               name,
-    const string&               unit,
+    const std::string&          name,
+    const std::string&          unit,
     const uint64                value)
   : Entry(name, unit)
   , m_value(value)
 {
 }
 
-unique_ptr<Statistics::Entry> Statistics::UnsignedIntegerEntry::clone() const
+std::unique_ptr<Statistics::Entry> Statistics::UnsignedIntegerEntry::clone() const
 {
-    return unique_ptr<Entry>(new UnsignedIntegerEntry(*this));
+    return std::unique_ptr<Entry>(new UnsignedIntegerEntry(*this));
 }
 
 void Statistics::UnsignedIntegerEntry::merge(const Entry* other)
@@ -212,7 +211,7 @@ void Statistics::UnsignedIntegerEntry::merge(const Entry* other)
     m_value += cast<UnsignedIntegerEntry>(other)->m_value;
 }
 
-string Statistics::UnsignedIntegerEntry::to_string() const
+std::string Statistics::UnsignedIntegerEntry::to_string() const
 {
     return pretty_uint(m_value);
 }
@@ -223,17 +222,17 @@ string Statistics::UnsignedIntegerEntry::to_string() const
 //
 
 Statistics::FloatingPointEntry::FloatingPointEntry(
-    const string&               name,
-    const string&               unit,
+    const std::string&          name,
+    const std::string&          unit,
     const double                value)
   : Entry(name, unit)
   , m_value(value)
 {
 }
 
-unique_ptr<Statistics::Entry> Statistics::FloatingPointEntry::clone() const
+std::unique_ptr<Statistics::Entry> Statistics::FloatingPointEntry::clone() const
 {
-    return unique_ptr<Entry>(new FloatingPointEntry(*this));
+    return std::unique_ptr<Entry>(new FloatingPointEntry(*this));
 }
 
 void Statistics::FloatingPointEntry::merge(const Entry* other)
@@ -241,7 +240,7 @@ void Statistics::FloatingPointEntry::merge(const Entry* other)
     m_value += cast<FloatingPointEntry>(other)->m_value;
 }
 
-string Statistics::FloatingPointEntry::to_string() const
+std::string Statistics::FloatingPointEntry::to_string() const
 {
     return pretty_scalar(m_value);
 }
@@ -252,17 +251,17 @@ string Statistics::FloatingPointEntry::to_string() const
 //
 
 Statistics::StringEntry::StringEntry(
-    const string&               name,
-    const string&               unit,
-    const string&               value)
+    const std::string&               name,
+    const std::string&               unit,
+    const std::string&               value)
   : Entry(name, unit)
   , m_value(value)
 {
 }
 
-unique_ptr<Statistics::Entry> Statistics::StringEntry::clone() const
+std::unique_ptr<Statistics::Entry> Statistics::StringEntry::clone() const
 {
-    return unique_ptr<Entry>(new StringEntry(*this));
+    return std::unique_ptr<Entry>(new StringEntry(*this));
 }
 
 void Statistics::StringEntry::merge(const Entry* other)
@@ -270,7 +269,7 @@ void Statistics::StringEntry::merge(const Entry* other)
     // String statistics are not merged.
 }
 
-string Statistics::StringEntry::to_string() const
+std::string Statistics::StringEntry::to_string() const
 {
     return m_value;
 }
@@ -281,7 +280,7 @@ string Statistics::StringEntry::to_string() const
 //
 
 StatisticsVector StatisticsVector::make(
-    const string&               name,
+    const std::string&          name,
     const Statistics&           stats)
 {
     StatisticsVector vec;
@@ -290,7 +289,7 @@ StatisticsVector StatisticsVector::make(
 }
 
 void StatisticsVector::insert(
-    const string&               name,
+    const std::string&          name,
     const Statistics&           stats)
 {
     NamedStatistics named_stats;
@@ -319,16 +318,16 @@ void StatisticsVector::merge(const NamedStatistics& other)
     m_stats.push_back(other);
 }
 
-string StatisticsVector::to_string(const size_t max_header_length) const
+std::string StatisticsVector::to_string(const size_t max_header_length) const
 {
-    stringstream sstr;
+    std::stringstream sstr;
 
     for (const_each<NamedStatisticsVector> i = m_stats; i; ++i)
     {
         if (i.it() > m_stats.begin())
-            sstr << endl;
+            sstr << std::endl;
 
-        sstr << i->m_name << ":" << endl;
+        sstr << i->m_name << ":" << std::endl;
         sstr << i->m_stats.to_string(max_header_length);
     }
 

--- a/src/appleseed/foundation/utility/statistics.cpp
+++ b/src/appleseed/foundation/utility/statistics.cpp
@@ -33,7 +33,6 @@
 // appleseed.foundation headers.
 #include "foundation/utility/foreach.h"
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/string.cpp
+++ b/src/appleseed/foundation/utility/string.cpp
@@ -33,7 +33,6 @@
 // Standard headers.
 #include <cstring>
 
-using namespace std;
 
 namespace foundation
 {

--- a/src/appleseed/foundation/utility/string.cpp
+++ b/src/appleseed/foundation/utility/string.cpp
@@ -33,7 +33,6 @@
 // Standard headers.
 #include <cstring>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/test/loggertestlistener.cpp
+++ b/src/appleseed/foundation/utility/test/loggertestlistener.cpp
@@ -46,7 +46,6 @@
 #include <string>
 #include <vector>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/test/loggertestlistener.cpp
+++ b/src/appleseed/foundation/utility/test/loggertestlistener.cpp
@@ -46,7 +46,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 
 namespace foundation
 {
@@ -150,11 +149,11 @@ namespace
             }
 
             // Split the message into multiple components, one for each line.
-            vector<string> tokens;
+            std::vector<std::string> tokens;
             split(message, "\n", tokens);
 
             // Print the message.
-            for (const_each<vector<string>> i = tokens; i; ++i)
+            for (const_each<std::vector<std::string>> i = tokens; i; ++i)
                 LOG_ERROR(m_logger, "      %s", i->c_str());
         }
 

--- a/src/appleseed/foundation/utility/test/testlistenercollection.cpp
+++ b/src/appleseed/foundation/utility/test/testlistenercollection.cpp
@@ -37,7 +37,6 @@
 #include <cassert>
 #include <list>
 
-using namespace std;
 
 namespace foundation
 {
@@ -48,7 +47,7 @@ namespace foundation
 
 struct TestListenerCollection::Impl
 {
-    typedef list<ITestListener*> TestListenerContainer;
+    typedef std::list<ITestListener*> TestListenerContainer;
 
     TestListenerContainer m_listeners;
 };

--- a/src/appleseed/foundation/utility/test/testlistenercollection.cpp
+++ b/src/appleseed/foundation/utility/test/testlistenercollection.cpp
@@ -37,7 +37,6 @@
 #include <cassert>
 #include <list>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/test/testlistenerhelper.cpp
+++ b/src/appleseed/foundation/utility/test/testlistenerhelper.cpp
@@ -37,7 +37,6 @@
 // Standard headers.
 #include <cstdarg>
 
-using namespace std;
 
 namespace foundation
 {

--- a/src/appleseed/foundation/utility/test/testlistenerhelper.cpp
+++ b/src/appleseed/foundation/utility/test/testlistenerhelper.cpp
@@ -37,7 +37,6 @@
 // Standard headers.
 #include <cstdarg>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/test/testsuite.cpp
+++ b/src/appleseed/foundation/utility/test/testsuite.cpp
@@ -47,7 +47,6 @@
 #include <string>
 #include <vector>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/test/testsuite.cpp
+++ b/src/appleseed/foundation/utility/test/testsuite.cpp
@@ -47,7 +47,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 
 namespace foundation
 {
@@ -58,8 +57,8 @@ namespace foundation
 
 struct TestSuite::Impl
 {
-    string                      m_name;
-    vector<ITestCaseFactory*>   m_factories;
+    std::string                      m_name;
+    std::vector<ITestCaseFactory*>   m_factories;
 };
 
 TestSuite::TestSuite(const char* name)
@@ -190,7 +189,7 @@ void TestSuite::run_case(
 
     try
     {
-        unique_ptr<ITestCase> test_case(test_case_factory.create());
+        std::unique_ptr<ITestCase> test_case(test_case_factory.create());
 
         test_case->run(test_listener, test_case_result);
 
@@ -202,7 +201,7 @@ void TestSuite::run_case(
         test_case_result.signal_case_failure();
     }
 #ifdef NDEBUG
-    catch (const exception& e)
+    catch (const std::exception& e)
     {
         if (e.what()[0] != '\0')
         {

--- a/src/appleseed/foundation/utility/test/testsuiterepository.cpp
+++ b/src/appleseed/foundation/utility/test/testsuiterepository.cpp
@@ -39,7 +39,6 @@
 #include <cassert>
 #include <vector>
 
-using namespace std;
 
 namespace foundation
 {
@@ -50,7 +49,7 @@ namespace foundation
 
 struct TestSuiteRepository::Impl
 {
-    vector<TestSuite*> m_suites;
+    std::vector<TestSuite*> m_suites;
 };
 
 TestSuiteRepository::TestSuiteRepository()

--- a/src/appleseed/foundation/utility/test/testsuiterepository.cpp
+++ b/src/appleseed/foundation/utility/test/testsuiterepository.cpp
@@ -39,7 +39,6 @@
 #include <cassert>
 #include <vector>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/testutils.cpp
+++ b/src/appleseed/foundation/utility/testutils.cpp
@@ -45,7 +45,6 @@
 #include <fstream>
 #include <sstream>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/testutils.cpp
+++ b/src/appleseed/foundation/utility/testutils.cpp
@@ -45,33 +45,32 @@
 #include <fstream>
 #include <sstream>
 
-using namespace std;
 
 namespace foundation
 {
 
-bool load_text_file(const string& filename, string& contents)
+bool load_text_file(const std::string& filename, std::string& contents)
 {
-    ifstream file(filename.c_str());
+    std::ifstream file(filename.c_str());
 
     if (!file.is_open())
         return false;
 
-    stringstream sstr;
+    std::stringstream sstr;
     sstr << file.rdbuf();
     contents = sstr.str();
 
     return true;
 }
 
-bool compare_text_files(const string& filename1, const string& filename2)
+bool compare_text_files(const std::string& filename1, const std::string& filename2)
 {
-    string contents1;
+    std::string contents1;
 
     if (!load_text_file(filename1, contents1))
         return false;
 
-    string contents2;
+    std::string contents2;
 
     if (!load_text_file(filename2, contents2))
         return false;
@@ -119,7 +118,7 @@ bool are_images_feq(
 }
 
 void fit_point_cloud_to_image(
-    vector<Vector2d>&           points)
+    std::vector<Vector2d>&           points)
 {
     AABB2d aabb;
     aabb.invalidate();
@@ -139,10 +138,10 @@ void fit_point_cloud_to_image(
 }
 
 void write_point_cloud_image(
-    const string&               image_path,
-    const size_t                image_width,
-    const size_t                image_height,
-    const vector<Vector2d>&     points)
+    const std::string&               image_path,
+    const size_t                     image_width,
+    const size_t                     image_height,
+    const std::vector<Vector2d>&     points)
 {
     Image image(
         image_width,
@@ -163,8 +162,8 @@ void write_point_cloud_image(
 }
 
 void write_point_cloud_image(
-    const string&               image_path,
-    const vector<Vector2d>&     points)
+    const std::string&               image_path,
+    const std::vector<Vector2d>&     points)
 {
     write_point_cloud_image(
         image_path,

--- a/src/appleseed/foundation/utility/vpythonfile.cpp
+++ b/src/appleseed/foundation/utility/vpythonfile.cpp
@@ -37,7 +37,6 @@
 // Standard headers.
 #include <sstream>
 
-
 namespace foundation
 {
 

--- a/src/appleseed/foundation/utility/vpythonfile.cpp
+++ b/src/appleseed/foundation/utility/vpythonfile.cpp
@@ -37,7 +37,6 @@
 // Standard headers.
 #include <sstream>
 
-using namespace std;
 
 namespace foundation
 {
@@ -46,7 +45,7 @@ namespace foundation
 // VPythonFile class implementation.
 //
 
-VPythonFile::VPythonFile(const string& filename)
+VPythonFile::VPythonFile(const std::string& filename)
 {
     m_file = fopen(filename.c_str(), "wt");
 
@@ -73,9 +72,9 @@ void VPythonFile::close()
 
 namespace
 {
-    string points_to_string(const size_t point_count, const Vector3d points[])
+    std::string points_to_string(const size_t point_count, const Vector3d points[])
     {
-        stringstream sstr;
+        std::stringstream sstr;
 
         for (size_t i = 0; i < point_count; ++i)
         {

--- a/src/appleseed/foundation/utility/xercesc.cpp
+++ b/src/appleseed/foundation/utility/xercesc.cpp
@@ -38,7 +38,6 @@
 #include "xercesc/util/XMLException.hpp"
 #include "xercesc/util/XMLExceptMsgs.hpp"
 
-using namespace std;
 using namespace xercesc;
 
 namespace foundation
@@ -125,8 +124,8 @@ bool XercesCContext::is_initialized() const
 //
 
 ErrorLogger::ErrorLogger(
-    Logger&         logger,
-    const string&   input_filepath)
+    Logger&              logger,
+    const std::string&   input_filepath)
   : m_logger(logger)
   , m_input_filepath(input_filepath)
 {

--- a/src/appleseed/foundation/utility/zip.cpp
+++ b/src/appleseed/foundation/utility/zip.cpp
@@ -44,7 +44,6 @@
 #include <set>
 #include <vector>
 
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace foundation
@@ -61,7 +60,7 @@ ZipException::ZipException(const char* what)
 
 ZipException::ZipException(const char* what, const int err)
 {
-    const string string_what = string(what) + " (error code: " + to_string(err) + ")";
+    const std::string string_what = std::string(what) + " (error code: " + to_string(err) + ")";
     set_what(string_what.c_str());
 }
 
@@ -72,7 +71,7 @@ ZipException::ZipException(const char* what, const int err)
 
 namespace
 {
-    bool is_zip_entry_directory(const string& dirname)
+    bool is_zip_entry_directory(const std::string& dirname)
     {
         // Use our own implementation of is_zip_entry_directory instead of Boost's one
         // because this directory is not in the filesystem but in the zip file.
@@ -111,12 +110,12 @@ namespace
             throw ZipException("crc error");
     }
 
-    string read_filename(unzFile& zip_file)
+    std::string read_filename(unzFile& zip_file)
     {
         unz_file_info zip_file_info;
         unzGetCurrentFileInfo(zip_file, &zip_file_info, nullptr, 0, nullptr, 0, nullptr, 0);
 
-        vector<char> filename(zip_file_info.size_filename + 1);
+        std::vector<char> filename(zip_file_info.size_filename + 1);
         unzGetCurrentFileInfo(
             zip_file,
             &zip_file_info,
@@ -126,25 +125,25 @@ namespace
             nullptr, 0);
         filename[filename.size() - 1] = '\0';
 
-        return string(&filename[0]);
+        return std::string(&filename[0]);
     }
 
-    string get_filepath(unzFile& zip_file, const string& unzipped_dir)
+    std::string get_filepath(unzFile& zip_file, const std::string& unzipped_dir)
     {
-        const string filename = read_filename(zip_file);
+        const std::string filename = read_filename(zip_file);
         return (bf::path(unzipped_dir) / bf::path(filename)).string();
     }
 
-    void create_subdirectories(const string& filepath)
+    void create_subdirectories(const std::string& filepath)
     {
         const bf::path parent_path = bf::path(filepath).parent_path();
         if (!bf::exists(parent_path))
             bf::create_directories(parent_path);
     }
 
-    void extract_current_file(unzFile& zip_file, const string& unzipped_dir)
+    void extract_current_file(unzFile& zip_file, const std::string& unzipped_dir)
     {
-        const string filepath = get_filepath(zip_file, unzipped_dir);
+        const std::string filepath = get_filepath(zip_file, unzipped_dir);
 
         if (is_zip_entry_directory(filepath))
             return;
@@ -152,7 +151,7 @@ namespace
         create_subdirectories(filepath);
         open_current_file(zip_file);
 
-        fstream out(filepath.c_str(), ios_base::out | ios_base::binary);
+        std::fstream out(filepath.c_str(), std::ios_base::out | std::ios_base::binary);
         if (out.fail())
             throw ZipException(("can't open file " + filepath).c_str());
 
@@ -190,7 +189,7 @@ namespace
             throw ZipException("error while writing to zip", err);
     }
 
-    void open_new_file_in_zip(zipFile& zip_file, string filename_in_zip, zip_fileinfo zip_file_info)
+    void open_new_file_in_zip(zipFile& zip_file, std::string filename_in_zip, zip_fileinfo zip_file_info)
     {
         const int err =
             zipOpenNewFileInZip(
@@ -205,7 +204,7 @@ namespace
             throw ZipException(("error while opening " + filename_in_zip + " in zipfile").c_str());
     }
 
-    zip_fileinfo make_zip_fileinfo(const string& filename)
+    zip_fileinfo make_zip_fileinfo(const std::string& filename)
     {
         time_t timestamp = bf::last_write_time(filename);
         tm* timestamp_components = localtime(&timestamp);
@@ -225,15 +224,15 @@ namespace
         return zip_file_info;
     }
 
-    void zip_current_file(zipFile& zip_file, const string& filename, const string& base_directory)
+    void zip_current_file(zipFile& zip_file, const std::string& filename, const std::string& base_directory)
     {
-        const string filename_in_fs = (bf::path(base_directory) / filename).string();
+        const std::string filename_in_fs = (bf::path(base_directory) / filename).string();
 
         const zip_fileinfo zip_file_info = make_zip_fileinfo(filename_in_fs);
 
         open_new_file_in_zip(zip_file, filename, zip_file_info);
 
-        fstream in(filename_in_fs.c_str(), ios_base::in | ios_base::binary);
+        std::fstream in(filename_in_fs.c_str(), std::ios_base::in | std::ios_base::binary);
         if (in.fail())
             throw ZipException(("can't open file " + filename_in_fs).c_str());
 
@@ -252,7 +251,7 @@ namespace
     }
 }
 
-void unzip(const string& zip_filename, const string& unzipped_dir)
+void unzip(const std::string& zip_filename, const std::string& unzipped_dir)
 {
     try
     {
@@ -273,33 +272,33 @@ void unzip(const string& zip_filename, const string& unzipped_dir)
 
         unzClose(zip_file);
     }
-    catch (const exception& e)
+    catch (const std::exception& e)
     {
         bf::remove_all(unzipped_dir);
         throw e;
     }
 }
 
-void zip(const string& zip_filename, const string& directory_to_zip)
+void zip(const std::string& zip_filename, const std::string& directory_to_zip)
 {
     try
     {
-        set<string> files_to_zip = recursive_ls(directory_to_zip);
+        std::set<std::string> files_to_zip = recursive_ls(directory_to_zip);
 
         zipFile zip_file = zipOpen(zip_filename.c_str(), 0);
         if (zip_file == nullptr)
             throw ZipException(("can't open file " + zip_filename).c_str());
 
-        for (set<string>::iterator it = files_to_zip.begin();
+        for (std::set<std::string>::iterator it = files_to_zip.begin();
              it != files_to_zip.end(); ++it)
         {
-            const string filename_to_zip = *it;
+            const std::string filename_to_zip = *it;
             zip_current_file(zip_file, filename_to_zip, directory_to_zip);
         }
 
         zipClose(zip_file, nullptr);
     }
-    catch (const exception& e)
+    catch (const std::exception& e)
     {
         bf::remove(zip_filename);
         throw e;
@@ -319,9 +318,9 @@ bool is_zip_file(const char* filename)
     }
 }
 
-vector<string> get_filenames_with_extension_from_zip(const string& zip_filename, const string& extension)
+std::vector<std::string> get_filenames_with_extension_from_zip(const std::string& zip_filename, const std::string& extension)
 {
-    vector<string> filenames;
+    std::vector<std::string> filenames;
 
     unzFile zip_file = unzOpen(zip_filename.c_str());
     if (zip_file == nullptr)
@@ -332,7 +331,7 @@ vector<string> get_filenames_with_extension_from_zip(const string& zip_filename,
     int has_next = UNZ_OK;
     while (has_next == UNZ_OK)
     {
-        const string filename = read_filename(zip_file);
+        const std::string filename = read_filename(zip_file);
 
         if (ends_with(filename, extension))
             filenames.push_back(filename);
@@ -345,9 +344,9 @@ vector<string> get_filenames_with_extension_from_zip(const string& zip_filename,
     return filenames;
 }
 
-set<string> recursive_ls(const bf::path& dir)
+std::set<std::string> recursive_ls(const bf::path& dir)
 {
-    set<string> files;
+    std::set<std::string> files;
 
     // A default-constructed directory_iterator acts as the end iterator.
     for (bf::directory_iterator di(dir), de; di != de; ++di)
@@ -356,10 +355,10 @@ set<string> recursive_ls(const bf::path& dir)
 
         if (bf::is_directory(current_path))
         {
-            const string dirname = current_path.filename().string();
-            const set<string> files_in_subdir = recursive_ls(current_path);
+            const std::string dirname = current_path.filename().string();
+            const std::set<std::string> files_in_subdir = recursive_ls(current_path);
 
-            for (const_each<set<string>> fi = files_in_subdir; fi; ++fi)
+            for (const_each<std::set<std::string>> fi = files_in_subdir; fi; ++fi)
                 files.insert(dirname + "/" + *fi);
         }
         else


### PR DESCRIPTION
This PR part of a series.
Fixes #2641 for appleseed/foundation.

See also: #2689, #2690, #2691, #2692, #2694