### PR TITLE
Use interned strings in dictionaries and param arrays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ write_compiler_detection_header (
         cxx_defaulted_functions
         cxx_deleted_functions
         cxx_generalized_initializers
+        cxx_attribute_deprecated
 )
 
 

--- a/src/appleseed.cli/main.cpp
+++ b/src/appleseed.cli/main.cpp
@@ -297,7 +297,7 @@ namespace
             const std::string value = s.substr(equal_pos + 1);
 
             // Insert the parameter.
-            params.insert_path(path, value);
+            params.insert_path(path.c_str(), value);
         }
     }
 

--- a/src/appleseed.studio/mainwindow/falsecolorswindow.cpp
+++ b/src/appleseed.studio/mainwindow/falsecolorswindow.cpp
@@ -84,12 +84,12 @@ namespace
                 Dictionary im = m_input_metadata[i];
                 const std::string input_name = im.get<std::string>("name");
 
-                // Don't expose the order input either. 
+                // Don't expose the order input either.
                 if (input_name == "order")
                     continue;
 
                 im.insert("value",
-                    values.strings().exist(input_name) ? values.get<std::string>(input_name) :
+                    values.strings().exist(input_name.c_str()) ? values.get<std::string>(input_name.c_str()) :
                     im.strings().exist("default") ? im.get<std::string>("default") :
                     "");
 

--- a/src/appleseed.studio/mainwindow/project/disneymaterialcustomui.cpp
+++ b/src/appleseed.studio/mainwindow/project/disneymaterialcustomui.cpp
@@ -139,7 +139,7 @@ Dictionary DisneyMaterialCustomUI::get_values() const
         Dictionary layer_values = m_layers[i]->get_values();
 
         values.insert(
-            layer_values.get<std::string>("layer_name"),
+            layer_values.get<std::string>("layer_name").c_str(),
             layer_values.insert("layer_number", i));
     }
 

--- a/src/appleseed.studio/mainwindow/project/disneymateriallayerui.cpp
+++ b/src/appleseed.studio/mainwindow/project/disneymateriallayerui.cpp
@@ -168,7 +168,7 @@ void DisneyMaterialLayerUI::create_input_widgets(const Dictionary& values)
         const std::string input_type = im.get<std::string>("type");
 
         im.insert("value",
-            values.strings().exist(input_name) ? values.get<std::string>(input_name) :
+            values.strings().exist(input_name.c_str()) ? values.get<std::string>(input_name.c_str()) :
             im.strings().exist("default") ? im.get<std::string>("default") :
             "");
 

--- a/src/appleseed.studio/mainwindow/project/entityeditor.h
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.h
@@ -81,8 +81,8 @@ class EntityEditor
             const std::string&              name,
             const std::string&              default_value)
         {
-            return values.strings().exist(name)
-                ? values.strings().get<std::string>(name)
+            return values.strings().exist(name.c_str())
+                ? values.strings().get<std::string>(name.c_str())
                 : default_value;
         }
     };

--- a/src/appleseed.studio/mainwindow/project/entityeditorformfactorybase.cpp
+++ b/src/appleseed.studio/mainwindow/project/entityeditorformfactorybase.cpp
@@ -77,7 +77,7 @@ void EntityEditorFormFactoryBase::add_input_metadata(
         const std::string input_name = im.get<std::string>("name");
 
         im.insert("value",
-            input_values.strings().exist(input_name) ? input_values.get<std::string>(input_name) :
+            input_values.strings().exist(input_name.c_str()) ? input_values.get<std::string>(input_name.c_str()) :
             im.strings().exist("default") ? im.get<std::string>("default") :
             "");
 

--- a/src/appleseed.studio/mainwindow/project/fixedmodelentityeditorformfactory.h
+++ b/src/appleseed.studio/mainwindow/project/fixedmodelentityeditorformfactory.h
@@ -93,7 +93,7 @@ void FixedModelEntityEditorFormFactory<FactoryRegistrar>::update(
 
     metadata.push_back(
         foundation::Dictionary()
-            .insert("name", ModelParameter)
+            .insert("name", ModelParameter.c_str())
             .insert("label", "Model")
             .insert("type", "enumeration")
             .insert("items", model_items)

--- a/src/appleseed.studio/mainwindow/project/fixedmodelentityitem.h
+++ b/src/appleseed.studio/mainwindow/project/fixedmodelentityitem.h
@@ -109,7 +109,7 @@ foundation::Dictionary FixedModelEntityItem<Entity, ParentEntity, CollectionItem
         renderer::EntityTraits<Entity>::get_entity_values(Base::m_entity);
 
     values.insert(
-        EntityEditorFormFactoryBase::ModelParameter,
+        EntityEditorFormFactoryBase::ModelParameter.c_str(),
         Base::m_entity->get_model());
 
     return values;

--- a/src/appleseed.studio/mainwindow/project/materialassignmenteditorwindow.cpp
+++ b/src/appleseed.studio/mainwindow/project/materialassignmenteditorwindow.cpp
@@ -310,8 +310,8 @@ MaterialAssignmentEditorWindow::SlotValue MaterialAssignmentEditorWindow::get_sl
     else if (slot_info.get_mode() == "same")
     {
         const StringDictionary& front_mappings = m_object_instance.get_front_material_mappings();
-        if (front_mappings.exist(slot_info.m_slot_name))
-            slot_value.m_material_name = front_mappings.get<std::string>(slot_info.m_slot_name);
+        if (front_mappings.exist(slot_info.m_slot_name.c_str()))
+            slot_value.m_material_name = front_mappings.get<std::string>(slot_info.m_slot_name.c_str());
     }
 
     return slot_value;

--- a/src/appleseed.studio/mainwindow/project/multimodelentityeditorformfactory.h
+++ b/src/appleseed.studio/mainwindow/project/multimodelentityeditorformfactory.h
@@ -131,7 +131,7 @@ std::string MultiModelEntityEditorFormFactory<FactoryRegistrar>::add_model_widge
 
     metadata.push_back(
         foundation::Dictionary()
-            .insert("name", ModelParameter)
+            .insert("name", ModelParameter.c_str())
             .insert("label", "Model")
             .insert("type", "enumeration")
             .insert("items", model_items)

--- a/src/appleseed.studio/mainwindow/project/multimodelentityitem.h
+++ b/src/appleseed.studio/mainwindow/project/multimodelentityitem.h
@@ -105,7 +105,7 @@ foundation::Dictionary MultiModelEntityItem<Entity, ParentEntity, CollectionItem
         renderer::EntityTraits<Entity>::get_entity_values(Base::m_entity);
 
     values.insert(
-        EntityEditorFormFactoryBase::ModelParameter,
+        EntityEditorFormFactoryBase::ModelParameter.c_str(),
         Base::m_entity->get_model());
 
     return values;

--- a/src/appleseed.studio/mainwindow/project/projectbuilder.cpp
+++ b/src/appleseed.studio/mainwindow/project/projectbuilder.cpp
@@ -59,7 +59,7 @@ Frame* ProjectBuilder::edit_frame(
     const std::string name = get_entity_name(values);
 
     Dictionary clean_values(values);
-    clean_values.strings().remove(EntityEditorFormFactoryBase::NameParameter);
+    clean_values.strings().remove(EntityEditorFormFactoryBase::NameParameter.c_str());
 
     Frame* old_frame = m_project.get_frame();
     const size_t old_canvas_width = old_frame->image().properties().m_canvas_width;
@@ -88,11 +88,11 @@ void ProjectBuilder::slot_notify_project_modification() const
 
 std::string ProjectBuilder::get_entity_name(const Dictionary& values)
 {
-    if (!values.strings().exist(EntityEditorFormFactoryBase::NameParameter))
+    if (!values.strings().exist(EntityEditorFormFactoryBase::NameParameter.c_str()))
         throw ExceptionInvalidEntityName();
 
     const std::string name = trim_both(
-        values.get<std::string>(EntityEditorFormFactoryBase::NameParameter));
+        values.get<std::string>(EntityEditorFormFactoryBase::NameParameter.c_str()));
 
     if (!is_valid_entity_name(name))
         throw ExceptionInvalidEntityName();

--- a/src/appleseed.studio/mainwindow/project/projectbuilder.h
+++ b/src/appleseed.studio/mainwindow/project/projectbuilder.h
@@ -232,7 +232,7 @@ inline renderer::ObjectInstance* ProjectBuilder::edit_entity(
     const std::string name = get_entity_name(values);
 
     foundation::Dictionary clean_values(values);
-    clean_values.strings().remove(EntityEditorFormFactoryBase::NameParameter);
+    clean_values.strings().remove(EntityEditorFormFactoryBase::NameParameter.c_str());
 
     foundation::auto_release_ptr<renderer::ObjectInstance> new_entity(
         renderer::ObjectInstanceFactory::create(
@@ -263,7 +263,7 @@ inline renderer::TextureInstance* ProjectBuilder::edit_entity(
     const std::string name = get_entity_name(values);
 
     foundation::Dictionary clean_values(values);
-    clean_values.strings().remove(EntityEditorFormFactoryBase::NameParameter);
+    clean_values.strings().remove(EntityEditorFormFactoryBase::NameParameter.c_str());
 
     foundation::auto_release_ptr<renderer::TextureInstance> new_entity(
         renderer::TextureInstanceFactory::create(
@@ -309,11 +309,11 @@ foundation::auto_release_ptr<Entity> ProjectBuilder::create_entity(
     typedef MultiModelEntityEditorFormFactory<FactoryRegistrarType> EntityEditorFormFactoryType;
 
     const std::string name = get_entity_name(values);
-    const std::string model = values.get<std::string>(EntityEditorFormFactoryType::ModelParameter);
+    const std::string model = values.get<std::string>(EntityEditorFormFactoryType::ModelParameter.c_str());
 
     foundation::Dictionary clean_values(values);
-    clean_values.strings().remove(EntityEditorFormFactoryType::NameParameter);
-    clean_values.strings().remove(EntityEditorFormFactoryType::ModelParameter);
+    clean_values.strings().remove(EntityEditorFormFactoryType::NameParameter.c_str());
+    clean_values.strings().remove(EntityEditorFormFactoryType::ModelParameter.c_str());
 
     const FactoryRegistrarType& factory_registrar = m_project.get_factory_registrar<Entity>();
     const FactoryType* factory = factory_registrar.lookup(model.c_str());
@@ -329,7 +329,7 @@ inline foundation::auto_release_ptr<renderer::ColorEntity> ProjectBuilder::creat
     const std::string name = get_entity_name(values);
 
     foundation::Dictionary clean_values(values);
-    clean_values.strings().remove(EntityEditorFormFactoryBase::NameParameter);
+    clean_values.strings().remove(EntityEditorFormFactoryBase::NameParameter.c_str());
 
     return renderer::ColorEntityFactory::create(name.c_str(), clean_values);
 }
@@ -343,11 +343,11 @@ inline foundation::auto_release_ptr<renderer::Texture> ProjectBuilder::create_en
     typedef MultiModelEntityEditorFormFactory<FactoryRegistrarType> EntityEditorFormFactoryType;
 
     const std::string name = get_entity_name(values);
-    const std::string model = values.get<std::string>(EntityEditorFormFactoryType::ModelParameter);
+    const std::string model = values.get<std::string>(EntityEditorFormFactoryType::ModelParameter.c_str());
 
     foundation::Dictionary clean_values(values);
-    clean_values.strings().remove(EntityEditorFormFactoryType::NameParameter);
-    clean_values.strings().remove(EntityEditorFormFactoryType::ModelParameter);
+    clean_values.strings().remove(EntityEditorFormFactoryType::NameParameter.c_str());
+    clean_values.strings().remove(EntityEditorFormFactoryType::ModelParameter.c_str());
 
     const FactoryRegistrarType& factory_registrar = m_project.get_factory_registrar<renderer::Texture>();
     const FactoryType* factory = factory_registrar.lookup(model.c_str());
@@ -363,7 +363,7 @@ inline foundation::auto_release_ptr<renderer::Environment> ProjectBuilder::creat
     const std::string name = get_entity_name(values);
 
     foundation::Dictionary clean_values(values);
-    clean_values.strings().remove(EntityEditorFormFactoryBase::NameParameter);
+    clean_values.strings().remove(EntityEditorFormFactoryBase::NameParameter.c_str());
 
     return renderer::EnvironmentFactory::create(name.c_str(), clean_values);
 }
@@ -375,7 +375,7 @@ inline foundation::auto_release_ptr<renderer::ShaderGroup> ProjectBuilder::creat
     const std::string name = get_entity_name(values);
 
     foundation::Dictionary clean_values(values);
-    clean_values.strings().remove(EntityEditorFormFactoryBase::NameParameter);
+    clean_values.strings().remove(EntityEditorFormFactoryBase::NameParameter.c_str());
 
     return renderer::ShaderGroupFactory::create(name.c_str(), clean_values);
 }

--- a/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
+++ b/src/appleseed.studio/mainwindow/renderingsettingswindow.cpp
@@ -425,7 +425,7 @@ class RenderSettingsPanel
         const std::string&      param_path,
         const T&                value)
     {
-        configuration.get_parameters().insert_path(param_path, value);
+        configuration.get_parameters().insert_path(param_path.c_str(), value);
     }
 };
 

--- a/src/appleseed.studio/utility/inputwidgetproxies.cpp
+++ b/src/appleseed.studio/utility/inputwidgetproxies.cpp
@@ -440,7 +440,7 @@ Dictionary InputWidgetProxyCollection::get_values() const
         const std::string value = i->second->get();
 
         if (!value.empty())
-            values.insert(i->first, value);
+            values.insert(i->first.c_str(), value);
     }
 
     return values;

--- a/src/appleseed/foundation/containers/dictionary.cpp
+++ b/src/appleseed/foundation/containers/dictionary.cpp
@@ -36,6 +36,7 @@
 // Standard headers.
 #include <cassert>
 #include <map>
+#include <string>
 
 namespace foundation
 {

--- a/src/appleseed/foundation/containers/dictionary.cpp
+++ b/src/appleseed/foundation/containers/dictionary.cpp
@@ -41,8 +41,8 @@
 namespace foundation
 {
 
-typedef std::map<std::string, std::string> StringMap;
-typedef std::map<std::string, Dictionary> DictionaryMap;
+typedef std::map<InternedString, std::string> StringMap;
+typedef std::map<InternedString, Dictionary> DictionaryMap;
 
 
 //
@@ -185,7 +185,7 @@ StringDictionary& StringDictionary::insert(const char* key, const char* value)
     assert(key);
     assert(value);
 
-    impl->m_strings[key] = value;
+    impl->m_strings[InternedString(key)] = value;
 
     return *this;
 }
@@ -195,7 +195,7 @@ StringDictionary& StringDictionary::set(const char* key, const char* value)
     assert(key);
     assert(value);
 
-    const StringMap::iterator i = impl->m_strings.find(key);
+    const StringMap::iterator i = impl->m_strings.find(InternedString(key));
 
     if (i == impl->m_strings.end())
         throw ExceptionDictionaryKeyNotFound(key);
@@ -209,7 +209,7 @@ const char* StringDictionary::get(const char* key) const
 {
     assert(key);
 
-    const StringMap::const_iterator i = impl->m_strings.find(key);
+    const StringMap::const_iterator i = impl->m_strings.find(InternedString(key));
 
     if (i == impl->m_strings.end())
         throw ExceptionDictionaryKeyNotFound(key);
@@ -221,14 +221,14 @@ bool StringDictionary::exist(const char* key) const
 {
     assert(key);
 
-    return impl->m_strings.find(key) != impl->m_strings.end();
+    return impl->m_strings.find(InternedString(key)) != impl->m_strings.end();
 }
 
 StringDictionary& StringDictionary::remove(const char* key)
 {
     assert(key);
 
-    const StringMap::iterator i = impl->m_strings.find(key);
+    const StringMap::iterator i = impl->m_strings.find(InternedString(key));
 
     if (i != impl->m_strings.end())
         impl->m_strings.erase(i);
@@ -465,7 +465,7 @@ DictionaryDictionary& DictionaryDictionary::insert(const char* key, const Dictio
 {
     assert(key);
 
-    impl->m_dictionaries[key] = value;
+    impl->m_dictionaries[InternedString(key)] = value;
 
     return *this;
 }
@@ -474,7 +474,7 @@ DictionaryDictionary& DictionaryDictionary::set(const char* key, const Dictionar
 {
     assert(key);
 
-    const DictionaryMap::iterator i = impl->m_dictionaries.find(key);
+    const DictionaryMap::iterator i = impl->m_dictionaries.find(InternedString(key));
 
     if (i == impl->m_dictionaries.end())
         throw ExceptionDictionaryKeyNotFound(key);
@@ -488,7 +488,7 @@ Dictionary& DictionaryDictionary::get(const char* key)
 {
     assert(key);
 
-    const DictionaryMap::iterator i = impl->m_dictionaries.find(key);
+    const DictionaryMap::iterator i = impl->m_dictionaries.find(InternedString(key));
 
     if (i == impl->m_dictionaries.end())
         throw ExceptionDictionaryKeyNotFound(key);
@@ -500,7 +500,7 @@ const Dictionary& DictionaryDictionary::get(const char* key) const
 {
     assert(key);
 
-    const DictionaryMap::const_iterator i = impl->m_dictionaries.find(key);
+    const DictionaryMap::const_iterator i = impl->m_dictionaries.find(InternedString(key));
 
     if (i == impl->m_dictionaries.end())
         throw ExceptionDictionaryKeyNotFound(key);
@@ -512,14 +512,14 @@ bool DictionaryDictionary::exist(const char* key) const
 {
     assert(key);
 
-    return impl->m_dictionaries.find(key) != impl->m_dictionaries.end();
+    return impl->m_dictionaries.find(InternedString(key)) != impl->m_dictionaries.end();
 }
 
 DictionaryDictionary& DictionaryDictionary::remove(const char* key)
 {
     assert(key);
 
-    const DictionaryMap::iterator i = impl->m_dictionaries.find(key);
+    const DictionaryMap::iterator i = impl->m_dictionaries.find(InternedString(key));
 
     if (i != impl->m_dictionaries.end())
         impl->m_dictionaries.erase(i);

--- a/src/appleseed/foundation/containers/dictionary.h
+++ b/src/appleseed/foundation/containers/dictionary.h
@@ -31,6 +31,7 @@
 
 // appleseed.foundation headers.
 #include "foundation/core/exceptions/stringexception.h"
+#include "foundation/string/internedstring.h"
 #include "foundation/string/string.h"
 
 // appleseed.main headers.
@@ -38,7 +39,6 @@
 
 // Standard headers.
 #include <cstddef>
-#include <string>
 
 // Forward declarations.
 namespace foundation    { class Dictionary; }
@@ -135,29 +135,24 @@ class APPLESEED_DLLSYMBOL StringDictionary
     // Returns the dictionary itself to allow chaining of operations.
     StringDictionary& insert(const char* key, const char* value);
     template <typename T> StringDictionary& insert(const char* key, const T& value);
-    template <typename T> StringDictionary& insert(const std::string& key, const T& value);
 
     // Set the value of an existing item.
     // Returns the dictionary itself to allow chaining of operations.
     // Throws a ExceptionDictionaryKeyNotFound exception if the item could not be found.
     StringDictionary& set(const char* key, const char* value);
     template <typename T> StringDictionary& set(const char* key, const T& value);
-    template <typename T> StringDictionary& set(const std::string& key, const T& value);
 
     // Retrieve an item from the dictionary.
     // Throws a ExceptionDictionaryKeyNotFound exception if the item could not be found.
     const char* get(const char* key) const;
     template <typename T> T get(const char* key) const;
-    template <typename T> T get(const std::string& key) const;
 
     // Return true if an item with a given key exists in the dictionary.
     bool exist(const char* key) const;
-    template <typename T> bool exist(const std::basic_string<T>& key) const;
 
     // Remove an item from the dictionary, if it exists.
     // Returns the dictionary itself to allow chaining of operations.
     StringDictionary& remove(const char* key);
-    template <typename T> StringDictionary& remove(const std::basic_string<T>& key);
 
     // Return constant begin and end input iterators.
     const_iterator begin() const;
@@ -287,33 +282,23 @@ class APPLESEED_DLLSYMBOL DictionaryDictionary
     // Insert an item into the dictionary, replacing the previous item if one exists for that key.
     // Returns the dictionary itself to allow chaining of operations.
     DictionaryDictionary& insert(const char* key, const Dictionary& value);
-    template <typename T> DictionaryDictionary& insert(
-        const std::basic_string<T>& key,
-        const Dictionary&           value);
 
     // Set the value of an existing item.
     // Returns the dictionary itself to allow chaining of operations.
     // Throws a ExceptionDictionaryKeyNotFound exception if the item could not be found.
     DictionaryDictionary& set(const char* key, const Dictionary& value);
-    template <typename T> DictionaryDictionary& set(
-        const std::basic_string<T>& key,
-        const Dictionary&           value);
 
     // Retrieve an item from the dictionary.
     // Throws a ExceptionDictionaryKeyNotFound exception if the item could not be found.
     Dictionary& get(const char* key);
     const Dictionary& get(const char* key) const;
-    template <typename T> Dictionary& get(const std::basic_string<T>& key);
-    template <typename T> const Dictionary& get(const std::basic_string<T>& key) const;
 
     // Return true if an item with a given key exists in the dictionary.
     bool exist(const char* key) const;
-    template <typename T> bool exist(const std::basic_string<T>& key) const;
 
     // Remove an item from the dictionary, if it exists.
     // Returns the dictionary itself to allow chaining of operations.
     DictionaryDictionary& remove(const char* key);
-    template <typename T> DictionaryDictionary& remove(const std::basic_string<T>& key);
 
     // Return mutable begin and end input iterators.
     iterator begin();
@@ -353,27 +338,22 @@ class APPLESEED_DLLSYMBOL Dictionary
     // Returns the dictionary itself to allow chaining of operations.
     Dictionary& insert(const char* key, const char* value);
     template <typename T> Dictionary& insert(const char* key, const T& value);
-    template <typename T> Dictionary& insert(const std::string& key, const T& value);
 
     // Set the value of an existing item.
     // Returns the dictionary itself to allow chaining of operations.
     // Throws a ExceptionDictionaryKeyNotFound exception if the item could not be found.
     Dictionary& set(const char* key, const char* value);
     template <typename T> Dictionary& set(const char* key, const T& value);
-    template <typename T> Dictionary& set(const std::string& key, const T& value);
 
     // Retrieve a string item from the dictionary.
     // Throws a ExceptionDictionaryKeyNotFound exception if the item could not be found.
     const char* get(const char* key) const;
     template <typename T> T get(const char* key) const;
-    template <typename T> T get(const std::string& key) const;
 
     // Access a child dictionary.
     // Throws a ExceptionDictionaryKeyNotFound exception if the item could not be found.
     Dictionary& dictionary(const char* key);
     const Dictionary& dictionary(const char* key) const;
-    template <typename T> Dictionary& dictionary(const std::basic_string<T>& key);
-    template <typename T> const Dictionary& dictionary(const std::basic_string<T>& key) const;
 
     // Access the string dictionary.
     StringDictionary& strings();
@@ -415,90 +395,15 @@ inline StringDictionary& StringDictionary::insert(const char* key, const T& valu
 }
 
 template <typename T>
-inline StringDictionary& StringDictionary::insert(const std::string& key, const T& value)
-{
-    return insert(key.c_str(), value);
-}
-
-template <typename T>
 inline StringDictionary& StringDictionary::set(const char* key, const T& value)
 {
     return set(key, to_string(value).c_str());
 }
 
 template <typename T>
-inline StringDictionary& StringDictionary::set(const std::string& key, const T& value)
-{
-    return set(key.c_str(), value);
-}
-
-template <typename T>
 inline T StringDictionary::get(const char* key) const
 {
     return from_string<T>(get(key));
-}
-
-template <typename T>
-inline T StringDictionary::get(const std::string& key) const
-{
-    return get<T>(key.c_str());
-}
-
-template <typename T>
-inline bool StringDictionary::exist(const std::basic_string<T>& key) const
-{
-    return exist(key.c_str());
-}
-
-template <typename T>
-inline StringDictionary& StringDictionary::remove(const std::basic_string<T>& key)
-{
-    return remove(key.c_str());
-}
-
-
-//
-// DictionaryDictionary class implementation.
-//
-
-template <typename T>
-inline DictionaryDictionary& DictionaryDictionary::insert(
-    const std::basic_string<T>& key,
-    const Dictionary&           value)
-{
-    return insert(key.c_str(), value);
-}
-
-template <typename T>
-inline DictionaryDictionary& DictionaryDictionary::set(
-    const std::basic_string<T>& key,
-    const Dictionary&           value)
-{
-    return set(key.c_str(), value);
-}
-
-template <typename T>
-inline Dictionary& DictionaryDictionary::get(const std::basic_string<T>& key)
-{
-    return get(key.c_str());
-}
-
-template <typename T>
-inline const Dictionary& DictionaryDictionary::get(const std::basic_string<T>& key) const
-{
-    return get(key.c_str());
-}
-
-template <typename T>
-inline bool DictionaryDictionary::exist(const std::basic_string<T>& key) const
-{
-    return exist(key.c_str());
-}
-
-template <typename T>
-inline DictionaryDictionary& DictionaryDictionary::remove(const std::basic_string<T>& key)
-{
-    return remove(key.c_str());
 }
 
 
@@ -551,12 +456,6 @@ inline Dictionary& Dictionary::insert(const char* key, const Dictionary& value)
     return *this;
 }
 
-template <typename T>
-inline Dictionary& Dictionary::insert(const std::string& key, const T& value)
-{
-    return insert(key.c_str(), value);
-}
-
 inline Dictionary& Dictionary::set(const char* key, const char* value)
 {
     m_strings.set(key, value);
@@ -576,12 +475,6 @@ inline Dictionary& Dictionary::set(const char* key, const Dictionary& value)
     return *this;
 }
 
-template <typename T>
-inline Dictionary& Dictionary::set(const std::string& key, const T& value)
-{
-    return set(key.c_str(), value);
-}
-
 inline const char* Dictionary::get(const char* key) const
 {
     return m_strings.get(key);
@@ -589,12 +482,6 @@ inline const char* Dictionary::get(const char* key) const
 
 template <typename T>
 inline T Dictionary::get(const char* key) const
-{
-    return m_strings.get<T>(key);
-}
-
-template <typename T>
-inline T Dictionary::get(const std::string& key) const
 {
     return m_strings.get<T>(key);
 }
@@ -607,18 +494,6 @@ inline Dictionary& Dictionary::dictionary(const char* key)
 inline const Dictionary& Dictionary::dictionary(const char* key) const
 {
     return m_dictionaries.get(key);
-}
-
-template <typename T>
-inline Dictionary& Dictionary::dictionary(const std::basic_string<T>& key)
-{
-    return m_dictionaries.get(key.c_str());
-}
-
-template <typename T>
-inline const Dictionary& Dictionary::dictionary(const std::basic_string<T>& key) const
-{
-    return m_dictionaries.get(key.c_str());
 }
 
 inline StringDictionary& Dictionary::strings()

--- a/src/appleseed/foundation/meta/tests/test_dictionary.cpp
+++ b/src/appleseed/foundation/meta/tests/test_dictionary.cpp
@@ -123,32 +123,12 @@ TEST_SUITE(Foundation_Utility_StringDictionary)
         });
     }
 
-    TEST_CASE(GetAsInt_GivenStdStringKeyOfNonExistingItem_ThrowsExceptionDictionaryKeyNotFound)
-    {
-        StringDictionary sd;
-
-        EXPECT_EXCEPTION(ExceptionDictionaryKeyNotFound,
-        {
-            APPLESEED_UNUSED const int item = sd.get<int>(std::string("key"));
-        });
-    }
-
     TEST_CASE(Remove_GivenCStringKeyOfExistingItem_RemovesItem)
     {
         StringDictionary sd;
         sd.insert("key", "value");
 
         sd.remove("key");
-
-        EXPECT_FALSE(sd.exist("key"));
-    }
-
-    TEST_CASE(Remove_GivenStdStringKeyOfExistingItem_RemovesItem)
-    {
-        StringDictionary sd;
-        sd.insert("key", "value");
-
-        sd.remove(std::string("key"));
 
         EXPECT_FALSE(sd.exist("key"));
     }
@@ -311,28 +291,6 @@ TEST_SUITE(Foundation_Utility_Dictionary)
         EXPECT_EQ(42, dic.get<int>("key"));
     }
 
-    TEST_CASE(Insert_GivenStdStringKeyAndCStringValue_InsertsValue)
-    {
-        Dictionary dic;
-
-        dic.insert(std::string("key"), "value");
-
-        EXPECT_EQ(1, dic.size());
-        EXPECT_FALSE(dic.empty());
-        EXPECT_EQ("value", dic.get<std::string>("key"));
-    }
-
-    TEST_CASE(Insert_GivenStdStringKeyAndIntegerValue_InsertsValue)
-    {
-        Dictionary dic;
-
-        dic.insert(std::string("key"), 42);
-
-        EXPECT_EQ(1, dic.size());
-        EXPECT_FALSE(dic.empty());
-        EXPECT_EQ(42, dic.get<int>("key"));
-    }
-
     TEST_CASE(Insert_GivenDictionary_ReturnsThisPointer)
     {
         Dictionary dic;
@@ -358,16 +316,6 @@ TEST_SUITE(Foundation_Utility_Dictionary)
         EXPECT_EXCEPTION(ExceptionDictionaryKeyNotFound,
         {
             APPLESEED_UNUSED const int item = dic.get<int>("key");
-        });
-    }
-
-    TEST_CASE(GetAsInt_GivenStdStringKeyOfNonExistingItem_ThrowsExceptionDictionaryKeyNotFound)
-    {
-        Dictionary dic;
-
-        EXPECT_EXCEPTION(ExceptionDictionaryKeyNotFound,
-        {
-            APPLESEED_UNUSED const int item = dic.get<int>(std::string("key"));
         });
     }
 

--- a/src/appleseed/foundation/utility/benchmark/benchmarkaggregator.cpp
+++ b/src/appleseed/foundation/utility/benchmark/benchmarkaggregator.cpp
@@ -67,10 +67,10 @@ namespace
 {
     Dictionary& push(Dictionary& dictionary, const std::string& name)
     {
-        if (!dictionary.dictionaries().exist(name))
-            dictionary.dictionaries().insert(name, Dictionary());
+        if (!dictionary.dictionaries().exist(name.c_str()))
+            dictionary.dictionaries().insert(name.c_str(), Dictionary());
 
-        return dictionary.dictionaries().get(name);
+        return dictionary.dictionaries().get(name.c_str());
     }
 
     const DOMNode* find_next_element_node(const DOMNode* node)
@@ -175,12 +175,12 @@ struct BenchmarkAggregator::Impl
 
                     UniqueID series_uid;
 
-                    if (cases_dic.strings().exist(name))
-                        series_uid = cases_dic.get<UniqueID>(name);
+                    if (cases_dic.strings().exist(name.c_str()))
+                        series_uid = cases_dic.get<UniqueID>(name.c_str());
                     else
                     {
                         series_uid = new_guid();
-                        cases_dic.insert(name, series_uid);
+                        cases_dic.insert(name.c_str(), series_uid);
                     }
 
                     scan_results(node, date, m_series[series_uid]);

--- a/src/appleseed/foundation/utility/settings/settingsfilereader.cpp
+++ b/src/appleseed/foundation/utility/settings/settingsfilereader.cpp
@@ -80,7 +80,7 @@ namespace
                     build_dictionary(node, child_dictionary);
 
                     dictionary.insert(
-                        transcode(name_attribute->getNodeValue()),
+                        transcode(name_attribute->getNodeValue()).c_str(),
                         child_dictionary);
                 }
                 else if (element_name == "parameter")
@@ -92,13 +92,13 @@ namespace
                     if (value_attribute)
                     {
                         dictionary.insert(
-                            transcode(name_attribute->getNodeValue()),
+                            transcode(name_attribute->getNodeValue()).c_str(),
                             transcode(value_attribute->getNodeValue()));
                     }
                     else
                     {
                         dictionary.insert(
-                            transcode(name_attribute->getNodeValue()),
+                            transcode(name_attribute->getNodeValue()).c_str(),
                             transcode(node->getTextContent()));
                     }
                 }

--- a/src/appleseed/renderer/modeling/aov/cryptomatteaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/cryptomatteaov.cpp
@@ -870,10 +870,10 @@ bool CryptomatteAOV::write_images(
 
     ImageAttributes image_attributes_copy(image_attributes);
     image_attributes_copy.insert("color_space", "linear");
-    image_attributes_copy.insert(layer_prefix + "/name", layer_name);
-    image_attributes_copy.insert(layer_prefix + "/hash", "MurmurHash3_32");
-    image_attributes_copy.insert(layer_prefix + "/conversion", "uint32_to_float32");
-    image_attributes_copy.insert(layer_prefix + "/manifest", manifest);
+    image_attributes_copy.insert(std::string(layer_prefix + "/name").c_str(), layer_name);
+    image_attributes_copy.insert(std::string(layer_prefix + "/hash").c_str(), "MurmurHash3_32");
+    image_attributes_copy.insert(std::string(layer_prefix + "/conversion").c_str(), "uint32_to_float32");
+    image_attributes_copy.insert(std::string(layer_prefix + "/manifest").c_str(), manifest);
 
     const size_t channel_count = impl->get_channel_count();
     const std::vector<std::string> channel_names = impl->make_channel_names(layer_name);

--- a/src/appleseed/renderer/modeling/material/disneymaterial.cpp
+++ b/src/appleseed/renderer/modeling/material/disneymaterial.cpp
@@ -552,7 +552,7 @@ Dictionary DisneyMaterialLayer::get_default_values()
         if (im.strings().exist("default"))
         {
             const std::string input_value = im.get<std::string>("default");
-            values.insert(input_name, input_value);
+            values.insert(input_name.c_str(), input_value);
         }
     }
 
@@ -728,7 +728,7 @@ void DisneyMaterial::add_layer(Dictionary layer_values)
 
     // Insert the layer into the material.
     const std::string& layer_name = layer_values.get<std::string>("layer_name");
-    m_params.insert(layer_name, layer_values);
+    m_params.insert(layer_name.c_str(), layer_values);
 }
 
 void DisneyMaterial::add_new_default_layer()

--- a/src/appleseed/renderer/modeling/project/assethandler.cpp
+++ b/src/appleseed/renderer/modeling/project/assethandler.cpp
@@ -151,7 +151,7 @@ bool AssetHandler::handle_assets() const
             success = false;
 
         // Update mapping from old asset paths to new ones.
-        mappings.insert(unique_paths[i], asset_path);
+        mappings.insert(unique_paths[i].c_str(), asset_path);
     }
 
     if (!success)

--- a/src/appleseed/renderer/modeling/project/projectfilereader.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilereader.cpp
@@ -566,7 +566,7 @@ namespace
                 ParametersElementHandler* params_handler =
                     static_cast<ParametersElementHandler*>(handler);
                 m_params.dictionaries().insert(
-                    params_handler->get_name(),
+                    params_handler->get_name().c_str(),
                     params_handler->get_parameters());
             }
             break;
@@ -1719,13 +1719,13 @@ namespace
                     const std::string& material_name = assign_mat_handler->get_material_name();
 
                     if (material_side == "front")
-                        m_front_material_mappings.insert(material_slot, material_name);
+                        m_front_material_mappings.insert(material_slot.c_str(), material_name);
                     else if (material_side == "back")
-                        m_back_material_mappings.insert(material_slot, material_name);
+                        m_back_material_mappings.insert(material_slot.c_str(), material_name);
                     else if (material_side == "both")
                     {
-                        m_front_material_mappings.insert(material_slot, material_name);
-                        m_back_material_mappings.insert(material_slot, material_name);
+                        m_front_material_mappings.insert(material_slot.c_str(), material_name);
+                        m_back_material_mappings.insert(material_slot.c_str(), material_name);
                     }
                 }
                 break;

--- a/src/appleseed/renderer/modeling/project/projectfilereader.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfilereader.cpp
@@ -556,7 +556,7 @@ namespace
                 ParameterElementHandler* param_handler =
                     static_cast<ParameterElementHandler*>(handler);
                 m_params.insert_path(
-                    param_handler->get_name(),
+                    param_handler->get_name().c_str(),
                     param_handler->get_value());
             }
             break;

--- a/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
@@ -747,7 +747,7 @@ namespace
                 const std::string material_name = mappings.begin().value();
 
                 mappings.clear();
-                mappings.insert(slot_name, material_name);
+                mappings.insert(slot_name.c_str(), material_name);
             }
         }
     };

--- a/src/appleseed/renderer/utility/paramarray.cpp
+++ b/src/appleseed/renderer/utility/paramarray.cpp
@@ -86,13 +86,13 @@ ParamArray& ParamArray::insert_path(const char* path, const char* value)
     {
         const std::string& part = parts[i];
 
-        if (!leaf->dictionaries().exist(part))
-            leaf->insert(part, Dictionary());
+        if (!leaf->dictionaries().exist(part.c_str()))
+            leaf->insert(part.c_str(), Dictionary());
 
-        leaf = &leaf->dictionary(part);
+        leaf = &leaf->dictionary(part.c_str());
     }
 
-    leaf->insert(parts.back(), value);
+    leaf->insert(parts.back().c_str(), value);
 
     return *this;
 }
@@ -110,10 +110,10 @@ bool ParamArray::exist_path(const char* path) const
 
     for (size_t i = 0; i < parts.size() - 1; ++i)
     {
-        if (!leaf->dictionaries().exist(parts[i]))
+        if (!leaf->dictionaries().exist(parts[i].c_str()))
             return false;
 
-        leaf = &leaf->dictionary(parts[i]);
+        leaf = &leaf->dictionary(parts[i].c_str());
     }
 
     return leaf->strings().exist(parts.back().c_str());
@@ -131,7 +131,7 @@ const char* ParamArray::get_path(const char* path) const
     const Dictionary* leaf = this;
 
     for (size_t i = 0; i < parts.size() - 1; ++i)
-        leaf = &leaf->dictionary(parts[i]);
+        leaf = &leaf->dictionary(parts[i].c_str());
 
     return leaf->strings().get(parts.back().c_str());
 }
@@ -149,10 +149,10 @@ ParamArray& ParamArray::remove_path(const char* path)
 
     for (size_t i = 0; i < parts.size() - 1; ++i)
     {
-        if (!leaf->dictionaries().exist(parts[i]))
+        if (!leaf->dictionaries().exist(parts[i].c_str()))
             return *this;
 
-        leaf = &leaf->dictionary(parts[i]);
+        leaf = &leaf->dictionary(parts[i].c_str());
     }
 
     leaf->strings().remove(parts.back().c_str());

--- a/src/appleseed/renderer/utility/paramarray.h
+++ b/src/appleseed/renderer/utility/paramarray.h
@@ -32,7 +32,6 @@
 // appleseed.renderer headers.
 #include "renderer/global/globallogger.h"
 #include "renderer/utility/messagecontext.h"
-#include "renderer/utility/paramarray.h"
 
 // appleseed.foundation headers.
 #include "foundation/containers/dictionary.h"
@@ -70,7 +69,6 @@ class APPLESEED_DLLSYMBOL ParamArray
 
     // Insert an item into the dictionary.
     template <typename T> ParamArray& insert(const char* key, const T& value);
-    template <typename T> ParamArray& insert(const std::string& key, const T& value);
 
     //
     // Retrieve the value of a required parameter.
@@ -156,7 +154,6 @@ class APPLESEED_DLLSYMBOL ParamArray
 
     ParamArray& insert_path(const char* path, const char* value);
     template <typename T> ParamArray& insert_path(const char* path, const T& value);
-    template <typename T> ParamArray& insert_path(const std::string& path, const T& value);
 
     // Return true if a parameter with a given path exists.
     bool exist_path(const char* path) const;
@@ -267,20 +264,6 @@ inline ParamArray& ParamArray::insert(const char* key, const ParamArray& value)
 }
 
 template <typename T>
-inline ParamArray& ParamArray::insert(const std::string& key, const T& value)
-{
-    foundation::Dictionary::insert(key.c_str(), value);
-    return *this;
-}
-
-template <>
-inline ParamArray& ParamArray::insert(const std::string& key, const ParamArray& value)
-{
-    dictionaries().insert(key.c_str(), value);
-    return *this;
-}
-
-template <typename T>
 inline T ParamArray::get_required(
     const char*                 name,
     const T&                    default_value,
@@ -356,12 +339,6 @@ template <typename T>
 inline ParamArray& ParamArray::insert_path(const char* path, const T& value)
 {
     return insert_path(path, foundation::to_string(value).c_str());
-}
-
-template <typename T>
-inline ParamArray& ParamArray::insert_path(const std::string& path, const T& value)
-{
-    return insert_path(path.c_str(), value);
 }
 
 template <typename T>

--- a/src/appleseed/renderer/utility/paramarray.h
+++ b/src/appleseed/renderer/utility/paramarray.h
@@ -269,14 +269,14 @@ inline ParamArray& ParamArray::insert(const char* key, const ParamArray& value)
 template <typename T>
 inline ParamArray& ParamArray::insert(const std::string& key, const T& value)
 {
-    foundation::Dictionary::insert(key, value);
+    foundation::Dictionary::insert(key.c_str(), value);
     return *this;
 }
 
 template <>
 inline ParamArray& ParamArray::insert(const std::string& key, const ParamArray& value)
 {
-    dictionaries().insert(key, value);
+    dictionaries().insert(key.c_str(), value);
     return *this;
 }
 

--- a/src/tools/dumpmetadata/main.cpp
+++ b/src/tools/dumpmetadata/main.cpp
@@ -102,7 +102,7 @@ namespace
             metadata.strings().remove("name");
 
             Dictionary wrapped_metadata;
-            wrapped_metadata.insert(name, metadata);
+            wrapped_metadata.insert(name.c_str(), metadata);
 
             write_dictionary(wrapped_metadata, file, indenter);
         }


### PR DESCRIPTION
- Remove use of std::string in Dictionary and ParamArray interfaces.
- Use interned strings in Dictionary.
- add cxx_attribute_deprecated to compilerfeatures.h for future use.