### PR TITLE
Remove remaining 'using namespace std' statements

### DIFF
--- a/src/appleseed.cli/main.cpp
+++ b/src/appleseed.cli/main.cpp
@@ -76,7 +76,6 @@ using namespace appleseed::cli;
 using namespace appleseed::shared;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace
@@ -131,7 +130,7 @@ namespace
     {
         // Configure the renderer's logger: mute all log messages except warnings and errors.
         SaveLogFormatterConfig save_global_logger_config(global_logger());
-        global_logger().set_all_formats(string());
+        global_logger().set_all_formats(std::string());
         global_logger().reset_format(LogMessage::Warning);
         global_logger().reset_format(LogMessage::Error);
         global_logger().reset_format(LogMessage::Fatal);
@@ -190,7 +189,7 @@ namespace
     {
         // Configure the renderer's logger: mute all log messages except warnings and errors.
         SaveLogFormatterConfig save_global_logger_config(global_logger());
-        global_logger().set_all_formats(string());
+        global_logger().set_all_formats(std::string());
         global_logger().reset_format(LogMessage::Warning);
         global_logger().reset_format(LogMessage::Error);
         global_logger().reset_format(LogMessage::Fatal);
@@ -205,7 +204,7 @@ namespace
         // Try to add a benchmark listener that outputs to a XML file.
         auto_release_ptr<XMLFileBenchmarkListener> xmlfile_listener(
             create_xmlfile_benchmark_listener());
-        const string xmlfile_name = "benchmark." + get_time_stamp_string() + ".xml";
+        const std::string xmlfile_name = "benchmark." + get_time_stamp_string() + ".xml";
         const bf::path xmlfile_path =
               bf::path(Application::get_tests_root_path())
             / "unit benchmarks" / "results" / xmlfile_name;
@@ -288,12 +287,12 @@ namespace
         for (size_t i = 0; i < g_cl.m_params.values().size(); ++i)
         {
             // Retrieve the assignment string (of the form name=value).
-            const string& s = g_cl.m_params.values()[i];
+            const std::string& s = g_cl.m_params.values()[i];
 
             // Retrieve the name and the value of the parameter.
-            const string::size_type equal_pos = s.find_first_of('=');
-            const string path = s.substr(0, equal_pos);
-            const string value = s.substr(equal_pos + 1);
+            const std::string::size_type equal_pos = s.find_first_of('=');
+            const std::string path = s.substr(0, equal_pos);
+            const std::string value = s.substr(equal_pos + 1);
 
             // Insert the parameter.
             params.insert_path(path, value);
@@ -310,7 +309,7 @@ namespace
 
         if (g_cl.m_resolution.is_set())
         {
-            const string resolution =
+            const std::string resolution =
                   foundation::to_string(g_cl.m_resolution.values()[0]) + ' ' +
                   foundation::to_string(g_cl.m_resolution.values()[1]);
             new_params.insert("resolution", resolution);
@@ -318,7 +317,7 @@ namespace
 
         if (g_cl.m_window.is_set())
         {
-            const string crop_window =
+            const std::string crop_window =
                   foundation::to_string(g_cl.m_window.values()[0]) + ' ' +
                   foundation::to_string(g_cl.m_window.values()[1]) + ' ' +
                   foundation::to_string(g_cl.m_window.values()[2]) + ' ' +
@@ -430,12 +429,12 @@ namespace
     {
         if (g_cl.m_show_object_instances.is_set() || g_cl.m_hide_object_instances.is_set())
         {
-            const string show_regex =
+            const std::string show_regex =
                 g_cl.m_show_object_instances.is_set()
                     ? g_cl.m_show_object_instances.value()
                     : ".*";     // match everything
 
-            const string hide_regex =
+            const std::string hide_regex =
                 g_cl.m_hide_object_instances.is_set()
                     ? g_cl.m_hide_object_instances.value()
                     : "(?!)";   // match nothing
@@ -465,14 +464,14 @@ namespace
 #if defined __APPLE__ || defined _WIN32
 
     // Invoke a system command to open an image file.
-    void display_frame(const string& path)
+    void display_frame(const std::string& path)
     {
-        const string quoted_path = "\"" + path + "\"";
+        const std::string quoted_path = "\"" + path + "\"";
 
 #if defined __APPLE__
-        const string command = "open " + quoted_path;
+        const std::string command = "open " + quoted_path;
 #elif defined _WIN32
-        const string command = quoted_path;
+        const std::string command = quoted_path;
 #endif
 
         LOG_DEBUG(g_logger, "executing '%s'", command.c_str());
@@ -481,7 +480,7 @@ namespace
 
 #endif
 
-    auto_release_ptr<Project> load_project(const string& project_filepath)
+    auto_release_ptr<Project> load_project(const std::string& project_filepath)
     {
         // Construct the schema file path.
         const bf::path schema_filepath =
@@ -500,7 +499,7 @@ namespace
     bool configure_project(Project& project, ParamArray& params)
     {
         // Retrieve the name of the configuration to use.
-        const string config_name = g_cl.m_configuration.is_set()
+        const std::string config_name = g_cl.m_configuration.is_set()
             ? g_cl.m_configuration.value()
             : "final";
 
@@ -532,11 +531,11 @@ namespace
 
     bool is_progressive_render(const ParamArray& params)
     {
-        const string value = params.get_required<string>("frame_renderer", "generic");
+        const std::string value = params.get_required<std::string>("frame_renderer", "generic");
         return value == "progressive";
     }
 
-    bool render(const string& project_filename)
+    bool render(const std::string& project_filename)
     {
         // Load the project.
         auto_release_ptr<Project> project = load_project(project_filename);
@@ -549,7 +548,7 @@ namespace
             return false;
 
         // Create the tile callback factory.
-        unique_ptr<ITileCallbackFactory> tile_callback_factory;
+        std::unique_ptr<ITileCallbackFactory> tile_callback_factory;
         if (g_cl.m_send_to_stdout.is_set())
         {
             tile_callback_factory.reset(
@@ -559,7 +558,7 @@ namespace
         else if (project->get_display() == nullptr)
         {
             // Create a default tile callback if needed.
-            if (params.get_optional<string>("frame_renderer", "") != "progressive")
+            if (params.get_optional<std::string>("frame_renderer", "") != "progressive")
             {
                 tile_callback_factory.reset(
                     new ProgressTileCallbackFactory(
@@ -662,7 +661,7 @@ namespace
         return success;
     }
 
-    bool benchmark_render(const string& project_filename)
+    bool benchmark_render(const std::string& project_filename)
     {
         // Configure our logger.
         SaveLogFormatterConfig save_g_logger_config(g_logger);
@@ -671,7 +670,7 @@ namespace
 
         // Configure the renderer's logger: mute all log messages except warnings and errors.
         SaveLogFormatterConfig save_global_logger_config(global_logger());
-        global_logger().set_all_formats(string());
+        global_logger().set_all_formats(std::string());
         global_logger().reset_format(LogMessage::Warning);
         global_logger().reset_format(LogMessage::Error);
         global_logger().reset_format(LogMessage::Fatal);
@@ -777,7 +776,7 @@ int main(int argc, char* argv[])
     // Render the specified project.
     if (!g_cl.m_filename.values().empty())
     {
-        const string project_filename = g_cl.m_filename.value();
+        const std::string project_filename = g_cl.m_filename.value();
 
         if (g_cl.m_benchmark_mode.is_set())
             success = success && benchmark_render(project_filename);

--- a/src/appleseed.cli/stdouttilecallback.cpp
+++ b/src/appleseed.cli/stdouttilecallback.cpp
@@ -53,7 +53,6 @@
 
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 namespace appleseed {
 namespace cli {

--- a/src/appleseed.shared/application/application.cpp
+++ b/src/appleseed.shared/application/application.cpp
@@ -44,7 +44,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace appleseed {
@@ -154,7 +153,7 @@ namespace
 
     void copy_directory_path_to_buffer(const bf::path& path, char* output)
     {
-        const string path_string = path.string();
+        const std::string path_string = path.string();
 
         assert(path_string.size() <= FOUNDATION_MAX_PATH_LENGTH);
 
@@ -285,7 +284,7 @@ bool Application::load_settings(
     }
 
     // As a fallback, try to read settings from appleseed's installation directory.
-    const string settings_file_path = safe_canonical(root_path / "settings" / filename).string();
+    const std::string settings_file_path = safe_canonical(root_path / "settings" / filename).string();
     if (reader.read(
             settings_file_path.c_str(),
             schema_file_path.string().c_str(),
@@ -315,7 +314,7 @@ bool Application::save_settings(
             const bf::path user_settings_path(user_path);
             bf::create_directories(user_settings_path);
 
-            const string user_settings_file_path = safe_canonical(user_settings_path / filename).string();
+            const std::string user_settings_file_path = safe_canonical(user_settings_path / filename).string();
             if (writer.write(user_settings_file_path.c_str(), settings))
             {
                 LOG(logger, category, "successfully saved settings to %s.", user_settings_file_path.c_str());
@@ -329,7 +328,7 @@ bool Application::save_settings(
 
     // As a fallback, try to write settings to appleseed's installation directory.
     const bf::path root_path(get_root_path());
-    const string settings_file_path = safe_canonical(root_path / "settings" / filename).string();
+    const std::string settings_file_path = safe_canonical(root_path / "settings" / filename).string();
     if (writer.write(settings_file_path.c_str(), settings))
     {
         LOG(logger, category, "successfully saved settings to %s.", settings_file_path.c_str());

--- a/src/appleseed.shared/application/commandlinehandlerbase.cpp
+++ b/src/appleseed.shared/application/commandlinehandlerbase.cpp
@@ -54,7 +54,6 @@
 #include <string>
 
 using namespace foundation;
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace appleseed {
@@ -62,23 +61,23 @@ namespace shared {
 
 struct CommandLineHandlerBase::Impl
 {
-    const string                m_application_name;
+    const std::string                m_application_name;
 
-    FlagOptionHandler           m_help;
-    FlagOptionHandler           m_version;
-    FlagOptionHandler           m_libraries;
-    FlagOptionHandler           m_system;
-    ValueOptionHandler<string>  m_message_verbosity;
-    FlagOptionHandler           m_message_coloring;
-    FlagOptionHandler           m_display_options;
+    FlagOptionHandler                m_help;
+    FlagOptionHandler                m_version;
+    FlagOptionHandler                m_libraries;
+    FlagOptionHandler                m_system;
+    ValueOptionHandler<std::string>  m_message_verbosity;
+    FlagOptionHandler                m_message_coloring;
+    FlagOptionHandler                m_display_options;
 
 #ifdef WIN32
-    FlagOptionHandler           m_disable_abort_dialogs;
+    FlagOptionHandler                m_disable_abort_dialogs;
 #endif
 
-    string                      m_executable_name;
-    CommandLineParser           m_parser;
-    ParseResults                m_parse_results;
+    std::string                      m_executable_name;
+    CommandLineParser                m_parser;
+    ParseResults                     m_parse_results;
 
     explicit Impl(const char* application_name)
       : m_application_name(application_name)
@@ -164,7 +163,7 @@ struct CommandLineHandlerBase::Impl
             const char* lib_name = version.m_first.c_str();
             const char* lib_version = version.m_second.c_str();
             const size_t lib_name_length = strlen(lib_name);
-            const string spacing(30 - lib_name_length, ' ');
+            const std::string spacing(30 - lib_name_length, ' ');
             LOG_INFO(logger, "  %s%s%s", lib_name, spacing.c_str(), lib_version);
         }
     }

--- a/src/appleseed.shared/application/progresstilecallback.cpp
+++ b/src/appleseed.shared/application/progresstilecallback.cpp
@@ -49,7 +49,6 @@
 
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 namespace appleseed {
 namespace shared {
@@ -138,7 +137,7 @@ namespace
 
 struct ProgressTileCallbackFactory::Impl
 {
-    unique_ptr<ITileCallback> m_callback;
+    std::unique_ptr<ITileCallback> m_callback;
 };
 
 ProgressTileCallbackFactory::ProgressTileCallbackFactory(
@@ -146,7 +145,7 @@ ProgressTileCallbackFactory::ProgressTileCallbackFactory(
     const size_t    pass_count)
   : impl(new Impl())
 {
-    impl->m_callback = unique_ptr<ITileCallback>(
+    impl->m_callback = std::unique_ptr<ITileCallback>(
         new ProgressTileCallback(logger, pass_count));
 }
 

--- a/src/appleseed.shared/application/superlogger.cpp
+++ b/src/appleseed.shared/application/superlogger.cpp
@@ -43,7 +43,6 @@
 #endif
 
 using namespace foundation;
-using namespace std;
 
 namespace appleseed {
 namespace shared {

--- a/src/appleseed/main/allocator.cpp
+++ b/src/appleseed/main/allocator.cpp
@@ -505,27 +505,27 @@ namespace
 
 _Ret_notnull_ _Post_writable_byte_size_(size)
 void* operator new(size_t size)
-  throw(bad_alloc)
+  throw(std::bad_alloc)
 {
     return new_impl(size);
 }
 
 _Ret_notnull_ _Post_writable_byte_size_(size)
 void* operator new[](size_t size)
-  throw(bad_alloc)
+  throw(std::bad_alloc)
 {
     return new_impl(size);
 }
 
 _Ret_maybenull_ _Post_writable_byte_size_(size)
-void* operator new(size_t size, const nothrow_t&)
+void* operator new(size_t size, const std::nothrow_t&)
   throw()
 {
     return new_impl(size);
 }
 
 _Ret_maybenull_ _Post_writable_byte_size_(size)
-void* operator new[](size_t size, const nothrow_t&)
+void* operator new[](size_t size, const std::nothrow_t&)
   throw()
 {
     return new_impl(size);
@@ -541,12 +541,12 @@ void operator delete[](void* ptr)
     delete_impl(ptr);
 }
 
-void operator delete(void* ptr, const nothrow_t&)
+void operator delete(void* ptr, const std::nothrow_t&)
 {
     delete_impl(ptr);
 }
 
-void operator delete[](void* ptr, const nothrow_t&)
+void operator delete[](void* ptr, const std::nothrow_t&)
 {
     delete_impl(ptr);
 }

--- a/src/appleseed/main/allocator.cpp
+++ b/src/appleseed/main/allocator.cpp
@@ -79,7 +79,6 @@
 
 using namespace boost;
 using namespace foundation;
-using namespace std;
 
 
 //
@@ -211,7 +210,7 @@ namespace
 
         const tm* local_time = localtime(&t);
 
-        stringstream sstr;
+        std::stringstream sstr;
         sstr << setfill('0');
 
         sstr << setw(2) << local_time->tm_hour << ':';
@@ -262,7 +261,7 @@ namespace
             "[%s] Deallocated %s at %s\n",
             get_timestamp_string().c_str(),
             pretty_size(size).c_str(),
-            to_string(ptr).c_str());
+            std::to_string(ptr).c_str());
 
 #ifdef DUMP_CALLSTACK_ON_ALLOCATION
         fprintf(g_log_file, "\n");
@@ -339,7 +338,7 @@ namespace
             for (const_each<MemoryBlockMap> i = g_allocated_mem_blocks; i; ++i)
                 sorted_blocks.push_back(*i);
 
-            sort(sorted_blocks.begin(), sorted_blocks.end(), SortByDecreasingSize());
+            std::sort(sorted_blocks.begin(), sorted_blocks.end(), SortByDecreasingSize());
 
             for (const_each<MemoryBlockVector> i = sorted_blocks; i; ++i)
             {
@@ -347,7 +346,7 @@ namespace
                     g_log_file,
                     "    %s at %s\n",
                     pretty_size(i->second).c_str(),
-                    to_string(i->first).c_str());
+                    std::to_string(i->first).c_str());
             }
         }
     }
@@ -369,9 +368,9 @@ void log_allocation(const void* ptr, const size_t size)
 
     ++g_allocation_count;
     g_allocated_bytes += size;
-    g_peak_allocated_bytes = max(g_peak_allocated_bytes, g_allocated_bytes);
+    g_peak_allocated_bytes = std::max(g_peak_allocated_bytes, g_allocated_bytes);
     g_total_allocated_bytes += size;
-    g_largest_allocation_bytes = max<uint64>(g_largest_allocation_bytes, size);
+    g_largest_allocation_bytes = std::max<uint64>(g_largest_allocation_bytes, size);
 
     g_allocated_mem_blocks[ptr] = size;
 
@@ -490,7 +489,7 @@ namespace
         void* ptr = aligned_malloc(size, MemoryAlignment);
 
         if (!ptr)
-            throw bad_alloc();
+            throw std::bad_alloc();
 
         return ptr;
     }

--- a/src/appleseed/main/dllmain.cpp
+++ b/src/appleseed/main/dllmain.cpp
@@ -61,7 +61,7 @@ namespace
         redirect(stderr, "w", STD_ERROR_HANDLE);
 
         // Make cout, wcout, cin, wcin, cerr, wcerr, clog and wclog point to the console as well.
-        ios::sync_with_stdio();
+        std::ios::sync_with_stdio();
     }
 }
 

--- a/src/appleseed/main/dllmain.cpp
+++ b/src/appleseed/main/dllmain.cpp
@@ -40,8 +40,6 @@
 #include <fcntl.h>
 #include <io.h>
 
-using namespace std;
-
 namespace
 {
     void redirect(FILE* fp, const char* mode, const DWORD std_device)

--- a/src/tools/animatecamera/animationpath.cpp
+++ b/src/tools/animatecamera/animationpath.cpp
@@ -44,7 +44,6 @@
 #include <cstring>
 
 using namespace foundation;
-using namespace std;
 
 namespace appleseed {
 namespace animatecamera {

--- a/src/tools/animatecamera/commandlinehandler.cpp
+++ b/src/tools/animatecamera/commandlinehandler.cpp
@@ -39,7 +39,6 @@
 
 using namespace appleseed::shared;
 using namespace foundation;
-using namespace std;
 
 namespace appleseed {
 namespace animatecamera {

--- a/src/tools/animatecamera/main.cpp
+++ b/src/tools/animatecamera/main.cpp
@@ -72,7 +72,6 @@ using namespace appleseed::animatecamera;
 using namespace appleseed::shared;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace
@@ -123,7 +122,7 @@ namespace
     template <typename T>
     struct TransformPairComparer
     {
-        typedef pair<Transform<T>, Transform<T>> TransformPair;
+        typedef std::pair<Transform<T>, Transform<T>> TransformPair;
 
         bool operator()(const TransformPair& lhs, const TransformPair& rhs) const
         {
@@ -145,8 +144,8 @@ namespace
     {
       public:
         AnimationGenerator(
-            const string&   base_output_filename,
-            Logger&         logger)
+            const std::string&   base_output_filename,
+            Logger&              logger)
           : m_base_output_filename(base_output_filename)
           , m_logger(logger)
         {
@@ -156,7 +155,7 @@ namespace
 
         void generate()
         {
-            const vector<size_t> frames = do_generate();
+            const std::vector<size_t> frames = do_generate();
 
             LOG_INFO(
                 m_logger,
@@ -171,22 +170,22 @@ namespace
         }
 
       protected:
-        const string        m_base_output_filename;
+        const std::string   m_base_output_filename;
         Logger&             m_logger;
 
-        virtual vector<size_t> do_generate() = 0;
+        virtual std::vector<size_t> do_generate() = 0;
 
-        static string make_numbered_filename(
-            const string&   filename,
-            const size_t    number,
-            const size_t    digits = 4)
+        static std::string make_numbered_filename(
+            const std::string&   filename,
+            const size_t         number,
+            const size_t         digits = 4)
         {
             const bf::path path(filename);
 
-            stringstream sstr;
+            std::stringstream sstr;
             sstr << path.stem().string();
             sstr << '.';
-            sstr << setw(digits) << setfill('0') << number;
+            sstr << std::setw(digits) << std::setfill('0') << number;
             sstr << path.extension().string();
 
             return sstr.str();
@@ -216,7 +215,7 @@ namespace
         }
 
       private:
-        void generate_windows_render_script(const vector<size_t>& frames) const
+        void generate_windows_render_script(const std::vector<size_t>& frames) const
         {
             const size_t part_count = g_cl.m_part_count.value();
             const size_t frames_per_part =
@@ -224,7 +223,7 @@ namespace
 
             for (size_t part = 1, frame_begin = 0; frame_begin < frames.size(); ++part)
             {
-                const size_t frame_end = min(frame_begin + frames_per_part, frames.size());
+                const size_t frame_end = std::min(frame_begin + frames_per_part, frames.size());
 
                 generate_windows_render_script(
                     frames,
@@ -237,14 +236,14 @@ namespace
         }
 
         void generate_windows_render_script(
-            const vector<size_t>&   frames,
-            const size_t            part,
-            const size_t            frame_begin,
-            const size_t            frame_end) const
+            const std::vector<size_t>&   frames,
+            const size_t                 part,
+            const size_t                 frame_begin,
+            const size_t                 frame_end) const
         {
-            const string RenderScriptBaseFileName = "render.bat";
+            const std::string RenderScriptBaseFileName = "render.bat";
 
-            const string script_filename =
+            const std::string script_filename =
                 frame_begin == 0 && frame_end == frames.size()
                     ? RenderScriptBaseFileName
                     : make_numbered_filename(RenderScriptBaseFileName, part);
@@ -283,16 +282,16 @@ namespace
                 ")\n"
                 "\n");
 
-            const string output_format = g_cl.m_output_format.value();
+            const std::string output_format = g_cl.m_output_format.value();
 
             for (size_t i = frame_begin; i < frame_end; ++i)
             {
                 const size_t current_frame = i + 1;
                 const size_t actual_frame = frames[i];
 
-                const string project_filename = make_numbered_filename(m_base_output_filename + ".appleseed", current_frame);
-                const string image_filename = make_numbered_filename(m_base_output_filename + "." + output_format, current_frame);
-                const string image_filepath = "%output_path%\\" + image_filename;
+                const std::string project_filename = make_numbered_filename(m_base_output_filename + ".appleseed", current_frame);
+                const std::string image_filename = make_numbered_filename(m_base_output_filename + "." + output_format, current_frame);
+                const std::string image_filepath = "%output_path%\\" + image_filename;
 
                 fprintf(script_file, "if exist \"%s\" (\n", image_filepath.c_str());
                 fprintf(script_file, "    echo Skipping %s because it was already rendered...\n", project_filename.c_str());
@@ -312,8 +311,8 @@ namespace
                 }
                 else
                 {
-                    const string source_image_filename = make_numbered_filename(m_base_output_filename + "." + output_format, actual_frame);
-                    const string source_image_filepath = "%output_path%\\" + source_image_filename;
+                    const std::string source_image_filename = make_numbered_filename(m_base_output_filename + "." + output_format, actual_frame);
+                    const std::string source_image_filepath = "%output_path%\\" + source_image_filename;
 
                     fprintf(
                         script_file,
@@ -352,19 +351,19 @@ namespace
     {
       public:
         PathAnimationGenerator(
-            const string&   base_output_filename,
-            Logger&         logger)
+            const std::string&   base_output_filename,
+            Logger&              logger)
           : AnimationGenerator(base_output_filename, logger)
         {
         }
 
       private:
-        vector<size_t> do_generate() override
+        std::vector<size_t> do_generate() override
         {
-            typedef pair<Transformd, Transformd> TransformPair;
-            typedef map<TransformPair, size_t, TransformPairComparer<double>> TransformMap;
+            typedef std::pair<Transformd, Transformd> TransformPair;
+            typedef std::map<TransformPair, size_t, TransformPairComparer<double>> TransformMap;
 
-            vector<size_t> frames;
+            std::vector<size_t> frames;
 
             // Load the animation path file from disk.
             AnimationPath animation_path(m_logger);
@@ -422,7 +421,7 @@ namespace
                 camera->get_parameters().insert("shutter_close_end_time", motion_blur_amount);
 
                 // Write the project file for this frame.
-                const string new_path = make_numbered_filename(m_base_output_filename + ".appleseed", frame);
+                const std::string new_path = make_numbered_filename(m_base_output_filename + ".appleseed", frame);
                 ProjectFileWriter::write(
                     project.ref(),
                     new_path.c_str(),
@@ -448,16 +447,16 @@ namespace
     {
       public:
         TurntableAnimationGenerator(
-            const string&   base_output_filename,
-            Logger&         logger)
+            const std::string&   base_output_filename,
+            Logger&              logger)
           : AnimationGenerator(base_output_filename, logger)
         {
         }
 
       private:
-        vector<size_t> do_generate() override
+        std::vector<size_t> do_generate() override
         {
-            vector<size_t> frames;
+            std::vector<size_t> frames;
 
             // Retrieve the command line parameter values.
             const int frame_count = g_cl.m_frame_count.value();
@@ -516,7 +515,7 @@ namespace
 
                 // Write the project file for this frame.
                 const size_t frame = static_cast<size_t>(i + 1);
-                const string new_path = make_numbered_filename(m_base_output_filename + ".appleseed", frame);
+                const std::string new_path = make_numbered_filename(m_base_output_filename + ".appleseed", frame);
                 ProjectFileWriter::write(
                     project.ref(),
                     new_path.c_str(),
@@ -566,10 +565,10 @@ int main(int argc, char* argv[])
     // target of the global logger.
     global_logger().initialize_from(logger);
 
-    const string base_output_filename =
+    const std::string base_output_filename =
         bf::path(g_cl.m_filenames.values()[1]).stem().string();
 
-    unique_ptr<AnimationGenerator> generator;
+    std::unique_ptr<AnimationGenerator> generator;
 
     if (g_cl.m_animation_path.is_set())
         generator.reset(new PathAnimationGenerator(base_output_filename, logger));

--- a/src/tools/convertmeshfile/commandlinehandler.cpp
+++ b/src/tools/convertmeshfile/commandlinehandler.cpp
@@ -38,7 +38,6 @@
 
 using namespace appleseed::shared;
 using namespace foundation;
-using namespace std;
 
 namespace appleseed {
 namespace convertmeshfile {

--- a/src/tools/convertmeshfile/main.cpp
+++ b/src/tools/convertmeshfile/main.cpp
@@ -57,33 +57,32 @@
 using namespace appleseed::convertmeshfile;
 using namespace appleseed::shared;
 using namespace foundation;
-using namespace std;
 
 namespace
 {
     struct Face
     {
-        vector<size_t>      m_vertices;
-        vector<size_t>      m_vertex_normals;
-        vector<size_t>      m_vertex_tex_coords;
-        size_t              m_material;
+        std::vector<size_t>        m_vertices;
+        std::vector<size_t>        m_vertex_normals;
+        std::vector<size_t>        m_vertex_tex_coords;
+        size_t                     m_material;
     };
 
     struct Mesh
     {
-        string              m_name;
-        vector<Vector3d>    m_vertices;
-        vector<Vector3d>    m_vertex_normals;
-        vector<Vector2d>    m_tex_coords;
-        vector<string>      m_material_slots;
-        deque<Face>         m_faces;
+        std::string                m_name;
+        std::vector<Vector3d>      m_vertices;
+        std::vector<Vector3d>      m_vertex_normals;
+        std::vector<Vector2d>      m_tex_coords;
+        std::vector<std::string>   m_material_slots;
+        std::deque<Face>           m_faces;
     };
 
     class MeshBuilder
       : public IMeshBuilder
     {
       public:
-        const list<Mesh>& get_meshes() const
+        const std::list<Mesh>& get_meshes() const
         {
             return m_meshes;
         }
@@ -161,9 +160,9 @@ namespace
         }
 
       private:
-        list<Mesh>  m_meshes;
-        Mesh        m_current_mesh;
-        Face        m_current_face;
+        std::list<Mesh>  m_meshes;
+        Mesh             m_current_mesh;
+        Face             m_current_face;
     };
 
     class MeshWalker
@@ -300,8 +299,8 @@ int main(int argc, char* argv[])
     cl.apply(logger);
 
     // Retrieve the input and output file paths.
-    const string& input_filepath = cl.m_filenames.values()[0];
-    const string& output_filepath = cl.m_filenames.values()[1];
+    const std::string& input_filepath = cl.m_filenames.values()[0];
+    const std::string& output_filepath = cl.m_filenames.values()[1];
 
     // Read the input mesh file.
     MeshBuilder builder;
@@ -310,7 +309,7 @@ int main(int argc, char* argv[])
         GenericMeshFileReader reader(input_filepath.c_str());
         reader.read(builder);
     }
-    catch (const exception& e)
+    catch (const std::exception& e)
     {
         LOG_FATAL(
             logger,
@@ -329,7 +328,7 @@ int main(int argc, char* argv[])
     // Optionally print the bounding box of each loaded mesh.
     if (cl.m_print_bboxes.is_set())
     {
-        for (const_each<list<Mesh>> i = builder.get_meshes(); i; ++i)
+        for (const_each<std::list<Mesh>> i = builder.get_meshes(); i; ++i)
             print_bbox(logger, *i);
     }
 
@@ -337,13 +336,13 @@ int main(int argc, char* argv[])
     GenericMeshFileWriter writer(output_filepath.c_str());
     try
     {
-        for (const_each<list<Mesh>> i = builder.get_meshes(); i; ++i)
+        for (const_each<std::list<Mesh>> i = builder.get_meshes(); i; ++i)
         {
             const MeshWalker walker(*i);
             writer.write(walker);
         }
     }
-    catch (const exception& e)
+    catch (const std::exception& e)
     {
         LOG_FATAL(
             logger,

--- a/src/tools/denoiser/main.cpp
+++ b/src/tools/denoiser/main.cpp
@@ -26,7 +26,6 @@
 #include <memory>
 #include <string>
 
-using namespace std;
 using namespace bcd;
 
 static const char* g_pProgramPath;
@@ -49,7 +48,7 @@ class ProgramArguments
     {
     }
 
-    string m_denoisedOutputFilePath; // File path to the denoised image output
+    std::string m_denoisedOutputFilePath; // File path to the denoised image output
     Deepimf m_colorImage; // Pixel color values
     Deepimf m_nbOfSamplesImage; // Pixel number of samples
     Deepimf m_histogramImage; // Pixel histograms
@@ -86,22 +85,22 @@ class Callbacks
   private:
     void logInfo(const char* msg) const override
     {
-        cout << "Info: " << msg << std::endl;
+        std::cout << "Info: " << msg << std::endl;
     }
 
     void logWarning(const char* msg) const override
     {
-        cout << "Warning: " << msg << std::endl;
+        std::cout << "Warning: " << msg << std::endl;
     }
 
     void logError(const char* msg) const override
     {
-        cout << "Error: " << msg << std::endl;
+        std::cout << "Error: " << msg << std::endl;
     }
 
     void logDebug(const char* msg) const override
     {
-        cout << "Debug: " << msg << std::endl;
+        std::cout << "Debug: " << msg << std::endl;
     }
 };
 
@@ -115,32 +114,32 @@ void initializeRandomSeed()
 static void printUsage()
 {
     ProgramArguments defaultProgramArgs;
-    cout << "Bayesian Collaborative Denoising"<< endl << endl;
-    cout << "Usage: " << g_pProgramPath << " <arguments list>" << endl;
-    cout << "Only EXR images are supported." << endl << endl;
-    cout << "Required arguments list:" << endl;
-    cout << "    -o <output>          The file path to the output image" << endl;
-    cout << "    -i <input>           The file path to the input image" << endl;
-    cout << "    -h <hist>            The file path to the input histograms buffer" << endl;
-    cout << "    -c <cov>             The file path to the input covariance matrices buffer" << endl;
-    cout << "Optional arguments list:" << endl;
-    cout << "    -d <float>           Histogram patch distance threshold (default: " << defaultProgramArgs.m_histogramPatchDistanceThreshold << ")" << endl;
-    cout << "    -b <int>             Radius of search windows (default: " << defaultProgramArgs.m_searchWindowRadius << ")" << endl;
-    cout << "    -w <int>             Radius of patches (default: " << defaultProgramArgs.m_patchRadius << ")" << endl;
-    cout << "    -r <0/1>             1 for random pixel order (in case of grid artifacts) (default: " << (defaultProgramArgs.m_useRandomPixelOrder ? 1 : 0) << ")" << endl;
-    cout << "    -p <0/1>             1 for a spike removal prefiltering (default: " << (defaultProgramArgs.m_prefilterSpikes ? 1 : 0) << ")" << endl;
-    cout << "    --p-factor <float>   Factor that is multiplied by standard deviation to get the threshold for classifying spikes during prefiltering. Put lower value to remove more spikes (default: " << defaultProgramArgs.m_prefilterThresholdStDevFactor << ")" << endl;
-    cout << "    -m <float in [0,1]>  Probability of skipping marked centers of denoised patches. 1 accelerates a lot the computations. 0 helps removing potential grid artifacts (default: " << defaultProgramArgs.m_markedPixelsSkippingProbability << ")" << endl;
-    cout << "    -s <int>             Number of Scales for Multi-Scaling (default: " << defaultProgramArgs.m_nbOfScales << ")" << endl;
-    cout << "    --ncores <nbOfCores> Number of cores used by OpenMP (default: environment variable OMP_NUM_THREADS)" << endl;
-    cout << "    -e <float>           Minimum eigen value for matrix inversion (default: " << defaultProgramArgs.m_minEigenValue << ")" << endl;
+    std::cout << "Bayesian Collaborative Denoising"<< std::endl << std::endl;
+    std::cout << "Usage: " << g_pProgramPath << " <arguments list>" << std::endl;
+    std::cout << "Only EXR images are supported." << std::endl << std::endl;
+    std::cout << "Required arguments list:" << std::endl;
+    std::cout << "    -o <output>          The file path to the output image" << std::endl;
+    std::cout << "    -i <input>           The file path to the input image" << std::endl;
+    std::cout << "    -h <hist>            The file path to the input histograms buffer" << std::endl;
+    std::cout << "    -c <cov>             The file path to the input covariance matrices buffer" << std::endl;
+    std::cout << "Optional arguments list:" << std::endl;
+    std::cout << "    -d <float>           Histogram patch distance threshold (default: " << defaultProgramArgs.m_histogramPatchDistanceThreshold << ")" << std::endl;
+    std::cout << "    -b <int>             Radius of search windows (default: " << defaultProgramArgs.m_searchWindowRadius << ")" << std::endl;
+    std::cout << "    -w <int>             Radius of patches (default: " << defaultProgramArgs.m_patchRadius << ")" << std::endl;
+    std::cout << "    -r <0/1>             1 for random pixel order (in case of grid artifacts) (default: " << (defaultProgramArgs.m_useRandomPixelOrder ? 1 : 0) << ")" << std::endl;
+    std::cout << "    -p <0/1>             1 for a spike removal prefiltering (default: " << (defaultProgramArgs.m_prefilterSpikes ? 1 : 0) << ")" << std::endl;
+    std::cout << "    --p-factor <float>   Factor that is multiplied by standard deviation to get the threshold for classifying spikes during prefiltering. Put lower value to remove more spikes (default: " << defaultProgramArgs.m_prefilterThresholdStDevFactor << ")" << std::endl;
+    std::cout << "    -m <float in [0,1]>  Probability of skipping marked centers of denoised patches. 1 accelerates a lot the computations. 0 helps removing potential grid artifacts (default: " << defaultProgramArgs.m_markedPixelsSkippingProbability << ")" << std::endl;
+    std::cout << "    -s <int>             Number of Scales for Multi-Scaling (default: " << defaultProgramArgs.m_nbOfScales << ")" << std::endl;
+    std::cout << "    --ncores <nbOfCores> Number of cores used by OpenMP (default: environment variable OMP_NUM_THREADS)" << std::endl;
+    std::cout << "    -e <float>           Minimum eigen value for matrix inversion (default: " << defaultProgramArgs.m_minEigenValue << ")" << std::endl;
 }
 
 bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rProgramArguments)
 {
     int argIndex = 0;
     bool missingColor = true, missingHist = true, missingCov = true, missingOutput = true;
-    string inputColorFilePath;
+    std::string inputColorFilePath;
     while (++argIndex < argc)
     {
         if (strcmp(argv[argIndex], "-o") == 0)
@@ -148,14 +147,14 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                cout << "Error in program arguments: expecting file path to the output image after '-o'" << endl;
+                std::cout << "Error in program arguments: expecting file path to the output image after '-o'" << std::endl;
                 return false;
             }
-            o_rProgramArguments.m_denoisedOutputFilePath = string(argv[argIndex]);
-            ofstream outputFile(o_rProgramArguments.m_denoisedOutputFilePath, ofstream::out | ofstream::app);
+            o_rProgramArguments.m_denoisedOutputFilePath = std::string(argv[argIndex]);
+            std::ofstream outputFile(o_rProgramArguments.m_denoisedOutputFilePath, std::ofstream::out | std::ofstream::app);
             if(!outputFile)
             {
-                cout << "Error in program arguments: cannot write output file '" << o_rProgramArguments.m_denoisedOutputFilePath << "'" << endl;
+                std::cout << "Error in program arguments: cannot write output file '" << o_rProgramArguments.m_denoisedOutputFilePath << "'" << std::endl;
                 return false;
             }
             missingOutput = false;
@@ -165,13 +164,13 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                cout << "Error in program arguments: expecting file path to the input color image after '-i'" << endl;
+                std::cout << "Error in program arguments: expecting file path to the input color image after '-i'" << std::endl;
                 return false;
             }
             inputColorFilePath = argv[argIndex];
             if (!ImageIO::loadEXR(o_rProgramArguments.m_colorImage, argv[argIndex]))
             {
-                cout << "Error in program arguments: couldn't load input color image file '" << argv[argIndex] << "'" << endl;
+                std::cout << "Error in program arguments: couldn't load input color image file '" << argv[argIndex] << "'" << std::endl;
                 return false;
             }
             missingColor = false;
@@ -181,13 +180,13 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                cout << "Error in program arguments: expecting file path to the input histogram image after '-h'" << endl;
+                std::cout << "Error in program arguments: expecting file path to the input histogram image after '-h'" << std::endl;
                 return false;
             }
             Deepimf histAndNbOfSamplesImage;
             if (!ImageIO::loadMultiChannelsEXR(histAndNbOfSamplesImage, argv[argIndex]))
             {
-                cout << "Error in program arguments: couldn't load input histogram image file '" << argv[argIndex] << "'" << endl;
+                std::cout << "Error in program arguments: couldn't load input histogram image file '" << argv[argIndex] << "'" << std::endl;
                 return false;
             }
             Utils::separateNbOfSamplesFromHistogram(o_rProgramArguments.m_histogramImage, o_rProgramArguments.m_nbOfSamplesImage, histAndNbOfSamplesImage);
@@ -198,12 +197,12 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                cout << "Error in program arguments: expecting file path to the input covariance matrix image after '-c'" << endl;
+                std::cout << "Error in program arguments: expecting file path to the input covariance matrix image after '-c'" << std::endl;
                 return false;
             }
             if (!ImageIO::loadMultiChannelsEXR(o_rProgramArguments.m_covarianceImage, argv[argIndex]))
             {
-                cout << "Error in program arguments: couldn't load input covariance matrix image file '" << argv[argIndex] << "'" << endl;
+                std::cout << "Error in program arguments: couldn't load input covariance matrix image file '" << argv[argIndex] << "'" << std::endl;
                 return false;
             }
             missingCov = false;
@@ -213,10 +212,10 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                cout << "Error in program arguments: expecting histogram patch distance threshold after '-d'" << endl;
+                std::cout << "Error in program arguments: expecting histogram patch distance threshold after '-d'" << std::endl;
                 return false;
             }
-            istringstream iss(argv[argIndex]);
+            std::istringstream iss(argv[argIndex]);
             iss >> o_rProgramArguments.m_histogramPatchDistanceThreshold;
         }
         else if (strcmp(argv[argIndex], "-b") == 0)
@@ -224,10 +223,10 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                cout << "Error in program arguments: expecting radius of search window after '-b'" << endl;
+                std::cout << "Error in program arguments: expecting radius of search window after '-b'" << std::endl;
                 return false;
             }
-            istringstream iss(argv[argIndex]);
+            std::istringstream iss(argv[argIndex]);
             iss >> o_rProgramArguments.m_searchWindowRadius;
         }
         else if (strcmp(argv[argIndex], "-w") == 0)
@@ -235,10 +234,10 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                cout << "Error in program arguments: expecting radius of patch after '-w'" << endl;
+                std::cout << "Error in program arguments: expecting radius of patch after '-w'" << std::endl;
                 return false;
             }
-            istringstream iss(argv[argIndex]);
+            std::istringstream iss(argv[argIndex]);
             iss >> o_rProgramArguments.m_patchRadius;
         }
         else if (strcmp(argv[argIndex], "-e") == 0)
@@ -246,10 +245,10 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                cout << "Error in program arguments: expecting minimum eigen value after '-e'" << endl;
+                std::cout << "Error in program arguments: expecting minimum eigen value after '-e'" << std::endl;
                 return false;
             }
-            istringstream iss(argv[argIndex]);
+            std::istringstream iss(argv[argIndex]);
             iss >> o_rProgramArguments.m_minEigenValue;
         }
         else if (strcmp(argv[argIndex], "-r") == 0)
@@ -257,15 +256,15 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                cout << "Error in program arguments: expecting 0 or 1 after '-r'" << endl;
+                std::cout << "Error in program arguments: expecting 0 or 1 after '-r'" << std::endl;
                 return false;
             }
-            istringstream iss(argv[argIndex]);
+            std::istringstream iss(argv[argIndex]);
             int useRandomPixelOrder;
             iss >> useRandomPixelOrder;
             if(useRandomPixelOrder != 0 && useRandomPixelOrder != 1)
             {
-                cout << "Error in program arguments: expecting 0 or 1 after '-r'" << endl;
+                std::cout << "Error in program arguments: expecting 0 or 1 after '-r'" << std::endl;
                 return false;
             }
             o_rProgramArguments.m_useRandomPixelOrder = (useRandomPixelOrder==1);
@@ -275,15 +274,15 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                cout << "Error in program arguments: expecting 0 or 1 after '-p'" << endl;
+                std::cout << "Error in program arguments: expecting 0 or 1 after '-p'" << std::endl;
                 return false;
             }
-            istringstream iss(argv[argIndex]);
+            std::istringstream iss(argv[argIndex]);
             int prefilterSpikes;
             iss >> prefilterSpikes;
             if(prefilterSpikes != 0 && prefilterSpikes != 1)
             {
-                cout << "Error in program arguments: expecting 0 or 1 after '-p'" << endl;
+                std::cout << "Error in program arguments: expecting 0 or 1 after '-p'" << std::endl;
                 return false;
             }
             o_rProgramArguments.m_prefilterSpikes = (prefilterSpikes==1);
@@ -293,10 +292,10 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                cout << "Error in program arguments: expecting standard deviation factor for spike prefiltering threshold after '--p-factor'" << endl;
+                std::cout << "Error in program arguments: expecting standard deviation factor for spike prefiltering threshold after '--p-factor'" << std::endl;
                 return false;
             }
-            istringstream iss(argv[argIndex]);
+            std::istringstream iss(argv[argIndex]);
             iss >> o_rProgramArguments.m_prefilterThresholdStDevFactor;
         }
         else if(strcmp(argv[argIndex], "-m") == 0)
@@ -304,15 +303,15 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if(argIndex == argc)
             {
-                cout << "Error in program arguments: expecting float in [0,1] after '-m'" << endl;
+                std::cout << "Error in program arguments: expecting float in [0,1] after '-m'" << std::endl;
                 return false;
             }
-            istringstream iss(argv[argIndex]);
+            std::istringstream iss(argv[argIndex]);
             float markedPixelsSkippingProbability;
             iss >> markedPixelsSkippingProbability;
             if(markedPixelsSkippingProbability < 0 || markedPixelsSkippingProbability > 1)
             {
-                cout << "Error in program arguments: expecting float in [0,1] after '-m'" << endl;
+                std::cout << "Error in program arguments: expecting float in [0,1] after '-m'" << std::endl;
                 return false;
             }
             o_rProgramArguments.m_markedPixelsSkippingProbability = markedPixelsSkippingProbability;
@@ -322,10 +321,10 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                cout << "Error in program arguments: expecting number of scales after '-s'" << endl;
+                std::cout << "Error in program arguments: expecting number of scales after '-s'" << std::endl;
                 return false;
             }
-            istringstream iss(argv[argIndex]);
+            std::istringstream iss(argv[argIndex]);
             iss >> o_rProgramArguments.m_nbOfScales;
         }
         else if (strcmp(argv[argIndex], "--ncores") == 0)
@@ -333,10 +332,10 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                cout << "Error in program arguments: expecting number of cores for OpenMP after '--ncores'" << endl;
+                std::cout << "Error in program arguments: expecting number of cores for OpenMP after '--ncores'" << std::endl;
                 return false;
             }
-            istringstream iss(argv[argIndex]);
+            std::istringstream iss(argv[argIndex]);
             iss >> o_rProgramArguments.m_nbOfCores;
         }
     }
@@ -344,12 +343,12 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
     {
         if(missingHist)
         {
-            string inputHistFilePath = inputColorFilePath.substr(0, inputColorFilePath.length() - 4) + "_hist.exr"; // "-4" for removing extension .exr
-            cout << "Warning: input histogram file not provided by -h argument: assuming '" + inputHistFilePath + "'" << endl;
+            std::string inputHistFilePath = inputColorFilePath.substr(0, inputColorFilePath.length() - 4) + "_hist.exr"; // "-4" for removing extension .exr
+            std::cout << "Warning: input histogram file not provided by -h argument: assuming '" + inputHistFilePath + "'" << std::endl;
             Deepimf histAndNbOfSamplesImage;
             if (!ImageIO::loadMultiChannelsEXR(histAndNbOfSamplesImage, inputHistFilePath.c_str()))
             {
-                cout << "Error in program arguments: couldn't load input histogram image file '" << inputHistFilePath << "'" << endl;
+                std::cout << "Error in program arguments: couldn't load input histogram image file '" << inputHistFilePath << "'" << std::endl;
                 return false;
             }
             Utils::separateNbOfSamplesFromHistogram(o_rProgramArguments.m_histogramImage, o_rProgramArguments.m_nbOfSamplesImage, histAndNbOfSamplesImage);
@@ -357,11 +356,11 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
         }
         if(missingCov)
         {
-            string inputCovFilePath = inputColorFilePath.substr(0, inputColorFilePath.length() - 4) + "_cov.exr"; // "-4" for removing extension .exr
-            cout << "Warning: input covariance file not provided by -c argument: assuming '" + inputCovFilePath + "'" << endl;
+            std::string inputCovFilePath = inputColorFilePath.substr(0, inputColorFilePath.length() - 4) + "_cov.exr"; // "-4" for removing extension .exr
+            std::cout << "Warning: input covariance file not provided by -c argument: assuming '" + inputCovFilePath + "'" << std::endl;
             if (!ImageIO::loadMultiChannelsEXR(o_rProgramArguments.m_covarianceImage, inputCovFilePath.c_str()))
             {
-                cout << "Error in program arguments: couldn't load input covariance matrix image file '" << inputCovFilePath << "'" << endl;
+                std::cout << "Error in program arguments: couldn't load input covariance matrix image file '" << inputCovFilePath << "'" << std::endl;
                 return false;
             }
             missingCov = false;
@@ -369,16 +368,16 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
     }
     if (missingColor || missingHist || missingCov || missingOutput)
     {
-        cout << "Error: Missing required program argument(s):";
+        std::cout << "Error: Missing required program argument(s):";
         if (missingColor)
-            cout << " -i";
+            std::cout << " -i";
         if (missingHist)
-            cout << " -h";
+            std::cout << " -h";
         if (missingCov)
-            cout << " -c";
+            std::cout << " -c";
         if (missingOutput)
-            cout << " -o";
-        cout << endl << endl;
+            std::cout << " -o";
+        std::cout << std::endl << std::endl;
         printUsage();
         return false;
     }
@@ -419,7 +418,7 @@ int launchBayesianCollaborativeDenoising(int argc, const char** argv)
     parameters.m_markedPixelsSkippingProbability = programArgs.m_markedPixelsSkippingProbability;
     parameters.m_nbOfCores = programArgs.m_nbOfCores;
 
-    unique_ptr<IDenoiser> uDenoiser = nullptr;
+    std::unique_ptr<IDenoiser> uDenoiser = nullptr;
 
     if(programArgs.m_nbOfScales > 1)
         uDenoiser.reset(new MultiscaleDenoiser(programArgs.m_nbOfScales));
@@ -439,7 +438,7 @@ int launchBayesianCollaborativeDenoising(int argc, const char** argv)
 
     ImageIO::writeEXR(outputDenoisedColorImage, programArgs.m_denoisedOutputFilePath.c_str());
 
-    cout << "Written denoised output in file " << programArgs.m_denoisedOutputFilePath.c_str() << std::endl;
+    std::cout << "Written denoised output in file " << programArgs.m_denoisedOutputFilePath.c_str() << std::endl;
 
     return 0;
 }

--- a/src/tools/denoiser/main.cpp
+++ b/src/tools/denoiser/main.cpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <string>
 
+using namespace std;
 using namespace bcd;
 
 static const char* g_pProgramPath;
@@ -48,7 +49,7 @@ class ProgramArguments
     {
     }
 
-    std::string m_denoisedOutputFilePath; // File path to the denoised image output
+    string m_denoisedOutputFilePath; // File path to the denoised image output
     Deepimf m_colorImage; // Pixel color values
     Deepimf m_nbOfSamplesImage; // Pixel number of samples
     Deepimf m_histogramImage; // Pixel histograms
@@ -85,22 +86,22 @@ class Callbacks
   private:
     void logInfo(const char* msg) const override
     {
-        std::cout << "Info: " << msg << std::endl;
+        cout << "Info: " << msg << std::endl;
     }
 
     void logWarning(const char* msg) const override
     {
-        std::cout << "Warning: " << msg << std::endl;
+        cout << "Warning: " << msg << std::endl;
     }
 
     void logError(const char* msg) const override
     {
-        std::cout << "Error: " << msg << std::endl;
+        cout << "Error: " << msg << std::endl;
     }
 
     void logDebug(const char* msg) const override
     {
-        std::cout << "Debug: " << msg << std::endl;
+        cout << "Debug: " << msg << std::endl;
     }
 };
 
@@ -114,32 +115,32 @@ void initializeRandomSeed()
 static void printUsage()
 {
     ProgramArguments defaultProgramArgs;
-    std::cout << "Bayesian Collaborative Denoising"<< std::endl << std::endl;
-    std::cout << "Usage: " << g_pProgramPath << " <arguments list>" << std::endl;
-    std::cout << "Only EXR images are supported." << std::endl << std::endl;
-    std::cout << "Required arguments list:" << std::endl;
-    std::cout << "    -o <output>          The file path to the output image" << std::endl;
-    std::cout << "    -i <input>           The file path to the input image" << std::endl;
-    std::cout << "    -h <hist>            The file path to the input histograms buffer" << std::endl;
-    std::cout << "    -c <cov>             The file path to the input covariance matrices buffer" << std::endl;
-    std::cout << "Optional arguments list:" << std::endl;
-    std::cout << "    -d <float>           Histogram patch distance threshold (default: " << defaultProgramArgs.m_histogramPatchDistanceThreshold << ")" << std::endl;
-    std::cout << "    -b <int>             Radius of search windows (default: " << defaultProgramArgs.m_searchWindowRadius << ")" << std::endl;
-    std::cout << "    -w <int>             Radius of patches (default: " << defaultProgramArgs.m_patchRadius << ")" << std::endl;
-    std::cout << "    -r <0/1>             1 for random pixel order (in case of grid artifacts) (default: " << (defaultProgramArgs.m_useRandomPixelOrder ? 1 : 0) << ")" << std::endl;
-    std::cout << "    -p <0/1>             1 for a spike removal prefiltering (default: " << (defaultProgramArgs.m_prefilterSpikes ? 1 : 0) << ")" << std::endl;
-    std::cout << "    --p-factor <float>   Factor that is multiplied by standard deviation to get the threshold for classifying spikes during prefiltering. Put lower value to remove more spikes (default: " << defaultProgramArgs.m_prefilterThresholdStDevFactor << ")" << std::endl;
-    std::cout << "    -m <float in [0,1]>  Probability of skipping marked centers of denoised patches. 1 accelerates a lot the computations. 0 helps removing potential grid artifacts (default: " << defaultProgramArgs.m_markedPixelsSkippingProbability << ")" << std::endl;
-    std::cout << "    -s <int>             Number of Scales for Multi-Scaling (default: " << defaultProgramArgs.m_nbOfScales << ")" << std::endl;
-    std::cout << "    --ncores <nbOfCores> Number of cores used by OpenMP (default: environment variable OMP_NUM_THREADS)" << std::endl;
-    std::cout << "    -e <float>           Minimum eigen value for matrix inversion (default: " << defaultProgramArgs.m_minEigenValue << ")" << std::endl;
+    cout << "Bayesian Collaborative Denoising"<< endl << endl;
+    cout << "Usage: " << g_pProgramPath << " <arguments list>" << endl;
+    cout << "Only EXR images are supported." << endl << endl;
+    cout << "Required arguments list:" << endl;
+    cout << "    -o <output>          The file path to the output image" << endl;
+    cout << "    -i <input>           The file path to the input image" << endl;
+    cout << "    -h <hist>            The file path to the input histograms buffer" << endl;
+    cout << "    -c <cov>             The file path to the input covariance matrices buffer" << endl;
+    cout << "Optional arguments list:" << endl;
+    cout << "    -d <float>           Histogram patch distance threshold (default: " << defaultProgramArgs.m_histogramPatchDistanceThreshold << ")" << endl;
+    cout << "    -b <int>             Radius of search windows (default: " << defaultProgramArgs.m_searchWindowRadius << ")" << endl;
+    cout << "    -w <int>             Radius of patches (default: " << defaultProgramArgs.m_patchRadius << ")" << endl;
+    cout << "    -r <0/1>             1 for random pixel order (in case of grid artifacts) (default: " << (defaultProgramArgs.m_useRandomPixelOrder ? 1 : 0) << ")" << endl;
+    cout << "    -p <0/1>             1 for a spike removal prefiltering (default: " << (defaultProgramArgs.m_prefilterSpikes ? 1 : 0) << ")" << endl;
+    cout << "    --p-factor <float>   Factor that is multiplied by standard deviation to get the threshold for classifying spikes during prefiltering. Put lower value to remove more spikes (default: " << defaultProgramArgs.m_prefilterThresholdStDevFactor << ")" << endl;
+    cout << "    -m <float in [0,1]>  Probability of skipping marked centers of denoised patches. 1 accelerates a lot the computations. 0 helps removing potential grid artifacts (default: " << defaultProgramArgs.m_markedPixelsSkippingProbability << ")" << endl;
+    cout << "    -s <int>             Number of Scales for Multi-Scaling (default: " << defaultProgramArgs.m_nbOfScales << ")" << endl;
+    cout << "    --ncores <nbOfCores> Number of cores used by OpenMP (default: environment variable OMP_NUM_THREADS)" << endl;
+    cout << "    -e <float>           Minimum eigen value for matrix inversion (default: " << defaultProgramArgs.m_minEigenValue << ")" << endl;
 }
 
 bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rProgramArguments)
 {
     int argIndex = 0;
     bool missingColor = true, missingHist = true, missingCov = true, missingOutput = true;
-    std::string inputColorFilePath;
+    string inputColorFilePath;
     while (++argIndex < argc)
     {
         if (strcmp(argv[argIndex], "-o") == 0)
@@ -147,14 +148,14 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                std::cout << "Error in program arguments: expecting file path to the output image after '-o'" << std::endl;
+                cout << "Error in program arguments: expecting file path to the output image after '-o'" << endl;
                 return false;
             }
-            o_rProgramArguments.m_denoisedOutputFilePath = std::string(argv[argIndex]);
-            std::ofstream outputFile(o_rProgramArguments.m_denoisedOutputFilePath, std::ofstream::out | std::ofstream::app);
+            o_rProgramArguments.m_denoisedOutputFilePath = string(argv[argIndex]);
+            ofstream outputFile(o_rProgramArguments.m_denoisedOutputFilePath, ofstream::out | ofstream::app);
             if(!outputFile)
             {
-                std::cout << "Error in program arguments: cannot write output file '" << o_rProgramArguments.m_denoisedOutputFilePath << "'" << std::endl;
+                cout << "Error in program arguments: cannot write output file '" << o_rProgramArguments.m_denoisedOutputFilePath << "'" << endl;
                 return false;
             }
             missingOutput = false;
@@ -164,13 +165,13 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                std::cout << "Error in program arguments: expecting file path to the input color image after '-i'" << std::endl;
+                cout << "Error in program arguments: expecting file path to the input color image after '-i'" << endl;
                 return false;
             }
             inputColorFilePath = argv[argIndex];
             if (!ImageIO::loadEXR(o_rProgramArguments.m_colorImage, argv[argIndex]))
             {
-                std::cout << "Error in program arguments: couldn't load input color image file '" << argv[argIndex] << "'" << std::endl;
+                cout << "Error in program arguments: couldn't load input color image file '" << argv[argIndex] << "'" << endl;
                 return false;
             }
             missingColor = false;
@@ -180,13 +181,13 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                std::cout << "Error in program arguments: expecting file path to the input histogram image after '-h'" << std::endl;
+                cout << "Error in program arguments: expecting file path to the input histogram image after '-h'" << endl;
                 return false;
             }
             Deepimf histAndNbOfSamplesImage;
             if (!ImageIO::loadMultiChannelsEXR(histAndNbOfSamplesImage, argv[argIndex]))
             {
-                std::cout << "Error in program arguments: couldn't load input histogram image file '" << argv[argIndex] << "'" << std::endl;
+                cout << "Error in program arguments: couldn't load input histogram image file '" << argv[argIndex] << "'" << endl;
                 return false;
             }
             Utils::separateNbOfSamplesFromHistogram(o_rProgramArguments.m_histogramImage, o_rProgramArguments.m_nbOfSamplesImage, histAndNbOfSamplesImage);
@@ -197,12 +198,12 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                std::cout << "Error in program arguments: expecting file path to the input covariance matrix image after '-c'" << std::endl;
+                cout << "Error in program arguments: expecting file path to the input covariance matrix image after '-c'" << endl;
                 return false;
             }
             if (!ImageIO::loadMultiChannelsEXR(o_rProgramArguments.m_covarianceImage, argv[argIndex]))
             {
-                std::cout << "Error in program arguments: couldn't load input covariance matrix image file '" << argv[argIndex] << "'" << std::endl;
+                cout << "Error in program arguments: couldn't load input covariance matrix image file '" << argv[argIndex] << "'" << endl;
                 return false;
             }
             missingCov = false;
@@ -212,10 +213,10 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                std::cout << "Error in program arguments: expecting histogram patch distance threshold after '-d'" << std::endl;
+                cout << "Error in program arguments: expecting histogram patch distance threshold after '-d'" << endl;
                 return false;
             }
-            std::istringstream iss(argv[argIndex]);
+            istringstream iss(argv[argIndex]);
             iss >> o_rProgramArguments.m_histogramPatchDistanceThreshold;
         }
         else if (strcmp(argv[argIndex], "-b") == 0)
@@ -223,10 +224,10 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                std::cout << "Error in program arguments: expecting radius of search window after '-b'" << std::endl;
+                cout << "Error in program arguments: expecting radius of search window after '-b'" << endl;
                 return false;
             }
-            std::istringstream iss(argv[argIndex]);
+            istringstream iss(argv[argIndex]);
             iss >> o_rProgramArguments.m_searchWindowRadius;
         }
         else if (strcmp(argv[argIndex], "-w") == 0)
@@ -234,10 +235,10 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                std::cout << "Error in program arguments: expecting radius of patch after '-w'" << std::endl;
+                cout << "Error in program arguments: expecting radius of patch after '-w'" << endl;
                 return false;
             }
-            std::istringstream iss(argv[argIndex]);
+            istringstream iss(argv[argIndex]);
             iss >> o_rProgramArguments.m_patchRadius;
         }
         else if (strcmp(argv[argIndex], "-e") == 0)
@@ -245,10 +246,10 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                std::cout << "Error in program arguments: expecting minimum eigen value after '-e'" << std::endl;
+                cout << "Error in program arguments: expecting minimum eigen value after '-e'" << endl;
                 return false;
             }
-            std::istringstream iss(argv[argIndex]);
+            istringstream iss(argv[argIndex]);
             iss >> o_rProgramArguments.m_minEigenValue;
         }
         else if (strcmp(argv[argIndex], "-r") == 0)
@@ -256,15 +257,15 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                std::cout << "Error in program arguments: expecting 0 or 1 after '-r'" << std::endl;
+                cout << "Error in program arguments: expecting 0 or 1 after '-r'" << endl;
                 return false;
             }
-            std::istringstream iss(argv[argIndex]);
+            istringstream iss(argv[argIndex]);
             int useRandomPixelOrder;
             iss >> useRandomPixelOrder;
             if(useRandomPixelOrder != 0 && useRandomPixelOrder != 1)
             {
-                std::cout << "Error in program arguments: expecting 0 or 1 after '-r'" << std::endl;
+                cout << "Error in program arguments: expecting 0 or 1 after '-r'" << endl;
                 return false;
             }
             o_rProgramArguments.m_useRandomPixelOrder = (useRandomPixelOrder==1);
@@ -274,15 +275,15 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                std::cout << "Error in program arguments: expecting 0 or 1 after '-p'" << std::endl;
+                cout << "Error in program arguments: expecting 0 or 1 after '-p'" << endl;
                 return false;
             }
-            std::istringstream iss(argv[argIndex]);
+            istringstream iss(argv[argIndex]);
             int prefilterSpikes;
             iss >> prefilterSpikes;
             if(prefilterSpikes != 0 && prefilterSpikes != 1)
             {
-                std::cout << "Error in program arguments: expecting 0 or 1 after '-p'" << std::endl;
+                cout << "Error in program arguments: expecting 0 or 1 after '-p'" << endl;
                 return false;
             }
             o_rProgramArguments.m_prefilterSpikes = (prefilterSpikes==1);
@@ -292,10 +293,10 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                std::cout << "Error in program arguments: expecting standard deviation factor for spike prefiltering threshold after '--p-factor'" << std::endl;
+                cout << "Error in program arguments: expecting standard deviation factor for spike prefiltering threshold after '--p-factor'" << endl;
                 return false;
             }
-            std::istringstream iss(argv[argIndex]);
+            istringstream iss(argv[argIndex]);
             iss >> o_rProgramArguments.m_prefilterThresholdStDevFactor;
         }
         else if(strcmp(argv[argIndex], "-m") == 0)
@@ -303,15 +304,15 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if(argIndex == argc)
             {
-                std::cout << "Error in program arguments: expecting float in [0,1] after '-m'" << std::endl;
+                cout << "Error in program arguments: expecting float in [0,1] after '-m'" << endl;
                 return false;
             }
-            std::istringstream iss(argv[argIndex]);
+            istringstream iss(argv[argIndex]);
             float markedPixelsSkippingProbability;
             iss >> markedPixelsSkippingProbability;
             if(markedPixelsSkippingProbability < 0 || markedPixelsSkippingProbability > 1)
             {
-                std::cout << "Error in program arguments: expecting float in [0,1] after '-m'" << std::endl;
+                cout << "Error in program arguments: expecting float in [0,1] after '-m'" << endl;
                 return false;
             }
             o_rProgramArguments.m_markedPixelsSkippingProbability = markedPixelsSkippingProbability;
@@ -321,10 +322,10 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                std::cout << "Error in program arguments: expecting number of scales after '-s'" << std::endl;
+                cout << "Error in program arguments: expecting number of scales after '-s'" << endl;
                 return false;
             }
-            std::istringstream iss(argv[argIndex]);
+            istringstream iss(argv[argIndex]);
             iss >> o_rProgramArguments.m_nbOfScales;
         }
         else if (strcmp(argv[argIndex], "--ncores") == 0)
@@ -332,10 +333,10 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
             argIndex++;
             if (argIndex == argc)
             {
-                std::cout << "Error in program arguments: expecting number of cores for OpenMP after '--ncores'" << std::endl;
+                cout << "Error in program arguments: expecting number of cores for OpenMP after '--ncores'" << endl;
                 return false;
             }
-            std::istringstream iss(argv[argIndex]);
+            istringstream iss(argv[argIndex]);
             iss >> o_rProgramArguments.m_nbOfCores;
         }
     }
@@ -343,12 +344,12 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
     {
         if(missingHist)
         {
-            std::string inputHistFilePath = inputColorFilePath.substr(0, inputColorFilePath.length() - 4) + "_hist.exr"; // "-4" for removing extension .exr
-            std::cout << "Warning: input histogram file not provided by -h argument: assuming '" + inputHistFilePath + "'" << std::endl;
+            string inputHistFilePath = inputColorFilePath.substr(0, inputColorFilePath.length() - 4) + "_hist.exr"; // "-4" for removing extension .exr
+            cout << "Warning: input histogram file not provided by -h argument: assuming '" + inputHistFilePath + "'" << endl;
             Deepimf histAndNbOfSamplesImage;
             if (!ImageIO::loadMultiChannelsEXR(histAndNbOfSamplesImage, inputHistFilePath.c_str()))
             {
-                std::cout << "Error in program arguments: couldn't load input histogram image file '" << inputHistFilePath << "'" << std::endl;
+                cout << "Error in program arguments: couldn't load input histogram image file '" << inputHistFilePath << "'" << endl;
                 return false;
             }
             Utils::separateNbOfSamplesFromHistogram(o_rProgramArguments.m_histogramImage, o_rProgramArguments.m_nbOfSamplesImage, histAndNbOfSamplesImage);
@@ -356,11 +357,11 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
         }
         if(missingCov)
         {
-            std::string inputCovFilePath = inputColorFilePath.substr(0, inputColorFilePath.length() - 4) + "_cov.exr"; // "-4" for removing extension .exr
-            std::cout << "Warning: input covariance file not provided by -c argument: assuming '" + inputCovFilePath + "'" << std::endl;
+            string inputCovFilePath = inputColorFilePath.substr(0, inputColorFilePath.length() - 4) + "_cov.exr"; // "-4" for removing extension .exr
+            cout << "Warning: input covariance file not provided by -c argument: assuming '" + inputCovFilePath + "'" << endl;
             if (!ImageIO::loadMultiChannelsEXR(o_rProgramArguments.m_covarianceImage, inputCovFilePath.c_str()))
             {
-                std::cout << "Error in program arguments: couldn't load input covariance matrix image file '" << inputCovFilePath << "'" << std::endl;
+                cout << "Error in program arguments: couldn't load input covariance matrix image file '" << inputCovFilePath << "'" << endl;
                 return false;
             }
             missingCov = false;
@@ -368,16 +369,16 @@ bool parseProgramArguments(int argc, const char** argv, ProgramArguments& o_rPro
     }
     if (missingColor || missingHist || missingCov || missingOutput)
     {
-        std::cout << "Error: Missing required program argument(s):";
+        cout << "Error: Missing required program argument(s):";
         if (missingColor)
-            std::cout << " -i";
+            cout << " -i";
         if (missingHist)
-            std::cout << " -h";
+            cout << " -h";
         if (missingCov)
-            std::cout << " -c";
+            cout << " -c";
         if (missingOutput)
-            std::cout << " -o";
-        std::cout << std::endl << std::endl;
+            cout << " -o";
+        cout << endl << endl;
         printUsage();
         return false;
     }
@@ -418,7 +419,7 @@ int launchBayesianCollaborativeDenoising(int argc, const char** argv)
     parameters.m_markedPixelsSkippingProbability = programArgs.m_markedPixelsSkippingProbability;
     parameters.m_nbOfCores = programArgs.m_nbOfCores;
 
-    std::unique_ptr<IDenoiser> uDenoiser = nullptr;
+    unique_ptr<IDenoiser> uDenoiser = nullptr;
 
     if(programArgs.m_nbOfScales > 1)
         uDenoiser.reset(new MultiscaleDenoiser(programArgs.m_nbOfScales));
@@ -438,7 +439,7 @@ int launchBayesianCollaborativeDenoising(int argc, const char** argv)
 
     ImageIO::writeEXR(outputDenoisedColorImage, programArgs.m_denoisedOutputFilePath.c_str());
 
-    std::cout << "Written denoised output in file " << programArgs.m_denoisedOutputFilePath.c_str() << std::endl;
+    cout << "Written denoised output in file " << programArgs.m_denoisedOutputFilePath.c_str() << std::endl;
 
     return 0;
 }

--- a/src/tools/dumpmetadata/commandlinehandler.cpp
+++ b/src/tools/dumpmetadata/commandlinehandler.cpp
@@ -37,7 +37,6 @@
 
 using namespace appleseed::shared;
 using namespace foundation;
-using namespace std;
 
 namespace appleseed {
 namespace dumpmetadata {

--- a/src/tools/dumpmetadata/main.cpp
+++ b/src/tools/dumpmetadata/main.cpp
@@ -74,7 +74,6 @@ using namespace appleseed::dumpmetadata;
 using namespace appleseed::shared;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 
 namespace
 {
@@ -98,7 +97,7 @@ namespace
         {
             Dictionary metadata = metadata_array[i];
 
-            const string name = metadata.get<string>("name");
+            const std::string name = metadata.get<std::string>("name");
             metadata.strings().remove("name");
 
             Dictionary wrapped_metadata;
@@ -166,12 +165,12 @@ namespace
     // Dump as Markdown.
     //
 
-    bool is_numeric_value(const string& s)
+    bool is_numeric_value(const std::string& s)
     {
-        istringstream iss(s);
+        std::istringstream iss(s);
 
         double val;
-        iss >> noskipws >> val;     // noskipws considers leading whitespace invalid
+        iss >> std::noskipws >> val;     // noskipws considers leading whitespace invalid
 
         return iss && iss.eof();
     }
@@ -188,24 +187,24 @@ namespace
             Dictionary metadata = metadata_array[i];
 
             // Parameter, Label.
-            const string param_name = metadata.get<string>("name");
-            const string param_label = metadata.get<string>("label");
+            const std::string param_name = metadata.get<std::string>("name");
+            const std::string param_label = metadata.get<std::string>("label");
 
             // Presence.
-            string param_use = metadata.get<string>("use");
+            std::string param_use = metadata.get<std::string>("use");
             if (param_use == "required")
                 param_use = format("**{0}**", param_use);
 
             // Default.
-            string param_default = metadata.strings().exist("default") ? metadata.get<string>("default") : "";
+            std::string param_default = metadata.strings().exist("default") ? metadata.get<std::string>("default") : "";
             if (param_default.empty())
                 param_default = "_None_";
             else if (!is_numeric_value(param_default))
                 param_default = format("`{0}`", param_default);
 
             // Description.
-            string param_desc = metadata.strings().exist("help") ? metadata.get<string>("help") : "";
-            if (metadata.get<string>("type") == "enumeration")
+            std::string param_desc = metadata.strings().exist("help") ? metadata.get<std::string>("help") : "";
+            if (metadata.get<std::string>("type") == "enumeration")
             {
                 if (!param_desc.empty() && !ends_with(param_desc, "."))
                     param_desc += ".";
@@ -307,7 +306,7 @@ namespace
         dump_metadata_markdown<Volume>(section_number++, file);
     }
 
-    void dump_metadata(const string& format, Logger& logger)
+    void dump_metadata(const std::string& format, Logger& logger)
     {
         if (format == "xml")
             dump_metadata_xml();

--- a/src/tools/makefluffy/commandlinehandler.cpp
+++ b/src/tools/makefluffy/commandlinehandler.cpp
@@ -37,7 +37,6 @@
 
 using namespace appleseed::shared;
 using namespace foundation;
-using namespace std;
 
 namespace appleseed {
 namespace makefluffy {

--- a/src/tools/makefluffy/main.cpp
+++ b/src/tools/makefluffy/main.cpp
@@ -69,7 +69,6 @@ using namespace appleseed::makefluffy;
 using namespace appleseed::shared;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace
@@ -119,9 +118,9 @@ namespace
     };
 
     void extract_support_triangles(
-        const MeshObject&           object,
-        vector<SupportTriangle>&    support_triangles,
-        CDF<size_t, GScalar>&       cdf)
+        const MeshObject&                object,
+        std::vector<SupportTriangle>&    support_triangles,
+        CDF<size_t, GScalar>&            cdf)
     {
         const size_t triangle_count = object.get_triangle_count();
         for (size_t triangle_index = 0; triangle_index < triangle_count; ++triangle_index)
@@ -183,11 +182,11 @@ namespace
     {
         const size_t ControlPointCount = 4;
 
-        vector<SupportTriangle> support_triangles;
+        std::vector<SupportTriangle> support_triangles;
         CDF<size_t, GScalar> cdf;
         extract_support_triangles(support_object, support_triangles, cdf);
 
-        const string curve_object_name = string(support_object.get_name()) + "_curves";
+        const std::string curve_object_name = std::string(support_object.get_name()) + "_curves";
         auto_release_ptr<CurveObject> curve_object(
             CurveObjectFactory().create(
                 curve_object_name.c_str(),
@@ -243,8 +242,8 @@ namespace
 
     void make_fluffy(const Assembly& assembly, const FluffParams& params)
     {
-        typedef vector<const ObjectInstance*> ObjectInstanceVector;
-        typedef map<const MeshObject*, ObjectInstanceVector> ObjectToInstanceMap;
+        typedef std::vector<const ObjectInstance*> ObjectInstanceVector;
+        typedef std::map<const MeshObject*, ObjectInstanceVector> ObjectToInstanceMap;
 
         // Establish an object -> object instance mapping.
         ObjectToInstanceMap objects_to_instances;
@@ -285,7 +284,7 @@ namespace
             for (const_each<ObjectInstanceVector> j = support_object_instances; j; ++j)
             {
                 const ObjectInstance& support_instance = **j;
-                const string curve_object_instance_name = string(curve_object->get_name()) + "_inst";
+                const std::string curve_object_instance_name = std::string(curve_object->get_name()) + "_inst";
                 assembly.object_instances().insert(
                     ObjectInstanceFactory::create(
                         curve_object_instance_name.c_str(),
@@ -347,8 +346,8 @@ int main(int argc, char* argv[])
     global_logger().initialize_from(logger);
 
     // Retrieve the command line arguments.
-    const string& input_filepath = cl.m_filenames.values()[0];
-    const string& output_filepath = cl.m_filenames.values()[1];
+    const std::string& input_filepath = cl.m_filenames.values()[0];
+    const std::string& output_filepath = cl.m_filenames.values()[1];
     const FluffParams params(cl);
 
     // Construct the schema file path.

--- a/src/tools/projecttool/commandlinehandler.cpp
+++ b/src/tools/projecttool/commandlinehandler.cpp
@@ -38,7 +38,6 @@
 
 using namespace appleseed::shared;
 using namespace foundation;
-using namespace std;
 
 namespace appleseed {
 namespace projecttool {

--- a/src/tools/projecttool/main.cpp
+++ b/src/tools/projecttool/main.cpp
@@ -52,14 +52,13 @@ using namespace appleseed::projecttool;
 using namespace appleseed::shared;
 using namespace foundation;
 using namespace renderer;
-using namespace std;
 namespace bf = boost::filesystem;
 
 namespace
 {
     CommandLineHandler g_cl;
 
-    auto_release_ptr<Project> load_project(const string& project_filepath)
+    auto_release_ptr<Project> load_project(const std::string& project_filepath)
     {
         // Construct the schema file path.
         const bf::path schema_filepath =
@@ -88,7 +87,7 @@ namespace
 bool update_project()
 {
     // Retrieve the input project path.
-    const string& input_filepath = g_cl.m_positional_args.values()[1];
+    const std::string& input_filepath = g_cl.m_positional_args.values()[1];
 
     // Read the input project from disk.
     auto_release_ptr<Project> project(load_project(input_filepath));
@@ -120,7 +119,7 @@ bool update_project()
 bool remove_unused_entities()
 {
     // Retrieve the input project path.
-    const string& input_filepath = g_cl.m_positional_args.values()[1];
+    const std::string& input_filepath = g_cl.m_positional_args.values()[1];
 
     // Read the input project from disk.
     auto_release_ptr<Project> project(load_project(input_filepath));
@@ -153,7 +152,7 @@ bool remove_unused_entities()
 bool pack_project()
 {
     // Retrieve the input project path.
-    const string& input_filepath = g_cl.m_positional_args.values()[1];
+    const std::string& input_filepath = g_cl.m_positional_args.values()[1];
 
     // Read the input project from disk.
     auto_release_ptr<Project> project(load_project(input_filepath));
@@ -161,7 +160,7 @@ bool pack_project()
         return false;
 
     // Build the path of the output project.
-    const string packed_file_path =
+    const std::string packed_file_path =
         bf::path(input_filepath).replace_extension(".appleseedz").string();
 
     // Write the project to disk.
@@ -176,7 +175,7 @@ bool pack_project()
 bool unpack_project()
 {
     // Retrieve the input project path.
-    const string& input_filepath = g_cl.m_positional_args.values()[1];
+    const std::string& input_filepath = g_cl.m_positional_args.values()[1];
 
     // Read the input project from disk.
     auto_release_ptr<Project> project(load_project(input_filepath));
@@ -184,7 +183,7 @@ bool unpack_project()
         return false;
 
     // Build the path of the output project.
-    const string unpacked_file_path =
+    const std::string unpacked_file_path =
         bf::path(input_filepath).replace_extension(".appleseed").string();
 
     // Write the project to disk.
@@ -208,7 +207,7 @@ bool unpack_project()
 bool print_entity_dependencies(SuperLogger& logger)
 {
     // Retrieve the input project path.
-    const string& input_filepath = g_cl.m_positional_args.values()[1];
+    const std::string& input_filepath = g_cl.m_positional_args.values()[1];
 
     // Read the input project from disk.
     auto_release_ptr<Project> project(load_project(input_filepath));
@@ -256,7 +255,7 @@ int main(int argc, char* argv[])
     global_logger().initialize_from(logger);
 
     // Retrieve the command.
-    const string& command = g_cl.m_positional_args.values()[0];
+    const std::string& command = g_cl.m_positional_args.values()[0];
 
     // Execute the command.
     bool success = false;


### PR DESCRIPTION
This PR part of a series.
Fixes #2641 for appleseed/ except foundation, tools, appleseed.cli and appleseed.shared, 

See also: #2689, #2690, #2691, #2692, #2693