### PR TITLE
Fix compile issue with xcode 7.3.1

### DIFF
--- a/src/appleseed/foundation/meta/tests/test_microfacet.cpp
+++ b/src/appleseed/foundation/meta/tests/test_microfacet.cpp
@@ -253,7 +253,7 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
     TEST_CASE(BlinnMDF_Evaluate_ReturnsNonNegativeValues)
     {
-        const BlinnMDF mdf;
+        const BlinnMDF mdf = {};
 
         EXPECT_TRUE(is_positive(mdf, 10.0f, 10.0f, PositivityTestSampleCount));
     }
@@ -267,7 +267,7 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
     TEST_CASE(BlinnMDF_Integral_EqualsOne)
     {
-        const BlinnMDF mdf;
+        const BlinnMDF mdf = {};
 
         const float integral = integrate(mdf, 10.0f, IntegrationSampleCount);
 
@@ -281,7 +281,7 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
     TEST_CASE(BeckmannMDF_Evaluate_ReturnsNonNegativeValues)
     {
-        const BeckmannMDF mdf;
+        const BeckmannMDF mdf = {};
 
         EXPECT_TRUE(is_positive(mdf, 0.5f, 0.5f, PositivityTestSampleCount));
     }
@@ -295,7 +295,7 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
     TEST_CASE(BeckmannMDF_Integral_EqualsOne)
     {
-        const BeckmannMDF mdf;
+        const BeckmannMDF mdf = {};
 
         const float integral = integrate(mdf, 0.5f, IntegrationSampleCount);
 
@@ -337,7 +337,7 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
     TEST_CASE(GGXMDF_Evaluate_ReturnsNonNegativeValues)
     {
-        const GGXMDF mdf;
+        const GGXMDF mdf = {};
 
         EXPECT_TRUE(is_positive(mdf, 0.5f, 0.5f, PositivityTestSampleCount));
     }
@@ -354,7 +354,7 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
     TEST_CASE(GGXMDF_Integral_EqualsOne)
     {
-        const GGXMDF mdf;
+        const GGXMDF mdf = {};
 
         const float integral = integrate(mdf, 0.5f, IntegrationSampleCount);
 
@@ -396,7 +396,7 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
     TEST_CASE(WardMDF_Evaluate_ReturnsNonNegativeValues)
     {
-        const WardMDF mdf;
+        const WardMDF mdf = {};
 
         EXPECT_TRUE(is_positive(mdf, 0.5f, 0.5f, PositivityTestSampleCount));
     }
@@ -415,14 +415,14 @@ TEST_SUITE(Foundation_Math_Microfacet)
 
     TEST_CASE(GTR1MDF_Evaluate_ReturnsNonNegativeValues)
     {
-        const GTR1MDF mdf;
+        const GTR1MDF mdf = {};
 
         EXPECT_TRUE(is_positive(mdf, 10.0f, 10.0f, PositivityTestSampleCount));
     }
 
     TEST_CASE(GTR1MDF_Integral_EqualsOne)
     {
-        const GTR1MDF mdf;
+        const GTR1MDF mdf = {};
 
         const float integral = integrate(mdf, 10.0f, IntegrationSampleCount);
 

--- a/src/appleseed/renderer/modeling/bsdf/microfacethelper.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/microfacethelper.cpp
@@ -216,7 +216,7 @@ void write_microfacet_directional_albedo_tables(
 {
     const bf::path dir(directory);
 
-    const GGXMDF ggx;
+    const GGXMDF ggx = {};
     const MDFAlbedoTable ggx_table(ggx);
     ggx_table.write_table_to_image(dir / "glossy_ggx_albedo_table.exr");
     ggx_table.write_table_to_cpp_array(


### PR DESCRIPTION
In the process of building the maya plugin for macOS 10.11, I got this compile error on a couple tests when building appleseed with xcode 7.3.1

default initialization of an object of const without a user-provided default constructor

This a pull request seems to fix the issue.
Newer versions of xcode don't appear to have this issue.
