### PR TITLE
Adapt C++ examples to recent changes in appleseed

### DIFF
--- a/sandbox/examples/cpp/distancefieldobject/distancefieldobject.cpp
+++ b/sandbox/examples/cpp/distancefieldobject/distancefieldobject.cpp
@@ -44,7 +44,6 @@
 #include "foundation/math/rng/xoroshiro128plus.h"
 #include "foundation/math/scalar.h"
 #include "foundation/math/vector.h"
-#include "foundation/platform/types.h"
 #include "foundation/utility/api/specializedapiarrays.h"
 #include "foundation/utility/containers/dictionary.h"
 #include "foundation/utility/job/iabortswitch.h"
@@ -59,6 +58,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 
 namespace asf = foundation;
 namespace asr = renderer;
@@ -151,6 +151,13 @@ namespace
             return raymarch(ray, t, p);
         }
 
+        void refine_and_offset(
+            const foundation::Ray3d& obj_inst_ray,
+            foundation::Vector3d& obj_inst_front_point,
+            foundation::Vector3d& obj_inst_back_point,
+            foundation::Vector3d& obj_inst_geo_normal) const override
+        {}
+
       private:
 
         //
@@ -181,12 +188,12 @@ namespace
         {
             return
                 asf::Xoroshiro128plus(
-                    asf::hash_uint64(asf::binary_cast<asf::uint64>(ray.m_org.x)) ^
-                    asf::hash_uint64(asf::binary_cast<asf::uint64>(ray.m_org.y)) ^
-                    asf::hash_uint64(asf::binary_cast<asf::uint64>(ray.m_org.z)),
-                    asf::hash_uint64(asf::binary_cast<asf::uint64>(ray.m_dir.x)) ^
-                    asf::hash_uint64(asf::binary_cast<asf::uint64>(ray.m_dir.y)) ^
-                    asf::hash_uint64(asf::binary_cast<asf::uint64>(ray.m_dir.z)));
+                    asf::hash_uint64(asf::binary_cast<uint64_t>(ray.m_org.x)) ^
+                    asf::hash_uint64(asf::binary_cast<uint64_t>(ray.m_org.y)) ^
+                    asf::hash_uint64(asf::binary_cast<uint64_t>(ray.m_org.z)),
+                    asf::hash_uint64(asf::binary_cast<uint64_t>(ray.m_dir.x)) ^
+                    asf::hash_uint64(asf::binary_cast<uint64_t>(ray.m_dir.y)) ^
+                    asf::hash_uint64(asf::binary_cast<uint64_t>(ray.m_dir.z)));
         }
 
         static float op_union(const float a, const float b)

--- a/sandbox/examples/cpp/heightfield/heightfield.cpp
+++ b/sandbox/examples/cpp/heightfield/heightfield.cpp
@@ -52,8 +52,6 @@
 #include "foundation/math/matrix.h"
 #include "foundation/math/scalar.h"
 #include "foundation/math/transform.h"
-#include "foundation/platform/compiler.h"
-#include "foundation/platform/types.h"
 #include "foundation/utility/containers/dictionary.h"
 #include "foundation/utility/log/consolelogtarget.h"
 #include "foundation/utility/autoreleaseptr.h"
@@ -65,6 +63,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <iomanip>
 #include <memory>
 #include <sstream>
@@ -403,13 +402,13 @@ class SingleBakedMeshProjectBuilder
         for (size_t i = 0; i < m_cube->get_triangle_count(); ++i)
         {
             Triangle triangle = m_cube->get_triangle(i);
-            triangle.m_v0 += static_cast<uint32>(base_vertex_index);
-            triangle.m_v1 += static_cast<uint32>(base_vertex_index);
-            triangle.m_v2 += static_cast<uint32>(base_vertex_index);
-            triangle.m_n0 += static_cast<uint32>(base_vertex_normal_index);
-            triangle.m_n1 += static_cast<uint32>(base_vertex_normal_index);
-            triangle.m_n2 += static_cast<uint32>(base_vertex_normal_index);
-            triangle.m_a0 = triangle.m_a1 = triangle.m_a2 = static_cast<uint32>(tex_coords_index);
+            triangle.m_v0 += static_cast<uint32_t>(base_vertex_index);
+            triangle.m_v1 += static_cast<uint32_t>(base_vertex_index);
+            triangle.m_v2 += static_cast<uint32_t>(base_vertex_index);
+            triangle.m_n0 += static_cast<uint32_t>(base_vertex_normal_index);
+            triangle.m_n1 += static_cast<uint32_t>(base_vertex_normal_index);
+            triangle.m_n2 += static_cast<uint32_t>(base_vertex_normal_index);
+            triangle.m_a0 = triangle.m_a1 = triangle.m_a2 = static_cast<uint32_t>(tex_coords_index);
             m_mesh->push_triangle(triangle);
         }
     }

--- a/sandbox/examples/cpp/infiniteplaneobject/infiniteplaneobject.cpp
+++ b/sandbox/examples/cpp/infiniteplaneobject/infiniteplaneobject.cpp
@@ -155,6 +155,13 @@ namespace
 
             return true;
         }
+
+        void refine_and_offset(
+            const foundation::Ray3d& obj_inst_ray,
+            foundation::Vector3d& obj_inst_front_point,
+            foundation::Vector3d& obj_inst_back_point,
+            foundation::Vector3d& obj_inst_geo_normal) const override
+        {}
     };
 
 

--- a/sandbox/examples/cpp/sphereobject/sphereobject.cpp
+++ b/sandbox/examples/cpp/sphereobject/sphereobject.cpp
@@ -194,6 +194,13 @@ namespace
             return false;
         }
 
+        void refine_and_offset(
+            const foundation::Ray3d& obj_inst_ray,
+            foundation::Vector3d& obj_inst_front_point,
+            foundation::Vector3d& obj_inst_back_point,
+            foundation::Vector3d& obj_inst_geo_normal) const override
+        {}
+
       private:
         double  m_radius;
         double  m_rcp_radius;


### PR DESCRIPTION
- Removed obsolete appleseed integer types
- Added override of pure virtual function of derived class to be able to instantiate it.

These changes allow building of the example files though I'm not sure it is the most elegant way to do it (adding the override). 
Also there is still an issue with parts of the objects appearing black when rendering (see screenshot of sphereobject)
![sphereobject](https://user-images.githubusercontent.com/22252558/71447167-1ad26480-2734-11ea-9f6e-32fe5ef7a1f4.png)

