### PR TITLE
Replace some usages of each<> and const_each<>

### DIFF
--- a/src/appleseed/renderer/kernel/intersection/treerepository.h
+++ b/src/appleseed/renderer/kernel/intersection/treerepository.h
@@ -86,7 +86,7 @@ class TreeRepository
 template <typename TreeType>
 TreeRepository<TreeType>::~TreeRepository()
 {
-    for (std::pair<const std::uint64_t, TreeInfo>& tree : m_trees)
+    for (std::pair<std::uint64_t, TreeInfo>& tree : m_trees)
         delete tree.second.m_tree;
 }
 
@@ -139,7 +139,7 @@ template <typename TreeType>
 template <typename Func>
 void TreeRepository<TreeType>::for_each(Func& func)
 {
-    for (std::pair<const std::uint64_t, TreeInfo>& tree : m_trees)
+    for (std::pair<std::uint64_t, TreeInfo>& tree : m_trees)
         func(*(tree.second.m_tree), tree.second.m_ref);
 }
 

--- a/src/appleseed/renderer/kernel/intersection/treerepository.h
+++ b/src/appleseed/renderer/kernel/intersection/treerepository.h
@@ -86,7 +86,7 @@ class TreeRepository
 template <typename TreeType>
 TreeRepository<TreeType>::~TreeRepository()
 {
-    for (std::pair<std::uint64_t, TreeInfo>& tree : m_trees)
+    for (std::pair<const std::uint64_t, TreeInfo>& tree : m_trees)
         delete tree.second.m_tree;
 }
 
@@ -139,7 +139,7 @@ template <typename TreeType>
 template <typename Func>
 void TreeRepository<TreeType>::for_each(Func& func)
 {
-    for (std::pair<std::uint64_t, TreeInfo>& tree : m_trees)
+    for (std::pair<const std::uint64_t, TreeInfo>& tree : m_trees)
         func(*(tree.second.m_tree), tree.second.m_ref);
 }
 

--- a/src/appleseed/renderer/kernel/intersection/treerepository.h
+++ b/src/appleseed/renderer/kernel/intersection/treerepository.h
@@ -86,8 +86,8 @@ class TreeRepository
 template <typename TreeType>
 TreeRepository<TreeType>::~TreeRepository()
 {
-    for (auto &i : m_trees)
-        delete i.second.m_tree;
+    for (std::pair<const std::uint64_t, TreeInfo>& tree : m_trees)
+        delete tree.second.m_tree;
 }
 
 template <typename TreeType>
@@ -139,8 +139,8 @@ template <typename TreeType>
 template <typename Func>
 void TreeRepository<TreeType>::for_each(Func& func)
 {
-    for (auto &i : m_trees)
-        func(*(i.second.m_tree), i.second.m_ref);
+    for (std::pair<const std::uint64_t, TreeInfo>& tree : m_trees)
+        func(*(tree.second.m_tree), tree.second.m_ref);
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/kernel/intersection/treerepository.h
+++ b/src/appleseed/renderer/kernel/intersection/treerepository.h
@@ -86,8 +86,8 @@ class TreeRepository
 template <typename TreeType>
 TreeRepository<TreeType>::~TreeRepository()
 {
-    for (foundation::each<TreeContainer> i = m_trees; i; ++i)
-        delete i->second.m_tree;
+    for (auto& i : m_trees)
+        delete i.second.m_tree;
 }
 
 template <typename TreeType>
@@ -139,8 +139,8 @@ template <typename TreeType>
 template <typename Func>
 void TreeRepository<TreeType>::for_each(Func& func)
 {
-    for (foundation::each<TreeContainer> i = m_trees; i; ++i)
-        func(*(i->second.m_tree), i->second.m_ref);
+    for (auto& i : m_trees)
+        func(*(i.second.m_tree), i.second.m_ref);
 }
 
 }   // namespace renderer

--- a/src/appleseed/renderer/kernel/intersection/treerepository.h
+++ b/src/appleseed/renderer/kernel/intersection/treerepository.h
@@ -86,7 +86,7 @@ class TreeRepository
 template <typename TreeType>
 TreeRepository<TreeType>::~TreeRepository()
 {
-    for (auto& i : m_trees)
+    for (auto &i : m_trees)
         delete i.second.m_tree;
 }
 
@@ -139,7 +139,7 @@ template <typename TreeType>
 template <typename Func>
 void TreeRepository<TreeType>::for_each(Func& func)
 {
-    for (auto& i : m_trees)
+    for (auto &i : m_trees)
         func(*(i.second.m_tree), i.second.m_ref);
 }
 

--- a/src/appleseed/renderer/utility/paramarray.h
+++ b/src/appleseed/renderer/utility/paramarray.h
@@ -578,7 +578,7 @@ bool ParamArray::contains(
     const StringVec&            allowed_values,
     const T&                    value)
 {
-    for (auto const &i : allowed_values)
+    for (std::string const& i : allowed_values)
     {
         if (value == foundation::from_string<T>(i))
             return true;

--- a/src/appleseed/renderer/utility/paramarray.h
+++ b/src/appleseed/renderer/utility/paramarray.h
@@ -578,9 +578,9 @@ bool ParamArray::contains(
     const StringVec&            allowed_values,
     const T&                    value)
 {
-    for (std::string const& i : allowed_values)
+    for (const std::string& s : allowed_values)
     {
-        if (value == foundation::from_string<T>(i))
+        if (value == foundation::from_string<T>(s))
             return true;
     }
 

--- a/src/appleseed/renderer/utility/paramarray.h
+++ b/src/appleseed/renderer/utility/paramarray.h
@@ -578,9 +578,9 @@ bool ParamArray::contains(
     const StringVec&            allowed_values,
     const T&                    value)
 {
-    for (foundation::const_each<StringVec> i = allowed_values; i; ++i)
+    for (auto const &i : allowed_values)
     {
-        if (value == foundation::from_string<T>(*i))
+        if (value == foundation::from_string<T>(i))
             return true;
     }
 


### PR DESCRIPTION
Hi,

This PR aims to solve issue #2704.

Two instances of `foundation::each` in the file `src/appleseed/renderer/kernel/intersection/treerepository.h` and one instance of `foundation::each_const` in `src/appleseed/renderer/utility/paramarray.h` has been replaced with  a range based for loop.

I have run tests under 'Debug' and all of them have passed.

Please review and let me know if there are any further changes required.

Thanks,
Haard

 

