### PR TITLE
Add missing firstchannel token to texture node

### DIFF
--- a/src/appleseed.shaders/src/appleseed/as_texture.osl
+++ b/src/appleseed.shaders/src/appleseed/as_texture.osl
@@ -439,6 +439,7 @@ shader as_texture
             "twidth", in_t_filter_width,
             "swrap", wrap_mode[0],
             "twrap", wrap_mode[1],
+            "firstchannel", in_starting_channel,
             "missingcolor", in_color,
             "missingalpha", in_alpha,
             "alpha", out_alpha,


### PR DESCRIPTION
No one noticed this since no one was using TX files with more than 4
channels (i.e, bumpslopes).