### PR TITLE
appleseed.cli's --samples option now takes a single argument

### DIFF
--- a/src/appleseed.cli/commandlinehandler.cpp
+++ b/src/appleseed.cli/commandlinehandler.cpp
@@ -104,9 +104,9 @@ CommandLineHandler::CommandLineHandler()
         &m_samples
             .add_name("--samples")
             .add_name("-s")
-            .set_description("set the minimum and maximum numbers of samples per pixel")
-            .set_syntax("min max")
-            .set_exact_value_count(2));
+            .set_description("set the number of samples per pixel")
+            .set_syntax("n")
+            .set_exact_value_count(1));
 
     parser().add_option_handler(
         &m_passes

--- a/src/appleseed.cli/main.cpp
+++ b/src/appleseed.cli/main.cpp
@@ -264,7 +264,7 @@ namespace
         {
             params.insert_path(
                 "uniform_pixel_renderer.samples",
-                g_cl.m_samples.values());
+                g_cl.m_samples.value());
         }
 
         if (g_cl.m_passes.is_set())

--- a/src/appleseed.cli/main.cpp
+++ b/src/appleseed.cli/main.cpp
@@ -264,7 +264,7 @@ namespace
         {
             params.insert_path(
                 "uniform_pixel_renderer.samples",
-                g_cl.m_samples.values()[1]);
+                g_cl.m_samples.values());
         }
 
         if (g_cl.m_passes.is_set())


### PR DESCRIPTION
fixes #2716 

Saw this as I was going through the tracker and figured I'd submit a PR real quick.