### PR TITLE
Fix OpenGL lighting regression

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,8 +9,9 @@ root = true
 # C++
 # Python
 # CMake
+# OpenGL shaders
 
-[*.{cpp,h,py,txt}]
+[*.{cpp,h,py,txt,frag,vert}]
 charset = utf-8
 indent_style = space
 indent_size = 4

--- a/src/appleseed.studio/mainwindow/rendering/lightpathswidget.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathswidget.cpp
@@ -156,7 +156,6 @@ void LightPathsWidget::set_transform(const Transformd& transform)
 {
     m_camera_matrix = transform.get_parent_to_local();
     m_gl_view_matrix = transpose(m_camera_matrix);
-    m_camera_position = Vector3f(m_camera_matrix.extract_translation());
 }
 
 void LightPathsWidget::set_light_paths(const LightPathArray& light_paths)
@@ -615,7 +614,6 @@ void LightPathsWidget::initializeGL()
 
     m_scene_view_mat_location = m_gl->glGetUniformLocation(m_scene_shader_program, "u_view");
     m_scene_proj_mat_location = m_gl->glGetUniformLocation(m_scene_shader_program, "u_proj");
-    m_scene_camera_pos_location = m_gl->glGetUniformLocation(m_scene_shader_program, "u_camera_pos");
 
     m_light_paths_view_mat_location = m_gl->glGetUniformLocation(m_light_paths_shader_program, "u_view");
     m_light_paths_proj_mat_location = m_gl->glGetUniformLocation(m_light_paths_shader_program, "u_proj");
@@ -769,10 +767,6 @@ void LightPathsWidget::render_geometry()
         1,
         false,
         const_cast<const GLfloat*>(&m_gl_proj_matrix[0]));
-    m_gl->glUniform3fv(
-        m_scene_camera_pos_location,
-        1,
-        const_cast<const GLfloat*>(&m_camera_position[0]));
 
     for (size_t i = 0; i < m_scene_object_data_vbos.size(); i++)
     {

--- a/src/appleseed.studio/mainwindow/rendering/lightpathswidget.h
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathswidget.h
@@ -106,7 +106,6 @@ class LightPathsWidget
     const renderer::Project&                m_project;
     renderer::Camera&                       m_camera;
     foundation::Matrix4d                    m_camera_matrix;
-    foundation::Vector3f                    m_camera_position;
 
     bool                                    m_backface_culling_enabled;
 
@@ -125,7 +124,6 @@ class LightPathsWidget
     GLuint                                  m_scene_shader_program;
     GLint                                   m_scene_view_mat_location;
     GLint                                   m_scene_proj_mat_location;
-    GLint                                   m_scene_camera_pos_location;
     GLuint                                  m_light_paths_vbo;
     std::vector<GLsizei>                    m_light_paths_index_offsets;
     GLuint                                  m_light_paths_vao;

--- a/src/appleseed.studio/resources/shaders/scene.frag
+++ b/src/appleseed.studio/resources/shaders/scene.frag
@@ -28,37 +28,28 @@
 #version 330
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(location = 0) in vec3 v_world_pos;
-layout(location = 1) in vec3 v_norm;
-
-uniform vec3 u_camera_pos;
-
-const vec3 LIGHT_POS = vec3(0.0, 0.0, 0.0);
-const vec3 LIGHT_COLOR = vec3(1.0);
-const vec3 AMBIENT_COLOR = vec3(0.05);
+layout(location = 0) in vec3 frag_pos;
+layout(location = 1) in vec3 frag_norm;
 
 const vec3 MATERIAL_BASE_COLOR = vec3(0.8, 0.8, 0.8);
 const float MATERIAL_DIFFUSE_FACTOR = 0.4;
 const float MATERIAL_SPECULAR_FACTOR = 0.15;
-const float MATERIAL_METALNESS_FACTOR = 0.0;
-const float MATERIAL_SHININESS = 80.0;
+const float MATERIAL_SHININESS = 32.0;
 
 out vec4 Target0;
 
 void main()
 {
-    vec3 acc = vec3(0.0);
+    vec3 norm = normalize(frag_norm);
 
-    vec3 N = normalize(v_norm);
-    vec3 L = normalize(LIGHT_POS - v_world_pos);
-    vec3 V = normalize(u_camera_pos - v_world_pos);
-    vec3 H = normalize(L + V);
+    vec3 view_dir = normalize(-frag_pos);
+    vec3 reflect_dir = reflect(-view_dir, norm);
 
-    vec3 specular_color = mix(vec3(1.0), MATERIAL_BASE_COLOR, MATERIAL_METALNESS_FACTOR);
+    float diffuse_ratio = max(0.0, dot(view_dir, norm));
+    float specular_ratio = pow(max(0.0, dot(view_dir, reflect_dir)), MATERIAL_SHININESS);
 
-    acc += AMBIENT_COLOR * MATERIAL_BASE_COLOR;
-    acc += LIGHT_COLOR * MATERIAL_DIFFUSE_FACTOR * MATERIAL_BASE_COLOR * clamp(dot(N, L), 0.0, 1.0);
-    acc += LIGHT_COLOR * specular_color * pow(clamp(dot(N, H), 0.0, 1.0), MATERIAL_SHININESS);
+    vec3 diffuse = MATERIAL_DIFFUSE_FACTOR * MATERIAL_BASE_COLOR * diffuse_ratio;
+    vec3 specular = MATERIAL_SPECULAR_FACTOR * MATERIAL_BASE_COLOR * specular_ratio;
 
-    Target0 = vec4(acc, 1.0);
+    Target0 = vec4(diffuse + specular, 1.0);
 }

--- a/src/appleseed.studio/resources/shaders/scene.vert
+++ b/src/appleseed.studio/resources/shaders/scene.vert
@@ -35,13 +35,17 @@ layout(location = 2) in mat4 i_model;
 uniform mat4 u_view;
 uniform mat4 u_proj;
 
-layout(location = 1) out vec3 v_world_pos;
-layout(location = 0) out vec3 v_norm;
+layout(location = 0) out vec3 frag_pos;
+layout(location = 1) out vec3 frag_norm;
 
 void main()
 {
-    vec4 world_pos = i_model * vec4(a_pos, 1.0);
-    v_world_pos = world_pos.xyz;
-    v_norm = a_norm;
-    gl_Position = u_proj * u_view * world_pos;
+    mat4 model_view = u_view * i_model;
+    vec4 world_pos = model_view * vec4(a_pos, 1.0);
+    frag_pos = world_pos.xyz;
+
+    mat3 normal_matrix = mat3(transpose(inverse(model_view)));
+    frag_norm = normal_matrix * a_norm;
+
+    gl_Position = u_proj * world_pos;
 }


### PR DESCRIPTION
Fix #2755

The facing ratio lighting model was removed with the introduction of OpenGL 3.3 (commit 9fee17f8e31550de476b0a24073e4206b070765c).

Future potential improvements:
- Computing the normal matrix in the vertex shader is expensive, we can cache it and compute it on the CPU.

![image](https://user-images.githubusercontent.com/4656466/73785385-74986680-4797-11ea-99a7-5c9eb1df3be2.png)
