### PR TITLE
Do not include the scenepicker in API headers.

### DIFF
--- a/src/appleseed/renderer/api/rendering.h
+++ b/src/appleseed/renderer/api/rendering.h
@@ -45,7 +45,6 @@
 #include "renderer/kernel/rendering/nulltilecallback.h"
 #include "renderer/kernel/rendering/progressive/progressiveframerenderer.h"
 #include "renderer/kernel/rendering/renderercontrollercollection.h"
-#include "renderer/kernel/rendering/scenepicker.h"
 #include "renderer/kernel/rendering/tilecallbackbase.h"
 #include "renderer/kernel/rendering/tilecallbackcollection.h"
 #include "renderer/kernel/rendering/timedrenderercontroller.h"


### PR DESCRIPTION
The scene picker includes indirectly OSL headers and force all plugins to have a dependency on OSL.
