### PR TITLE
Fix transmittance default value in as_glass

### DIFF
--- a/src/appleseed.shaders/src/appleseed/as_glass.osl
+++ b/src/appleseed.shaders/src/appleseed/as_glass.osl
@@ -49,7 +49,7 @@ shader as_glass
         string label = "Transmittance Color",
         string page = "Transmittance"
     ]],
-    float in_transmittance_amount = 0.8
+    float in_transmittance_amount = 0.99
     [[
         string as_maya_attribute_name = "transmittanceAmount",
         string as_maya_attribute_short_name = "ta",

--- a/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2016-2018 Esteban Tovagliari, The appleseedhq Organization
+// Copyright (c) 2016-2019 Esteban Tovagliari, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -982,7 +982,7 @@ DictionaryArray GlassBSDFFactory::get_input_metadata() const
                     .insert("color", "Colors")
                     .insert("texture_instance", "Texture Instances"))
             .insert("use", "required")
-            .insert("default", "0.85"));
+            .insert("default", "0.99"));
 
     metadata.push_back(
         Dictionary()


### PR DESCRIPTION
- Increases the default transmittance value for Glass from 80% to more realistic 99% (see Figure below, From [Shott TIE-35: Transmittance of optical glass](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=2ahUKEwih5OaL0YflAhUy_SoKHVmhCxIQFjAAegQIAhAC&url=https%3A%2F%2Fwww.schott.com%2Fd%2Fadvanced_optics%2Fe434285e-65f6-4f21-a1b8-af282e17629c%2F1.5%2Fschott_tie-35_transmittance_of_optical_glass_us.pdf&usg=AOvVaw39HA1oA07n7H86vzTitnd_)) 

![Capture](https://user-images.githubusercontent.com/22252558/66269166-0033d200-e84e-11e9-962a-2df3fd56ecd1.PNG)
