### PR TITLE
Enable OSL importance map build in on_render_begin

### DIFF
--- a/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
@@ -343,6 +343,13 @@ struct MasterRenderer::Impl
         // Construct an abort switch that will allow to abort initialization or rendering.
         RendererControllerAbortSwitch abort_switch(renderer_controller);
 
+        // Initialize the render device. Here is OSL shader compilation performed.
+        const bool success =
+            m_render_device->initialize(
+                m_resource_search_paths,
+                m_tile_callback_factory,
+                abort_switch);
+
         // Let scene entities perform their pre-render actions. Don't proceed if that failed.
         // This is done before creating renderer components because renderer components need
         // to access the scene's render data such as the scene's bounding box.
@@ -354,12 +361,6 @@ struct MasterRenderer::Impl
             return renderer_controller.get_status();
         }
 
-        // Initialize the render device.
-        const bool success =
-            m_render_device->initialize(
-                m_resource_search_paths,
-                m_tile_callback_factory,
-                abort_switch);
         if (!success || abort_switch.is_aborted())
         {
             recorder.on_render_end(m_project);

--- a/src/appleseed/renderer/modeling/environmentedf/oslenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/oslenvironmentedf.cpp
@@ -186,6 +186,15 @@ namespace
             m_shader_group =
                 static_cast<ShaderGroup*>(m_inputs.get_entity("osl_background"));
 
+            if (!m_importance_sampler || m_shader_group->get_version_id() != m_shader_group_version_id)
+            {
+                m_shader_group_version_id = m_shader_group->get_version_id();
+
+                // Build importance map only if this environment EDF is the active one.
+                if (project.get_scene()->get_environment()->get_uncached_environment_edf() == this)
+                    build_importance_map(project, abort_switch);
+            }
+
             return true;
         }
 
@@ -200,15 +209,6 @@ namespace
 
             m_shader_group =
                 static_cast<ShaderGroup*>(m_inputs.get_entity("osl_background"));
-
-            if (!m_importance_sampler || m_shader_group->get_version_id() != m_shader_group_version_id)
-            {
-                m_shader_group_version_id = m_shader_group->get_version_id();
-
-                // Build importance map only if this environment EDF is the active one.
-                if (project.get_scene()->get_environment()->get_uncached_environment_edf() == this)
-                    build_importance_map(project, abort_switch);
-            }
 
             return true;
         }


### PR DESCRIPTION
### Intro
This PR is for issue  #2808. Investigate there for more introduction information.

### Contribution
* Moving `build_importance_map()` from `on_frame_begin()` to `on_render_begin()` in `OSLEnvironmentEDF`. This enables less workload in `on_frame_begin()`.
* Moving `m_render_device->initialize()` before `on_render_begin()` in `initialize_and_render_frame()` in `masterrenderer.cpp`. This enables OSL shader compilation before work in `on_render_begin()` is performed in entity (this case in `OSLEnvironmentEDF` entity).

### Further work
Passing the shading system as an argument in `on_render_begin()`.