### PR TITLE
Fix warning

### DIFF
--- a/src/appleseed/renderer/modeling/bsdf/hairbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/hairbsdf.cpp
@@ -573,7 +573,7 @@ namespace
 
             // Sample longitudinal function for given component of scattering.
 
-            float sin_theta_i = 0.0;
+            float sin_theta_i;
             if (p == 0)
             {
                 sin_theta_i = sample_longitudinal(
@@ -590,7 +590,7 @@ namespace
                     values->m_precomputed.m_v * 0.25f,
                     sample_M);
             }
-            else if (p == 2)
+            else
             {
                 sin_theta_i = sample_longitudinal(
                     std::sin(theta_o_TRT),

--- a/src/appleseed/renderer/modeling/bsdf/hairbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/hairbsdf.cpp
@@ -573,7 +573,7 @@ namespace
 
             // Sample longitudinal function for given component of scattering.
 
-            float sin_theta_i;
+            float sin_theta_i = 0.0;
             if (p == 0)
             {
                 sin_theta_i = sample_longitudinal(
@@ -582,7 +582,7 @@ namespace
                     values->m_precomputed.m_v,
                     sample_M);
             }
-            if (p == 1)
+            else if (p == 1)
             {
                 sin_theta_i = sample_longitudinal(
                     std::sin(theta_o_TT),
@@ -590,7 +590,7 @@ namespace
                     values->m_precomputed.m_v * 0.25f,
                     sample_M);
             }
-            if (p == 2)
+            else if (p == 2)
             {
                 sin_theta_i = sample_longitudinal(
                     std::sin(theta_o_TRT),


### PR DESCRIPTION
In previous implementation, use if(...) if(...) will cause warning when we build this project.

```
/home/yucwang/develop/appleseed/src/appleseed/renderer/modeling/bsdf/hairbsdf.cpp: In member function 'virtual void renderer::{anonymous}::HairBSDFImpl::sample(renderer::SamplingContext&, const void*, bool, bool, const renderer::BSDF::LocalGeometry&, const Dual3f&, int, renderer::BSDFSample&) const':
/home/yucwang/develop/appleseed/src/appleseed/renderer/modeling/bsdf/hairbsdf.cpp:601:83: warning: 'sin_theta_i' may be used uninitialized in this function [-Wmaybe-uninitialized]
             const float cos_theta_i = std::sqrt(std::max(0.0f, 1.0f - sin_theta_i * sin_theta_i));
```

We replace it with if(...) else if(...) to mitigate this issue.