### PR TITLE
Remove unused includes from asr/modeling (part 1)

### DIFF
--- a/src/appleseed/renderer/modeling/bsdf/blinnbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/blinnbrdf.cpp
@@ -38,26 +38,19 @@
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 #include "renderer/modeling/bsdf/fresnel.h"
 #include "renderer/modeling/bsdf/microfacethelper.h"
-#include "renderer/utility/messagecontext.h"
 #include "renderer/utility/paramarray.h"
 
 // appleseed.foundation headers.
 #include "foundation/containers/dictionary.h"
-#include "foundation/math/basis.h"
 #include "foundation/math/dual.h"
 #include "foundation/math/microfacet.h"
-#include "foundation/math/minmax.h"
-#include "foundation/math/sampling/mappings.h"
 #include "foundation/math/vector.h"
 #include "foundation/utility/api/specializedapiarrays.h"
 #include "foundation/utility/makevector.h"
-#include "foundation/utility/otherwise.h"
 
 // Standard headers.
-#include <algorithm>
 #include <cmath>
 #include <cstddef>
-#include <string>
 
 // Forward declarations.
 namespace foundation    { class IAbortSwitch; }

--- a/src/appleseed/renderer/modeling/bsdf/bsdfblend.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfblend.cpp
@@ -41,7 +41,6 @@
 
 // appleseed.foundation headers.
 #include "foundation/containers/dictionary.h"
-#include "foundation/math/basis.h"
 #include "foundation/math/dual.h"
 #include "foundation/math/vector.h"
 #include "foundation/memory/arena.h"

--- a/src/appleseed/renderer/modeling/bsdf/bsdfblend.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfblend.h
@@ -34,7 +34,6 @@
 
 // appleseed.foundation headers.
 #include "foundation/memory/autoreleaseptr.h"
-#include "foundation/platform/compiler.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"

--- a/src/appleseed/renderer/modeling/bsdf/bsdfmix.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfmix.cpp
@@ -41,7 +41,6 @@
 
 // appleseed.foundation headers.
 #include "foundation/containers/dictionary.h"
-#include "foundation/math/basis.h"
 #include "foundation/math/dual.h"
 #include "foundation/math/vector.h"
 #include "foundation/memory/arena.h"

--- a/src/appleseed/renderer/modeling/bsdf/bsdfmix.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfmix.h
@@ -34,7 +34,6 @@
 
 // appleseed.foundation headers.
 #include "foundation/memory/autoreleaseptr.h"
-#include "foundation/platform/compiler.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"

--- a/src/appleseed/renderer/modeling/bsdf/bsdfsample.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfsample.cpp
@@ -33,7 +33,6 @@
 #include "foundation/math/basis.h"
 
 // Standard headers.
-#include <algorithm>
 #include <cmath>
 
 using namespace foundation;

--- a/src/appleseed/renderer/modeling/bsdf/bsdfsample.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfsample.h
@@ -37,7 +37,6 @@
 
 // appleseed.foundation headers.
 #include "foundation/math/dual.h"
-#include "foundation/math/vector.h"
 
 // Standard headers.
 #include <cassert>

--- a/src/appleseed/renderer/modeling/bsdf/bsdfwrapper.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfwrapper.h
@@ -32,7 +32,6 @@
 // appleseed.renderer headers.
 #include "renderer/global/globaltypes.h"
 #include "renderer/kernel/shading/directshadingcomponents.h"
-#include "renderer/kernel/shading/shadingpoint.h"
 #include "renderer/modeling/bsdf/bsdfsample.h"
 #include "renderer/modeling/scene/objectinstance.h"
 #include "renderer/utility/shadowterminator.h"

--- a/src/appleseed/renderer/modeling/bsdf/diffusebtdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/diffusebtdf.cpp
@@ -48,7 +48,6 @@
 #include "foundation/utility/api/specializedapiarrays.h"
 
 // Standard headers.
-#include <algorithm>
 #include <cmath>
 #include <cstddef>
 

--- a/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/disneybrdf.cpp
@@ -36,14 +36,12 @@
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 #include "renderer/modeling/bsdf/microfacethelper.h"
 #include "renderer/modeling/color/colorspace.h"
-#include "renderer/modeling/color/wavelengths.h"
 
 // appleseed.foundation headers.
 #include "foundation/containers/dictionary.h"
 #include "foundation/image/colorspace.h"
 #include "foundation/math/basis.h"
 #include "foundation/math/dual.h"
-#include "foundation/math/fresnel.h"
 #include "foundation/math/microfacet.h"
 #include "foundation/math/sampling/mappings.h"
 #include "foundation/math/scalar.h"

--- a/src/appleseed/renderer/modeling/bsdf/disneylayeredbrdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/disneylayeredbrdf.h
@@ -33,11 +33,9 @@
 #include "renderer/modeling/bsdf/bsdf.h"
 
 // appleseed.foundation headers.
-#include "foundation/math/basis.h"
 #include "foundation/math/dual.h"
 #include "foundation/math/vector.h"
 #include "foundation/memory/autoreleaseptr.h"
-#include "foundation/platform/compiler.h"
 
 // Standard headers.
 #include <cstddef>

--- a/src/appleseed/renderer/modeling/bsdf/energycompensation.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/energycompensation.cpp
@@ -30,13 +30,11 @@
 #include "energycompensation.h"
 
 // appleseed.foundation headers.
-#include "foundation/core/concepts/noncopyable.h"
 #include "foundation/image/color.h"
 #include "foundation/image/genericimagefilewriter.h"
 #include "foundation/image/image.h"
 #include "foundation/image/tile.h"
 #include "foundation/math/scalar.h"
-#include "foundation/math/vector.h"
 
 // Boost headers.
 #include "boost/filesystem/fstream.hpp"

--- a/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glassbsdf.cpp
@@ -48,8 +48,6 @@
 #include "foundation/math/dual.h"
 #include "foundation/math/fresnel.h"
 #include "foundation/math/microfacet.h"
-#include "foundation/math/minmax.h"
-#include "foundation/math/sampling/mappings.h"
 #include "foundation/math/scalar.h"
 #include "foundation/math/vector.h"
 #include "foundation/utility/api/specializedapiarrays.h"

--- a/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/glossybrdf.cpp
@@ -39,7 +39,6 @@
 #include "renderer/modeling/bsdf/fresnel.h"
 #include "renderer/modeling/bsdf/microfacethelper.h"
 #include "renderer/modeling/bsdf/specularhelper.h"
-#include "renderer/utility/messagecontext.h"
 #include "renderer/utility/paramarray.h"
 
 // appleseed.foundation headers.
@@ -47,18 +46,14 @@
 #include "foundation/math/basis.h"
 #include "foundation/math/dual.h"
 #include "foundation/math/microfacet.h"
-#include "foundation/math/minmax.h"
-#include "foundation/math/sampling/mappings.h"
 #include "foundation/math/vector.h"
 #include "foundation/utility/api/specializedapiarrays.h"
 #include "foundation/utility/makevector.h"
-#include "foundation/utility/otherwise.h"
 
 // Standard headers.
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
-#include <string>
 
 // Forward declarations.
 namespace foundation    { class IAbortSwitch; }

--- a/src/appleseed/renderer/modeling/bsdf/hairbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/hairbsdf.cpp
@@ -37,23 +37,16 @@
 #include "renderer/modeling/bsdf/bsdfsample.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 #include "renderer/modeling/bsdf/fresnel.h"
-#include "renderer/modeling/bsdf/microfacethelper.h"
-#include "renderer/modeling/bsdf/specularhelper.h"
 #include "renderer/modeling/color/colorspace.h"
-#include "renderer/utility/dynamicspectrum.h"
-#include "renderer/utility/messagecontext.h"
 #include "renderer/utility/paramarray.h"
 
 // appleseed.foundation headers.
 #include "foundation/containers/dictionary.h"
 #include "foundation/math/basis.h"
-#include "foundation/math/minmax.h"
-#include "foundation/math/sampling/mappings.h"
 #include "foundation/math/specialfunctions.h"
 #include "foundation/math/vector.h"
 #include "foundation/utility/api/specializedapiarrays.h"
 #include "foundation/utility/makevector.h"
-#include "foundation/utility/otherwise.h"
 
 // Standard headers.
 #include <algorithm>
@@ -61,7 +54,6 @@
 #include <cmath>
 #include <cstddef>
 #include <numeric>
-#include <string>
 
 // Forward declarations.
 namespace foundation    { class IAbortSwitch; }

--- a/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.cpp
@@ -59,7 +59,6 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
-#include <iomanip>
 #include <memory>
 #include <sstream>
 #include <string>

--- a/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/kelemenbrdf.h
@@ -34,7 +34,6 @@
 
 // appleseed.foundation headers.
 #include "foundation/memory/autoreleaseptr.h"
-#include "foundation/platform/compiler.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"

--- a/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/metalbrdf.cpp
@@ -39,7 +39,6 @@
 #include "renderer/modeling/bsdf/fresnel.h"
 #include "renderer/modeling/bsdf/microfacethelper.h"
 #include "renderer/modeling/bsdf/specularhelper.h"
-#include "renderer/utility/messagecontext.h"
 #include "renderer/utility/paramarray.h"
 
 // appleseed.foundation headers.
@@ -47,17 +46,13 @@
 #include "foundation/math/basis.h"
 #include "foundation/math/dual.h"
 #include "foundation/math/microfacet.h"
-#include "foundation/math/minmax.h"
-#include "foundation/math/sampling/mappings.h"
 #include "foundation/math/vector.h"
 #include "foundation/utility/api/specializedapiarrays.h"
 #include "foundation/utility/makevector.h"
-#include "foundation/utility/otherwise.h"
 
 // Standard headers.
 #include <algorithm>
 #include <cmath>
-#include <string>
 
 // Forward declarations.
 namespace foundation    { class IAbortSwitch; }

--- a/src/appleseed/renderer/modeling/bsdf/microfacethelper.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/microfacethelper.cpp
@@ -37,7 +37,6 @@
 #include "foundation/core/concepts/noncopyable.h"
 #include "foundation/math/microfacet.h"
 #include "foundation/math/qmc.h"
-#include "foundation/math/sampling/mappings.h"
 #include "foundation/math/scalar.h"
 #include "foundation/math/vector.h"
 

--- a/src/appleseed/renderer/modeling/bsdf/microfacethelper.h
+++ b/src/appleseed/renderer/modeling/bsdf/microfacethelper.h
@@ -40,7 +40,6 @@
 // appleseed.foundation headers.
 #include "foundation/math/basis.h"
 #include "foundation/math/dual.h"
-#include "foundation/math/microfacet.h"
 #include "foundation/math/scalar.h"
 #include "foundation/math/vector.h"
 

--- a/src/appleseed/renderer/modeling/bsdf/nullbsdf.h
+++ b/src/appleseed/renderer/modeling/bsdf/nullbsdf.h
@@ -36,10 +36,8 @@
 #include "renderer/modeling/bsdf/bsdf.h"
 
 // appleseed.foundation headers.
-#include "foundation/math/basis.h"
 #include "foundation/math/dual.h"
 #include "foundation/math/vector.h"
-#include "foundation/platform/compiler.h"
 
 // Forward declarations.
 namespace renderer  { class BSDFSample; }

--- a/src/appleseed/renderer/modeling/bsdf/oslbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/oslbsdf.cpp
@@ -30,7 +30,6 @@
 #include "oslbsdf.h"
 
 // appleseed.renderer headers.
-#include "renderer/global/globallogger.h"
 #include "renderer/global/globaltypes.h"
 #include "renderer/kernel/shading/closures.h"
 #include "renderer/kernel/shading/directshadingcomponents.h"
@@ -41,28 +40,20 @@
 #include "renderer/modeling/bsdf/bsdffactoryregistrar.h"
 #include "renderer/modeling/bsdf/bsdfsample.h"
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
-#include "renderer/modeling/bsdf/diffusebtdf.h"
-#include "renderer/modeling/bsdf/glassbsdf.h"
-#include "renderer/modeling/bsdf/glossybrdf.h"
 #include "renderer/modeling/bsdf/glossylayerbsdf.h"
 #include "renderer/modeling/bsdf/ibsdffactory.h"
-#include "renderer/modeling/bsdf/metalbrdf.h"
-#include "renderer/modeling/bsdf/plasticbrdf.h"
 #include "renderer/modeling/scene/assembly.h"
 #include "renderer/utility/paramarray.h"
 
 // appleseed.foundation headers.
-#include "foundation/containers/dictionary.h"
 #include "foundation/math/dual.h"
 #include "foundation/math/vector.h"
 #include "foundation/memory/arena.h"
-#include "foundation/utility/api/specializedapiarrays.h"
 
 // Standard headers.
 #include <cassert>
 #include <cstddef>
 #include <cstring>
-#include <string>
 
 // Forward declarations.
 namespace foundation    { class IAbortSwitch; }

--- a/src/appleseed/renderer/modeling/bsdf/plasticbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/plasticbrdf.cpp
@@ -38,8 +38,6 @@
 #include "renderer/modeling/bsdf/bsdfwrapper.h"
 #include "renderer/modeling/bsdf/fresnel.h"
 #include "renderer/modeling/bsdf/microfacethelper.h"
-#include "renderer/modeling/bssrdf/sss.h"
-#include "renderer/utility/messagecontext.h"
 #include "renderer/utility/paramarray.h"
 
 // appleseed.foundation headers.
@@ -48,12 +46,10 @@
 #include "foundation/math/dual.h"
 #include "foundation/math/fresnel.h"
 #include "foundation/math/microfacet.h"
-#include "foundation/math/minmax.h"
 #include "foundation/math/sampling/mappings.h"
 #include "foundation/math/vector.h"
 #include "foundation/utility/api/specializedapiarrays.h"
 #include "foundation/utility/makevector.h"
-#include "foundation/utility/otherwise.h"
 
 // Standard headers.
 #include <algorithm>

--- a/src/appleseed/renderer/modeling/bsdf/sheenbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/sheenbrdf.cpp
@@ -44,9 +44,6 @@
 #include "foundation/math/vector.h"
 #include "foundation/utility/api/specializedapiarrays.h"
 
-// Standard headers.
-#include <cmath>
-
 // Forward declarations.
 namespace foundation    { class IAbortSwitch; }
 namespace renderer      { class Assembly; }

--- a/src/appleseed/renderer/modeling/bsdf/specularbtdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/specularbtdf.cpp
@@ -46,7 +46,6 @@
 #include "foundation/utility/api/specializedapiarrays.h"
 
 // Standard headers.
-#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstddef>

--- a/src/appleseed/renderer/modeling/bssrdf/betterdipolebssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/betterdipolebssrdf.h
@@ -33,7 +33,6 @@
 
 // appleseed.foundation headers.
 #include "foundation/memory/autoreleaseptr.h"
-#include "foundation/platform/compiler.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"

--- a/src/appleseed/renderer/modeling/bssrdf/dipolebssrdffactory.h
+++ b/src/appleseed/renderer/modeling/bssrdf/dipolebssrdffactory.h
@@ -32,9 +32,6 @@
 // appleseed.renderer headers.
 #include "renderer/modeling/bssrdf/ibssrdffactory.h"
 
-// appleseed.foundation headers.
-#include "foundation/platform/compiler.h"
-
 // Forward declarations.
 namespace foundation    { class DictionaryArray; }
 

--- a/src/appleseed/renderer/modeling/bssrdf/directionaldipolebssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/directionaldipolebssrdf.h
@@ -33,7 +33,6 @@
 
 // appleseed.foundation headers.
 #include "foundation/memory/autoreleaseptr.h"
-#include "foundation/platform/compiler.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"

--- a/src/appleseed/renderer/modeling/bssrdf/oslbssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/oslbssrdf.cpp
@@ -46,9 +46,7 @@
 #include "renderer/modeling/bssrdf/standarddipolebssrdf.h"
 
 // appleseed.foundation headers.
-#include "foundation/containers/dictionary.h"
 #include "foundation/memory/arena.h"
-#include "foundation/utility/api/specializedapiarrays.h"
 
 // Standard headers.
 #include <cassert>

--- a/src/appleseed/renderer/modeling/bssrdf/sss.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/sss.cpp
@@ -32,7 +32,6 @@
 // appleseed.foundation headers.
 #include "foundation/math/cdf.h"
 #include "foundation/math/fresnel.h"
-#include "foundation/math/sampling/mappings.h"
 #include "foundation/math/scalar.h"
 
 // Standard headers.

--- a/src/appleseed/renderer/modeling/bssrdf/standarddipolebssrdf.h
+++ b/src/appleseed/renderer/modeling/bssrdf/standarddipolebssrdf.h
@@ -33,7 +33,6 @@
 
 // appleseed.foundation headers.
 #include "foundation/memory/autoreleaseptr.h"
-#include "foundation/platform/compiler.h"
 
 // appleseed.main headers.
 #include "main/dllsymbol.h"

--- a/src/appleseed/renderer/modeling/camera/fisheyelenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/fisheyelenscamera.cpp
@@ -37,7 +37,6 @@
 #include "renderer/utility/transformsequence.h"
 
 // appleseed.foundation headers.
-#include "foundation/image/canvasproperties.h"
 #include "foundation/image/image.h"
 #include "foundation/math/dual.h"
 #include "foundation/math/matrix.h"

--- a/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/pinholecamera.cpp
@@ -38,8 +38,6 @@
 #include "renderer/utility/transformsequence.h"
 
 // appleseed.foundation headers.
-#include "foundation/image/canvasproperties.h"
-#include "foundation/image/image.h"
 #include "foundation/math/dual.h"
 #include "foundation/math/matrix.h"
 #include "foundation/math/transform.h"
@@ -47,9 +45,6 @@
 #include "foundation/memory/autoreleaseptr.h"
 #include "foundation/utility/api/apistring.h"
 #include "foundation/utility/api/specializedapiarrays.h"
-
-// Standard headers.
-#include <cstddef>
 
 // Forward declarations.
 namespace foundation    { class IAbortSwitch; }

--- a/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/thinlenscamera.cpp
@@ -49,8 +49,6 @@
 
 // appleseed.foundation headers.
 #include "foundation/containers/dictionary.h"
-#include "foundation/image/canvasproperties.h"
-#include "foundation/image/image.h"
 #include "foundation/math/dual.h"
 #include "foundation/math/matrix.h"
 #include "foundation/math/sampling/imageimportancesampler.h"


### PR DESCRIPTION
Spring cleaning, part 1
- Removes some unused includes in appleseed/renderer/modeling/
- Compiles fine with vc141 on Windows, Linux not tested