### PR TITLE
Add Vignette post-processing stage

### DIFF
--- a/src/appleseed/CMakeLists.txt
+++ b/src/appleseed/CMakeLists.txt
@@ -2021,6 +2021,8 @@ set (renderer_modeling_postprocessingstage_sources
     renderer/modeling/postprocessingstage/postprocessingstagetraits.h
     renderer/modeling/postprocessingstage/renderstamppostprocessingstage.cpp
     renderer/modeling/postprocessingstage/renderstamppostprocessingstage.h
+    renderer/modeling/postprocessingstage/vignettepostprocessingstage.cpp
+    renderer/modeling/postprocessingstage/vignettepostprocessingstage.h
 )
 list (APPEND appleseed_sources
     ${renderer_modeling_postprocessingstage_sources}

--- a/src/appleseed/renderer/api/postprocessing.h
+++ b/src/appleseed/renderer/api/postprocessing.h
@@ -36,3 +36,4 @@
 #include "renderer/modeling/postprocessingstage/postprocessingstagefactoryregistrar.h"
 #include "renderer/modeling/postprocessingstage/postprocessingstagetraits.h"
 #include "renderer/modeling/postprocessingstage/renderstamppostprocessingstage.h"
+#include "renderer/modeling/postprocessingstage/vignettepostprocessingstage.h"

--- a/src/appleseed/renderer/modeling/postprocessingstage/postprocessingstagefactoryregistrar.cpp
+++ b/src/appleseed/renderer/modeling/postprocessingstage/postprocessingstagefactoryregistrar.cpp
@@ -35,6 +35,7 @@
 #include "renderer/modeling/postprocessingstage/ipostprocessingstagefactory.h"
 #include "renderer/modeling/postprocessingstage/postprocessingstagetraits.h"
 #include "renderer/modeling/postprocessingstage/renderstamppostprocessingstage.h"
+#include "renderer/modeling/postprocessingstage/vignettepostprocessingstage.h"
 
 // appleseed.foundation headers.
 #include "foundation/memory/autoreleaseptr.h"
@@ -61,6 +62,7 @@ PostProcessingStageFactoryRegistrar::PostProcessingStageFactoryRegistrar(const S
     // Register built-in factories.
     impl->register_factory(auto_release_ptr<FactoryType>(new ColorMapPostProcessingStageFactory()));
     impl->register_factory(auto_release_ptr<FactoryType>(new RenderStampPostProcessingStageFactory()));
+    impl->register_factory(auto_release_ptr<FactoryType>(new VignettePostProcessingStageFactory()));
 }
 
 PostProcessingStageFactoryRegistrar::~PostProcessingStageFactoryRegistrar()

--- a/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.cpp
+++ b/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.cpp
@@ -1,0 +1,192 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Francois Beaune, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "vignettepostprocessingstage.h"
+
+// appleseed.renderer headers.
+#include "renderer/modeling/frame/frame.h"
+#include "renderer/modeling/postprocessingstage/postprocessingstage.h"
+
+// appleseed.foundation headers.
+#include "foundation/containers/dictionary.h"
+#include "foundation/image/canvasproperties.h"
+#include "foundation/image/color.h"
+#include "foundation/image/image.h"
+#include "foundation/math/vector.h"
+#include "foundation/utility/api/specializedapiarrays.h"
+
+using namespace foundation;
+
+namespace renderer
+{
+
+namespace
+{
+    //
+    // Vignette post-processing stage.
+    //
+
+    const char* Model = "vignette_post_processing_stage";
+
+    const float DefaultIntensity = 0.5f;
+    const float MinIntensity = 0.0f;
+    const float MaxIntensity = 1.0f;
+
+    class VignettePostProcessingStage
+        : PostProcessingStage
+    {
+      public:
+        VignettePostProcessingStage(
+            const char*				name,
+            const ParamArray&		params)
+          : PostProcessingStage(name, params)
+        {
+        }
+
+        void release() override
+        {
+            delete this;
+        }
+
+        const char* get_model() const override {
+            return Model;
+        }
+
+        bool on_frame_begin(
+            const Project&			project,
+            const BaseGroup*		parent,
+            OnFrameBeginRecorder&	recorder,
+            IAbortSwitch*			abort_switch) override
+        {
+            const OnFrameBeginMessageContext context("post-processing stage", this);
+
+            m_intensity = m_params.get_optional("intensity", DefaultIntensity, context);
+
+            return true;
+        }
+
+        void execute(Frame& frame) const override
+        {
+            const CanvasProperties& props = frame.image().properties();
+            const Vector2f resolution(props.m_canvas_width, props.m_canvas_height);
+            const Vector2f aspect(resolution.x / resolution.y, 1);
+
+            Image& image = frame.image();
+
+            for (size_t y = 0; y <= resolution.y - 1; ++y)
+            {
+                for (size_t x = 0; x <= resolution.x - 1; ++x)
+                {
+                    Vector2f coord = (2.0f * Vector2f(x, y) - resolution) / resolution.y;
+
+                    //
+                    // Port of Keijiro Takahashi's natural vignetting effect for Unity.
+                    //
+                    // Reference:
+                    //
+                    //   https://github.com/keijiro/KinoVignette
+                    //
+
+                    float rf = norm(coord) * m_intensity;
+                    float rf2_1 = rf * rf + 1.0;
+                    float e = 1.0 / (rf2_1 * rf2_1);
+
+                    Color4f background_premult;
+                    image.get_pixel(x, y, background_premult);
+
+                    image.set_pixel(
+                        x, y,
+                        e * background_premult);
+                }
+            }
+        }
+
+      private:
+          float m_intensity;
+    };
+
+}
+
+
+//
+// VignettePostProcessingStageFactory class implementation.
+//
+
+void VignettePostProcessingStageFactory::release()
+{
+    delete this;
+}
+
+const char* VignettePostProcessingStageFactory::get_model() const
+{
+    return Model;
+}
+
+Dictionary VignettePostProcessingStageFactory::get_model_metadata() const
+{
+    return
+        Dictionary()
+        .insert("name", Model)
+        .insert("label", "Vignette");
+}
+
+DictionaryArray VignettePostProcessingStageFactory::get_input_metadata() const
+{
+    DictionaryArray metadata;
+
+    add_common_input_metadata(metadata);
+
+    metadata.push_back(
+        Dictionary()
+            .insert("name", "intensity")
+            .insert("label", "Intensity")
+            .insert("type", "numeric")
+            .insert("min",
+                    Dictionary()
+                        .insert("value", "0.0")
+                        .insert("type", "hard"))
+            .insert("max",
+                    Dictionary()
+                        .insert("value", "1.0")
+                        .insert("type", "hard"))
+            .insert("use", "optional")
+            .insert("default", "0.5"));
+
+    return metadata;
+}
+
+auto_release_ptr<PostProcessingStage> VignettePostProcessingStageFactory::create(
+    const char*         name,
+    const ParamArray&   params) const
+{
+    return auto_release_ptr<PostProcessingStage>(
+        new VignettePostProcessingStage(name, params));
+}
+
+}   // namespace renderer

--- a/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.cpp
+++ b/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.cpp
@@ -99,9 +99,9 @@ namespace
 
             Image& image = frame.image();
 
-            for (size_t y = 0; y <= resolution.y - 1; ++y)
+            for (size_t y = 0; y < resolution.y; ++y)
             {
-                for (size_t x = 0; x <= resolution.x - 1; ++x)
+                for (size_t x = 0; x < resolution.x; ++x)
                 {
                     Vector2f coord = (2.0f * Vector2f(static_cast<float>(x), static_cast<float>(y)) - resolution) / resolution.y;
 
@@ -111,11 +111,13 @@ namespace
                     // Reference:
                     //
                     //   https://github.com/keijiro/KinoVignette
+                    //   https://en.wikipedia.org/wiki/Vignetting#Natural_vignetting
                     //
 
-                    float rf = norm(coord) * m_intensity;
+                    // Recreates natural illumination falloff, which is approximated by the "cosine fourth" law of illumination falloff.
+                    float rf = norm(coord) * m_intensity; // radial falloff
                     float rf2_1 = rf * rf + 1.0f;
-                    float e = 1.0f / (rf2_1 * rf2_1);
+                    float e = 1.0f / (rf2_1 * rf2_1); // inversely proportional to the fourth power of the distance to the center
 
                     Color4f background_premult;
                     image.get_pixel(x, y, background_premult);

--- a/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.cpp
+++ b/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.cpp
@@ -59,7 +59,7 @@ namespace
     const float MaxIntensity = 1.0f;
 
     class VignettePostProcessingStage
-        : PostProcessingStage
+        : public PostProcessingStage
     {
       public:
         VignettePostProcessingStage(
@@ -94,7 +94,7 @@ namespace
         void execute(Frame& frame) const override
         {
             const CanvasProperties& props = frame.image().properties();
-            const Vector2f resolution(props.m_canvas_width, props.m_canvas_height);
+            const Vector2f resolution(static_cast<float>(props.m_canvas_width), static_cast<float>(props.m_canvas_height));
             const Vector2f aspect(resolution.x / resolution.y, 1);
 
             Image& image = frame.image();
@@ -103,7 +103,7 @@ namespace
             {
                 for (size_t x = 0; x <= resolution.x - 1; ++x)
                 {
-                    Vector2f coord = (2.0f * Vector2f(x, y) - resolution) / resolution.y;
+                    Vector2f coord = (2.0f * Vector2f(static_cast<float>(x), static_cast<float>(y)) - resolution) / resolution.y;
 
                     //
                     // Port of Keijiro Takahashi's natural vignetting effect for Unity.
@@ -114,8 +114,8 @@ namespace
                     //
 
                     float rf = norm(coord) * m_intensity;
-                    float rf2_1 = rf * rf + 1.0;
-                    float e = 1.0 / (rf2_1 * rf2_1);
+                    float rf2_1 = rf * rf + 1.0f;
+                    float e = 1.0f / (rf2_1 * rf2_1);
 
                     Color4f background_premult;
                     image.get_pixel(x, y, background_premult);

--- a/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.cpp
+++ b/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.cpp
@@ -63,8 +63,8 @@ namespace
     {
       public:
         VignettePostProcessingStage(
-            const char*				name,
-            const ParamArray&		params)
+            const char*             name,
+            const ParamArray&       params)
           : PostProcessingStage(name, params)
         {
         }
@@ -79,10 +79,10 @@ namespace
         }
 
         bool on_frame_begin(
-            const Project&			project,
-            const BaseGroup*		parent,
-            OnFrameBeginRecorder&	recorder,
-            IAbortSwitch*			abort_switch) override
+            const Project&          project,
+            const BaseGroup*        parent,
+            OnFrameBeginRecorder&   recorder,
+            IAbortSwitch*           abort_switch) override
         {
             const OnFrameBeginMessageContext context("post-processing stage", this);
 
@@ -120,9 +120,13 @@ namespace
                     Color4f background_premult;
                     image.get_pixel(x, y, background_premult);
 
+                    background_premult.r *= e;
+                    background_premult.g *= e;
+                    background_premult.b *= e;
+
                     image.set_pixel(
                         x, y,
-                        e * background_premult);
+                        background_premult);
                 }
             }
         }

--- a/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.h
+++ b/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.h
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2020 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2020 Tiago Chaves, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -35,9 +35,9 @@
 #include "main/dllsymbol.h"
 
 // Forward declarations.
-namespace foundation { class Dictionary; }
-namespace foundation { class DictionaryArray; }
-namespace renderer { class ParamArray; }
+namespace foundation    { class Dictionary; }
+namespace foundation    { class DictionaryArray; }
+namespace renderer      { class ParamArray; }
 
 namespace renderer
 {
@@ -47,7 +47,7 @@ namespace renderer
 //
 
 class APPLESEED_DLLSYMBOL VignettePostProcessingStageFactory
-    : public IPostProcessingStageFactory
+  : public IPostProcessingStageFactory
 {
   public:
     // Delete this instance.

--- a/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.h
+++ b/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.h
@@ -1,0 +1,71 @@
+
+//
+// This source file is part of appleseed.
+// Visit https://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2020 Francois Beaune, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.renderer headers.
+#include "renderer/modeling/postprocessingstage/ipostprocessingstagefactory.h"
+
+// appleseed.main headers.
+#include "main/dllsymbol.h"
+
+// Forward declarations.
+namespace foundation { class Dictionary; }
+namespace foundation { class DictionaryArray; }
+namespace renderer { class ParamArray; }
+
+namespace renderer
+{
+
+//
+// A post-processing stage that adds vignetting to the frame.
+//
+
+class APPLESEED_DLLSYMBOL VignettePostProcessingStageFactory
+    : public IPostProcessingStageFactory
+{
+  public:
+    // Delete this instance.
+    void release() override;
+
+    // Return a string identifying this stage model.
+    const char* get_model() const override;
+
+    // Return metadata for this stage model.
+    foundation::Dictionary get_model_metadata() const override;
+
+    // Return metadata for the inputs of this stage model.
+    foundation::DictionaryArray get_input_metadata() const override;
+
+    // Create a new stage instance.
+    foundation::auto_release_ptr<PostProcessingStage> create(
+        const char*         name,
+        const ParamArray&   params) const override;
+};
+
+}   // namespace renderer


### PR DESCRIPTION
Added a new post-processing effect implementing Keijiro Takahashi's [KinoVignette](https://github.com/keijiro/KinoVignette).

![image](https://user-images.githubusercontent.com/13294013/77115197-a6deea00-6a0c-11ea-8bb9-0126fdd2f742.png)


This is a naive (almost) direct port of the aforementioned algorithm, as an attempt to add a simple new effect to appleseed.

| no vignetting | 0.5 intensity (**default**) | 1.0 intensity |
|---|---|---|
| ![no_vignette](https://user-images.githubusercontent.com/13294013/77114745-d3463680-6a0b-11ea-90b9-c1d46a6ec636.png) | ![vignette_0_5](https://user-images.githubusercontent.com/13294013/77114868-0ee10080-6a0c-11ea-8d61-a85135b4bd0f.png) | ![vignette_1_0](https://user-images.githubusercontent.com/13294013/77114874-10122d80-6a0c-11ea-81fd-9e0613325677.png) |

See https://www.shadertoy.com/view/3dXyDH for a GLSL port of the algorithm.