### PR TITLE
Fix spectral illuminance to CIE XYZ conversions

### DIFF
--- a/src/appleseed.studio/utility/inputwidgetproxies.cpp
+++ b/src/appleseed.studio/utility/inputwidgetproxies.cpp
@@ -308,6 +308,7 @@ namespace
                     output_spectrum);
 
                 Color3f ciexyz;
+                // todo: this is not correct for emmiter. Use refractance_to_ciexyz for emiiters.
                 spectral_reflectance_to_ciexyz_standard(&output_spectrum[0], &ciexyz[0]);
 
                 return linear_rgb_to_srgb(ciexyz_to_linear_rgb(ciexyz));

--- a/src/appleseed.studio/utility/inputwidgetproxies.cpp
+++ b/src/appleseed.studio/utility/inputwidgetproxies.cpp
@@ -308,7 +308,7 @@ namespace
                     output_spectrum);
 
                 Color3f ciexyz;
-                spectrum_to_ciexyz_standard(&output_spectrum[0], &ciexyz[0]);
+                spectral_reflectance_to_ciexyz_standard(&output_spectrum[0], &ciexyz[0]);
 
                 return linear_rgb_to_srgb(ciexyz_to_linear_rgb(ciexyz));
             }

--- a/src/appleseed.studio/utility/inputwidgetproxies.cpp
+++ b/src/appleseed.studio/utility/inputwidgetproxies.cpp
@@ -307,8 +307,8 @@ namespace
                     &values[0],
                     output_spectrum);
 
+                // todo: spectral_illuminance_to_ciexyz_standard() should be used for emitters.
                 Color3f ciexyz;
-                // todo: this is not correct for emmiter. Use refractance_to_ciexyz for emiiters.
                 spectral_reflectance_to_ciexyz_standard(&output_spectrum[0], &ciexyz[0]);
 
                 return linear_rgb_to_srgb(ciexyz_to_linear_rgb(ciexyz));

--- a/src/appleseed/foundation/image/colorspace.cpp
+++ b/src/appleseed/foundation/image/colorspace.cpp
@@ -1443,13 +1443,16 @@ const RegularSpectrum31f RGBToSpectrumRedIlluminance(RegularSpectrum31f::from_ar
 const RegularSpectrum31f RGBToSpectrumGreenIlluminance(RegularSpectrum31f::from_array(RGBToSpectrumGreenIlluminanceTab));
 const RegularSpectrum31f RGBToSpectrumBlueIlluminance(RegularSpectrum31f::from_array(RGBToSpectrumBlueIlluminanceTab));
 
-// Get color matching functions normalizer
-float get_cmf_normalizer(Color4f cmf[32])
+namespace
 {
-    float n = 0.0f;
-    for (std::size_t w = 0; w < 31; ++w)
-        n += cmf[w][1];
-   return 1.0f / n;
+    // Get color matching functions normalizer
+    float get_cmf_normalizer(const Color4f cmf[32])
+    {
+        float n = 0.0f;
+        for (std::size_t w = 0; w < 31; ++w)
+            n += cmf[w][1];
+        return 1.0f / n;
+    }
 }
 
 

--- a/src/appleseed/foundation/image/colorspace.h
+++ b/src/appleseed/foundation/image/colorspace.h
@@ -161,8 +161,8 @@ extern const RegularSpectrum31f RGBToSpectrumBlueIlluminance;
 class LightingConditions
 {
   public:
-    APPLESEED_SIMD4_ALIGN Color4f   m_cmf_reflectance[32];      // precomputed values of (cmf[0], cmf[1], cmf[2]) * illuminant
-    APPLESEED_SIMD4_ALIGN Color4f   m_cmf_illuminance[32];      // Rescale the color matching functions such that luminance integrates to 1.
+    APPLESEED_SIMD4_ALIGN Color4f   m_cmf_reflectance[32];      // precomputed normalized values of (cmf[0], cmf[1], cmf[2]) * illuminant
+    APPLESEED_SIMD4_ALIGN Color4f   m_cmf_illuminance[32];      // precomputed normalized values of cmf
 
     LightingConditions();                                       // leaves the object uninitialized
 
@@ -847,12 +847,12 @@ inline T luminance(const Color<T, 3>& linear_rgb)
 
 template <typename T, typename SpectrumType>
 inline Color<T, 3> spectrum_to_ciexyz(
-    const Color4f   cmf[32],
-    const SpectrumType& spectrum)
+    const Color4f               cmf[32],
+    const SpectrumType&         spectrum)
 {
     static_assert(
         SpectrumType::Samples == 31,
-        "foundation::spectral_reflectance_to_ciexyz() expects 31-channel spectra");
+        "foundation::spectrum_to_ciexyz() expects 31-channel spectra");
 
     T x = T(0.0);
     T y = T(0.0);
@@ -872,8 +872,8 @@ inline Color<T, 3> spectrum_to_ciexyz(
 #ifdef APPLESEED_USE_SSE
 template <>
 inline Color3f spectrum_to_ciexyz<float, RegularSpectrum31f>(
-    const Color4f   cmf[32],
-    const RegularSpectrum31f& spectrum)
+    const Color4f               cmf[32],
+    const RegularSpectrum31f&   spectrum)
 {
     __m128 xyz1 = _mm_setzero_ps();
     __m128 xyz2 = _mm_setzero_ps();
@@ -900,7 +900,7 @@ inline Color3f spectrum_to_ciexyz<float, RegularSpectrum31f>(
 #endif  // APPLESEED_USE_SSE
 
 template <typename T, typename SpectrumType>
-Color<T, 3> spectral_reflectance_to_ciexyz(
+inline Color<T, 3> spectral_reflectance_to_ciexyz(
     const LightingConditions&   lighting,
     const SpectrumType&         spectrum)
 {
@@ -908,9 +908,9 @@ Color<T, 3> spectral_reflectance_to_ciexyz(
 }
 
 template <typename T, typename SpectrumType>
-Color<T, 3> spectral_illuminance_to_ciexyz(
-    const LightingConditions& lighting,
-    const SpectrumType& spectrum)
+inline Color<T, 3> spectral_illuminance_to_ciexyz(
+    const LightingConditions&   lighting,
+    const SpectrumType&         spectrum)
 {
     return spectrum_to_ciexyz<T, SpectrumType>(lighting.m_cmf_illuminance, spectrum);
 }

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_colorspace.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_colorspace.cpp
@@ -79,7 +79,7 @@ BENCHMARK_SUITE(Foundation_Image_ColorSpace)
         }
     };
 
-    BENCHMARK_CASE_F(SpectrumToCIEXYZ, SpectrumToCIEXYZFixture)
+    BENCHMARK_CASE_F(SpectralReflectanceToCIEXYZ, SpectrumToCIEXYZFixture)
     {
         m_output = spectral_reflectance_to_ciexyz<float>(m_lighting_conditions, m_input);
     }

--- a/src/appleseed/foundation/meta/benchmarks/benchmark_colorspace.cpp
+++ b/src/appleseed/foundation/meta/benchmarks/benchmark_colorspace.cpp
@@ -81,7 +81,7 @@ BENCHMARK_SUITE(Foundation_Image_ColorSpace)
 
     BENCHMARK_CASE_F(SpectrumToCIEXYZ, SpectrumToCIEXYZFixture)
     {
-        m_output = spectrum_to_ciexyz<float>(m_lighting_conditions, m_input);
+        m_output = spectral_reflectance_to_ciexyz<float>(m_lighting_conditions, m_input);
     }
 
     struct LinearRGBToSpectrumFixture

--- a/src/appleseed/foundation/meta/tests/test_colorspace.cpp
+++ b/src/appleseed/foundation/meta/tests/test_colorspace.cpp
@@ -478,7 +478,7 @@ TEST_SUITE(Foundation_Image_ColorSpace)
         return RegularSpectrum31f::from_array(Values);
     }
 
-    TEST_CASE(TestSpectrumToCIEXYZConversion)
+    TEST_CASE(TestReclectanceSpectrumToCIEXYZConversion)
     {
         const RegularSpectrum31f spectrum = get_white_spectrum();
         const LightingConditions lighting_conditions(IlluminantCIED65, XYZCMFCIE19312Deg);

--- a/src/appleseed/foundation/meta/tests/test_colorspace.cpp
+++ b/src/appleseed/foundation/meta/tests/test_colorspace.cpp
@@ -482,7 +482,7 @@ TEST_SUITE(Foundation_Image_ColorSpace)
     {
         const RegularSpectrum31f spectrum = get_white_spectrum();
         const LightingConditions lighting_conditions(IlluminantCIED65, XYZCMFCIE19312Deg);
-        const Color3f ciexyz = spectrum_to_ciexyz<float>(lighting_conditions, spectrum);
+        const Color3f ciexyz = spectral_reflectance_to_ciexyz<float>(lighting_conditions, spectrum);
 
         EXPECT_FEQ_EPS(
             Color3f(0.701480f, 0.73824f, 0.804104f),

--- a/src/appleseed/foundation/meta/tests/test_colorspace.cpp
+++ b/src/appleseed/foundation/meta/tests/test_colorspace.cpp
@@ -478,7 +478,7 @@ TEST_SUITE(Foundation_Image_ColorSpace)
         return RegularSpectrum31f::from_array(Values);
     }
 
-    TEST_CASE(TestReclectanceSpectrumToCIEXYZConversion)
+    TEST_CASE(TestSpectralReflectanceToCIEXYZConversion)
     {
         const RegularSpectrum31f spectrum = get_white_spectrum();
         const LightingConditions lighting_conditions(IlluminantCIED65, XYZCMFCIE19312Deg);

--- a/src/appleseed/renderer/kernel/lighting/lightpathstream.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lightpathstream.cpp
@@ -107,7 +107,7 @@ void LightPathStream::hit_reflector(const PathVertex& vertex)
     HitReflectorData data;
     data.m_object_instance = &vertex.m_shading_point->get_object_instance();
     data.m_vertex_position = Vector3f(vertex.get_point());
-    data.m_path_throughput = vertex.m_throughput.illuminance_to_rgb(g_std_cmf);
+    data.m_path_throughput = vertex.m_throughput.illuminance_to_rgb(g_std_lighting_conditions);
     m_hit_reflector_data.push_back(data);
 }
 
@@ -126,8 +126,8 @@ void LightPathStream::hit_emitter(
     HitEmitterData data;
     data.m_object_instance = &vertex.m_shading_point->get_object_instance();
     data.m_vertex_position = Vector3f(vertex.get_point());
-    data.m_path_throughput = vertex.m_throughput.illuminance_to_rgb(g_std_cmf);
-    data.m_emitted_radiance = emitted_radiance.illuminance_to_rgb(g_std_cmf);
+    data.m_path_throughput = vertex.m_throughput.illuminance_to_rgb(g_std_lighting_conditions);
+    data.m_emitted_radiance = emitted_radiance.illuminance_to_rgb(g_std_lighting_conditions);
     m_hit_emitter_data.push_back(data);
 }
 
@@ -148,7 +148,7 @@ void LightPathStream::sampled_emitting_shape(
             shape.get_object_instance_index());
     data.m_vertex_position = Vector3f(emission_position);
     data.m_material_value = material_value.reflectance_to_rgb(g_std_lighting_conditions);
-    data.m_emitted_radiance = emitted_radiance.illuminance_to_rgb(g_std_cmf);
+    data.m_emitted_radiance = emitted_radiance.illuminance_to_rgb(g_std_lighting_conditions);
     m_sampled_emitter_data.push_back(data);
 }
 
@@ -167,7 +167,7 @@ void LightPathStream::sampled_non_physical_light(
     data.m_entity = &light;
     data.m_vertex_position = Vector3f(emission_position);
     data.m_material_value = material_value.reflectance_to_rgb(g_std_lighting_conditions);
-    data.m_emitted_radiance = emitted_radiance.illuminance_to_rgb(g_std_cmf);
+    data.m_emitted_radiance = emitted_radiance.illuminance_to_rgb(g_std_lighting_conditions);
     m_sampled_emitter_data.push_back(data);
 }
 
@@ -186,7 +186,7 @@ void LightPathStream::sampled_environment(
     data.m_environment_edf = &environment_edf;
     data.m_emission_direction = emission_direction;
     data.m_material_value = material_value.reflectance_to_rgb(g_std_lighting_conditions);
-    data.m_emitted_radiance = emitted_radiance.illuminance_to_rgb(g_std_cmf);
+    data.m_emitted_radiance = emitted_radiance.illuminance_to_rgb(g_std_lighting_conditions);
     m_sampled_env_data.push_back(data);
 }
 

--- a/src/appleseed/renderer/kernel/lighting/lightpathstream.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lightpathstream.cpp
@@ -107,7 +107,7 @@ void LightPathStream::hit_reflector(const PathVertex& vertex)
     HitReflectorData data;
     data.m_object_instance = &vertex.m_shading_point->get_object_instance();
     data.m_vertex_position = Vector3f(vertex.get_point());
-    data.m_path_throughput = vertex.m_throughput.to_rgb(g_std_lighting_conditions);
+    data.m_path_throughput = vertex.m_throughput.illuminance_to_rgb(g_std_cmf);
     m_hit_reflector_data.push_back(data);
 }
 
@@ -126,8 +126,8 @@ void LightPathStream::hit_emitter(
     HitEmitterData data;
     data.m_object_instance = &vertex.m_shading_point->get_object_instance();
     data.m_vertex_position = Vector3f(vertex.get_point());
-    data.m_path_throughput = vertex.m_throughput.to_rgb(g_std_lighting_conditions);
-    data.m_emitted_radiance = emitted_radiance.to_rgb(g_std_lighting_conditions);
+    data.m_path_throughput = vertex.m_throughput.illuminance_to_rgb(g_std_cmf);
+    data.m_emitted_radiance = emitted_radiance.illuminance_to_rgb(g_std_cmf);
     m_hit_emitter_data.push_back(data);
 }
 
@@ -147,8 +147,8 @@ void LightPathStream::sampled_emitting_shape(
         shape.get_assembly_instance()->get_assembly().object_instances().get_by_index(
             shape.get_object_instance_index());
     data.m_vertex_position = Vector3f(emission_position);
-    data.m_material_value = material_value.to_rgb(g_std_lighting_conditions);
-    data.m_emitted_radiance = emitted_radiance.to_rgb(g_std_lighting_conditions);
+    data.m_material_value = material_value.reflectance_to_rgb(g_std_lighting_conditions);
+    data.m_emitted_radiance = emitted_radiance.illuminance_to_rgb(g_std_cmf);
     m_sampled_emitter_data.push_back(data);
 }
 
@@ -166,8 +166,8 @@ void LightPathStream::sampled_non_physical_light(
     SampledEmitterData data;
     data.m_entity = &light;
     data.m_vertex_position = Vector3f(emission_position);
-    data.m_material_value = material_value.to_rgb(g_std_lighting_conditions);
-    data.m_emitted_radiance = emitted_radiance.to_rgb(g_std_lighting_conditions);
+    data.m_material_value = material_value.reflectance_to_rgb(g_std_lighting_conditions);
+    data.m_emitted_radiance = emitted_radiance.illuminance_to_rgb(g_std_cmf);
     m_sampled_emitter_data.push_back(data);
 }
 
@@ -185,8 +185,8 @@ void LightPathStream::sampled_environment(
     SampledEnvData data;
     data.m_environment_edf = &environment_edf;
     data.m_emission_direction = emission_direction;
-    data.m_material_value = material_value.to_rgb(g_std_lighting_conditions);
-    data.m_emitted_radiance = emitted_radiance.to_rgb(g_std_lighting_conditions);
+    data.m_material_value = material_value.reflectance_to_rgb(g_std_lighting_conditions);
+    data.m_emitted_radiance = emitted_radiance.illuminance_to_rgb(g_std_cmf);
     m_sampled_env_data.push_back(data);
 }
 

--- a/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
@@ -515,7 +515,7 @@ namespace
             {
                 assert(min_value(radiance) >= 0.0f);
 
-                const Color3f linear_rgb = radiance.illuminance_to_rgb(g_std_cmf);
+                const Color3f linear_rgb = radiance.illuminance_to_rgb(g_std_lighting_conditions);
 
                 Sample sample;
                 sample.m_pixel_coords.x = static_cast<int>(position_ndc.x * m_canvas_width);

--- a/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
+++ b/src/appleseed/renderer/kernel/lighting/lighttracing/lighttracingsamplegenerator.cpp
@@ -515,7 +515,7 @@ namespace
             {
                 assert(min_value(radiance) >= 0.0f);
 
-                const Color3f linear_rgb = radiance.to_rgb(g_std_lighting_conditions);
+                const Color3f linear_rgb = radiance.illuminance_to_rgb(g_std_cmf);
 
                 Sample sample;
                 sample.m_pixel_coords.x = static_cast<int>(position_ndc.x * m_canvas_width);

--- a/src/appleseed/renderer/meta/tests/test_inputarray.cpp
+++ b/src/appleseed/renderer/meta/tests/test_inputarray.cpp
@@ -45,7 +45,7 @@ TEST_SUITE(Renderer_Modeling_Input_InputArray)
     TEST_CASE(Find_GivenNameOfExistingInput_ReturnsInputIterator)
     {
         InputArray inputs;
-        inputs.declare("x", InputFormatFloat);
+        inputs.declare("x", InputFormat::Float);
 
         const InputArray::const_iterator i = inputs.find("x");
 
@@ -55,7 +55,7 @@ TEST_SUITE(Renderer_Modeling_Input_InputArray)
     TEST_CASE(Find_GivenNameOfNonExistingInput_ReturnsEndIterator)
     {
         InputArray inputs;
-        inputs.declare("x", InputFormatFloat);
+        inputs.declare("x", InputFormat::Float);
 
         const InputArray::const_iterator i = inputs.find("y");
 
@@ -65,7 +65,7 @@ TEST_SUITE(Renderer_Modeling_Input_InputArray)
     TEST_CASE(Source_GivenNameOfNonExistingInput_ReturnsZero)
     {
         InputArray inputs;
-        inputs.declare("x", InputFormatFloat);
+        inputs.declare("x", InputFormat::Float);
 
         const Source* source = inputs.source("y");
 
@@ -75,7 +75,7 @@ TEST_SUITE(Renderer_Modeling_Input_InputArray)
     TEST_CASE(Source_GivenNameOfUnboundExistingInput_ReturnsZero)
     {
         InputArray inputs;
-        inputs.declare("x", InputFormatFloat);
+        inputs.declare("x", InputFormat::Float);
 
         const Source* source = inputs.source("x");
 
@@ -85,7 +85,7 @@ TEST_SUITE(Renderer_Modeling_Input_InputArray)
     TEST_CASE(Source_GivenNameOfBoundExistingInput_ReturnsBoundSource)
     {
         InputArray inputs;
-        inputs.declare("x", InputFormatFloat);
+        inputs.declare("x", InputFormat::Float);
 
         Source* expected_source = new ScalarSource(1.0);
         inputs.find("x").bind(expected_source);

--- a/src/appleseed/renderer/modeling/aov/albedoaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/albedoaov.cpp
@@ -74,7 +74,7 @@ namespace
             ShadingResult&              shading_result) override
         {
             shading_result.m_aovs[m_index].rgb() =
-                aov_components.m_albedo.to_rgb(g_std_lighting_conditions);
+                aov_components.m_albedo.reflectance_to_rgb(g_std_lighting_conditions);
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }

--- a/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/diffuseaov.cpp
@@ -74,8 +74,8 @@ namespace
             ShadingResult&              shading_result) override
         {
             shading_result.m_aovs[m_index].rgb() =
-                shading_components.m_diffuse.to_rgb(g_std_lighting_conditions) +
-                shading_components.m_indirect_diffuse.to_rgb(g_std_lighting_conditions);
+                shading_components.m_diffuse.reflectance_to_rgb(g_std_lighting_conditions) +
+                shading_components.m_indirect_diffuse.reflectance_to_rgb(g_std_lighting_conditions);
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
@@ -106,7 +106,7 @@ namespace
             ShadingResult&              shading_result) override
         {
             shading_result.m_aovs[m_index].rgb() =
-                shading_components.m_diffuse.to_rgb(g_std_lighting_conditions);
+                shading_components.m_diffuse.reflectance_to_rgb(g_std_lighting_conditions);
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
@@ -137,7 +137,7 @@ namespace
             ShadingResult&              shading_result) override
         {
             shading_result.m_aovs[m_index].rgb() =
-                shading_components.m_indirect_diffuse.to_rgb(g_std_lighting_conditions);
+                shading_components.m_indirect_diffuse.reflectance_to_rgb(g_std_lighting_conditions);
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }

--- a/src/appleseed/renderer/modeling/aov/emissionaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/emissionaov.cpp
@@ -74,7 +74,7 @@ namespace
             ShadingResult&              shading_result) override
         {
             shading_result.m_aovs[m_index].rgb() =
-                shading_components.m_emission.to_rgb(g_std_lighting_conditions);
+                shading_components.m_emission.illuminance_to_rgb(g_std_cmf);
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }

--- a/src/appleseed/renderer/modeling/aov/emissionaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/emissionaov.cpp
@@ -74,7 +74,7 @@ namespace
             ShadingResult&              shading_result) override
         {
             shading_result.m_aovs[m_index].rgb() =
-                shading_components.m_emission.illuminance_to_rgb(g_std_cmf);
+                shading_components.m_emission.illuminance_to_rgb(g_std_lighting_conditions);
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }

--- a/src/appleseed/renderer/modeling/aov/glossyaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/glossyaov.cpp
@@ -73,8 +73,8 @@ namespace
             ShadingResult&              shading_result) override
         {
             shading_result.m_aovs[m_index].rgb() =
-                shading_components.m_glossy.to_rgb(g_std_lighting_conditions) +
-                shading_components.m_indirect_glossy.to_rgb(g_std_lighting_conditions);
+                shading_components.m_glossy.reflectance_to_rgb(g_std_lighting_conditions) +
+                shading_components.m_indirect_glossy.reflectance_to_rgb(g_std_lighting_conditions);
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
@@ -105,7 +105,7 @@ namespace
             ShadingResult&              shading_result) override
         {
             shading_result.m_aovs[m_index].rgb() =
-                shading_components.m_glossy.to_rgb(g_std_lighting_conditions);
+                shading_components.m_glossy.reflectance_to_rgb(g_std_lighting_conditions);
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }
@@ -136,7 +136,7 @@ namespace
             ShadingResult&              shading_result) override
         {
             shading_result.m_aovs[m_index].rgb() =
-                shading_components.m_indirect_glossy.to_rgb(g_std_lighting_conditions);
+                shading_components.m_indirect_glossy.reflectance_to_rgb(g_std_lighting_conditions);
 
             shading_result.m_aovs[m_index].a = shading_result.m_main.a;
         }

--- a/src/appleseed/renderer/modeling/bsdf/ashikhminbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/ashikhminbrdf.cpp
@@ -83,13 +83,13 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Diffuse | ScatteringMode::Glossy, params)
         {
-            m_inputs.declare("diffuse_reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("diffuse_reflectance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("glossy_reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("glossy_reflectance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("fresnel_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("shininess_u", InputFormatFloat);
-            m_inputs.declare("shininess_v", InputFormatFloat);
+            m_inputs.declare("diffuse_reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("diffuse_reflectance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("glossy_reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("glossy_reflectance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("fresnel_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("shininess_u", InputFormat::Float);
+            m_inputs.declare("shininess_v", InputFormat::Float);
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/blinnbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/blinnbrdf.cpp
@@ -105,8 +105,8 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Glossy, params)
         {
-            m_inputs.declare("exponent", InputFormatFloat, "0.5");
-            m_inputs.declare("ior", InputFormatFloat, "1.5");
+            m_inputs.declare("exponent", InputFormat::Float, "0.5");
+            m_inputs.declare("ior", InputFormat::Float, "1.5");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/bsdfblend.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfblend.cpp
@@ -81,9 +81,9 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::All, params)
         {
-            m_inputs.declare("bsdf0", InputFormatEntity);
-            m_inputs.declare("bsdf1", InputFormatEntity);
-            m_inputs.declare("weight", InputFormatFloat);
+            m_inputs.declare("bsdf0", InputFormat::Entity);
+            m_inputs.declare("bsdf1", InputFormat::Entity);
+            m_inputs.declare("weight", InputFormat::Float);
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/bsdfmix.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfmix.cpp
@@ -81,10 +81,10 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::All, params)
         {
-            m_inputs.declare("bsdf0", InputFormatEntity);
-            m_inputs.declare("weight0", InputFormatFloat);
-            m_inputs.declare("bsdf1", InputFormatEntity);
-            m_inputs.declare("weight1", InputFormatFloat);
+            m_inputs.declare("bsdf0", InputFormat::Entity);
+            m_inputs.declare("weight0", InputFormat::Float);
+            m_inputs.declare("bsdf1", InputFormat::Entity);
+            m_inputs.declare("weight1", InputFormat::Float);
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/diffusebtdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/diffusebtdf.cpp
@@ -73,8 +73,8 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Transmissive, ScatteringMode::Diffuse, params)
         {
-            m_inputs.declare("transmittance", InputFormatSpectralReflectance);
-            m_inputs.declare("transmittance_multiplier", InputFormatFloat, "1.0");
+            m_inputs.declare("transmittance", InputFormat::SpectralReflectance);
+            m_inputs.declare("transmittance_multiplier", InputFormat::Float, "1.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
@@ -358,17 +358,17 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Diffuse | ScatteringMode::Glossy, params)
         {
-            m_inputs.declare("base_color", InputFormatSpectralReflectance);
-            m_inputs.declare("subsurface", InputFormatFloat, "0.0");
-            m_inputs.declare("metallic", InputFormatFloat, "0.0");
-            m_inputs.declare("specular", InputFormatFloat, "0.0");
-            m_inputs.declare("specular_tint", InputFormatFloat, "0.0");
-            m_inputs.declare("anisotropic", InputFormatFloat, "0.0");
-            m_inputs.declare("roughness", InputFormatFloat, "0.1");
-            m_inputs.declare("sheen", InputFormatFloat, "0.0");
-            m_inputs.declare("sheen_tint", InputFormatFloat, "0.0");
-            m_inputs.declare("clearcoat", InputFormatFloat, "0.0");
-            m_inputs.declare("clearcoat_gloss", InputFormatFloat, "1.0");
+            m_inputs.declare("base_color", InputFormat::SpectralReflectance);
+            m_inputs.declare("subsurface", InputFormat::Float, "0.0");
+            m_inputs.declare("metallic", InputFormat::Float, "0.0");
+            m_inputs.declare("specular", InputFormat::Float, "0.0");
+            m_inputs.declare("specular_tint", InputFormat::Float, "0.0");
+            m_inputs.declare("anisotropic", InputFormat::Float, "0.0");
+            m_inputs.declare("roughness", InputFormat::Float, "0.1");
+            m_inputs.declare("sheen", InputFormat::Float, "0.0");
+            m_inputs.declare("sheen_tint", InputFormat::Float, "0.0");
+            m_inputs.declare("clearcoat", InputFormat::Float, "0.0");
+            m_inputs.declare("clearcoat_gloss", InputFormat::Float, "1.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
@@ -398,7 +398,7 @@ namespace
             new (&values->m_precomputed) InputValues::Precomputed();
 
             const Color3f tint_xyz =
-                values->m_base_color.to_ciexyz(g_std_lighting_conditions);
+                values->m_base_color.reflectance_to_ciexyz(g_std_lighting_conditions);
 
             values->m_precomputed.m_tint_color.set(
                 tint_xyz[1] > 0.0f

--- a/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
@@ -155,19 +155,19 @@ namespace
             const ParamArray&           params)
           : BSDF(name, AllBSDFTypes, ScatteringMode::Glossy, params)
         {
-            m_inputs.declare("surface_transmittance", InputFormatSpectralReflectance);
-            m_inputs.declare("surface_transmittance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("reflection_tint", InputFormatSpectralReflectance, "1.0");
-            m_inputs.declare("refraction_tint", InputFormatSpectralReflectance, "1.0");
-            m_inputs.declare("roughness", InputFormatFloat, "0.15");
-            m_inputs.declare("anisotropy", InputFormatFloat, "0.0");
-            m_inputs.declare("ior", InputFormatFloat, "1.5");
-            m_inputs.declare("volume_transmittance", InputFormatSpectralReflectance, "1.0");
-            m_inputs.declare("volume_transmittance_distance", InputFormatFloat, "0.0");
-            m_inputs.declare("volume_absorption", InputFormatSpectralReflectance, "0.0");
-            m_inputs.declare("volume_density", InputFormatFloat, "0.0");
-            m_inputs.declare("volume_scale", InputFormatFloat, "1.0");
-            m_inputs.declare("energy_compensation", InputFormatFloat, "0.0");
+            m_inputs.declare("surface_transmittance", InputFormat::SpectralReflectance);
+            m_inputs.declare("surface_transmittance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("reflection_tint", InputFormat::SpectralReflectance, "1.0");
+            m_inputs.declare("refraction_tint", InputFormat::SpectralReflectance, "1.0");
+            m_inputs.declare("roughness", InputFormat::Float, "0.15");
+            m_inputs.declare("anisotropy", InputFormat::Float, "0.0");
+            m_inputs.declare("ior", InputFormat::Float, "1.5");
+            m_inputs.declare("volume_transmittance", InputFormat::SpectralReflectance, "1.0");
+            m_inputs.declare("volume_transmittance_distance", InputFormat::Float, "0.0");
+            m_inputs.declare("volume_absorption", InputFormat::SpectralReflectance, "0.0");
+            m_inputs.declare("volume_density", InputFormat::Float, "0.0");
+            m_inputs.declare("volume_scale", InputFormat::Float, "1.0");
+            m_inputs.declare("energy_compensation", InputFormat::Float, "0.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
@@ -96,13 +96,13 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Glossy | ScatteringMode::Specular, params)
         {
-            m_inputs.declare("reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("reflectance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("roughness", InputFormatFloat, "0.15");
-            m_inputs.declare("anisotropy", InputFormatFloat, "0.0");
-            m_inputs.declare("ior", InputFormatFloat, "1.5");
-            m_inputs.declare("fresnel_weight", InputFormatFloat, "1.0");
-            m_inputs.declare("energy_compensation", InputFormatFloat, "0.0");
+            m_inputs.declare("reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("reflectance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("roughness", InputFormat::Float, "0.15");
+            m_inputs.declare("anisotropy", InputFormat::Float, "0.0");
+            m_inputs.declare("ior", InputFormat::Float, "1.5");
+            m_inputs.declare("fresnel_weight", InputFormat::Float, "1.0");
+            m_inputs.declare("energy_compensation", InputFormat::Float, "0.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/hairbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/hairbsdf.cpp
@@ -171,7 +171,7 @@ namespace
     {
         return std::accumulate(retAp.begin(), retAp.end(), 0.0f, [](float s, const Spectrum& ap)
         {
-            return s + luminance(ap.to_rgb(g_std_lighting_conditions));
+            return s + luminance(ap.illuminance_to_ciexyz(g_std_cmf));
         });
     }
 
@@ -222,7 +222,7 @@ namespace
 
         const float sumY = sum_luminance(retAp);
         for (int i = 0; i <= 3; i++)
-            ret[i] = luminance(retAp[i].to_rgb(g_std_lighting_conditions)) / sumY;
+            ret[i] = luminance(retAp[i].illuminance_to_rgb(g_std_cmf)) / sumY;
     }
 
     //

--- a/src/appleseed/renderer/modeling/bsdf/hairbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/hairbsdf.cpp
@@ -443,13 +443,13 @@ namespace
             const ParamArray&           params)
           : BSDF(name, AllBSDFTypes, ScatteringMode::Glossy, params)
         {
-            m_inputs.declare("reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("melanin", InputFormatFloat, "0.3");
-            m_inputs.declare("melanin_redness", InputFormatFloat, "0.0");
-            m_inputs.declare("eta", InputFormatFloat, "1.55");
-            m_inputs.declare("beta_M", InputFormatFloat, "0.3");
-            m_inputs.declare("beta_N", InputFormatFloat, "0.3");
-            m_inputs.declare("alpha", InputFormatFloat, "2.0");
+            m_inputs.declare("reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("melanin", InputFormat::Float, "0.3");
+            m_inputs.declare("melanin_redness", InputFormat::Float, "0.0");
+            m_inputs.declare("eta", InputFormat::Float, "1.55");
+            m_inputs.declare("beta_M", InputFormat::Float, "0.3");
+            m_inputs.declare("beta_N", InputFormat::Float, "0.3");
+            m_inputs.declare("alpha", InputFormat::Float, "2.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/hairbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/hairbsdf.cpp
@@ -171,7 +171,7 @@ namespace
     {
         return std::accumulate(retAp.begin(), retAp.end(), 0.0f, [](float s, const Spectrum& ap)
         {
-            return s + luminance(ap.illuminance_to_ciexyz(g_std_cmf));
+            return s + luminance(ap.illuminance_to_rgb(g_std_lighting_conditions));
         });
     }
 
@@ -222,7 +222,7 @@ namespace
 
         const float sumY = sum_luminance(retAp);
         for (int i = 0; i <= 3; i++)
-            ret[i] = luminance(retAp[i].illuminance_to_rgb(g_std_cmf)) / sumY;
+            ret[i] = luminance(retAp[i].illuminance_to_rgb(g_std_lighting_conditions)) / sumY;
     }
 
     //

--- a/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.cpp
@@ -139,11 +139,11 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Diffuse | ScatteringMode::Glossy, params)
         {
-            m_inputs.declare("matte_reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("matte_reflectance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("specular_reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("specular_reflectance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("roughness", InputFormatFloat);
+            m_inputs.declare("matte_reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("matte_reflectance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("specular_reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("specular_reflectance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("roughness", InputFormat::Float);
         }
 
         ~KelemenBRDFImpl() override

--- a/src/appleseed/renderer/modeling/bsdf/lambertianbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/lambertianbrdf.cpp
@@ -76,8 +76,8 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Diffuse, params)
         {
-            m_inputs.declare("reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("reflectance_multiplier", InputFormatFloat, "1.0");
+            m_inputs.declare("reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("reflectance_multiplier", InputFormat::Float, "1.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
@@ -92,13 +92,13 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Glossy | ScatteringMode::Specular, params)
         {
-            m_inputs.declare("normal_reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("edge_tint", InputFormatSpectralReflectance);
-            m_inputs.declare("edge_tint_weight", InputFormatFloat, "1.0");
-            m_inputs.declare("reflectance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("roughness", InputFormatFloat, "0.15");
-            m_inputs.declare("anisotropy", InputFormatFloat, "0.0");
-            m_inputs.declare("energy_compensation", InputFormatFloat, "0.0");
+            m_inputs.declare("normal_reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("edge_tint", InputFormat::SpectralReflectance);
+            m_inputs.declare("edge_tint_weight", InputFormat::Float, "1.0");
+            m_inputs.declare("reflectance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("roughness", InputFormat::Float, "0.15");
+            m_inputs.declare("anisotropy", InputFormat::Float, "0.0");
+            m_inputs.declare("energy_compensation", InputFormat::Float, "0.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/orennayarbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/orennayarbrdf.cpp
@@ -81,9 +81,9 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Diffuse, params)
         {
-            m_inputs.declare("reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("reflectance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("roughness" , InputFormatFloat, "0.1");
+            m_inputs.declare("reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("reflectance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("roughness" , InputFormat::Float, "0.1");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/plasticbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/plasticbrdf.cpp
@@ -92,13 +92,13 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Diffuse | ScatteringMode::Glossy | ScatteringMode::Specular, params)
         {
-            m_inputs.declare("diffuse_reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("diffuse_reflectance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("specular_reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("specular_reflectance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("roughness", InputFormatFloat, "0.15");
-            m_inputs.declare("ior", InputFormatFloat, "1.5");
-            m_inputs.declare("internal_scattering", InputFormatFloat, "1.0");
+            m_inputs.declare("diffuse_reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("diffuse_reflectance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("specular_reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("specular_reflectance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("roughness", InputFormat::Float, "0.15");
+            m_inputs.declare("ior", InputFormat::Float, "1.5");
+            m_inputs.declare("internal_scattering", InputFormat::Float, "1.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/sheenbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/sheenbrdf.cpp
@@ -76,8 +76,8 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Glossy, params)
         {
-            m_inputs.declare("reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("reflectance_multiplier", InputFormatFloat, "1.0");
+            m_inputs.declare("reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("reflectance_multiplier", InputFormat::Float, "1.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/specularbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/specularbrdf.cpp
@@ -68,8 +68,8 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Reflective, ScatteringMode::Specular, params)
         {
-            m_inputs.declare("reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("reflectance_multiplier", InputFormatFloat, "1.0");
+            m_inputs.declare("reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("reflectance_multiplier", InputFormat::Float, "1.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bsdf/specularbtdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/specularbtdf.cpp
@@ -72,14 +72,14 @@ namespace
             const ParamArray&           params)
           : BSDF(name, Transmissive, ScatteringMode::Specular, params)
         {
-            m_inputs.declare("reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("reflectance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("transmittance", InputFormatSpectralReflectance);
-            m_inputs.declare("transmittance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("fresnel_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("ior", InputFormatFloat);
-            m_inputs.declare("volume_density", InputFormatFloat, "0.0");
-            m_inputs.declare("volume_scale", InputFormatFloat, "1.0");
+            m_inputs.declare("reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("reflectance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("transmittance", InputFormat::SpectralReflectance);
+            m_inputs.declare("transmittance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("fresnel_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("ior", InputFormat::Float);
+            m_inputs.declare("volume_density", InputFormat::Float, "0.0");
+            m_inputs.declare("volume_scale", InputFormat::Float, "1.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/dipolebssrdf.cpp
@@ -52,16 +52,16 @@ DipoleBSSRDF::DipoleBSSRDF(
   : SeparableBSSRDF(name, params)
   , m_has_sigma_sources(false)
 {
-    m_inputs.declare("weight", InputFormatFloat, "1.0");
-    m_inputs.declare("reflectance", InputFormatSpectralReflectance);
-    m_inputs.declare("reflectance_multiplier", InputFormatFloat, "1.0");
-    m_inputs.declare("mfp", InputFormatSpectralReflectance);
-    m_inputs.declare("mfp_multiplier", InputFormatFloat, "1.0");
-    m_inputs.declare("sigma_a", InputFormatSpectralReflectance, "");
-    m_inputs.declare("sigma_s", InputFormatSpectralReflectance, "");
-    m_inputs.declare("g", InputFormatFloat, "0.0");
-    m_inputs.declare("ior", InputFormatFloat);
-    m_inputs.declare("fresnel_weight", InputFormatFloat, "1.0");
+    m_inputs.declare("weight", InputFormat::Float, "1.0");
+    m_inputs.declare("reflectance", InputFormat::SpectralReflectance);
+    m_inputs.declare("reflectance_multiplier", InputFormat::Float, "1.0");
+    m_inputs.declare("mfp", InputFormat::SpectralReflectance);
+    m_inputs.declare("mfp_multiplier", InputFormat::Float, "1.0");
+    m_inputs.declare("sigma_a", InputFormat::SpectralReflectance, "");
+    m_inputs.declare("sigma_s", InputFormat::SpectralReflectance, "");
+    m_inputs.declare("g", InputFormat::Float, "0.0");
+    m_inputs.declare("ior", InputFormat::Float);
+    m_inputs.declare("fresnel_weight", InputFormat::Float, "1.0");
 }
 
 size_t DipoleBSSRDF::compute_input_data_size() const

--- a/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/gaussianbssrdf.cpp
@@ -129,13 +129,13 @@ namespace
             const ParamArray&       params)
           : SeparableBSSRDF(name, params)
         {
-            m_inputs.declare("weight", InputFormatFloat, "1.0");
-            m_inputs.declare("reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("reflectance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("mfp", InputFormatSpectralReflectance);
-            m_inputs.declare("mfp_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("ior", InputFormatFloat);
-            m_inputs.declare("fresnel_weight", InputFormatFloat, "1.0");
+            m_inputs.declare("weight", InputFormat::Float, "1.0");
+            m_inputs.declare("reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("reflectance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("mfp", InputFormat::SpectralReflectance);
+            m_inputs.declare("mfp_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("ior", InputFormat::Float);
+            m_inputs.declare("fresnel_weight", InputFormat::Float, "1.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/normalizeddiffusionbssrdf.cpp
@@ -76,13 +76,13 @@ namespace
             const ParamArray&       params)
           : SeparableBSSRDF(name, params)
         {
-            m_inputs.declare("weight", InputFormatFloat, "1.0");
-            m_inputs.declare("reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("reflectance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("mfp", InputFormatSpectralReflectance);
-            m_inputs.declare("mfp_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("ior", InputFormatFloat);
-            m_inputs.declare("fresnel_weight", InputFormatFloat, "1.0");
+            m_inputs.declare("weight", InputFormat::Float, "1.0");
+            m_inputs.declare("reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("reflectance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("mfp", InputFormat::SpectralReflectance);
+            m_inputs.declare("mfp_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("ior", InputFormat::Float);
+            m_inputs.declare("fresnel_weight", InputFormat::Float, "1.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/bssrdf/randomwalkbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/randomwalkbssrdf.cpp
@@ -99,15 +99,15 @@ namespace
             const ParamArray&       params)
           : BSSRDF(name, params)
         {
-            m_inputs.declare("weight", InputFormatFloat, "1.0");
-            m_inputs.declare("reflectance", InputFormatSpectralReflectance);
-            m_inputs.declare("reflectance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("mfp", InputFormatSpectralReflectance);
-            m_inputs.declare("mfp_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("ior", InputFormatFloat);
-            m_inputs.declare("fresnel_weight", InputFormatFloat, "1.0");
-            m_inputs.declare("volume_anisotropy", InputFormatFloat, "0.0");
-            m_inputs.declare("surface_roughness", InputFormatFloat, "0.01");
+            m_inputs.declare("weight", InputFormat::Float, "1.0");
+            m_inputs.declare("reflectance", InputFormat::SpectralReflectance);
+            m_inputs.declare("reflectance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("mfp", InputFormat::SpectralReflectance);
+            m_inputs.declare("mfp_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("ior", InputFormat::Float);
+            m_inputs.declare("fresnel_weight", InputFormat::Float, "1.0");
+            m_inputs.declare("volume_anisotropy", InputFormat::Float, "0.0");
+            m_inputs.declare("surface_roughness", InputFormat::Float, "0.01");
 
             const std::string lambertian_brdf_name = std::string(name) + "_lambertian_brdf";
             m_lambertian_brdf = LambertianBRDFFactory().create(lambertian_brdf_name.c_str(), ParamArray());

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -178,7 +178,7 @@ namespace
             const ParamArray&       params)
           : PerspectiveCamera(name, params)
         {
-            m_inputs.declare("diaphragm_map", InputFormatSpectralReflectance, "");
+            m_inputs.declare("diaphragm_map", InputFormat::SpectralReflectance, "");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/color/colorspace.cpp
+++ b/src/appleseed/renderer/modeling/color/colorspace.cpp
@@ -35,7 +35,6 @@ namespace renderer
 {
 
 LightingConditions      g_std_lighting_conditions;
-ColorMatchingFunction   g_std_cmf;
 
 namespace
 {
@@ -47,16 +46,7 @@ namespace
         }
     };
 
-    struct InitilizeStdColorMatchingFunction
-    { 
-        InitilizeStdColorMatchingFunction()
-        {
-            g_std_cmf = ColorMatchingFunction(XYZCMFCIE19312Deg);
-        }
-    };
-
     InitializeStdLightingConditions initialize_std_lighting_conditions;
-    InitilizeStdColorMatchingFunction initialize_std_cmf;
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/color/colorspace.cpp
+++ b/src/appleseed/renderer/modeling/color/colorspace.cpp
@@ -34,7 +34,8 @@ using namespace foundation;
 namespace renderer
 {
 
-LightingConditions g_std_lighting_conditions;
+LightingConditions      g_std_lighting_conditions;
+ColorMatchingFunction   g_std_cmf;
 
 namespace
 {
@@ -46,7 +47,16 @@ namespace
         }
     };
 
+    struct InitilizeStdColorMatchingFunction
+    { 
+        InitilizeStdColorMatchingFunction()
+        {
+            g_std_cmf = ColorMatchingFunction(XYZCMFCIE19312Deg);
+        }
+    };
+
     InitializeStdLightingConditions initialize_std_lighting_conditions;
+    InitilizeStdColorMatchingFunction initialize_std_cmf;
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/color/colorspace.cpp
+++ b/src/appleseed/renderer/modeling/color/colorspace.cpp
@@ -34,7 +34,7 @@ using namespace foundation;
 namespace renderer
 {
 
-LightingConditions      g_std_lighting_conditions;
+LightingConditions g_std_lighting_conditions;
 
 namespace
 {

--- a/src/appleseed/renderer/modeling/color/colorspace.h
+++ b/src/appleseed/renderer/modeling/color/colorspace.h
@@ -41,11 +41,4 @@ namespace renderer
 
 extern foundation::LightingConditions       g_std_lighting_conditions;
 
-
-//
-// Standard Color matching function CIE 1931 2-deg
-//
-
-extern foundation::ColorMatchingFunction    g_std_cmf;
-
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/color/colorspace.h
+++ b/src/appleseed/renderer/modeling/color/colorspace.h
@@ -34,10 +34,18 @@
 namespace renderer
 {
 
+
 //
-// Standard lighting conditions (D65 illuminant, CIE 1964 10-deg color matching functions).
+// Standard lighting conditions (D65 illuminant, CIE 1931 2-deg color matching functions).
 //
 
-extern foundation::LightingConditions g_std_lighting_conditions;
+extern foundation::LightingConditions       g_std_lighting_conditions;
+
+
+//
+// Standard Color matching function CIE 1931 2-deg
+//
+
+extern foundation::ColorMatchingFunction    g_std_cmf;
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/color/colorspace.h
+++ b/src/appleseed/renderer/modeling/color/colorspace.h
@@ -39,6 +39,6 @@ namespace renderer
 // Standard lighting conditions (D65 illuminant, CIE 1931 2-deg color matching functions).
 //
 
-extern foundation::LightingConditions       g_std_lighting_conditions;
+extern foundation::LightingConditions g_std_lighting_conditions;
 
 }   // namespace renderer

--- a/src/appleseed/renderer/modeling/edf/coneedf.cpp
+++ b/src/appleseed/renderer/modeling/edf/coneedf.cpp
@@ -72,10 +72,10 @@ namespace
             const ParamArray&       params)
           : EDF(name, params)
         {
-            m_inputs.declare("radiance", InputFormatSpectralIlluminance);
-            m_inputs.declare("radiance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("exposure", InputFormatFloat, "0.0");
-            m_inputs.declare("angle", InputFormatFloat, "90.0");
+            m_inputs.declare("radiance", InputFormat::SpectralIlluminance);
+            m_inputs.declare("radiance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("exposure", InputFormat::Float, "0.0");
+            m_inputs.declare("angle", InputFormat::Float, "90.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/edf/diffuseedf.cpp
+++ b/src/appleseed/renderer/modeling/edf/diffuseedf.cpp
@@ -72,9 +72,9 @@ namespace
             const ParamArray&       params)
           : EDF(name, params)
         {
-            m_inputs.declare("radiance", InputFormatSpectralIlluminance);
-            m_inputs.declare("radiance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("exposure", InputFormatFloat, "0.0");
+            m_inputs.declare("radiance", InputFormat::SpectralIlluminance);
+            m_inputs.declare("radiance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("exposure", InputFormat::Float, "0.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/environment/environment.cpp
+++ b/src/appleseed/renderer/modeling/environment/environment.cpp
@@ -67,8 +67,8 @@ Environment::Environment(
 {
     set_name(name);
 
-    m_inputs.declare("environment_edf", InputFormatEntity, "");
-    m_inputs.declare("environment_shader", InputFormatEntity, "");
+    m_inputs.declare("environment_edf", InputFormat::Entity, "");
+    m_inputs.declare("environment_shader", InputFormat::Entity, "");
 }
 
 void Environment::release()

--- a/src/appleseed/renderer/modeling/environmentedf/constantenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/constantenvironmentedf.cpp
@@ -73,7 +73,7 @@ namespace
             const ParamArray&       params)
           : EnvironmentEDF(name, params)
         {
-            m_inputs.declare("radiance", InputFormatSpectralIlluminance);
+            m_inputs.declare("radiance", InputFormat::SpectralIlluminance);
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/environmentedf/constanthemisphereenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/constanthemisphereenvironmentedf.cpp
@@ -75,8 +75,8 @@ namespace
             const ParamArray&       params)
           : EnvironmentEDF(name, params)
         {
-            m_inputs.declare("upper_hemi_radiance", InputFormatSpectralIlluminance);
-            m_inputs.declare("lower_hemi_radiance", InputFormatSpectralIlluminance);
+            m_inputs.declare("upper_hemi_radiance", InputFormat::SpectralIlluminance);
+            m_inputs.declare("lower_hemi_radiance", InputFormat::SpectralIlluminance);
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/environmentedf/gradientenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/gradientenvironmentedf.cpp
@@ -77,8 +77,8 @@ namespace
             const ParamArray&       params)
           : EnvironmentEDF(name, params)
         {
-            m_inputs.declare("horizon_radiance", InputFormatSpectralIlluminance);
-            m_inputs.declare("zenith_radiance", InputFormatSpectralIlluminance);
+            m_inputs.declare("horizon_radiance", InputFormat::SpectralIlluminance);
+            m_inputs.declare("zenith_radiance", InputFormat::SpectralIlluminance);
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/environmentedf/hosekenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/hosekenvironmentedf.cpp
@@ -100,15 +100,15 @@ namespace
             const ParamArray&       params)
           : EnvironmentEDF(name, params)
         {
-            m_inputs.declare("sun_theta", InputFormatFloat);
-            m_inputs.declare("sun_phi", InputFormatFloat);
-            m_inputs.declare("turbidity", InputFormatFloat);
-            m_inputs.declare("turbidity_multiplier", InputFormatFloat, "2.0");
-            m_inputs.declare("ground_albedo", InputFormatFloat, "0.3");
-            m_inputs.declare("luminance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("luminance_gamma", InputFormatFloat, "1.0");
-            m_inputs.declare("saturation_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("horizon_shift", InputFormatFloat, "0.0");
+            m_inputs.declare("sun_theta", InputFormat::Float);
+            m_inputs.declare("sun_phi", InputFormat::Float);
+            m_inputs.declare("turbidity", InputFormat::Float);
+            m_inputs.declare("turbidity_multiplier", InputFormat::Float, "2.0");
+            m_inputs.declare("ground_albedo", InputFormat::Float, "0.3");
+            m_inputs.declare("luminance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("luminance_gamma", InputFormat::Float, "1.0");
+            m_inputs.declare("saturation_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("horizon_shift", InputFormat::Float, "0.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/environmentedf/hosekenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/hosekenvironmentedf.cpp
@@ -177,7 +177,7 @@ namespace
                 compute_sky_radiance(shading_context, shifted_outgoing, radiance);
             else radiance.set(0.0f);
 
-            value.set(radiance, g_std_cmf, Spectrum::Illuminance);
+            value.set(radiance, g_std_lighting_conditions, Spectrum::Illuminance);
             probability = shifted_outgoing.y > 0.0f ? shifted_outgoing.y * RcpPi<float>() : 0.0f;
             assert(probability >= 0.0f);
         }
@@ -199,7 +199,7 @@ namespace
                 compute_sky_radiance(shading_context, shifted_outgoing, radiance);
             else radiance.set(0.0f);
 
-            value.set(radiance, g_std_cmf, Spectrum::Illuminance);
+            value.set(radiance, g_std_lighting_conditions, Spectrum::Illuminance);
         }
 
         void evaluate(
@@ -220,7 +220,7 @@ namespace
                 compute_sky_radiance(shading_context, shifted_outgoing, radiance);
             else radiance.set(0.0f);
 
-            value.set(radiance, g_std_cmf, Spectrum::Illuminance);
+            value.set(radiance, g_std_lighting_conditions, Spectrum::Illuminance);
             probability = shifted_outgoing.y > 0.0f ? shifted_outgoing.y * RcpPi<float>() : 0.0f;
             assert(probability >= 0.0f);
         }

--- a/src/appleseed/renderer/modeling/environmentedf/hosekenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/hosekenvironmentedf.cpp
@@ -177,7 +177,7 @@ namespace
                 compute_sky_radiance(shading_context, shifted_outgoing, radiance);
             else radiance.set(0.0f);
 
-            value.set(radiance, g_std_lighting_conditions, Spectrum::Illuminance);
+            value.set(radiance, g_std_cmf, Spectrum::Illuminance);
             probability = shifted_outgoing.y > 0.0f ? shifted_outgoing.y * RcpPi<float>() : 0.0f;
             assert(probability >= 0.0f);
         }
@@ -199,7 +199,7 @@ namespace
                 compute_sky_radiance(shading_context, shifted_outgoing, radiance);
             else radiance.set(0.0f);
 
-            value.set(radiance, g_std_lighting_conditions, Spectrum::Illuminance);
+            value.set(radiance, g_std_cmf, Spectrum::Illuminance);
         }
 
         void evaluate(
@@ -220,7 +220,7 @@ namespace
                 compute_sky_radiance(shading_context, shifted_outgoing, radiance);
             else radiance.set(0.0f);
 
-            value.set(radiance, g_std_lighting_conditions, Spectrum::Illuminance);
+            value.set(radiance, g_std_cmf, Spectrum::Illuminance);
             probability = shifted_outgoing.y > 0.0f ? shifted_outgoing.y * RcpPi<float>() : 0.0f;
             assert(probability >= 0.0f);
         }

--- a/src/appleseed/renderer/modeling/environmentedf/latlongmapenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/latlongmapenvironmentedf.cpp
@@ -168,9 +168,9 @@ namespace
           , m_importance_map_height(0)
           , m_probability_scale(0.0f)
         {
-            m_inputs.declare("radiance", InputFormatSpectralIlluminance);
-            m_inputs.declare("radiance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("exposure", InputFormatFloat, "0.0");
+            m_inputs.declare("radiance", InputFormat::SpectralIlluminance);
+            m_inputs.declare("radiance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("exposure", InputFormat::Float, "0.0");
 
             m_phi_shift = deg_to_rad(m_params.get_optional<float>("horizontal_shift", 0.0f));
             m_theta_shift = deg_to_rad(m_params.get_optional<float>("vertical_shift", 0.0f));

--- a/src/appleseed/renderer/modeling/environmentedf/mirrorballmapenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/mirrorballmapenvironmentedf.cpp
@@ -83,9 +83,9 @@ namespace
             const ParamArray&       params)
           : EnvironmentEDF(name, params)
         {
-            m_inputs.declare("radiance", InputFormatSpectralIlluminance);
-            m_inputs.declare("radiance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("exposure", InputFormatFloat, "0.0");
+            m_inputs.declare("radiance", InputFormat::SpectralIlluminance);
+            m_inputs.declare("radiance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("exposure", InputFormat::Float, "0.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/environmentedf/oslenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/oslenvironmentedf.cpp
@@ -159,7 +159,7 @@ namespace
           , m_importance_map_size(0)
           , m_probability_scale(0.0f)
         {
-            m_inputs.declare("osl_background", InputFormatEntity, "");
+            m_inputs.declare("osl_background", InputFormat::Entity, "");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/environmentedf/preethamenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/preethamenvironmentedf.cpp
@@ -94,14 +94,14 @@ namespace
             const ParamArray&       params)
           : EnvironmentEDF(name, params)
         {
-            m_inputs.declare("sun_theta", InputFormatFloat);
-            m_inputs.declare("sun_phi", InputFormatFloat);
-            m_inputs.declare("turbidity", InputFormatFloat);
-            m_inputs.declare("turbidity_multiplier", InputFormatFloat, "2.0");
-            m_inputs.declare("luminance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("luminance_gamma", InputFormatFloat, "1.0");
-            m_inputs.declare("saturation_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("horizon_shift", InputFormatFloat, "0.0");
+            m_inputs.declare("sun_theta", InputFormat::Float);
+            m_inputs.declare("sun_phi", InputFormat::Float);
+            m_inputs.declare("turbidity", InputFormat::Float);
+            m_inputs.declare("turbidity_multiplier", InputFormat::Float, "2.0");
+            m_inputs.declare("luminance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("luminance_gamma", InputFormat::Float, "1.0");
+            m_inputs.declare("saturation_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("horizon_shift", InputFormat::Float, "0.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/environmentedf/preethamenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/preethamenvironmentedf.cpp
@@ -173,7 +173,7 @@ namespace
                 compute_sky_radiance(shading_context, shifted_outgoing, radiance);
             else radiance.set(0.0f);
 
-            value.set(radiance, g_std_cmf, Spectrum::Illuminance);
+            value.set(radiance, g_std_lighting_conditions, Spectrum::Illuminance);
             probability = shifted_outgoing.y > 0.0f ? shifted_outgoing.y * RcpPi<float>() : 0.0f;
             assert(probability >= 0.0f);
         }
@@ -195,7 +195,7 @@ namespace
                 compute_sky_radiance(shading_context, shifted_outgoing, radiance);
             else radiance.set(0.0f);
 
-            value.set(radiance, g_std_cmf, Spectrum::Illuminance);
+            value.set(radiance, g_std_lighting_conditions, Spectrum::Illuminance);
         }
 
         void evaluate(
@@ -216,7 +216,7 @@ namespace
                 compute_sky_radiance(shading_context, shifted_outgoing, radiance);
             else radiance.set(0.0f);
 
-            value.set(radiance, g_std_cmf, Spectrum::Illuminance);
+            value.set(radiance, g_std_lighting_conditions, Spectrum::Illuminance);
             probability = shifted_outgoing.y > 0.0f ? shifted_outgoing.y * RcpPi<float>() : 0.0f;
             assert(probability >= 0.0f);
         }

--- a/src/appleseed/renderer/modeling/environmentedf/preethamenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/preethamenvironmentedf.cpp
@@ -173,7 +173,7 @@ namespace
                 compute_sky_radiance(shading_context, shifted_outgoing, radiance);
             else radiance.set(0.0f);
 
-            value.set(radiance, g_std_lighting_conditions, Spectrum::Illuminance);
+            value.set(radiance, g_std_cmf, Spectrum::Illuminance);
             probability = shifted_outgoing.y > 0.0f ? shifted_outgoing.y * RcpPi<float>() : 0.0f;
             assert(probability >= 0.0f);
         }
@@ -195,7 +195,7 @@ namespace
                 compute_sky_radiance(shading_context, shifted_outgoing, radiance);
             else radiance.set(0.0f);
 
-            value.set(radiance, g_std_lighting_conditions, Spectrum::Illuminance);
+            value.set(radiance, g_std_cmf, Spectrum::Illuminance);
         }
 
         void evaluate(
@@ -216,7 +216,7 @@ namespace
                 compute_sky_radiance(shading_context, shifted_outgoing, radiance);
             else radiance.set(0.0f);
 
-            value.set(radiance, g_std_lighting_conditions, Spectrum::Illuminance);
+            value.set(radiance, g_std_cmf, Spectrum::Illuminance);
             probability = shifted_outgoing.y > 0.0f ? shifted_outgoing.y * RcpPi<float>() : 0.0f;
             assert(probability >= 0.0f);
         }

--- a/src/appleseed/renderer/modeling/environmentshader/backgroundenvironmentshader.cpp
+++ b/src/appleseed/renderer/modeling/environmentshader/backgroundenvironmentshader.cpp
@@ -101,7 +101,7 @@ namespace
                 SourceInputs(uv),
                 &values);
 
-            shading_result.m_main.rgb() = values.m_color.to_rgb(g_std_lighting_conditions);
+            shading_result.m_main.rgb() = values.m_color.illuminance_to_rgb(g_std_cmf);
             shading_result.m_main.a = values.m_alpha;
         }
 

--- a/src/appleseed/renderer/modeling/environmentshader/backgroundenvironmentshader.cpp
+++ b/src/appleseed/renderer/modeling/environmentshader/backgroundenvironmentshader.cpp
@@ -70,8 +70,8 @@ namespace
             const ParamArray&       params)
           : EnvironmentShader(name, params)
         {
-            m_inputs.declare("color", InputFormatSpectralIlluminance);
-            m_inputs.declare("alpha", InputFormatFloat, "1.0");
+            m_inputs.declare("color", InputFormat::SpectralIlluminance);
+            m_inputs.declare("alpha", InputFormat::Float, "1.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/environmentshader/backgroundenvironmentshader.cpp
+++ b/src/appleseed/renderer/modeling/environmentshader/backgroundenvironmentshader.cpp
@@ -101,7 +101,7 @@ namespace
                 SourceInputs(uv),
                 &values);
 
-            shading_result.m_main.rgb() = values.m_color.illuminance_to_rgb(g_std_cmf);
+            shading_result.m_main.rgb() = values.m_color.illuminance_to_rgb(g_std_lighting_conditions);
             shading_result.m_main.a = values.m_alpha;
         }
 

--- a/src/appleseed/renderer/modeling/environmentshader/edfenvironmentshader.cpp
+++ b/src/appleseed/renderer/modeling/environmentshader/edfenvironmentshader.cpp
@@ -137,7 +137,7 @@ namespace
 
             shading_components.m_emission = value;
 
-            shading_result.m_main.rgb() = value.illuminance_to_rgb(g_std_cmf);
+            shading_result.m_main.rgb() = value.illuminance_to_rgb(g_std_lighting_conditions);
             shading_result.m_main.a = m_alpha_value;
         }
 

--- a/src/appleseed/renderer/modeling/environmentshader/edfenvironmentshader.cpp
+++ b/src/appleseed/renderer/modeling/environmentshader/edfenvironmentshader.cpp
@@ -78,8 +78,8 @@ namespace
           : EnvironmentShader(name, params)
           , m_env_edf(nullptr)
         {
-            m_inputs.declare("environment_edf", InputFormatEntity);
-            m_inputs.declare("alpha_value", InputFormatFloat, "1.0");
+            m_inputs.declare("environment_edf", InputFormat::Entity);
+            m_inputs.declare("alpha_value", InputFormat::Float, "1.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/environmentshader/edfenvironmentshader.cpp
+++ b/src/appleseed/renderer/modeling/environmentshader/edfenvironmentshader.cpp
@@ -137,7 +137,7 @@ namespace
 
             shading_components.m_emission = value;
 
-            shading_result.m_main.rgb() = value.to_rgb(g_std_lighting_conditions);
+            shading_result.m_main.rgb() = value.illuminance_to_rgb(g_std_cmf);
             shading_result.m_main.a = m_alpha_value;
         }
 

--- a/src/appleseed/renderer/modeling/input/colorsource.cpp
+++ b/src/appleseed/renderer/modeling/input/colorsource.cpp
@@ -36,7 +36,6 @@
 #include "renderer/modeling/color/wavelengths.h"
 #include "renderer/modeling/entity/entity.h"
 
-
 // appleseed.foundation headers.
 #include "foundation/image/colorspace.h"
 #include "foundation/image/regularspectrum.h"
@@ -126,10 +125,10 @@ void ColorSource::initialize_from_spectrum(const ColorEntity& color_entity, cons
     }
     else
     {
-        m_spectrum.set(s, g_std_cmf, intent);
+        m_spectrum.set(s, g_std_lighting_conditions, intent);
         m_linear_rgb =
             ciexyz_to_linear_rgb(
-                spectral_illuminance_to_ciexyz<float>(g_std_cmf, s));
+                spectral_illuminance_to_ciexyz<float>(g_std_lighting_conditions, s));
     }
 }
 

--- a/src/appleseed/renderer/modeling/input/colorsource.cpp
+++ b/src/appleseed/renderer/modeling/input/colorsource.cpp
@@ -116,16 +116,15 @@ void ColorSource::initialize_from_spectrum(const ColorEntity& color_entity, cons
         &values[0],
         s);
 
+    m_spectrum.set(s, g_std_lighting_conditions, intent);
     if (intent == Spectrum::Reflectance)
     {
-        m_spectrum.set(s, g_std_lighting_conditions, intent);
         m_linear_rgb =
             ciexyz_to_linear_rgb(
                 spectral_reflectance_to_ciexyz<float>(g_std_lighting_conditions, s));
     }
     else
     {
-        m_spectrum.set(s, g_std_lighting_conditions, intent);
         m_linear_rgb =
             ciexyz_to_linear_rgb(
                 spectral_illuminance_to_ciexyz<float>(g_std_lighting_conditions, s));

--- a/src/appleseed/renderer/modeling/input/colorsource.cpp
+++ b/src/appleseed/renderer/modeling/input/colorsource.cpp
@@ -60,13 +60,13 @@ ColorSource::ColorSource(const ColorEntity& color_entity, const InputFormat form
     // Retrieve the color values.
     if (color_entity.get_color_space() == ColorSpaceSpectral)
     {
-        initialize_from_spectrum(color_entity, (format == InputFormatSpectralIlluminance ||
-            format == InputFormatSpectralIlluminanceWithAlpha) ? Spectrum::Illuminance : Spectrum::Reflectance);
+        initialize_from_spectrum(color_entity, (format == InputFormat::SpectralIlluminance ||
+            format == InputFormat::SpectralIlluminanceWithAlpha) ? Spectrum::Illuminance : Spectrum::Reflectance);
     }
     else
     {
-        initialize_from_color3(color_entity, (format == InputFormat::InputFormatSpectralIlluminance ||
-            format == InputFormatSpectralIlluminanceWithAlpha) ? Spectrum::Illuminance : Spectrum::Reflectance);
+        initialize_from_color3(color_entity, (format == InputFormat::SpectralIlluminance ||
+            format == InputFormat::SpectralIlluminanceWithAlpha) ? Spectrum::Illuminance : Spectrum::Reflectance);
     }
 
     // Apply the multiplier to the color values.

--- a/src/appleseed/renderer/modeling/input/colorsource.h
+++ b/src/appleseed/renderer/modeling/input/colorsource.h
@@ -31,8 +31,8 @@
 
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
-#include "renderer/modeling/input/source.h"
 #include "renderer/modeling/input/inputarray.h"
+#include "renderer/modeling/input/source.h"
 
 // appleseed.foundation headers.
 #include "foundation/image/color.h"

--- a/src/appleseed/renderer/modeling/input/colorsource.h
+++ b/src/appleseed/renderer/modeling/input/colorsource.h
@@ -32,6 +32,7 @@
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
 #include "renderer/modeling/input/source.h"
+#include "renderer/modeling/input/inputarray.h"
 
 // appleseed.foundation headers.
 #include "foundation/image/color.h"
@@ -55,7 +56,7 @@ class ColorSource
 {
   public:
     // Constructor.
-    explicit ColorSource(const ColorEntity& color_entity);
+    explicit ColorSource(const ColorEntity& color_entity, const InputFormat format);
 
     // Retrieve the color entity used by this source.
     const ColorEntity& get_color_entity() const;
@@ -89,8 +90,8 @@ class ColorSource
     Spectrum                        m_spectrum;
     Alpha                           m_alpha;
 
-    void initialize_from_spectrum(const ColorEntity& color_entity);
-    void initialize_from_color3(const ColorEntity& color_entity);
+    void initialize_from_spectrum(const ColorEntity& color_entity, const Spectrum::Intent intent);
+    void initialize_from_color3(const ColorEntity& color_entity, const Spectrum::Intent intent);
 };
 
 

--- a/src/appleseed/renderer/modeling/input/inputarray.cpp
+++ b/src/appleseed/renderer/modeling/input/inputarray.cpp
@@ -93,25 +93,25 @@ namespace
         {
             switch (m_format)
             {
-              case InputFormatFloat:
+              case InputFormat::Float:
                 size = align_to<float>(size);
                 size += sizeof(float);
                 break;
 
-              case InputFormatSpectralReflectance:
-              case InputFormatSpectralIlluminance:
+              case InputFormat::SpectralReflectance:
+              case InputFormat::SpectralIlluminance:
                 size = align_to<Spectrum>(size);
                 size += sizeof(Spectrum);
                 break;
 
-              case InputFormatSpectralReflectanceWithAlpha:
-              case InputFormatSpectralIlluminanceWithAlpha:
+              case InputFormat::SpectralReflectanceWithAlpha:
+              case InputFormat::SpectralIlluminanceWithAlpha:
                 size = align_to<Spectrum>(size);
                 size += sizeof(Spectrum);
                 size += sizeof(Alpha);
                 break;
 
-              case InputFormatEntity:
+              case InputFormat::Entity:
                 // Nothing to do.
                 break;
 
@@ -128,7 +128,7 @@ namespace
         {
             switch (m_format)
             {
-              case InputFormatFloat:
+              case InputFormat::Float:
                 {
                     ptr = align_to<float>(ptr);
                     float* out_scalar = reinterpret_cast<float*>(ptr);
@@ -141,7 +141,7 @@ namespace
                 }
                 break;
 
-              case InputFormatSpectralReflectance:
+              case InputFormat::SpectralReflectance:
                 {
                     ptr = align_to<Spectrum>(ptr);
                     Spectrum* out_spectrum = reinterpret_cast<Spectrum*>(ptr);
@@ -156,7 +156,7 @@ namespace
                 }
                 break;
 
-              case InputFormatSpectralIlluminance:
+              case InputFormat::SpectralIlluminance:
                 {
                     ptr = align_to<Spectrum>(ptr);
                     Spectrum* out_spectrum = reinterpret_cast<Spectrum*>(ptr);
@@ -171,7 +171,7 @@ namespace
                 }
                 break;
 
-              case InputFormatSpectralReflectanceWithAlpha:
+              case InputFormat::SpectralReflectanceWithAlpha:
                 {
                     ptr = align_to<Spectrum>(ptr);
                     Spectrum* out_spectrum = reinterpret_cast<Spectrum*>(ptr);
@@ -193,7 +193,7 @@ namespace
                 }
                 break;
 
-              case InputFormatSpectralIlluminanceWithAlpha:
+              case InputFormat::SpectralIlluminanceWithAlpha:
                 {
                     ptr = align_to<Spectrum>(ptr);
                     Spectrum* out_spectrum = reinterpret_cast<Spectrum*>(ptr);
@@ -215,7 +215,7 @@ namespace
                 }
                 break;
 
-              case InputFormatEntity:
+              case InputFormat::Entity:
                 // Nothing to do.
                 break;
 
@@ -229,7 +229,7 @@ namespace
         {
             switch (m_format)
             {
-              case InputFormatFloat:
+              case InputFormat::Float:
                 {
                     ptr = align_to<float>(ptr);
                     float* out_scalar = reinterpret_cast<float*>(ptr);
@@ -242,7 +242,7 @@ namespace
                 }
                 break;
 
-              case InputFormatSpectralReflectance:
+              case InputFormat::SpectralReflectance:
                 {
                     ptr = align_to<Spectrum>(ptr);
                     Spectrum* out_spectrum = reinterpret_cast<Spectrum*>(ptr);
@@ -257,7 +257,7 @@ namespace
                 }
                 break;
 
-              case InputFormatSpectralIlluminance:
+              case InputFormat::SpectralIlluminance:
                 {
                     ptr = align_to<Spectrum>(ptr);
                     Spectrum* out_spectrum = reinterpret_cast<Spectrum*>(ptr);
@@ -272,7 +272,7 @@ namespace
                 }
                 break;
 
-              case InputFormatSpectralReflectanceWithAlpha:
+              case InputFormat::SpectralReflectanceWithAlpha:
                 {
                     ptr = align_to<Spectrum>(ptr);
                     Spectrum* out_spectrum = reinterpret_cast<Spectrum*>(ptr);
@@ -294,7 +294,7 @@ namespace
                 }
                 break;
 
-              case InputFormatSpectralIlluminanceWithAlpha:
+              case InputFormat::SpectralIlluminanceWithAlpha:
                 {
                     ptr = align_to<Spectrum>(ptr);
                     Spectrum* out_spectrum = reinterpret_cast<Spectrum*>(ptr);
@@ -316,7 +316,7 @@ namespace
                 }
                 break;
 
-              case InputFormatEntity:
+              case InputFormat::Entity:
                 // Nothing to do.
                 break;
 

--- a/src/appleseed/renderer/modeling/input/inputarray.h
+++ b/src/appleseed/renderer/modeling/input/inputarray.h
@@ -53,14 +53,14 @@ namespace renderer
 // Input formats.
 //
 
-enum InputFormat
+enum class InputFormat
 {
-    InputFormatFloat,
-    InputFormatSpectralReflectance,
-    InputFormatSpectralIlluminance,
-    InputFormatSpectralReflectanceWithAlpha,
-    InputFormatSpectralIlluminanceWithAlpha,
-    InputFormatEntity
+    Float,
+    SpectralReflectance,
+    SpectralIlluminance,
+    SpectralReflectanceWithAlpha,
+    SpectralIlluminanceWithAlpha,
+    Entity
 };
 
 

--- a/src/appleseed/renderer/modeling/input/inputbinder.cpp
+++ b/src/appleseed/renderer/modeling/input/inputbinder.cpp
@@ -556,7 +556,7 @@ bool InputBinder::try_bind_scene_entity_to_input(
     const char*                     param_value,
     InputArray::iterator&           input)
 {
-    if (input.format() == InputFormatEntity)
+    if (input.format() == InputFormat::Entity)
     {
         #define BIND(symbol, collection)                        \
             case symbol:                                        \
@@ -637,7 +637,7 @@ bool InputBinder::try_bind_assembly_entity_to_input(
     const char*                     param_value,
     InputArray::iterator&           input)
 {
-    if (input.format() == InputFormatEntity)
+    if (input.format() == InputFormat::Entity)
     {
         #define BIND(symbol, collection)                        \
             case symbol:                                        \

--- a/src/appleseed/renderer/modeling/input/inputbinder.cpp
+++ b/src/appleseed/renderer/modeling/input/inputbinder.cpp
@@ -720,7 +720,7 @@ void InputBinder::bind_color_to_input(
     const ColorEntity* color_entity = colors.get_by_name(param_value);
     assert(color_entity);
 
-    input.bind(new ColorSource(*color_entity));
+    input.bind(new ColorSource(*color_entity, input.format()));
 }
 
 void InputBinder::bind_texture_instance_to_input(

--- a/src/appleseed/renderer/modeling/light/directionallight.cpp
+++ b/src/appleseed/renderer/modeling/light/directionallight.cpp
@@ -77,9 +77,9 @@ namespace
             const ParamArray&       params)
           : Light(name, params)
         {
-            m_inputs.declare("irradiance", InputFormatSpectralIlluminance);
-            m_inputs.declare("irradiance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("exposure", InputFormatFloat, "0.0");
+            m_inputs.declare("irradiance", InputFormat::SpectralIlluminance);
+            m_inputs.declare("irradiance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("exposure", InputFormat::Float, "0.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/light/maxomnilight.cpp
+++ b/src/appleseed/renderer/modeling/light/maxomnilight.cpp
@@ -74,8 +74,8 @@ namespace
             const ParamArray&       params)
           : Light(name, params)
         {
-            m_inputs.declare("intensity", InputFormatSpectralIlluminance);
-            m_inputs.declare("intensity_multiplier", InputFormatFloat, "1.0");
+            m_inputs.declare("intensity", InputFormat::SpectralIlluminance);
+            m_inputs.declare("intensity_multiplier", InputFormat::Float, "1.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/light/maxspotlight.cpp
+++ b/src/appleseed/renderer/modeling/light/maxspotlight.cpp
@@ -78,8 +78,8 @@ namespace
             const ParamArray&       params)
           : Light(name, params)
         {
-            m_inputs.declare("intensity", InputFormatSpectralIlluminance);
-            m_inputs.declare("intensity_multiplier", InputFormatFloat, "1.0");
+            m_inputs.declare("intensity", InputFormat::SpectralIlluminance);
+            m_inputs.declare("intensity_multiplier", InputFormat::Float, "1.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/light/pointlight.cpp
+++ b/src/appleseed/renderer/modeling/light/pointlight.cpp
@@ -73,9 +73,9 @@ namespace
             const ParamArray&       params)
           : Light(name, params)
         {
-            m_inputs.declare("intensity", InputFormatSpectralIlluminance);
-            m_inputs.declare("intensity_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("exposure", InputFormatFloat, "0.0");
+            m_inputs.declare("intensity", InputFormat::SpectralIlluminance);
+            m_inputs.declare("intensity_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("exposure", InputFormat::Float, "0.0");
 
             // Point lights can be used by the LightTree.
             m_flags |= LightTreeCompatible;

--- a/src/appleseed/renderer/modeling/light/spotlight.cpp
+++ b/src/appleseed/renderer/modeling/light/spotlight.cpp
@@ -78,7 +78,7 @@ namespace
             const ParamArray&       params)
           : Light(name, params)
         {
-            m_inputs.declare("intensity", InputFormatSpectralIlluminance);
+            m_inputs.declare("intensity", InputFormatFloat);
             m_inputs.declare("intensity_multiplier", InputFormatFloat, "1.0");
             m_inputs.declare("exposure", InputFormatFloat, "0.0");
         }

--- a/src/appleseed/renderer/modeling/light/spotlight.cpp
+++ b/src/appleseed/renderer/modeling/light/spotlight.cpp
@@ -78,9 +78,9 @@ namespace
             const ParamArray&       params)
           : Light(name, params)
         {
-            m_inputs.declare("intensity", InputFormatFloat);
-            m_inputs.declare("intensity_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("exposure", InputFormatFloat, "0.0");
+            m_inputs.declare("intensity", InputFormat::Float);
+            m_inputs.declare("intensity_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("exposure", InputFormat::Float, "0.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/light/sunlight.cpp
+++ b/src/appleseed/renderer/modeling/light/sunlight.cpp
@@ -95,11 +95,11 @@ namespace
             const ParamArray&       params)
           : Light(name, params)
         {
-            m_inputs.declare("environment_edf", InputFormatEntity, "");
-            m_inputs.declare("turbidity", InputFormatFloat);
-            m_inputs.declare("radiance_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("size_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("distance", InputFormatFloat, "149.6");
+            m_inputs.declare("environment_edf", InputFormat::Entity, "");
+            m_inputs.declare("turbidity", InputFormat::Float);
+            m_inputs.declare("radiance_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("size_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("distance", InputFormat::Float, "149.6");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/material/genericmaterial.cpp
+++ b/src/appleseed/renderer/modeling/material/genericmaterial.cpp
@@ -59,12 +59,12 @@ namespace
             const ParamArray&       params)
           : Material(name, params)
         {
-            m_inputs.declare("bsdf", InputFormatEntity, "");
-            m_inputs.declare("bssrdf", InputFormatEntity, "");
-            m_inputs.declare("edf", InputFormatEntity, "");
-            m_inputs.declare("alpha_map", InputFormatFloat, "");
-            m_inputs.declare("displacement_map", InputFormatSpectralReflectance, "");
-            m_inputs.declare("volume", InputFormatEntity, "");
+            m_inputs.declare("bsdf", InputFormat::Entity, "");
+            m_inputs.declare("bssrdf", InputFormat::Entity, "");
+            m_inputs.declare("edf", InputFormat::Entity, "");
+            m_inputs.declare("alpha_map", InputFormat::Float, "");
+            m_inputs.declare("displacement_map", InputFormat::SpectralReflectance, "");
+            m_inputs.declare("volume", InputFormat::Entity, "");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/material/material.cpp
+++ b/src/appleseed/renderer/modeling/material/material.cpp
@@ -106,7 +106,7 @@ Material::Material(
 {
     set_name(name);
 
-    m_inputs.declare("surface_shader", InputFormatEntity, "");
+    m_inputs.declare("surface_shader", InputFormat::Entity, "");
 }
 
 const char* Material::get_surface_shader_name() const

--- a/src/appleseed/renderer/modeling/material/oslmaterial.cpp
+++ b/src/appleseed/renderer/modeling/material/oslmaterial.cpp
@@ -66,8 +66,8 @@ namespace
             const ParamArray&       params)
           : Material(name, params)
         {
-            m_inputs.declare("osl_surface", InputFormatEntity, "");
-            m_inputs.declare("alpha_map", InputFormatFloat, "");
+            m_inputs.declare("osl_surface", InputFormat::Entity, "");
+            m_inputs.declare("alpha_map", InputFormat::Float, "");
 
             m_osl_bsdf = OSLBSDFFactory().create();
             m_osl_bssrdf = OSLBSSRDFFactory().create();

--- a/src/appleseed/renderer/modeling/object/meshobject.cpp
+++ b/src/appleseed/renderer/modeling/object/meshobject.cpp
@@ -73,7 +73,7 @@ MeshObject::MeshObject(
   : Object(name, params)
   , impl(new Impl())
 {
-    m_inputs.declare("alpha_map", InputFormatFloat, "");
+    m_inputs.declare("alpha_map", InputFormat::Float, "");
 }
 
 MeshObject::~MeshObject()

--- a/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
@@ -564,7 +564,7 @@ namespace
 
                     if (color)
                     {
-                        const ColorSource source(*color);
+                        const ColorSource source(*color, InputFormatSpectralReflectance);
 
                         float mdf_param_value;
                         source.evaluate_uniform(mdf_param_value);

--- a/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
@@ -564,7 +564,7 @@ namespace
 
                     if (color)
                     {
-                        const ColorSource source(*color, InputFormatSpectralReflectance);
+                        const ColorSource source(*color, InputFormat::SpectralReflectance);
 
                         float mdf_param_value;
                         source.evaluate_uniform(mdf_param_value);

--- a/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
@@ -120,7 +120,7 @@ namespace
                 &values);
 
             // Initialize the shading result.
-            shading_result.m_main.rgb() = values.m_color.illuminance_to_ciexyz(g_std_cmf);
+            shading_result.m_main.rgb() = values.m_color.illuminance_to_rgb(g_std_lighting_conditions);
 
             // This surface shader can override alpha.
             if (m_alpha_source == AlphaSourceColor)

--- a/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
@@ -120,7 +120,7 @@ namespace
                 &values);
 
             // Initialize the shading result.
-            shading_result.m_main.rgb() = values.m_color.to_rgb(g_std_lighting_conditions);
+            shading_result.m_main.rgb() = values.m_color.illuminance_to_ciexyz(g_std_cmf);
 
             // This surface shader can override alpha.
             if (m_alpha_source == AlphaSourceColor)

--- a/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/constantsurfaceshader.cpp
@@ -74,9 +74,9 @@ namespace
             const ParamArray&           params)
           : SurfaceShader(name, params)
         {
-            m_inputs.declare("color", InputFormatSpectralIlluminanceWithAlpha);
-            m_inputs.declare("color_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("alpha_multiplier", InputFormatFloat, "1.0");
+            m_inputs.declare("color", InputFormat::SpectralIlluminanceWithAlpha);
+            m_inputs.declare("color_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("alpha_multiplier", InputFormat::Float, "1.0");
 
             const std::string alpha_source = m_params.get_optional<std::string>("alpha_source", "color");
             if (alpha_source == "color")

--- a/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
@@ -271,7 +271,7 @@ namespace
         ShadingResult&  shading_result,
         const Spectrum& value)
     {
-        shading_result.m_main.rgb() = value.to_rgb(g_std_lighting_conditions);
+        shading_result.m_main.rgb() = value.illuminance_to_ciexyz(g_std_cmf);
         shading_result.m_main.a = 1.0f;
     }
 }

--- a/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/diagnosticsurfaceshader.cpp
@@ -271,7 +271,7 @@ namespace
         ShadingResult&  shading_result,
         const Spectrum& value)
     {
-        shading_result.m_main.rgb() = value.illuminance_to_ciexyz(g_std_cmf);
+        shading_result.m_main.rgb() = value.illuminance_to_rgb(g_std_lighting_conditions);
         shading_result.m_main.a = 1.0f;
     }
 }

--- a/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
@@ -160,7 +160,7 @@ namespace
             }
 
             shading_result.m_main.rgb() =
-                shading_components.m_beauty.to_rgb(g_std_lighting_conditions);
+                shading_components.m_beauty.illuminance_to_rgb(g_std_cmf);
         }
 
       private:

--- a/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
@@ -78,8 +78,8 @@ namespace
             const ParamArray&           params)
           : SurfaceShader(name, params)
         {
-            m_inputs.declare("color_multiplier", InputFormatFloat, "1.0");
-            m_inputs.declare("alpha_multiplier", InputFormatFloat, "1.0");
+            m_inputs.declare("color_multiplier", InputFormat::Float, "1.0");
+            m_inputs.declare("alpha_multiplier", InputFormat::Float, "1.0");
         }
 
         void release() override

--- a/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
+++ b/src/appleseed/renderer/modeling/surfaceshader/physicalsurfaceshader.cpp
@@ -160,7 +160,7 @@ namespace
             }
 
             shading_result.m_main.rgb() =
-                shading_components.m_beauty.illuminance_to_rgb(g_std_cmf);
+                shading_components.m_beauty.illuminance_to_rgb(g_std_lighting_conditions);
         }
 
       private:

--- a/src/appleseed/renderer/modeling/volume/genericvolume.cpp
+++ b/src/appleseed/renderer/modeling/volume/genericvolume.cpp
@@ -71,11 +71,11 @@ class GenericVolume
         const ParamArray&   params)
       : Volume(name, params)
     {
-        m_inputs.declare("absorption", InputFormatSpectralReflectance);
-        m_inputs.declare("absorption_multiplier", InputFormatFloat, "1.0");
-        m_inputs.declare("scattering", InputFormatSpectralReflectance);
-        m_inputs.declare("scattering_multiplier", InputFormatFloat, "1.0");
-        m_inputs.declare("average_cosine", InputFormatFloat, "0.0");
+        m_inputs.declare("absorption", InputFormat::SpectralReflectance);
+        m_inputs.declare("absorption_multiplier", InputFormat::Float, "1.0");
+        m_inputs.declare("scattering", InputFormat::SpectralReflectance);
+        m_inputs.declare("scattering_multiplier", InputFormat::Float, "1.0");
+        m_inputs.declare("average_cosine", InputFormat::Float, "0.0");
     }
 
     void release() override

--- a/src/appleseed/renderer/utility/dynamicspectrum.h
+++ b/src/appleseed/renderer/utility/dynamicspectrum.h
@@ -496,7 +496,7 @@ inline foundation::Color<T, 3> DynamicSpectrum<T, N>::reflectance_to_rgb(
         s_mode == RGB
             ? foundation::Color<T, 3>(m_samples[0], m_samples[1], m_samples[2])
             : foundation::ciexyz_to_linear_rgb(
-                  foundation::spectral_reflectance_to_ciexyz<T>(lighting_conditions, *this));
+                foundation::spectral_reflectance_to_ciexyz<T>(lighting_conditions, *this));
 }
 
 template <typename T, size_t N>
@@ -505,9 +505,9 @@ inline foundation::Color<T, 3> DynamicSpectrum<T, N>::illuminance_to_rgb(
 {
     return
         s_mode == RGB
-        ? foundation::Color<T, 3>(m_samples[0], m_samples[1], m_samples[2])
-        : foundation::ciexyz_to_linear_rgb(
-            foundation::spectral_illuminance_to_ciexyz<T>(lighting_conditions, *this));
+            ? foundation::Color<T, 3>(m_samples[0], m_samples[1], m_samples[2])
+            : foundation::ciexyz_to_linear_rgb(
+                foundation::spectral_illuminance_to_ciexyz<T>(lighting_conditions, *this));
 }
 
 template <typename T, size_t N>
@@ -517,7 +517,7 @@ inline foundation::Color<T, 3> DynamicSpectrum<T, N>::reflectance_to_ciexyz(
     return
         s_mode == RGB
             ? linear_rgb_to_ciexyz(
-                  foundation::Color<T, 3>(m_samples[0], m_samples[1], m_samples[2]))
+                foundation::Color<T, 3>(m_samples[0], m_samples[1], m_samples[2]))
             : foundation::spectral_reflectance_to_ciexyz<T>(lighting_conditions, *this);
 }
 
@@ -527,9 +527,9 @@ inline foundation::Color<T, 3> DynamicSpectrum<T, N>::illuminance_to_ciexyz(
 {
     return
         s_mode == RGB
-        ? linear_rgb_to_ciexyz(
-            foundation::Color<T, 3>(m_samples[0], m_samples[1], m_samples[2]))
-        : foundation::spectral_illuminance_to_ciexyz<T>(lighting_conditions, *this);
+            ? linear_rgb_to_ciexyz(
+                foundation::Color<T, 3>(m_samples[0], m_samples[1], m_samples[2]))
+            : foundation::spectral_illuminance_to_ciexyz<T>(lighting_conditions, *this);
 }
 
 template <typename T, size_t N>

--- a/src/appleseed/renderer/utility/rgbspectrum.h
+++ b/src/appleseed/renderer/utility/rgbspectrum.h
@@ -390,9 +390,18 @@ void RGBSpectrum<T>::set(
     const foundation::LightingConditions&               lighting_conditions,
     const Intent                                        intent)
 {
-    reinterpret_cast<foundation::Color<T, 3>&>(m_samples[0]) =
-        foundation::ciexyz_to_linear_rgb(
-            foundation::spectrum_to_ciexyz<T>(lighting_conditions, spectrum));
+    if (intent == Reflectance)
+    {
+        reinterpret_cast<foundation::Color<T, 3>&>(m_samples[0]) =
+            foundation::ciexyz_to_linear_rgb(
+                foundation::spectral_reflectance_to_ciexyz<T>(lighting_conditions, spectrum));
+    }
+    else
+    {
+        reinterpret_cast<foundation::Color<T, 3>&>(m_samples[0]) =
+            foundation::ciexyz_to_linear_rgb(
+                foundation::spectral_illuminance_to_ciexyz<T>(spectrum));
+    }
 }
 
 template <typename T>


### PR DESCRIPTION
Hey guys, this is what I was working at before I stopped last year ...
This basically fix the green/blue tints when physically rendering sky:

![appleseed](https://user-images.githubusercontent.com/43460229/77813852-bf917480-708a-11ea-98e6-09817a2fff77.png)

This also improve conversion from cieXYZ to spectrum.

I changed the cornell box light radiance to the one used in: https://www.graphics.cornell.edu/online/box/data.html, I don't know where does your current data come from. But it got I bit reddish after the change:

![1_appleseed_new](https://user-images.githubusercontent.com/43460229/77814341-f1a4d580-708e-11ea-9f33-a284c4db232e.png)

Using data from https://www.graphics.cornell.edu/online/box/data.html,:
![1_appleseed_new_original_values](https://user-images.githubusercontent.com/43460229/77814361-1bf69300-708f-11ea-96ee-42af7d7a226f.png)