### PR TITLE
Shorten critical section when developing accumulation buffer to frame

### DIFF
--- a/src/appleseed/renderer/kernel/rendering/localsampleaccumulationbuffer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/localsampleaccumulationbuffer.cpp
@@ -92,6 +92,7 @@ LocalSampleAccumulationBuffer::LocalSampleAccumulationBuffer(
     while (true)
     {
         m_levels.push_back(new AccumulatorTile(level_width, level_height, 4));
+        m_read_levels.push_back(new AccumulatorTile(level_width, level_height, 4));
         m_level_scales.push_back(
             Vector2f(
                 static_cast<float>(level_width) / width,
@@ -276,10 +277,7 @@ void LocalSampleAccumulationBuffer::develop_to_frame(
         for (size_t tx = 0; tx < frame_props.m_tile_count_x; ++tx)
         {
             if (abort_switch.is_aborted())
-            {
-                m_lock.unlock_write();
                 return;
-            }
 
             const size_t origin_x = tx * frame_props.m_tile_width;
             const size_t origin_y = ty * frame_props.m_tile_height;

--- a/src/appleseed/renderer/kernel/rendering/localsampleaccumulationbuffer.h
+++ b/src/appleseed/renderer/kernel/rendering/localsampleaccumulationbuffer.h
@@ -96,6 +96,7 @@ class LocalSampleAccumulationBuffer
 
     LockType                                    m_lock;
     std::vector<foundation::AccumulatorTile*>   m_levels;
+    std::vector<foundation::AccumulatorTile*>   m_read_levels;
     std::vector<foundation::Vector2f>           m_level_scales;
     boost::atomic<std::int32_t>*                m_remaining_pixels;
     boost::atomic<std::uint32_t>                m_active_level;


### PR DESCRIPTION
When using interactive rendering the rendering is restarted often when updating the camera transformation.
A lot of time is spend developing the AccumulatorTile to the Frame at higher active frame levels. This is a serial bottleneck when rendering a frame.
By copying the AccumulatorTile in the critical section and developing outside,
more time can be spend in the renders threads, resulting in a less noisy overal image when interacting.
The cost is double the memory for the LocalSampleAccumulationBuffer.