### PR TITLE
Optimize OSL shaders before on_render_begin is called

### DIFF
--- a/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
@@ -343,6 +343,21 @@ struct MasterRenderer::Impl
         // Construct an abort switch that will allow to abort initialization or rendering.
         RendererControllerAbortSwitch abort_switch(renderer_controller);
 
+        // Initialize the render device.
+        const bool success =
+            m_render_device->initialize(
+                m_resource_search_paths,
+                m_tile_callback_factory,
+                abort_switch);
+        if (!success || abort_switch.is_aborted())
+        {
+            // If it wasn't an abort, it was a failure.
+            return
+                abort_switch.is_aborted()
+                    ? renderer_controller.get_status()
+                    : IRendererController::AbortRendering;
+        }
+
         // Let scene entities perform their pre-render actions. Don't proceed if that failed.
         // This is done before creating renderer components because renderer components need
         // to access the scene's render data such as the scene's bounding box.
@@ -352,23 +367,6 @@ struct MasterRenderer::Impl
         {
             recorder.on_render_end(m_project);
             return renderer_controller.get_status();
-        }
-
-        // Initialize the render device.
-        const bool success =
-            m_render_device->initialize(
-                m_resource_search_paths,
-                m_tile_callback_factory,
-                abort_switch);
-        if (!success || abort_switch.is_aborted())
-        {
-            recorder.on_render_end(m_project);
-
-            // If it wasn't an abort, it was a failure.
-            return
-                abort_switch.is_aborted()
-                    ? renderer_controller.get_status()
-                    : IRendererController::AbortRendering;
         }
 
         // Print render device settings.


### PR DESCRIPTION
This will allow building the importance map for OSL environments in on_render_begin.