### PR TITLE
Fix compilation when spectral support is disabled

### DIFF
--- a/src/appleseed/renderer/utility/rgbspectrum.h
+++ b/src/appleseed/renderer/utility/rgbspectrum.h
@@ -134,12 +134,20 @@ class RGBSpectrum
     const ValueType& operator[](const size_t i) const;
 
     // Convert the spectrum to a linear RGB color.
-    foundation::Color<ValueType, 3> to_rgb(
-        const foundation::LightingConditions&   lighting_conditions) const;
+    foundation::Color<ValueType, 3> reflectance_to_rgb(
+        const foundation::LightingConditions& lighting_conditions) const;
+
+    // Use in emissive samples.
+    foundation::Color<ValueType, 3> illuminance_to_rgb(
+        const foundation::LightingConditions& lighting_conditions) const;
 
     // Convert the spectrum to a CIE XYZ color.
-    foundation::Color<ValueType, 3> to_ciexyz(
-        const foundation::LightingConditions&   lighting_conditions) const;
+    foundation::Color<ValueType, 3> reflectance_to_ciexyz(
+        const foundation::LightingConditions& lighting_conditions) const;
+
+    // Use in emissive samples.
+    foundation::Color<ValueType, 3> illuminance_to_ciexyz(
+        const foundation::LightingConditions& lighting_conditions) const;
 
   private:
     APPLESEED_SIMD4_ALIGN ValueType m_samples[StoredSamples];
@@ -400,7 +408,7 @@ void RGBSpectrum<T>::set(
     {
         reinterpret_cast<foundation::Color<T, 3>&>(m_samples[0]) =
             foundation::ciexyz_to_linear_rgb(
-                foundation::spectral_illuminance_to_ciexyz<T>(spectrum));
+                foundation::spectral_illuminance_to_ciexyz<T>(lighting_conditions, spectrum));
     }
 }
 
@@ -419,19 +427,32 @@ inline const T& RGBSpectrum<T>::operator[](const size_t i) const
 }
 
 template <typename T>
-inline foundation::Color<T, 3> RGBSpectrum<T>::to_rgb(
+inline foundation::Color<T, 3> RGBSpectrum<T>::reflectance_to_rgb(
     const foundation::LightingConditions& lighting_conditions) const
 {
     return foundation::Color<T, 3>(m_samples[0], m_samples[1], m_samples[2]);
 }
 
+template<typename T>
+inline foundation::Color<T, 3> RGBSpectrum<T>::illuminance_to_rgb(const foundation::LightingConditions& lighting_conditions) const
+{
+    return reflectance_to_rgb(lighting_conditions);
+}
+
 template <typename T>
-inline foundation::Color<T, 3> RGBSpectrum<T>::to_ciexyz(
+inline foundation::Color<T, 3> RGBSpectrum<T>::reflectance_to_ciexyz(
     const foundation::LightingConditions& lighting_conditions) const
 {
     return
         linear_rgb_to_ciexyz(
             foundation::Color<T, 3>(m_samples[0], m_samples[1], m_samples[2]));
+}
+
+template <typename T>
+inline foundation::Color<T, 3> RGBSpectrum<T>::illuminance_to_ciexyz(
+    const foundation::LightingConditions& lighting_conditions) const
+{
+    return reflectance_to_ciexyz(lighting_conditions);
 }
 
 template <typename T>


### PR DESCRIPTION
Fix compilation error pointed by Mango3.

> appleseed-master fails to compile in RGB mode but compiles fine in spectral mode. In the RGBSpectrum class some new methods you introduced in the DynamicSpectrum class e.g. illuminance_to_rgb, reflectance_to_rgb are not available and compilation give errors.