### PR TITLE
Change LLVM version from 5 to 6 for Travis Mac

### DIFF
--- a/scripts/travis/build-macos.sh
+++ b/scripts/travis/build-macos.sh
@@ -69,7 +69,7 @@ brew upgrade python@2
 brew link python@2
 brew info python@2
 
-brew install boost@1.71 boost-python@1.71 embree llvm@5 lz4 openimageio openvdb qt xerces-c zlib
+brew install boost@1.71 boost-python@1.71 embree llvm@6 lz4 openimageio openvdb qt xerces-c zlib
 
 mkdir -p $HOME/Library/Python/2.7/lib/python/site-packages
 echo 'import site; site.addsitedir("/usr/local/lib/python2.7/site-packages")' \
@@ -100,7 +100,7 @@ cmake \
     -DENABLERTTI=ON \
     -DUSE_LIBCPLUSPLUS=ON \
     -DUSE_QT=OFF \
-    -DLLVM_DIRECTORY=/usr/local/opt/llvm@5/ \
+    -DLLVM_DIRECTORY=/usr/local/opt/llvm@6/ \
     -DCMAKE_INSTALL_PREFIX=$THISDIR \
     ..
 


### PR DESCRIPTION
As homebrew dropped `llvm@5` (see [here](https://formulae.brew.sh/formula/llvm)), I it changed to `llvm@6`, as discussed in the discord.
This is just a temprary solution. On the long run, going with #2706 should be better.