### PR TITLE
Print additional runtime details in Python utilities

### DIFF
--- a/scripts/appleseed.benchmark.py
+++ b/scripts/appleseed.benchmark.py
@@ -28,11 +28,15 @@
 # THE SOFTWARE.
 #
 
+from __future__ import print_function
+import argparse
 import datetime
 import os
 import re
 import subprocess
 import sys
+
+from utils import print_runtime_details  # local module
 
 
 # -------------------------------------------------------------------------------------------------
@@ -136,19 +140,20 @@ def print_configuration(appleseed_path, appleseed_args, logger):
 
 
 def main():
-    print("appleseed.benchmark version " + VERSION)
-    print
+    parser = argparse.ArgumentParser(description="benchmark appleseed")
 
-    if len(sys.argv) < 2:
-        print("Usage: {0} <path-to-appleseed.cli> [arguments]".format(sys.argv[0]))
-        sys.exit(1)
+    parser.add_argument("appleseed_path", help="set the path to the appleseed.cli tool")
+    parser.add_argument("appleseed_args", nargs=argparse.REMAINDER,
+                        help="forward additional arguments to appleseed")
 
-    appleseed_path = sys.argv[1]
-    appleseed_args = sys.argv[2:]
+    args = parser.parse_args()
+    appleseed_path = args.appleseed_path
+    appleseed_args = args.appleseed_args
 
     safe_make_directory("logs")
     logger = Logger("logs")
 
+    print_runtime_details("appleseed.benchmark", VERSION, os.path.realpath(__file__), print_function=logger.write)
     print_configuration(appleseed_path, appleseed_args, logger)
 
     safe_make_directory("renders")

--- a/scripts/appleseed.package.py
+++ b/scripts/appleseed.package.py
@@ -46,6 +46,8 @@ import time
 import traceback
 import zipfile
 
+from utils import print_runtime_details  # local module
+
 
 # -------------------------------------------------------------------------------------------------
 # Constants.
@@ -997,8 +999,7 @@ def main():
 
     no_zip = args.nozip
 
-    print("appleseed.package version {0}".format(VERSION))
-    print("")
+    print_runtime_details("appleseed.package", VERSION, os.path.realpath(__file__))
 
     print("VERY IMPORTANT:")
     print("")

--- a/scripts/cleanmany.py
+++ b/scripts/cleanmany.py
@@ -33,10 +33,13 @@ import datetime
 import os
 import subprocess
 
+from utils import print_runtime_details  # local module
 
 # -------------------------------------------------------------------------------------------------
 # Constants.
 # -------------------------------------------------------------------------------------------------
+
+VERSION = "1.0"
 
 DEFAULT_TOOL_FILENAME = "projecttool.exe" if os.name == "nt" else "projecttool"
 
@@ -94,6 +97,8 @@ def main():
                         help="scan the specified directory and all its subdirectories")
     parser.add_argument("directory", help="directory to scan")
     args = parser.parse_args()
+
+    print_runtime_details("cleanmany", VERSION, os.path.realpath(__file__))
 
     # If no tool path is provided, search for the tool in the same directory as this script.
     if args.tool_path is None:

--- a/scripts/convertmany.py
+++ b/scripts/convertmany.py
@@ -34,10 +34,14 @@ import fnmatch
 import os
 import subprocess
 
+from utils import print_runtime_details  # local module
+
 
 # -------------------------------------------------------------------------------------------------
 # Constants.
 # -------------------------------------------------------------------------------------------------
+
+VERSION = "1.0"
 
 DEFAULT_TOOL_FILENAME = "convertmeshfile.exe" if os.name == "nt" else "convertmeshfile"
 
@@ -102,6 +106,8 @@ def main():
     parser.add_argument("input_pattern", metavar="input-pattern", help="input files pattern (e.g. *.obj)")
     parser.add_argument("output_format", metavar="output-format", help="output file format (e.g. abc, binarymesh)")
     args = parser.parse_args()
+
+    print_runtime_details("convertmany", VERSION, os.path.realpath(__file__))
 
     # If no tool path is provided, search for the tool in the same directory as this script.
     if args.tool_path is None:

--- a/scripts/oslextractmeta.py
+++ b/scripts/oslextractmeta.py
@@ -40,6 +40,14 @@ import datetime
 import getpass
 import subprocess
 
+from utils import print_runtime_details  # local module
+
+
+# -------------------------------------------------------------------------------------------------
+# Constants.
+# -------------------------------------------------------------------------------------------------
+
+VERSION = "1.0"
 
 FileTypes = {'.oso': "openshadinglanguage"}
 
@@ -337,16 +345,16 @@ def cli():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description='''
-        oslextractmetadata stores the user interface and metadata of a 
-        compiled OSL (openshadinglanguage) shader(s) into a JSON file.
-        The JSON dictionary consists of a 'header' and a 'shader' part.
-        jsondict['shader'] will return a dictionary with all shaders. The
-        user interface of the shader is stored as a sub-dictionary, the
-        metadata can be retrieved using the 'ui' key on the elements, e.g.:
+oslextractmetadata stores the user interface and metadata of a
+compiled OSL (openshadinglanguage) shader(s) into a JSON file.
+The JSON dictionary consists of a 'header' and a 'shader' part.
+jsondict['shader'] will return a dictionary with all shaders. The
+user interface of the shader is stored as a sub-dictionary, the
+metadata can be retrieved using the 'ui' key on the elements, e.g.:
 
-        for x in jsondict['shaders'].values():
-            print x['ui']
-        ''')
+    for x in jsondict['shaders'].values():
+        print x['ui']
+''')
     parser.add_argument('-i', '--input', nargs='+', action='store', dest='files', metavar='compiled shaders', help='List of file(s) to parse.')
     parser.add_argument('-v', '--verbose', action='store_true', dest='verbosity', help='Increase output verbosity.')
     parser.add_argument('-o', '--output', nargs=1, action='store', dest='output',
@@ -379,6 +387,8 @@ def cli():
 
 def main():
     (args, output, existingFile) = cli()
+
+    print_runtime_details("oslextractmetadata", VERSION, os.path.realpath(__file__))
 
     # read configuration file
     cfg_defaults = {'oslpath': '/usr/bin/oslinfo'}

--- a/scripts/rendermanager.py
+++ b/scripts/rendermanager.py
@@ -40,6 +40,8 @@ import time
 import traceback
 import xml.dom.minidom as xml
 
+from utils import print_runtime_details
+
 
 # -------------------------------------------------------------------------------------------------
 # Constants.
@@ -529,6 +531,8 @@ def main():
     parser.add_argument("--frames", metavar="frames-directory", dest="frames_directory",
                         help="directory where the rendered frames should be stored")
     args = parser.parse_args()
+
+    print_runtime_details("rendermanager", VERSION, os.path.realpath(__file__))
 
     if args.max_size is None:
         args.max_size = 2 ** 40                 # default to 1 terabyte

--- a/scripts/rendermany.py
+++ b/scripts/rendermany.py
@@ -35,10 +35,14 @@ import os
 import subprocess
 import sys
 
+from utils import print_runtime_details  # local module
+
 
 # -------------------------------------------------------------------------------------------------
 # Constants.
 # -------------------------------------------------------------------------------------------------
+
+VERSION = "1.0"
 
 DEFAULT_TOOL_FILENAME = "appleseed.cli.exe" if os.name == "nt" else "appleseed.cli"
 
@@ -148,6 +152,8 @@ def main():
                         help="forward additional arguments to appleseed")
     parser.add_argument("directory", help="directory to scan")
     args = parser.parse_args()
+
+    print_runtime_details("rendermany", VERSION, os.path.realpath(__file__))
 
     # If no tool path is provided, search for the tool in the same directory as this script.
     if args.tool_path is None:

--- a/scripts/rendernode.py
+++ b/scripts/rendernode.py
@@ -41,6 +41,8 @@ import time
 import traceback
 import xml.dom.minidom as xml
 
+from utils import print_runtime_details
+
 
 # -------------------------------------------------------------------------------------------------
 # Constants.
@@ -440,6 +442,8 @@ def main():
                         help="print missing dependencies")
     parser.add_argument("directory", help="directory to watch")
     args = parser.parse_args()
+
+    print_runtime_details("rendernode", VERSION, os.path.realpath(__file__))
 
     # If no tool path is provided, search for the tool in the same directory as this script.
     if args.tool_path is None:

--- a/scripts/runtestsuite/header_template.html
+++ b/scripts/runtestsuite/header_template.html
@@ -346,11 +346,11 @@
                     <td>{python-version}</td>
                 </tr>
                 <tr>
-                    <td>Script Path</td>
-                    <td>{script-path}</td>
+                    <td>runtestsuite Path</td>
+                    <td><pre>{script-path}</pre></td>
                 </tr>
                 <tr>
-                    <td>Script Version</td>
+                    <td>runtestsuite Version</td>
                     <td>{script-version}</td>
                 </tr>
                 <tr>

--- a/scripts/runtestsuite/header_template.html
+++ b/scripts/runtestsuite/header_template.html
@@ -342,6 +342,18 @@
                     <td>{test-date}</td>
                 </tr>
                 <tr>
+                    <td>Python Version</td>
+                    <td>{python-version}</td>
+                </tr>
+                <tr>
+                    <td>Script Path</td>
+                    <td>{script-path}</td>
+                </tr>
+                <tr>
+                    <td>Script Version</td>
+                    <td>{script-version}</td>
+                </tr>
+                <tr>
                     <td>appleseed Binary</td>
                     <td><pre>{appleseed-binary-path}</pre></td>
                 </tr>

--- a/scripts/runtestsuite/runtestsuite.py
+++ b/scripts/runtestsuite/runtestsuite.py
@@ -43,10 +43,14 @@ import urllib
 # Constants.
 # --------------------------------------------------------------------------------------------------
 
+VERSION = "1.0"
+
 APPLESEED_BASE_ARGS = ""
 
 VALUE_THRESHOLD = 2                 # max allowed absolute diff between two pixel components, in [0, 255]
 MAX_DIFFERING_COMPONENTS = 4 * 2    # max number of pixel components that are allowed to differ significantly
+
+CURRENT_TIME = datetime.datetime.now()
 
 
 # --------------------------------------------------------------------------------------------------
@@ -108,6 +112,11 @@ def write_rgba_png_file(filepath, rows):
     writer = png.Writer(width=width, height=height, alpha=True)
     with open(filepath, 'wb') as file:
         writer.write(file, rows)
+
+
+def get_python_version():
+    return "{version.major}.{version.minor}.{version.micro}-{version.releaselevel}.{version.serial}" \
+        .format(version=sys.version_info)
 
 
 # --------------------------------------------------------------------------------------------------
@@ -228,8 +237,13 @@ class ReportWriter:
         self.file.flush()
 
     def __write_header(self, args):
+        script_path = os.path.realpath(__file__)
+
         self.file.write(self.__render(self.header_template,
-                                      {'test-date': datetime.datetime.now(),
+                                      {'test-date': CURRENT_TIME,
+                                       'python-version': get_python_version(),
+                                       'script-path': script_path,
+                                       'script-version': VERSION,
                                        'appleseed-binary-path': args.tool_path,
                                        'max-abs-diff-allowed': VALUE_THRESHOLD,
                                        'max-diff-comps-count-allowed': MAX_DIFFERING_COMPONENTS}))
@@ -498,6 +512,12 @@ def main():
     appleseed_args = APPLESEED_BASE_ARGS
     if args.args:
         appleseed_args += " {0}".format(" ".join(args.args))
+
+    print("Current Time    : {0}".format(CURRENT_TIME))
+    print("Python Version  : {0}".format(get_python_version()))
+    print("Script Path     : {0}".format(os.path.realpath(__file__)))
+    print("Script Version  : {0}".format(VERSION))
+    print()
 
     print("Configuration:")
     print("  Binary        : {0}".format(args.tool_path))

--- a/scripts/runtestsuite/runtestsuite.py
+++ b/scripts/runtestsuite/runtestsuite.py
@@ -38,6 +38,10 @@ import subprocess
 import sys
 import urllib
 
+# We can't import modules from parent directories without modifying sys.path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+import utils
+
 
 # --------------------------------------------------------------------------------------------------
 # Constants.
@@ -112,11 +116,6 @@ def write_rgba_png_file(filepath, rows):
     writer = png.Writer(width=width, height=height, alpha=True)
     with open(filepath, 'wb') as file:
         writer.write(file, rows)
-
-
-def get_python_version():
-    return "{version.major}.{version.minor}.{version.micro}-{version.releaselevel}.{version.serial}" \
-        .format(version=sys.version_info)
 
 
 # --------------------------------------------------------------------------------------------------
@@ -241,7 +240,7 @@ class ReportWriter:
 
         self.file.write(self.__render(self.header_template,
                                       {'test-date': CURRENT_TIME,
-                                       'python-version': get_python_version(),
+                                       'python-version': utils.get_python_version(),
                                        'script-path': script_path,
                                        'script-version': VERSION,
                                        'appleseed-binary-path': args.tool_path,
@@ -489,6 +488,13 @@ def render_test_scenes(script_directory, args):
 # Entry point.
 # --------------------------------------------------------------------------------------------------
 
+def print_configuration(appleseed_path, appleseed_args):
+    print("Configuration:")
+    print("  Binary         : {0}".format(appleseed_path))
+    print("  Arguments      : {0}".format(appleseed_args))
+    print()
+
+
 def main():
     colorama.init()
 
@@ -513,16 +519,8 @@ def main():
     if args.args:
         appleseed_args += " {0}".format(" ".join(args.args))
 
-    print("Current Time    : {0}".format(CURRENT_TIME))
-    print("Python Version  : {0}".format(get_python_version()))
-    print("Script Path     : {0}".format(os.path.realpath(__file__)))
-    print("Script Version  : {0}".format(VERSION))
-    print()
-
-    print("Configuration:")
-    print("  Binary        : {0}".format(args.tool_path))
-    print("  Arguments     : {0}".format(appleseed_args))
-    print()
+    utils.print_runtime_details("runtestsuite", VERSION, os.path.realpath(__file__), CURRENT_TIME)
+    print_configuration(args.tool_path, appleseed_args)
 
     start_time = datetime.datetime.now()
     rendered_scene_count, passing_scene_count = render_test_scenes(script_directory, args)
@@ -532,16 +530,16 @@ def main():
 
     print()
     print("Results:")
-    print("  Success Rate  : {0}{1:.2f} %{2}"
+    print("  Success Rate   : {0}{1:.2f} %{2}"
           .format(colorama.Fore.RED if passing_scene_count < rendered_scene_count else colorama.Fore.GREEN,
                   success,
                   colorama.Fore.RESET))
-    print("  Failures      : {0}{1} out of {2} test scene(s){3}"
+    print("  Failures       : {0}{1} out of {2} test scene(s){3}"
           .format(colorama.Fore.RED if passing_scene_count < rendered_scene_count else colorama.Fore.GREEN,
                   rendered_scene_count - passing_scene_count,
                   rendered_scene_count,
                   colorama.Fore.RESET))
-    print("  Total Time    : {0}".format(format_duration(end_time - start_time)))
+    print("  Total Time     : {0}".format(format_duration(end_time - start_time)))
 
 
 if __name__ == "__main__":

--- a/scripts/sortincludes.py
+++ b/scripts/sortincludes.py
@@ -31,6 +31,15 @@ import argparse
 import os
 import sys
 
+from utils import print_runtime_details  # local module
+
+
+# -------------------------------------------------------------------------------------------------
+# Constants.
+# -------------------------------------------------------------------------------------------------
+
+VERSION = "1.0"
+
 
 # -------------------------------------------------------------------------------------------------
 # Utility functions.
@@ -88,6 +97,8 @@ def main():
                         help="process all files in the specified directory and all its subdirectories")
     parser.add_argument("path", help="file or directory to process")
     args = parser.parse_args()
+
+    print_runtime_details("sortincludes", VERSION, os.path.realpath(__file__))
 
     if os.path.isfile(args.path):
         process_file(args.path)

--- a/scripts/updatetestsuiterefimages.py
+++ b/scripts/updatetestsuiterefimages.py
@@ -32,6 +32,15 @@ import argparse
 import os
 import shutil
 
+from utils import print_runtime_details  # local module
+
+
+# -------------------------------------------------------------------------------------------------
+# Constants.
+# -------------------------------------------------------------------------------------------------
+
+VERSION = "1.0"
+
 
 # -------------------------------------------------------------------------------------------------
 # Utility functions.
@@ -78,6 +87,8 @@ def main():
                         help="scan the specified directory and all its subdirectories")
     parser.add_argument("directory", nargs='?', default=".", help="directory to scan")
     args = parser.parse_args()
+
+    print_runtime_details("updatetestsuiterefimages", VERSION, os.path.realpath(__file__))
 
     for dirpath, dirnames, filenames in walk(args.directory, args.recursive):
         if "renders" in dirnames:

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+
+#
+# This source file is part of appleseed.
+# Visit https://appleseedhq.net/ for additional information and resources.
+#
+# This software is released under the MIT license.
+#
+# Copyright (c) 2020 Terry Chen, The appleseedhq Organization
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from __future__ import print_function
+import datetime
+import platform
+
+
+def get_python_version():
+    return "{0} ({1})".format(platform.python_version(), platform.platform())
+
+
+def print_runtime_details(script, version, script_path, current_time=datetime.datetime.now(), print_function=print):
+    print_function("{0} version {1}".format(script, version))
+    print_function("  Script Path    : {0}".format(script_path))
+    print_function("  Current Time   : {0}".format(current_time))
+    print_function("  Python Version : {0}".format(get_python_version()))
+    print_function()
+


### PR DESCRIPTION
This PR resolves issue #2284.

In addition to adding printing of the runtime details to the console, I've also added printing of the details to the HTML reports generated by runtestsuite.py and the log generated by appleseed.benchmark. I've also slightly refactored appleseed.benchmark to use argparse for parsing arguments, and added version numbers to all of the utility scripts.