### PR TITLE
Tile highlights are now colored

### DIFF
--- a/src/appleseed.bench/mainwindow/rendering/qttilecallback.cpp
+++ b/src/appleseed.bench/mainwindow/rendering/qttilecallback.cpp
@@ -66,10 +66,12 @@ void QtTileCallback::release()
 void QtTileCallback::on_tile_begin(
     const Frame*            frame,
     const size_t            tile_x,
-    const size_t            tile_y)
+    const size_t            tile_y,
+    const size_t            thread_index,
+    const size_t            nb_threads)
 {
     assert(m_render_widget);
-    m_render_widget->highlight_tile(*frame, tile_x, tile_y);
+    m_render_widget->highlight_tile(*frame, tile_x, tile_y, thread_index, nb_threads);
 
     emit signal_update();
 }

--- a/src/appleseed.bench/mainwindow/rendering/qttilecallback.cpp
+++ b/src/appleseed.bench/mainwindow/rendering/qttilecallback.cpp
@@ -68,10 +68,10 @@ void QtTileCallback::on_tile_begin(
     const size_t            tile_x,
     const size_t            tile_y,
     const size_t            thread_index,
-    const size_t            nb_threads)
+    const size_t            thread_count)
 {
     assert(m_render_widget);
-    m_render_widget->highlight_tile(*frame, tile_x, tile_y, thread_index, nb_threads);
+    m_render_widget->highlight_tile(*frame, tile_x, tile_y, thread_index, thread_count);
 
     emit signal_update();
 }

--- a/src/appleseed.bench/mainwindow/rendering/qttilecallback.h
+++ b/src/appleseed.bench/mainwindow/rendering/qttilecallback.h
@@ -65,8 +65,8 @@ class QtTileCallback
         const renderer::Frame*  frame,
         const size_t            tile_x,
         const size_t            tile_y,
-        const size_t            thread_index = -1,
-        const size_t            nb_threads = -1) override;
+        const size_t            thread_index = ~size_t(0),
+        const size_t            thread_count = ~size_t(0)) override;
 
     void on_tile_end(
         const renderer::Frame*  frame,

--- a/src/appleseed.bench/mainwindow/rendering/qttilecallback.h
+++ b/src/appleseed.bench/mainwindow/rendering/qttilecallback.h
@@ -64,7 +64,9 @@ class QtTileCallback
     void on_tile_begin(
         const renderer::Frame*  frame,
         const size_t            tile_x,
-        const size_t            tile_y) override;
+        const size_t            tile_y,
+        const size_t            thread_index = -1,
+        const size_t            nb_threads = -1) override;
 
     void on_tile_end(
         const renderer::Frame*  frame,

--- a/src/appleseed.bench/mainwindow/rendering/qttilecallback.h
+++ b/src/appleseed.bench/mainwindow/rendering/qttilecallback.h
@@ -65,8 +65,8 @@ class QtTileCallback
         const renderer::Frame*  frame,
         const size_t            tile_x,
         const size_t            tile_y,
-        const size_t            thread_index = ~size_t(0),
-        const size_t            thread_count = ~size_t(0)) override;
+        const size_t            thread_index,
+        const size_t            thread_count) override;
 
     void on_tile_end(
         const renderer::Frame*  frame,

--- a/src/appleseed.bench/mainwindow/rendering/renderwidget.cpp
+++ b/src/appleseed.bench/mainwindow/rendering/renderwidget.cpp
@@ -176,7 +176,9 @@ namespace
 void RenderWidget::highlight_tile(
     const Frame&    frame,
     const size_t    tile_x,
-    const size_t    tile_y)
+    const size_t    tile_y,
+    const size_t    thread_index,
+    const size_t    nb_threads)
 {
     QMutexLocker locker(&m_mutex);
 
@@ -205,7 +207,16 @@ void RenderWidget::highlight_tile(
 
     // Draw a bracket around the tile.
     const size_t BracketExtent = 5;
-    const std::uint8_t BracketColor[3] = { 255, 255, 255 };
+    std::uint8_t BracketColor[3] = { 255, 255, 255 }; // white
+    if (thread_index >= 0) {
+        // Choose one color per thread (see https://www.shadertoy.com/view/wlKXDm).
+        float t = TwoPi<float>() * (thread_index / static_cast<float>(nb_threads));
+        float cos_t = std::cos(t);
+        float sin_t = std::sin(t);
+        BracketColor[0] = 128 + static_cast<std::uint8_t>(127.5f * cos_t);
+        BracketColor[1] = 128 + static_cast<std::uint8_t>(127.5f * (-0.5f * cos_t - 0.866f * sin_t));
+        BracketColor[2] = 128 + static_cast<std::uint8_t>(127.5f * (-0.5f * cos_t + 0.866f * sin_t));
+    }
     draw_bracket(
         dest,
         width,

--- a/src/appleseed.bench/mainwindow/rendering/renderwidget.cpp
+++ b/src/appleseed.bench/mainwindow/rendering/renderwidget.cpp
@@ -178,7 +178,7 @@ void RenderWidget::highlight_tile(
     const size_t    tile_x,
     const size_t    tile_y,
     const size_t    thread_index,
-    const size_t    nb_threads)
+    const size_t    thread_count)
 {
     QMutexLocker locker(&m_mutex);
 
@@ -205,18 +205,17 @@ void RenderWidget::highlight_tile(
     // Get a pointer to the first destination pixel.
     std::uint8_t* dest = get_image_pointer(m_image, x, y);
 
+    // Choose one color per thread (see https://www.shadertoy.com/view/wlKXDm).
+    std::uint8_t BracketColor[3];
+    float t = TwoPi<float>() * (thread_index / static_cast<float>(thread_count));
+    float cos_t = std::cos(t);
+    float sin_t = std::sin(t);
+    BracketColor[0] = 128 + static_cast<std::uint8_t>(127.5f * cos_t);
+    BracketColor[1] = 128 + static_cast<std::uint8_t>(127.5f * (-0.5f * cos_t - 0.866f * sin_t));
+    BracketColor[2] = 128 + static_cast<std::uint8_t>(127.5f * (-0.5f * cos_t + 0.866f * sin_t));
+
     // Draw a bracket around the tile.
     const size_t BracketExtent = 5;
-    std::uint8_t BracketColor[3] = { 255, 255, 255 }; // white
-    if (thread_index >= 0) {
-        // Choose one color per thread (see https://www.shadertoy.com/view/wlKXDm).
-        float t = TwoPi<float>() * (thread_index / static_cast<float>(nb_threads));
-        float cos_t = std::cos(t);
-        float sin_t = std::sin(t);
-        BracketColor[0] = 128 + static_cast<std::uint8_t>(127.5f * cos_t);
-        BracketColor[1] = 128 + static_cast<std::uint8_t>(127.5f * (-0.5f * cos_t - 0.866f * sin_t));
-        BracketColor[2] = 128 + static_cast<std::uint8_t>(127.5f * (-0.5f * cos_t + 0.866f * sin_t));
-    }
     draw_bracket(
         dest,
         width,

--- a/src/appleseed.bench/mainwindow/rendering/renderwidget.h
+++ b/src/appleseed.bench/mainwindow/rendering/renderwidget.h
@@ -88,7 +88,9 @@ class RenderWidget
     void highlight_tile(
         const renderer::Frame&  frame,
         const size_t            tile_x,
-        const size_t            tile_y);
+        const size_t            tile_y,
+        const size_t            thread_index,
+        const size_t            nb_threads);
 
     // Thread-safe.
     void blit_tile(

--- a/src/appleseed.bench/mainwindow/rendering/renderwidget.h
+++ b/src/appleseed.bench/mainwindow/rendering/renderwidget.h
@@ -90,7 +90,7 @@ class RenderWidget
         const size_t            tile_x,
         const size_t            tile_y,
         const size_t            thread_index,
-        const size_t            nb_threads);
+        const size_t            thread_count);
 
     // Thread-safe.
     void blit_tile(

--- a/src/appleseed.cli/stdouttilecallback.cpp
+++ b/src/appleseed.cli/stdouttilecallback.cpp
@@ -82,7 +82,9 @@ namespace
         void on_tile_begin(
             const Frame*        frame,
             const size_t        tile_x,
-            const size_t        tile_y) override
+            const size_t        tile_y,
+            const size_t        thread_index,
+            const size_t        nb_threads) override
         {
             boost::mutex::scoped_lock lock(m_mutex);
 

--- a/src/appleseed.cli/stdouttilecallback.cpp
+++ b/src/appleseed.cli/stdouttilecallback.cpp
@@ -84,7 +84,7 @@ namespace
             const size_t        tile_x,
             const size_t        tile_y,
             const size_t        thread_index,
-            const size_t        nb_threads) override
+            const size_t        thread_count) override
         {
             boost::mutex::scoped_lock lock(m_mutex);
 

--- a/src/appleseed.python/bindblenderprogressivetilecallback.cpp
+++ b/src/appleseed.python/bindblenderprogressivetilecallback.cpp
@@ -109,7 +109,9 @@ namespace
         void on_tile_begin(
             const Frame*            /*frame*/,
             const size_t            /*tile_x*/,
-            const size_t            /*tile_y*/) override
+            const size_t            /*tile_y*/,
+            const size_t            /*thread_index*/,
+            const size_t            /*nb_threads*/) override
         {
             PyErr_SetString(PyExc_RuntimeError, "BlenderProgressiveTileCallback cannot be used for final renders");
             bpy::throw_error_already_set();

--- a/src/appleseed.python/bindblenderprogressivetilecallback.cpp
+++ b/src/appleseed.python/bindblenderprogressivetilecallback.cpp
@@ -111,7 +111,7 @@ namespace
             const size_t            /*tile_x*/,
             const size_t            /*tile_y*/,
             const size_t            /*thread_index*/,
-            const size_t            /*nb_threads*/) override
+            const size_t            /*thread_count*/) override
         {
             PyErr_SetString(PyExc_RuntimeError, "BlenderProgressiveTileCallback cannot be used for final renders");
             bpy::throw_error_already_set();

--- a/src/appleseed.python/bindtilecallback.cpp
+++ b/src/appleseed.python/bindtilecallback.cpp
@@ -87,19 +87,23 @@ namespace
         void on_tile_begin(
             const Frame*            frame,
             const size_t            tile_x,
-            const size_t            tile_y) override
+            const size_t            tile_y,
+            const size_t            thread_index,
+            const size_t            nb_threads) override
         {
             // Lock Python's global interpreter lock (it was released in MasterRenderer.render).
             ScopedGILLock lock;
 
             if (bpy::override f = this->get_override("on_tile_begin"))
-                f(bpy::ptr(frame), tile_x, tile_y);
+                f(bpy::ptr(frame), tile_x, tile_y, thread_index, nb_threads);
         }
 
         void default_on_tile_begin(
             const Frame*            frame,
             const size_t            tile_x,
-            const size_t            tile_y)
+            const size_t            tile_y,
+            const size_t            thread_index,
+            const size_t            nb_threads)
         {
         }
 

--- a/src/appleseed.python/bindtilecallback.cpp
+++ b/src/appleseed.python/bindtilecallback.cpp
@@ -89,13 +89,13 @@ namespace
             const size_t            tile_x,
             const size_t            tile_y,
             const size_t            thread_index,
-            const size_t            nb_threads) override
+            const size_t            thread_count) override
         {
             // Lock Python's global interpreter lock (it was released in MasterRenderer.render).
             ScopedGILLock lock;
 
             if (bpy::override f = this->get_override("on_tile_begin"))
-                f(bpy::ptr(frame), tile_x, tile_y, thread_index, nb_threads);
+                f(bpy::ptr(frame), tile_x, tile_y, thread_index, thread_count);
         }
 
         void default_on_tile_begin(
@@ -103,7 +103,7 @@ namespace
             const size_t            tile_x,
             const size_t            tile_y,
             const size_t            thread_index,
-            const size_t            nb_threads)
+            const size_t            thread_count)
         {
         }
 

--- a/src/appleseed.studio/mainwindow/rendering/qttilecallback.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/qttilecallback.cpp
@@ -79,10 +79,10 @@ namespace
             const size_t    tile_x,
             const size_t    tile_y,
             const size_t    thread_index,
-            const size_t    nb_threads) override
+            const size_t    thread_count) override
         {
             assert(m_render_widget);
-            m_render_widget->highlight_tile(*frame, tile_x, tile_y, thread_index, nb_threads);
+            m_render_widget->highlight_tile(*frame, tile_x, tile_y, thread_index, thread_count);
 
             emit signal_update();
         }

--- a/src/appleseed.studio/mainwindow/rendering/qttilecallback.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/qttilecallback.cpp
@@ -77,10 +77,12 @@ namespace
         void on_tile_begin(
             const Frame*    frame,
             const size_t    tile_x,
-            const size_t    tile_y) override
+            const size_t    tile_y,
+            const size_t    thread_index,
+            const size_t    nb_threads) override
         {
             assert(m_render_widget);
-            m_render_widget->highlight_tile(*frame, tile_x, tile_y);
+            m_render_widget->highlight_tile(*frame, tile_x, tile_y, thread_index, nb_threads);
 
             emit signal_update();
         }

--- a/src/appleseed.studio/mainwindow/rendering/renderwidget.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/renderwidget.cpp
@@ -204,7 +204,7 @@ void RenderWidget::highlight_tile(
     const size_t    tile_x,
     const size_t    tile_y,
     const size_t    thread_index,
-    const size_t    nb_threads)
+    const size_t    thread_count)
 {
     QMutexLocker locker(&m_mutex);
 
@@ -231,18 +231,17 @@ void RenderWidget::highlight_tile(
     // Get a pointer to the first destination pixel.
     std::uint8_t* dest = get_image_pointer(m_image, x, y);
 
+    // Choose one color per thread (see https://www.shadertoy.com/view/wlKXDm).
+    std::uint8_t BracketColor[3];
+    float t = TwoPi<float>() * (thread_index / static_cast<float>(thread_count));
+    float cos_t = std::cos(t);
+    float sin_t = std::sin(t);
+    BracketColor[0] = 128 + static_cast<std::uint8_t>(127.5f * cos_t);
+    BracketColor[1] = 128 + static_cast<std::uint8_t>(127.5f * (-0.5f * cos_t - 0.866f * sin_t));
+    BracketColor[2] = 128 + static_cast<std::uint8_t>(127.5f * (-0.5f * cos_t + 0.866f * sin_t));
+
     // Draw a bracket around the tile.
     const size_t BracketExtent = 5;
-    std::uint8_t BracketColor[3] = { 255, 255, 255 }; // white
-    if (thread_index >= 0) {
-        // Choose one color per thread (see https://www.shadertoy.com/view/wlKXDm).
-        float t = TwoPi<float>() * (thread_index / static_cast<float>(nb_threads));
-        float cos_t = std::cos(t);
-        float sin_t = std::sin(t);
-        BracketColor[0] = 128 + static_cast<std::uint8_t>(127.5f * cos_t);
-        BracketColor[1] = 128 + static_cast<std::uint8_t>(127.5f * (-0.5f * cos_t - 0.866f * sin_t));
-        BracketColor[2] = 128 + static_cast<std::uint8_t>(127.5f * (-0.5f * cos_t + 0.866f * sin_t));
-    }
     draw_bracket(
         dest,
         width,

--- a/src/appleseed.studio/mainwindow/rendering/renderwidget.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/renderwidget.cpp
@@ -202,7 +202,9 @@ namespace
 void RenderWidget::highlight_tile(
     const Frame&    frame,
     const size_t    tile_x,
-    const size_t    tile_y)
+    const size_t    tile_y,
+    const size_t    thread_index,
+    const size_t    nb_threads)
 {
     QMutexLocker locker(&m_mutex);
 
@@ -231,7 +233,16 @@ void RenderWidget::highlight_tile(
 
     // Draw a bracket around the tile.
     const size_t BracketExtent = 5;
-    const std::uint8_t BracketColor[3] = { 255, 255, 255 };
+    std::uint8_t BracketColor[3] = { 255, 255, 255 }; // white
+    if (thread_index >= 0) {
+        // Choose one color per thread (see https://www.shadertoy.com/view/wlKXDm).
+        float t = TwoPi<float>() * (thread_index / static_cast<float>(nb_threads));
+        float cos_t = std::cos(t);
+        float sin_t = std::sin(t);
+        BracketColor[0] = 128 + static_cast<std::uint8_t>(127.5f * cos_t);
+        BracketColor[1] = 128 + static_cast<std::uint8_t>(127.5f * (-0.5f * cos_t - 0.866f * sin_t));
+        BracketColor[2] = 128 + static_cast<std::uint8_t>(127.5f * (-0.5f * cos_t + 0.866f * sin_t));
+    }
     draw_bracket(
         dest,
         width,

--- a/src/appleseed.studio/mainwindow/rendering/renderwidget.h
+++ b/src/appleseed.studio/mainwindow/rendering/renderwidget.h
@@ -102,7 +102,9 @@ class RenderWidget
     void highlight_tile(
         const renderer::Frame&  frame,
         const size_t            tile_x,
-        const size_t            tile_y);
+        const size_t            tile_y,
+        const size_t            thread_index,
+        const size_t            nb_threads);
 
     // Thread-safe.
     void blit_tile(

--- a/src/appleseed.studio/mainwindow/rendering/renderwidget.h
+++ b/src/appleseed.studio/mainwindow/rendering/renderwidget.h
@@ -104,7 +104,7 @@ class RenderWidget
         const size_t            tile_x,
         const size_t            tile_y,
         const size_t            thread_index,
-        const size_t            nb_threads);
+        const size_t            thread_count);
 
     // Thread-safe.
     void blit_tile(

--- a/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
@@ -368,6 +368,7 @@ namespace
                         m_tile_ordering,
                         m_tile_renderers,
                         m_tile_callbacks,
+                        m_thread_count,
                         pass_hash,
                         m_spectrum_mode,
                         tile_jobs,

--- a/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/genericframerenderer.cpp
@@ -453,7 +453,7 @@ namespace
                     for (size_t ty = 0; ty < frame_props.m_tile_count_y; ++ty)
                     {
                         for (size_t tx = 0; tx < frame_props.m_tile_count_x; ++tx)
-                            tile_callback->on_tile_begin(&m_frame, tx, ty);
+                            tile_callback->on_tile_begin(&m_frame, tx, ty, 0, 1);
                     }
                 }
             }

--- a/src/appleseed/renderer/kernel/rendering/generic/tilejob.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/tilejob.cpp
@@ -136,9 +136,8 @@ void TileJob::execute(const size_t thread_index)
             : nullptr;
 
     // Call the pre-render tile callback.
-    if (tile_callback) {
+    if (tile_callback)
         tile_callback->on_tile_begin(&m_frame, m_tile_x, m_tile_y, thread_index, m_thread_count);
-    }
 
     try
     {

--- a/src/appleseed/renderer/kernel/rendering/generic/tilejob.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/tilejob.cpp
@@ -59,6 +59,7 @@ TileJob::TileJob(
     const Frame&                frame,
     const size_t                tile_x,
     const size_t                tile_y,
+    const size_t                thread_count,
     const std::uint32_t         pass_hash,
     const Spectrum::Mode        spectrum_mode,
     IAbortSwitch&               abort_switch)
@@ -67,6 +68,7 @@ TileJob::TileJob(
   , m_frame(frame)
   , m_tile_x(tile_x)
   , m_tile_y(tile_y)
+  , m_thread_count(thread_count)
   , m_pass_hash(pass_hash)
   , m_spectrum_mode(spectrum_mode)
   , m_abort_switch(abort_switch)
@@ -135,7 +137,7 @@ void TileJob::execute(const size_t thread_index)
 
     // Call the pre-render tile callback.
     if (tile_callback) {
-        tile_callback->on_tile_begin(&m_frame, m_tile_x, m_tile_y, thread_index, m_tile_renderers.size());
+        tile_callback->on_tile_begin(&m_frame, m_tile_x, m_tile_y, thread_index, m_thread_count);
     }
 
     try

--- a/src/appleseed/renderer/kernel/rendering/generic/tilejob.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/tilejob.cpp
@@ -134,8 +134,9 @@ void TileJob::execute(const size_t thread_index)
             : nullptr;
 
     // Call the pre-render tile callback.
-    if (tile_callback)
-        tile_callback->on_tile_begin(&m_frame, m_tile_x, m_tile_y);
+    if (tile_callback) {
+        tile_callback->on_tile_begin(&m_frame, m_tile_x, m_tile_y, thread_index, m_tile_renderers.size());
+    }
 
     try
     {

--- a/src/appleseed/renderer/kernel/rendering/generic/tilejob.h
+++ b/src/appleseed/renderer/kernel/rendering/generic/tilejob.h
@@ -66,6 +66,7 @@ class TileJob
         const Frame&                frame,
         const size_t                tile_x,
         const size_t                tile_y,
+        const size_t                thread_count,
         const std::uint32_t         pass_hash,
         const Spectrum::Mode        spectrum_mode,
         foundation::IAbortSwitch&   abort_switch);
@@ -79,6 +80,7 @@ class TileJob
     const Frame&                    m_frame;
     const size_t                    m_tile_x;
     const size_t                    m_tile_y;
+    const size_t                    m_thread_count;
     const std::uint32_t             m_pass_hash;
     const Spectrum::Mode            m_spectrum_mode;
     foundation::IAbortSwitch&       m_abort_switch;

--- a/src/appleseed/renderer/kernel/rendering/generic/tilejobfactory.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/tilejobfactory.cpp
@@ -56,6 +56,7 @@ void TileJobFactory::create(
     const TileOrdering                  tile_ordering,
     const TileJob::TileRendererVector&  tile_renderers,
     const TileJob::TileCallbackVector&  tile_callbacks,
+    const size_t                        thread_count,
     const std::uint32_t                 pass_hash,
     const Spectrum::Mode                spectrum_mode,
     TileJobVector&                      tile_jobs,
@@ -89,6 +90,7 @@ void TileJobFactory::create(
                 frame,
                 tile_x,
                 tile_y,
+                thread_count,
                 pass_hash,
                 spectrum_mode,
                 abort_switch));

--- a/src/appleseed/renderer/kernel/rendering/generic/tilejobfactory.h
+++ b/src/appleseed/renderer/kernel/rendering/generic/tilejobfactory.h
@@ -74,6 +74,7 @@ class TileJobFactory
         const TileOrdering                  tile_ordering,
         const TileJob::TileRendererVector&  tile_renderers,
         const TileJob::TileCallbackVector&  tile_callbacks,
+        const size_t                        thread_count,
         const std::uint32_t                 pass_hash,
         const Spectrum::Mode                spectrum_mode,
         TileJobVector&                      tile_jobs,

--- a/src/appleseed/renderer/kernel/rendering/itilecallback.h
+++ b/src/appleseed/renderer/kernel/rendering/itilecallback.h
@@ -71,7 +71,9 @@ class APPLESEED_DLLSYMBOL ITileCallback
     virtual void on_tile_begin(
         const Frame*            frame,
         const size_t            tile_x,
-        const size_t            tile_y) = 0;
+        const size_t            tile_y,
+        const size_t            thread_index = -1,
+        const size_t            nb_threads = -1) = 0;
 
     // This method is called after a tile is rendered.
     virtual void on_tile_end(

--- a/src/appleseed/renderer/kernel/rendering/itilecallback.h
+++ b/src/appleseed/renderer/kernel/rendering/itilecallback.h
@@ -72,8 +72,8 @@ class APPLESEED_DLLSYMBOL ITileCallback
         const Frame*            frame,
         const size_t            tile_x,
         const size_t            tile_y,
-        const size_t            thread_index = ~size_t(0),
-        const size_t            thread_count = ~size_t(0)) = 0;
+        const size_t            thread_index,
+        const size_t            thread_count) = 0;
 
     // This method is called after a tile is rendered.
     virtual void on_tile_end(

--- a/src/appleseed/renderer/kernel/rendering/itilecallback.h
+++ b/src/appleseed/renderer/kernel/rendering/itilecallback.h
@@ -72,8 +72,8 @@ class APPLESEED_DLLSYMBOL ITileCallback
         const Frame*            frame,
         const size_t            tile_x,
         const size_t            tile_y,
-        const size_t            thread_index = -1,
-        const size_t            nb_threads = -1) = 0;
+        const size_t            thread_index = ~size_t(0),
+        const size_t            thread_count = ~size_t(0)) = 0;
 
     // This method is called after a tile is rendered.
     virtual void on_tile_end(

--- a/src/appleseed/renderer/kernel/rendering/serialrenderercontroller.cpp
+++ b/src/appleseed/renderer/kernel/rendering/serialrenderercontroller.cpp
@@ -129,13 +129,17 @@ void SerialRendererController::add_on_tiled_frame_end_callback(
 void SerialRendererController::add_on_tile_begin_callback(
     const Frame*            frame,
     const size_t            tile_x,
-    const size_t            tile_y)
+    const size_t            tile_y,
+    const size_t            thread_index,
+    const size_t            nb_threads)
 {
     PendingTileCallback callback = {};
     callback.m_type = PendingTileCallback::OnTileBegin;
     callback.m_frame = frame;
     callback.m_tile_x = tile_x;
     callback.m_tile_y = tile_y;
+    callback.m_thread_index = thread_index;
+    callback.m_nb_threads = nb_threads;
 
     boost::mutex::scoped_lock lock(m_mutex);
     m_pending_callbacks.push_back(callback);
@@ -199,7 +203,7 @@ void SerialRendererController::exec_callback(const PendingTileCallback& cb)
         break;
 
       case PendingTileCallback::OnTileBegin:
-        m_tile_callback->on_tile_begin(cb.m_frame, cb.m_tile_x, cb.m_tile_y);
+        m_tile_callback->on_tile_begin(cb.m_frame, cb.m_tile_x, cb.m_tile_y, cb.m_thread_index, cb.m_nb_threads);
         break;
 
       case PendingTileCallback::OnTileEnd:

--- a/src/appleseed/renderer/kernel/rendering/serialrenderercontroller.cpp
+++ b/src/appleseed/renderer/kernel/rendering/serialrenderercontroller.cpp
@@ -131,7 +131,7 @@ void SerialRendererController::add_on_tile_begin_callback(
     const size_t            tile_x,
     const size_t            tile_y,
     const size_t            thread_index,
-    const size_t            nb_threads)
+    const size_t            thread_count)
 {
     PendingTileCallback callback = {};
     callback.m_type = PendingTileCallback::OnTileBegin;
@@ -139,7 +139,7 @@ void SerialRendererController::add_on_tile_begin_callback(
     callback.m_tile_x = tile_x;
     callback.m_tile_y = tile_y;
     callback.m_thread_index = thread_index;
-    callback.m_nb_threads = nb_threads;
+    callback.m_thread_count = thread_count;
 
     boost::mutex::scoped_lock lock(m_mutex);
     m_pending_callbacks.push_back(callback);
@@ -203,7 +203,7 @@ void SerialRendererController::exec_callback(const PendingTileCallback& cb)
         break;
 
       case PendingTileCallback::OnTileBegin:
-        m_tile_callback->on_tile_begin(cb.m_frame, cb.m_tile_x, cb.m_tile_y, cb.m_thread_index, cb.m_nb_threads);
+        m_tile_callback->on_tile_begin(cb.m_frame, cb.m_tile_x, cb.m_tile_y, cb.m_thread_index, cb.m_thread_count);
         break;
 
       case PendingTileCallback::OnTileEnd:

--- a/src/appleseed/renderer/kernel/rendering/serialrenderercontroller.h
+++ b/src/appleseed/renderer/kernel/rendering/serialrenderercontroller.h
@@ -83,7 +83,7 @@ class SerialRendererController
         const size_t            tile_x,
         const size_t            tile_y,
         const size_t            thread_index,
-        const size_t            nb_threads);
+        const size_t            thread_count);
 
     void add_on_tile_end_callback(
         const Frame*            frame,
@@ -120,7 +120,7 @@ class SerialRendererController
         double          m_samples_per_pixel;
         std::uint64_t   m_samples_per_second;
         size_t          m_thread_index;
-        size_t          m_nb_threads;
+        size_t          m_thread_count;
     };
 
     IRendererController*                m_controller;

--- a/src/appleseed/renderer/kernel/rendering/serialrenderercontroller.h
+++ b/src/appleseed/renderer/kernel/rendering/serialrenderercontroller.h
@@ -81,7 +81,9 @@ class SerialRendererController
     void add_on_tile_begin_callback(
         const Frame*            frame,
         const size_t            tile_x,
-        const size_t            tile_y);
+        const size_t            tile_y,
+        const size_t            thread_index,
+        const size_t            nb_threads);
 
     void add_on_tile_end_callback(
         const Frame*            frame,
@@ -117,6 +119,8 @@ class SerialRendererController
         std::uint64_t   m_samples;
         double          m_samples_per_pixel;
         std::uint64_t   m_samples_per_second;
+        size_t          m_thread_index;
+        size_t          m_nb_threads;
     };
 
     IRendererController*                m_controller;

--- a/src/appleseed/renderer/kernel/rendering/serialtilecallback.cpp
+++ b/src/appleseed/renderer/kernel/rendering/serialtilecallback.cpp
@@ -69,9 +69,11 @@ namespace
         void on_tile_begin(
             const Frame*            frame,
             const size_t            tile_x,
-            const size_t            tile_y) override
+            const size_t            tile_y,
+            const size_t            thread_index,
+            const size_t            nb_threads) override
         {
-            m_controller->add_on_tile_begin_callback(frame, tile_x, tile_y);
+            m_controller->add_on_tile_begin_callback(frame, tile_x, tile_y, thread_index, nb_threads);
         }
 
         void on_tile_end(

--- a/src/appleseed/renderer/kernel/rendering/serialtilecallback.cpp
+++ b/src/appleseed/renderer/kernel/rendering/serialtilecallback.cpp
@@ -71,9 +71,9 @@ namespace
             const size_t            tile_x,
             const size_t            tile_y,
             const size_t            thread_index,
-            const size_t            nb_threads) override
+            const size_t            thread_count) override
         {
-            m_controller->add_on_tile_begin_callback(frame, tile_x, tile_y, thread_index, nb_threads);
+            m_controller->add_on_tile_begin_callback(frame, tile_x, tile_y, thread_index, thread_count);
         }
 
         void on_tile_end(

--- a/src/appleseed/renderer/kernel/rendering/tilecallbackbase.h
+++ b/src/appleseed/renderer/kernel/rendering/tilecallbackbase.h
@@ -64,7 +64,9 @@ class TileCallbackBase
     void on_tile_begin(
         const Frame*            frame,
         const size_t            tile_x,
-        const size_t            tile_y) override
+        const size_t            tile_y,
+        const size_t            thread_index = -1,
+        const size_t            nb_threads = -1) override
     {
     }
 

--- a/src/appleseed/renderer/kernel/rendering/tilecallbackbase.h
+++ b/src/appleseed/renderer/kernel/rendering/tilecallbackbase.h
@@ -65,8 +65,8 @@ class TileCallbackBase
         const Frame*            frame,
         const size_t            tile_x,
         const size_t            tile_y,
-        const size_t            thread_index = ~size_t(0),
-        const size_t            thread_count = ~size_t(0)) override
+        const size_t            thread_index,
+        const size_t            thread_count) override
     {
     }
 

--- a/src/appleseed/renderer/kernel/rendering/tilecallbackbase.h
+++ b/src/appleseed/renderer/kernel/rendering/tilecallbackbase.h
@@ -65,8 +65,8 @@ class TileCallbackBase
         const Frame*            frame,
         const size_t            tile_x,
         const size_t            tile_y,
-        const size_t            thread_index = -1,
-        const size_t            nb_threads = -1) override
+        const size_t            thread_index = ~size_t(0),
+        const size_t            thread_count = ~size_t(0)) override
     {
     }
 

--- a/src/appleseed/renderer/kernel/rendering/tilecallbackcollection.cpp
+++ b/src/appleseed/renderer/kernel/rendering/tilecallbackcollection.cpp
@@ -72,10 +72,12 @@ namespace
         void on_tile_begin(
             const Frame*            frame,
             const size_t            tile_x,
-            const size_t            tile_y) override
+            const size_t            tile_y,
+            const size_t            thread_index,
+            const size_t            nb_threads) override
         {
             for (ITileCallback* callback : m_callbacks)
-                callback->on_tile_begin(frame, tile_x, tile_y);
+                callback->on_tile_begin(frame, tile_x, tile_y, thread_index, nb_threads);
         }
         
         void on_tile_end(

--- a/src/appleseed/renderer/kernel/rendering/tilecallbackcollection.cpp
+++ b/src/appleseed/renderer/kernel/rendering/tilecallbackcollection.cpp
@@ -74,10 +74,10 @@ namespace
             const size_t            tile_x,
             const size_t            tile_y,
             const size_t            thread_index,
-            const size_t            nb_threads) override
+            const size_t            thread_count) override
         {
             for (ITileCallback* callback : m_callbacks)
-                callback->on_tile_begin(frame, tile_x, tile_y, thread_index, nb_threads);
+                callback->on_tile_begin(frame, tile_x, tile_y, thread_index, thread_count);
         }
         
         void on_tile_end(


### PR DESCRIPTION
Addresses https://github.com/appleseedhq/appleseed/issues/1182.

Added _thread index_ and _number of threads_ as arguments to `on_tile_begin` and `highlight_tile`.

From these values, one color can be uniquely selected per thread, using one of [Inigo Quilez](http://iquilezles.org/www/articles/palettes/palettes.htm)'s color palettes.

 (See https://www.shadertoy.com/view/wlKXDm for a demo)