### PR TITLE
Limit self-intersection warnings to 20 per thread

### DIFF
--- a/src/appleseed/renderer/kernel/intersection/intersector.cpp
+++ b/src/appleseed/renderer/kernel/intersection/intersector.cpp
@@ -224,13 +224,27 @@ namespace
         const ShadingPoint&         shading_point,
         const ShadingPoint*         parent_shading_point)
     {
+        static const size_t MaxWarningsPerThread = 100;
+        static size_t warnings_count = 0;
+
         if (shading_point.hit_surface() &&
             parent_shading_point &&
             same_triangle(*parent_shading_point, shading_point))
         {
-            RENDERER_LOG_WARNING(
-                "self-intersection detected, distance %e.",
-                shading_point.get_distance());
+            if (warnings_count < MaxWarningsPerThread)
+            {
+                RENDERER_LOG_WARNING(
+                    "self-intersection detected, distance %e.",
+                    shading_point.get_distance());
+
+                warnings_count += 1;
+            }
+            else if (warnings_count == MaxWarningsPerThread)
+            {
+                RENDERER_LOG_WARNING("more self-intersections detected, omitting warning messages for brevity.");
+
+                warnings_count += 1;
+            }
         }
     }
 }

--- a/src/appleseed/renderer/kernel/intersection/intersector.cpp
+++ b/src/appleseed/renderer/kernel/intersection/intersector.cpp
@@ -231,7 +231,7 @@ namespace
             parent_shading_point &&
             same_triangle(*parent_shading_point, shading_point))
         {
-            if (warnings_count < MaxWarningsPerThread)
+            if (warning_count < MaxWarningsPerThread)
             {
                 RENDERER_LOG_WARNING(
                     "self-intersection detected, distance %e.",
@@ -239,7 +239,7 @@ namespace
 
                 ++warning_count;
             }
-            else if (warnings_count == MaxWarningsPerThread)
+            else if (warning_count == MaxWarningsPerThread)
             {
                 RENDERER_LOG_WARNING("more self-intersections detected, omitting warning messages for brevity.");
 

--- a/src/appleseed/renderer/kernel/intersection/intersector.cpp
+++ b/src/appleseed/renderer/kernel/intersection/intersector.cpp
@@ -224,8 +224,8 @@ namespace
         const ShadingPoint&         shading_point,
         const ShadingPoint*         parent_shading_point)
     {
-        static const size_t MaxWarningsPerThread = 100;
-        static size_t warnings_count = 0;
+        constexpr size_t MaxWarningsPerThread = 20;
+        static size_t warning_count = 0;
 
         if (shading_point.hit_surface() &&
             parent_shading_point &&
@@ -237,13 +237,13 @@ namespace
                     "self-intersection detected, distance %e.",
                     shading_point.get_distance());
 
-                warnings_count += 1;
+                ++warning_count;
             }
             else if (warnings_count == MaxWarningsPerThread)
             {
                 RENDERER_LOG_WARNING("more self-intersections detected, omitting warning messages for brevity.");
 
-                warnings_count += 1;
+                ++warning_count;
             }
         }
     }


### PR DESCRIPTION
Inspired from adaptive tile renderer invalid sample warnings