### PR TITLE
Fix black-body emission not working when emission color is black

### DIFF
--- a/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
+++ b/src/appleseed.shaders/src/appleseed/as_standard_surface.osl
@@ -722,8 +722,9 @@ shader as_standard_surface
         in_subsurface_weight == 0.0 || max(in_sss_mfp) <= in_sss_threshold)
         ? 0 : 1;
 
-    int compute_edf =
-        (in_incandescence_amount * max(in_incandescence_color) > 0.0) ? 1 : 0;
+    int compute_edf = (in_incandescence_type == 0)
+            ? ((in_incandescence_amount * max(in_incandescence_color) > 0.0) ? 1 : 0)
+            : ((in_incandescence_amount > 0.0) ? 1 : 0);
 
     // Specular first, to get the transmittance amount and bailout earlier.
 


### PR DESCRIPTION
Addresses https://github.com/appleseedhq/appleseed/issues/2765.

The emission color would [incorrectly](https://appleseed.readthedocs.io/projects/appleseed-maya/en/master/shaders/material/as_standard_surface.html#incandescence-parameters) affect black-body emission behaviour when it was black, as it made `compute_edf` equal to 0:

https://github.com/appleseedhq/appleseed/blob/bc952ad860ca6f93bfe4cdd2b966acac4cb42e20/src/appleseed.shaders/src/appleseed/as_standard_surface.osl#L852-L860

Now, `in_incandescence_color` has no effect when the emission type is "Black-body" (i.e. `in_incandescence_type == 1`). The "Custom" type behaviour remains unchanged.

![image](https://user-images.githubusercontent.com/13294013/76899000-87fa1f80-6875-11ea-83b8-dd3f65c6929e.png)
