### PR TITLE
Fix file path to texture sampler's mask file to naive format

### DIFF
--- a/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
+++ b/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
@@ -834,6 +834,7 @@ namespace
 
             if (!filepath.isEmpty())
             {
+                filepath = QDir::toNativeSeparators(filepath);
                 m_path_line_edit->setText(filepath);
             }
         }


### PR DESCRIPTION
Fix #2695 