### PR TITLE
Fix texture sampler panel display when loading project

### DIFF
--- a/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
+++ b/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
@@ -801,7 +801,7 @@ namespace
                 config, "pixel_renderer", default_pr_value);
 
             m_image_plane_sampler_combo->setCurrentIndex(
-                pr_value == "adaptive" ? 1 : 0);
+                pr_value == "texture" ? 2 : 0);
         }
 
       private slots:


### PR DESCRIPTION
Fix #2698 , the bug is because of the code checks if the current sampler is `"adaptive"` by `"pixel_renderer" value`, which is already been checked by `"tile_renderer" value` in previous if statement.