### PR TITLE
Metal BRDF changes

### DIFF
--- a/sandbox/tests/test scenes/osl/_shaders/as_metal_surface.osl
+++ b/sandbox/tests/test scenes/osl/_shaders/as_metal_surface.osl
@@ -74,6 +74,7 @@ shader as_metal_surface
         Tn,
         NormalReflectance,
         EdgeTint,
+        1.0,
         microfacet_roughness(Roughness, RoughnessDepthScale),
         Anisotropic);
 }

--- a/sandbox/tests/test scenes/osl/_shaders/as_metal_surface.oso
+++ b/sandbox/tests/test scenes/osl/_shaders/as_metal_surface.oso
@@ -1,5 +1,5 @@
 OpenShadingLanguage 1.00
-# Compiled by oslc 1.10.3
+# Compiled by oslc 1.10.9
 # options: -I/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/include
 shader as_metal_surface	%meta{string,help,"Metal surface shader"} 
 param	vector	Normal	0 0 0		%read{11,11} %write{0,0} %initexpr
@@ -12,12 +12,12 @@ param	float	RoughnessDepthScale	1		%meta{float,min,1}  %read{3,7} %write{2147483
 param	float	Anisotropic	0		%meta{string,help,"Anisotropy"} %meta{float,min,-1} %meta{float,max,1}  %read{11,11} %write{2147483647,-1}
 oparam	closure color	BRDF			%read{2147483647,-1} %write{12,12}
 global	normal	N	%read{0,0} %write{2147483647,-1}
-local	float	___351_out	%read{10,10} %write{2,9}
-local	int	___352_ray_depth	%read{6,8} %write{5,5}
+local	float	___364_out	%read{10,10} %write{2,9}
+local	int	___365_ray_depth	%read{6,8} %write{5,5}
 temp	closure color	$tmp1	%read{12,12} %write{11,11}
+const	float	$const1	1		%read{3,11} %write{2147483647,-1}
 temp	float	$tmp2	%read{11,11} %write{10,10}
-const	string	$const1	"microfacet_roughness"		%read{1,1} %write{2147483647,-1}
-const	float	$const2	1		%read{3,3} %write{2147483647,-1}
+const	string	$const2	"microfacet_roughness"		%read{1,1} %write{2147483647,-1}
 temp	int	$tmp3	%read{4,4} %write{3,3}
 temp	int	$tmp4	%read{2147483647,-1} %write{5,5}
 const	string	$const3	"path:ray_depth"		%read{5,5} %write{2147483647,-1}
@@ -29,32 +29,32 @@ code Normal
 #     vector               Normal = N,
 	assign		Normal N 	%filename{"as_metal_surface.osl"} %line{36} %argrw{"wr"}
 code ___main___
-# as_metal_surface.osl:77
+# as_metal_surface.osl:78
 #         microfacet_roughness(Roughness, RoughnessDepthScale),
-	functioncall	$const1 11 	%filename{"as_metal_surface.osl"} %line{77} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/include/appleseed/material/as_material_helpers.h:35
+	functioncall	$const2 11 	%filename{"as_metal_surface.osl"} %line{78} %argrw{"r"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/include/appleseed/material/as_material_helpers.h:45
 #     float out = roughness;
-	assign		___351_out Roughness 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/include/appleseed/material/as_material_helpers.h"} %line{35} %argrw{"wr"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/include/appleseed/material/as_material_helpers.h:37
-#     if (depth_scale > 1.0)
-	gt		$tmp3 RoughnessDepthScale $const2 	%line{37} %argrw{"wrr"}
-	if		$tmp3 10 10 	%argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/include/appleseed/material/as_material_helpers.h:40
-#         getattribute("path:ray_depth", ray_depth);
-	getattribute	$tmp4 $const3 ___352_ray_depth 	%line{40} %argrw{"wrw"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/include/appleseed/material/as_material_helpers.h:42
-#         if (ray_depth)
-	if		___352_ray_depth 10 10 	%line{42} %argrw{"r"}
-# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/include/appleseed/material/as_material_helpers.h:44
-#             out = roughness * depth_scale * ray_depth;
-	mul		$tmp5 Roughness RoughnessDepthScale 	%line{44} %argrw{"wrr"}
-	assign		$tmp6 ___352_ray_depth 	%argrw{"wr"}
-	mul		___351_out $tmp5 $tmp6 	%argrw{"wrr"}
+	assign		___364_out Roughness 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/include/appleseed/material/as_material_helpers.h"} %line{45} %argrw{"wr"}
 # /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/include/appleseed/material/as_material_helpers.h:47
+#     if (depth_scale > 1.0)
+	gt		$tmp3 RoughnessDepthScale $const1 	%line{47} %argrw{"wrr"}
+	if		$tmp3 10 10 	%argrw{"r"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/include/appleseed/material/as_material_helpers.h:50
+#         getattribute("path:ray_depth", ray_depth);
+	getattribute	$tmp4 $const3 ___365_ray_depth 	%line{50} %argrw{"wrw"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/include/appleseed/material/as_material_helpers.h:52
+#         if (ray_depth)
+	if		___365_ray_depth 10 10 	%line{52} %argrw{"r"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/include/appleseed/material/as_material_helpers.h:54
+#             out = roughness * depth_scale * ray_depth;
+	mul		$tmp5 Roughness RoughnessDepthScale 	%line{54} %argrw{"wrr"}
+	assign		$tmp6 ___365_ray_depth 	%argrw{"wr"}
+	mul		___364_out $tmp5 $tmp6 	%argrw{"wrr"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/include/appleseed/material/as_material_helpers.h:57
 #     return out;
-	assign		$tmp2 ___351_out 	%line{47} %argrw{"wr"}
+	assign		$tmp2 ___364_out 	%line{57} %argrw{"wr"}
 # as_metal_surface.osl:72
 #     BRDF = Reflectance * as_metal(
-	closure		$tmp1 $const4 Normal Tn NormalReflectance EdgeTint $tmp2 Anisotropic 	%filename{"as_metal_surface.osl"} %line{72} %argrw{"wrrrrrrr"}
+	closure		$tmp1 $const4 Normal Tn NormalReflectance EdgeTint $const1 $tmp2 Anisotropic 	%filename{"as_metal_surface.osl"} %line{72} %argrw{"wrrrrrrrr"}
 	mul		BRDF $tmp1 Reflectance 	%argrw{"wrr"}
 	end

--- a/src/appleseed.shaders/as_osl_extensions.h.in
+++ b/src/appleseed.shaders/as_osl_extensions.h.in
@@ -77,6 +77,7 @@ closure color as_metal(
     vector      T,
     color       normal_reflectance,
     color       edge_tint,
+    float       edge_tint_weight,
     float       roughness,
     float       anisotropic
     // keyword arguments:

--- a/src/appleseed.shaders/src/appleseed/as_metal.osl
+++ b/src/appleseed.shaders/src/appleseed/as_metal.osl
@@ -62,6 +62,15 @@ shader as_metal
         string help = "Reflectance at grazing incidence.",
         int as_max_param_id = 2
     ]],
+    float in_edge_reflectance_weight = 0.0
+    [[
+        string as_maya_attribute_name = "edgeReflectanceWeight",
+        string as_maya_attribute_short_name = "f90w",
+        string label = "Edge Reflectance Weight",
+        string page = "Fresnel",
+        string help = "Edge reflectance weight.",
+        int as_max_param_id = 26
+    ]],
     int in_distribution = 0
     [[
         string as_maya_attribute_name = "distribution",
@@ -401,6 +410,7 @@ shader as_metal
         tangent,
         in_face_reflectance,
         in_edge_reflectance,
+        in_edge_reflectance_weight,
         in_roughness,
         in_anisotropy_amount,
         "energy_compensation", in_energy_compensation);

--- a/src/appleseed.shaders/src/appleseed/as_sbs_pbrmaterial.osl
+++ b/src/appleseed.shaders/src/appleseed/as_sbs_pbrmaterial.osl
@@ -462,6 +462,7 @@ shader as_sbs_pbrmaterial
                 tangent,
                 in_baseColor,
                 color(1.0), // edge tint
+                0.0, // edge tint weight
                 max(0.01, in_roughness),
                 in_anisotropyLevel,
                 "energy_compensation", 0.0);

--- a/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
@@ -266,8 +266,22 @@ shader as_standard_surface
         int as_maya_attribute_hidden = 1,
         int as_blender_input_socket = 0,
         int gafferNoduleLayoutVisible = 0,
-        int divider = 1,
         int as_max_param_id = 27
+    ]],
+    float in_edge_tint_weight = 0.0
+    [[
+        string as_maya_attribute_name = "edgeTintWeight",
+        string as_maya_attribute_short_name = "f90w",
+        string label = "Edge Tint Weight",
+        string page = "Specular",
+        string help = "Edge tint weight.",
+        int as_maya_attribute_connectable = 0,
+        int as_maya_attribute_keyable = 0,
+        int as_maya_attribute_hidden = 1,
+        int as_blender_input_socket = 0,
+        int gafferNoduleLayoutVisible = 0,
+        int divider = 1,
+        int as_max_param_id = 71
     ]],
     float in_anisotropy_amount = 0.0
     [[
@@ -791,6 +805,7 @@ shader as_standard_surface
                     tangent,
                     in_face_tint,
                     in_edge_tint,
+                    in_edge_tint_weight,
                     in_specular_roughness,
                     in_anisotropy_amount);
         }

--- a/src/appleseed.shaders/src/max/as_max_metal_material.osl
+++ b/src/appleseed.shaders/src/max/as_max_metal_material.osl
@@ -81,6 +81,7 @@ shader as_max_metal_material
         Tn,
         NormalReflectance,
         EdgeTint,
+        1.0, // edge tint weight
         microfacet_roughness(Roughness, RoughnessDepthScale),
         Anisotropic,
         "energy_compensation", 1.0);

--- a/src/appleseed/foundation/math/fresnel.h
+++ b/src/appleseed/foundation/math/fresnel.h
@@ -145,6 +145,23 @@ void normal_reflectance_dielectric(
 //   [3] Memo on Fresnel equations.
 //       https://seblagarde.wordpress.com/2013/04/29/memo-on-fresnel-equations
 //
+//   [4] Fresnel Equations Considered Harmful.
+//       http://renderwonk.com/publications/mam2019/naty_mam2019.pdf
+//
+
+template <typename SpectrumType, typename T>
+void fresnel_reflectance_lazanyi_schlick(
+    SpectrumType&           reflectance,
+    const SpectrumType&     normal_reflectance,
+    const T                 cos_theta_i,
+    const SpectrumType&     edge_tint);
+
+template <typename SpectrumType, typename T>
+void fresnel_lazanyi_schlick_a(
+    SpectrumType&           a,
+    const SpectrumType&     normal_reflectance,
+    const SpectrumType&     edge_tint,
+    const T                 edge_tint_weight);
 
 // Compute the Fresnel reflectance for a conductor for unpolarized light.
 template <typename SpectrumType, typename T>
@@ -459,6 +476,66 @@ void normal_reflectance_dielectric(
     den += eta;
     normal_reflectance /= den;
     normal_reflectance *= normal_reflectance;
+}
+
+template <typename SpectrumType, typename T>
+void fresnel_reflectance_lazanyi_schlick(
+    SpectrumType&           reflectance,
+    const SpectrumType&     normal_reflectance,
+    const T                 cos_theta_i,
+    const SpectrumType&     a)
+{
+    //
+    // F = r + (1 - r) * [1 - cos(theta)]^5 - a * cos(theta) * [1 - cos(theta)]^6
+    //
+
+    typedef typename impl::GetValueType<SpectrumType>::ValueType ValueType;
+
+    assert(cos_theta_i >= T(0.0) && cos_theta_i <= T(1.0));
+
+    const T k1 = T(1.0) - cos_theta_i;
+    const T k2 = k1 * k1;
+    const T k5 = k2 * k2 * k1;
+    const T k6 = k5 * k1;
+
+    reflectance = SpectrumType(T(1.0));
+    reflectance -= normal_reflectance;
+    reflectance *= static_cast<ValueType>(k5);
+    reflectance += normal_reflectance;
+
+    SpectrumType h(a);
+    h *= cos_theta_i * k6;
+    reflectance -= h;
+
+    clamp(reflectance, T(0.0), T(1.0));
+}
+
+template <typename SpectrumType, typename T>
+void fresnel_lazanyi_schlick_a(
+    SpectrumType&           a,
+    const SpectrumType&     normal_reflectance,
+    const SpectrumType&     edge_tint,
+    const T                 edge_tint_weight)
+{
+    //
+    //      r + (1 - r) * [1 - cos(theta_max)]^5 - h
+    // a = ------------------------------------------
+    //      cos(theta_max) * [1 - cos(theta_max)]^6
+    //
+
+    const T cos_theta_max = std::cos(T(1.4259339988793673));
+    const T k1 = T(1.0) - cos_theta_max;
+    const T k2 = k1 * k1;
+    const T k4 = k2  * k2 ;
+    const T k5 = k4 * k1;
+    const T k6 = k5 * k1;
+
+    a = SpectrumType(T(1.0));
+    a -= normal_reflectance;
+    a *= k5;
+    a += normal_reflectance;
+    a -= edge_tint;
+    a *= edge_tint_weight / (cos_theta_max * k6 );
 }
 
 template <typename SpectrumType, typename T>

--- a/src/appleseed/renderer/kernel/shading/closures.cpp
+++ b/src/appleseed/renderer/kernel/shading/closures.cpp
@@ -879,6 +879,7 @@ namespace
             OSL::Vec3       T;
             OSL::Color3     normal_reflectance;
             OSL::Color3     edge_tint;
+            float           edge_tint_weight;
             float           roughness;
             float           anisotropy;
             float           energy_compensation;
@@ -917,6 +918,7 @@ namespace
                 CLOSURE_VECTOR_PARAM(Params, T),
                 CLOSURE_COLOR_PARAM(Params, normal_reflectance),
                 CLOSURE_COLOR_PARAM(Params, edge_tint),
+                CLOSURE_FLOAT_PARAM(Params, edge_tint_weight),
                 CLOSURE_FLOAT_PARAM(Params, roughness),
                 CLOSURE_FLOAT_PARAM(Params, anisotropy),
                 CLOSURE_FLOAT_KEYPARAM(Params, energy_compensation, "energy_compensation"),
@@ -948,7 +950,7 @@ namespace
 
             values->m_normal_reflectance.set(Color3f(p->normal_reflectance), g_std_lighting_conditions, Spectrum::Reflectance);
             values->m_edge_tint.set(Color3f(p->edge_tint), g_std_lighting_conditions, Spectrum::Reflectance);
-            values->m_edge_tint_weight = 1.0f;
+            values->m_edge_tint_weight = saturate(p->edge_tint_weight);
             values->m_reflectance_multiplier = 1.0f;
             values->m_roughness = std::max(p->roughness, 0.0f);
             values->m_anisotropy = clamp(p->anisotropy, -1.0f, 1.0f);

--- a/src/appleseed/renderer/kernel/shading/closures.cpp
+++ b/src/appleseed/renderer/kernel/shading/closures.cpp
@@ -948,6 +948,7 @@ namespace
 
             values->m_normal_reflectance.set(Color3f(p->normal_reflectance), g_std_lighting_conditions, Spectrum::Reflectance);
             values->m_edge_tint.set(Color3f(p->edge_tint), g_std_lighting_conditions, Spectrum::Reflectance);
+            values->m_edge_tint_weight = 1.0f;
             values->m_reflectance_multiplier = 1.0f;
             values->m_roughness = std::max(p->roughness, 0.0f);
             values->m_anisotropy = clamp(p->anisotropy, -1.0f, 1.0f);

--- a/src/appleseed/renderer/modeling/bsdf/fresnel.h
+++ b/src/appleseed/renderer/modeling/bsdf/fresnel.h
@@ -170,4 +170,34 @@ class FresnelConductorFun
     const float     m_reflectance_multiplier;
 };
 
+class FresnelConductorSchlickLazanyi
+{
+  public:
+    FresnelConductorSchlickLazanyi(
+        const Spectrum&             n,
+        const Spectrum&             a,
+        const float                 reflectance_multiplier)
+      : m_n(n)
+      , m_a(a)
+      , m_reflectance_multiplier(reflectance_multiplier)
+    {
+    }
+
+    void operator()(
+        const foundation::Vector3f& o,
+        const foundation::Vector3f& h,
+        const foundation::Vector3f& n,
+        Spectrum&                   value) const
+    {
+        const float cos_oh = std::min(std::abs(foundation::dot(o, h)), 1.0f);
+        foundation::fresnel_reflectance_lazanyi_schlick(value, m_n, cos_oh, m_a);
+        value *= m_reflectance_multiplier;
+    }
+
+  private:
+    const Spectrum& m_n;
+    const Spectrum& m_a;
+    const float     m_reflectance_multiplier;
+};
+
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
@@ -99,6 +99,7 @@ namespace
         {
             m_inputs.declare("normal_reflectance", InputFormatSpectralReflectance);
             m_inputs.declare("edge_tint", InputFormatSpectralReflectance);
+            m_inputs.declare("edge_tint_weight", InputFormatFloat, "1.0");
             m_inputs.declare("reflectance_multiplier", InputFormatFloat, "1.0");
             m_inputs.declare("roughness", InputFormatFloat, "0.15");
             m_inputs.declare("anisotropy", InputFormatFloat, "0.0");
@@ -130,17 +131,16 @@ namespace
 
             values->m_roughness = std::max(values->m_roughness, shading_point.get_ray().m_min_roughness);
 
-            artist_friendly_fresnel_conductor_reparameterization(
-                values->m_normal_reflectance,
-                values->m_edge_tint,
-                values->m_precomputed.m_n,
-                values->m_precomputed.m_k);
-            values->m_precomputed.m_outside_ior = shading_point.get_ray().get_current_ior();
-
-            average_artist_friendly_fresnel_reflectance_conductor(
-                values->m_normal_reflectance,
-                values->m_edge_tint,
-                values->m_precomputed.m_fresnel_average);
+            if (values->m_edge_tint_weight != 0.0f)
+            {
+                fresnel_lazanyi_schlick_a(
+                    values->m_precomputed.m_a,
+                    values->m_normal_reflectance,
+                    values->m_edge_tint,
+                    values->m_edge_tint_weight);
+            }
+            else
+                values->m_precomputed.m_a.set(0.0f);
         }
 
         void sample(
@@ -155,10 +155,9 @@ namespace
         {
             const InputValues* values = static_cast<const InputValues*>(data);
 
-            const FresnelConductorFun f(
-                values->m_precomputed.m_n,
-                values->m_precomputed.m_k,
-                values->m_precomputed.m_outside_ior,
+            const FresnelConductorSchlickLazanyi f(
+                values->m_normal_reflectance,
+                values->m_precomputed.m_a,
                 values->m_reflectance_multiplier);
 
             // If roughness is zero use reflection.
@@ -228,10 +227,9 @@ namespace
                 alpha_x,
                 alpha_y);
 
-            const FresnelConductorFun f(
-                values->m_precomputed.m_n,
-                values->m_precomputed.m_k,
-                values->m_precomputed.m_outside_ior,
+            const FresnelConductorSchlickLazanyi f(
+                values->m_normal_reflectance,
+                values->m_precomputed.m_a,
                 values->m_reflectance_multiplier);
 
             const float pdf =
@@ -299,25 +297,17 @@ namespace
         {
             if (values->m_energy_compensation != 0.0f)
             {
-                const float Ess =
-                    get_directional_albedo(
-                        std::abs(dot(outgoing, n)),
-                        values->m_roughness);
+                const float Ess = get_directional_albedo(
+                    std::abs(dot(outgoing, n)),
+                    values->m_roughness);
 
                 if (Ess == 0.0f)
                     return;
 
-                const float Eavg = get_average_albedo(values->m_roughness);
-                Spectrum fterm = values->m_precomputed.m_fresnel_average;
-                fterm *= fterm;
-                fterm *= Eavg;
-
-                const Spectrum one(1.0f);
-                fterm /= one - values->m_precomputed.m_fresnel_average * (1.0f - Eavg);
-
-                fterm *= values->m_energy_compensation * ((1.0f - Ess) / Ess);
-                fterm += one;
-                value *= fterm;
+                Spectrum fms = values->m_normal_reflectance;
+                fms *= values->m_energy_compensation * (1.0f - Ess) / Ess;
+                fms += Spectrum(1.0f);
+                value *= fms;
             }
         }
     };
@@ -375,6 +365,24 @@ DictionaryArray MetalBRDFFactory::get_input_metadata() const
                     .insert("texture_instance", "Texture Instances"))
             .insert("use", "required")
             .insert("default", "0.98"));
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "edge_tint_weight")
+            .insert("label", "Edge Tint Weight")
+            .insert("type", "colormap")
+            .insert("entity_types",
+                Dictionary().insert("texture_instance", "Texture Instances"))
+            .insert("use", "optional")
+            .insert("min",
+                Dictionary()
+                    .insert("value", "0.0")
+                    .insert("type", "hard"))
+            .insert("max",
+                Dictionary()
+                    .insert("value", "1.0")
+                    .insert("type", "hard"))
+            .insert("default", "1.0"));
 
     metadata.push_back(
         Dictionary()

--- a/src/appleseed/renderer/modeling/bsdf/metalbrdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/metalbrdf.h
@@ -57,6 +57,7 @@ APPLESEED_DECLARE_INPUT_VALUES(MetalBRDFInputValues)
 {
     Spectrum    m_normal_reflectance;
     Spectrum    m_edge_tint;
+    float       m_edge_tint_weight;
     float       m_reflectance_multiplier;
     float       m_roughness;
     float       m_anisotropy;
@@ -64,10 +65,7 @@ APPLESEED_DECLARE_INPUT_VALUES(MetalBRDFInputValues)
 
     struct Precomputed
     {
-        Spectrum m_n;
-        Spectrum m_k;
-        Spectrum m_fresnel_average;
-        float    m_outside_ior;
+        Spectrum m_a;
     };
 
     Precomputed m_precomputed;


### PR DESCRIPTION
- Implemented fresnel conductor variant from "Fresnel Equations Considered Harmful".
- Use the energy compensation variant from "Practical multiple scattering compensation for microfacet models"
- Update OSL shaders.