### PR TITLE
Fix issue #2778: move QDir::toNativeSeparators() to helper functions

### DIFF
--- a/src/appleseed.bench/mainwindow/mainwindow.cpp
+++ b/src/appleseed.bench/mainwindow/mainwindow.cpp
@@ -1079,8 +1079,6 @@ void MainWindow::slot_save_render()
     if (QFileInfo(filepath).suffix().isEmpty())
         filepath += ".png";
 
-    filepath = QDir::toNativeSeparators(filepath);
-
     m_render_widget->save(filepath);
 
     RENDERER_LOG_INFO("wrote image file %s.", filepath.toStdString().c_str());
@@ -1116,8 +1114,6 @@ void MainWindow::slot_export_chart()
 
     if (QFileInfo(filepath).suffix().isEmpty())
         filepath += ".png";
-
-    filepath = QDir::toNativeSeparators(filepath);
 
     m_chart_widget->grab().save(filepath);
 

--- a/src/appleseed.qtcommon/utility/miscellaneous.cpp
+++ b/src/appleseed.qtcommon/utility/miscellaneous.cpp
@@ -276,10 +276,9 @@ QString get_open_filename(
         settings,
         settings_key + SettingsLastDirectory,
         QDir::toNativeSeparators(QFileInfo(filepath).path()));
-        
+
     return QDir::toNativeSeparators(filepath);
 }
-
 
 QStringList get_open_filenames(
     QWidget*                parent,
@@ -313,7 +312,7 @@ QStringList get_open_filenames(
 
     for (int i = 0; i < filepaths.size(); ++i) 
     {
-        filepaths[i].replace(0, filepaths[i].length(), QDir::toNativeSeparators(filepaths[i]));
+        filepaths[i] = QDir::toNativeSeparators(filepaths[i]);
     }
 
     return filepaths;

--- a/src/appleseed.qtcommon/utility/miscellaneous.cpp
+++ b/src/appleseed.qtcommon/utility/miscellaneous.cpp
@@ -276,9 +276,10 @@ QString get_open_filename(
         settings,
         settings_key + SettingsLastDirectory,
         QDir::toNativeSeparators(QFileInfo(filepath).path()));
-
-    return filepath;
+        
+    return QDir::toNativeSeparators(filepath);
 }
+
 
 QStringList get_open_filenames(
     QWidget*                parent,
@@ -291,7 +292,7 @@ QStringList get_open_filenames(
     const QString dir = get_value(settings, settings_key + SettingsLastDirectory);
     QString selected_filter = get_value(settings, settings_key + SettingsSelectedFilter);
 
-    const QStringList filepaths =
+    QStringList filepaths =
         QFileDialog::getOpenFileNames(
             parent,
             caption,
@@ -309,6 +310,11 @@ QStringList get_open_filenames(
         settings,
         settings_key + SettingsLastDirectory,
         QDir::toNativeSeparators(QFileInfo(filepaths.first()).path()));
+
+    for (int i = 0; i < filepaths.size(); ++i) 
+    {
+        filepaths[i].replace(0, filepaths[i].length(), QDir::toNativeSeparators(filepaths[i]));
+    }
 
     return filepaths;
 }
@@ -355,7 +361,7 @@ QString get_save_filename(
         filepath += selected_filter.mid(begin, end - begin);
     }
 
-    return filepath;
+    return QDir::toNativeSeparators(filepath);
 }
 
 void disable_osx_focus_rect(QWidget* widget)

--- a/src/appleseed.studio/mainwindow/mainwindow.cpp
+++ b/src/appleseed.studio/mainwindow/mainwindow.cpp
@@ -1402,8 +1402,6 @@ void MainWindow::slot_open_project()
 
     if (!filepath.isEmpty())
     {
-        filepath = QDir::toNativeSeparators(filepath);
-
         open_project_async(filepath);
         update_recent_files_menu(filepath);
     }
@@ -1520,8 +1518,6 @@ void MainWindow::slot_save_project_as()
 
     if (!filepath.isEmpty())
     {
-        filepath = QDir::toNativeSeparators(filepath);
-
         save_project(filepath);
     }
 }

--- a/src/appleseed.studio/mainwindow/project/disneymateriallayerui.cpp
+++ b/src/appleseed.studio/mainwindow/project/disneymateriallayerui.cpp
@@ -346,7 +346,7 @@ void DisneyMaterialLayerUI::slot_open_file_picker(const QString& widget_name)
         widget_proxy->set(
             texture_to_expression(
                 m_project.search_paths(),
-                QDir::toNativeSeparators(filepath)));
+                filepath));
         widget_proxy->emit_signal_changed();
     }
 }

--- a/src/appleseed.studio/mainwindow/project/entityeditor.cpp
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.cpp
@@ -743,7 +743,7 @@ void EntityEditor::slot_open_file_picker(const QString& widget_name)
 
         if (!filepath.isEmpty())
         {
-            widget_proxy->set(QDir::toNativeSeparators(filepath).toStdString());
+            widget_proxy->set(filepath.toStdString());
             widget_proxy->emit_signal_changed();
         }
     }

--- a/src/appleseed.studio/mainwindow/project/expressioneditorwindow.cpp
+++ b/src/appleseed.studio/mainwindow/project/expressioneditorwindow.cpp
@@ -258,7 +258,6 @@ void ExpressionEditorWindow::slot_save_script()
             if (QFileInfo(filepath).suffix().isEmpty())
                 filepath += ".se";
 
-            filepath = QDir::toNativeSeparators(filepath);
             m_script_filepath = filepath.toStdString();
         }
     }
@@ -292,8 +291,6 @@ void ExpressionEditorWindow::slot_load_script()
 
     if (!filepath.isEmpty())
     {
-        filepath = QDir::toNativeSeparators(filepath);
-
         // Open script file.
         std::ifstream script_file(filepath.toStdString().c_str());
         if (!script_file.is_open())

--- a/src/appleseed.studio/mainwindow/project/materialcollectionitem.cpp
+++ b/src/appleseed.studio/mainwindow/project/materialcollectionitem.cpp
@@ -171,8 +171,6 @@ void MaterialCollectionItem::slot_import_disney()
 
     if (!filepath.isEmpty())
     {
-        filepath = QDir::toNativeSeparators(filepath);
-
         const bf::path root_path(Application::get_root_path());
         const bf::path schema_file_path = root_path / "schemas" / "settings.xsd";
 

--- a/src/appleseed.studio/mainwindow/project/materialitem.cpp
+++ b/src/appleseed.studio/mainwindow/project/materialitem.cpp
@@ -173,8 +173,6 @@ void MaterialItem::slot_export()
         if (QFileInfo(filepath).suffix().isEmpty())
             filepath += ".dmt";
 
-        filepath = QDir::toNativeSeparators(filepath);
-
         ParamArray parameters = m_entity->get_parameters();
         parameters.insert("__name", m_entity->get_name());
         parameters.insert("__model", m_entity->get_model());

--- a/src/appleseed.studio/mainwindow/project/objectcollectionitem.cpp
+++ b/src/appleseed.studio/mainwindow/project/objectcollectionitem.cpp
@@ -146,7 +146,7 @@ void ObjectCollectionItem::slot_import_objects()
 void ObjectCollectionItem::import_objects(const QStringList& filepaths)
 {
     for (int i = 0; i < filepaths.size(); ++i)
-        insert_objects(QDir::toNativeSeparators(filepaths[i]).toStdString());
+        insert_objects(filepaths[i].toStdString());
 }
 
 void ObjectCollectionItem::insert_objects(const std::string& path) const

--- a/src/appleseed.studio/mainwindow/project/texturecollectionitem.cpp
+++ b/src/appleseed.studio/mainwindow/project/texturecollectionitem.cpp
@@ -141,13 +141,10 @@ void TextureCollectionItem::slot_import_textures()
     if (filepaths.empty())
         return;
 
-    const bf::path path(
-        QDir::toNativeSeparators(filepaths.first()).toStdString());
-
     // todo: schedule creation of texture and texture instances when rendering.
     for (int i = 0; i < filepaths.size(); ++i)
     {
-        const std::string filepath = QDir::toNativeSeparators(filepaths[i]).toStdString();
+        const std::string filepath(filepaths[i].toStdString());
 
         auto_release_ptr<Texture> texture = create_texture(filepath);
         auto_release_ptr<TextureInstance> texture_instance = create_texture_instance(texture->get_name());

--- a/src/appleseed.studio/mainwindow/project/texturecollectionitem.cpp
+++ b/src/appleseed.studio/mainwindow/project/texturecollectionitem.cpp
@@ -144,7 +144,7 @@ void TextureCollectionItem::slot_import_textures()
     // todo: schedule creation of texture and texture instances when rendering.
     for (int i = 0; i < filepaths.size(); ++i)
     {
-        const std::string filepath(filepaths[i].toStdString());
+        const std::string filepath = filepaths[i].toStdString();
 
         auto_release_ptr<Texture> texture = create_texture(filepath);
         auto_release_ptr<TextureInstance> texture_instance = create_texture_instance(texture->get_name());

--- a/src/appleseed.studio/mainwindow/pythonconsole/pythonconsolewidget.cpp
+++ b/src/appleseed.studio/mainwindow/pythonconsole/pythonconsolewidget.cpp
@@ -210,7 +210,6 @@ void PythonConsoleWidget::slot_open_file()
 
     if (!filepath.isEmpty())
     {
-        filepath = QDir::toNativeSeparators(filepath);
         open_file(filepath.toStdString());
     }
 }

--- a/src/appleseed.studio/mainwindow/rendering/lightpathstab.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/lightpathstab.cpp
@@ -162,8 +162,6 @@ void LightPathsTab::slot_save_light_paths()
     if (QFileInfo(filepath).suffix().isEmpty())
         filepath += ".aspaths";
 
-    filepath = QDir::toNativeSeparators(filepath);
-
     // Write light paths to disk.
     m_project.get_light_path_recorder().write(filepath.toUtf8().constData());
 }

--- a/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
+++ b/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
@@ -837,7 +837,6 @@ namespace
 
             if (!filepath.isEmpty())
             {
-                filepath = QDir::toNativeSeparators(filepath);
                 m_path_line_edit->setText(filepath);
             }
         }


### PR DESCRIPTION
This pr aims to drive #2778 .
We will convert filepaths() to native separators in base functions we provide.