### PR TITLE
Fix false colors not being applied to all tiles on a final render

### DIFF
--- a/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
+++ b/src/appleseed.studio/mainwindow/rendering/renderingmanager.cpp
@@ -133,7 +133,7 @@ RenderingManager::RenderingManager(StatusBar& status_bar)
     //
     // They are using a queued connection because the emitting thread is different from
     // the receiving thread (the emitting thread is the master renderer thread, and the
-    // receiving thread is the UI thread of the main window (presumably).
+    // receiving thread is the UI thread of the main window (presumably)).
     //
     // They are using a blocking queue connection because we need the receiving slot to
     // have returned in the receiving thread before the emitting thread can continue.

--- a/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
@@ -225,8 +225,8 @@ struct MasterRenderer::Impl
             // Insert rendering time into frame's render info.
             render_info.insert("render_time", m_project.get_rendering_timer().get_seconds());
 
-            // Don't proceed further if rendering failed.
-            if (result.m_status == RenderingResult::Failed)
+            // Don't proceed further if rendering failed or aborted.
+            if (result.m_status != RenderingResult::Succeeded)
             {
                 controller.on_rendering_abort();
                 return result;
@@ -241,12 +241,7 @@ struct MasterRenderer::Impl
             // Insert post-processing time into frame's render info.
             render_info.insert("post_processing_time", stopwatch.get_seconds());
 
-            switch (result.m_status)
-            {
-              case RenderingResult::Succeeded: controller.on_rendering_success(); break;
-              case RenderingResult::Aborted: controller.on_rendering_abort(); break;
-              assert_otherwise;
-            }
+            controller.on_rendering_success();
         }
         catch (const std::bad_alloc&)
         {

--- a/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/masterrenderer.cpp
@@ -224,6 +224,7 @@ struct MasterRenderer::Impl
             // Insert rendering time into frame's render info.
             render_info.insert("render_time", m_project.get_rendering_timer().get_seconds());
 
+#if 0
             // Don't proceed further if rendering failed.
             if (result.m_status != RenderingResult::Succeeded)
                 return result;
@@ -236,6 +237,47 @@ struct MasterRenderer::Impl
 
             // Insert post-processing time into frame's render info.
             render_info.insert("post_processing_time", stopwatch.get_seconds());
+#else
+            IRendererController& controller =
+                m_serial_renderer_controller != nullptr
+                    ? *m_serial_renderer_controller
+                    : renderer_controller;
+
+            RenderingTimer stopwatch;
+
+            switch (result.m_status)
+            {
+              case RenderingResult::Succeeded:
+                // Post-process.
+                stopwatch.start();
+                postprocess();
+                stopwatch.measure();
+
+                // Insert post-processing time into frame's render info.
+                render_info.insert("post_processing_time", stopwatch.get_seconds());
+
+                controller.on_rendering_success();
+                break;
+
+              case RenderingResult::Aborted:
+                // Post-process.
+                stopwatch.start();
+                postprocess();
+                stopwatch.measure();
+
+                // Insert post-processing time into frame's render info.
+                render_info.insert("post_processing_time", stopwatch.get_seconds());
+
+                controller.on_rendering_abort(); // NOTE could fall-through
+                return result;
+
+              case RenderingResult::Failed:
+                controller.on_rendering_abort();
+                return result;
+
+              assert_otherwise;
+            }
+#endif
         }
         catch (const std::bad_alloc&)
         {
@@ -298,14 +340,14 @@ struct MasterRenderer::Impl
             // Expand procedural assemblies before scene entities inputs are bound.
             if (!m_project.get_scene()->expand_procedural_assemblies(m_project, &abort_switch))
             {
-                renderer_controller.on_rendering_abort();
+                /// renderer_controller.on_rendering_abort();
                 return RenderingResult::Aborted;
             }
 
             // Bind scene entities inputs.
             if (!bind_scene_entities_inputs())
             {
-                renderer_controller.on_rendering_abort();
+                /// renderer_controller.on_rendering_abort();
                 return RenderingResult::Aborted;
             }
 
@@ -314,11 +356,11 @@ struct MasterRenderer::Impl
             switch (status)
             {
               case IRendererController::TerminateRendering:
-                renderer_controller.on_rendering_success();
+                /// renderer_controller.on_rendering_success();
                 return RenderingResult::Succeeded;
 
               case IRendererController::AbortRendering:
-                renderer_controller.on_rendering_abort();
+                /// renderer_controller.on_rendering_abort();
                 return RenderingResult::Aborted;
 
               case IRendererController::ReinitializeRendering:


### PR DESCRIPTION
This PR fixes the following bug (which happens when we have post-processing stages, and `False Colors` is enabled):

![](https://cdn.discordapp.com/attachments/707230180233707591/727955871510036601/IdRVxIiHXU.gif)

**Edit:** I undid the changes I mention below because they don't fit well with https://github.com/appleseedhq/appleseed/pull/2885 (though, I intend to add them in a later PR, once we discuss what'd lead to the best "user experience").

~Also, these changes make post-processing effects always run when a rendering is stopped (e.g. `Shift+F5`).~
~If this behavior is desirable, https://github.com/appleseedhq/appleseed/pull/2878 can be closed. Otherwise, we can keeps effects only being applied to final renderings with:~

```diff
@@ -226,7 +226,7 @@ struct MasterRenderer::Impl
             render_info.insert("render_time", m_project.get_rendering_timer().get_seconds());

             // Don't proceed further if rendering failed.
-            if (result.m_status == RenderingResult::Failed)
+            if (result.m_status != RenderingResult::Succeeded)
             {
                 controller.on_rendering_abort();
                 return result;
@@ -241,12 +241,7 @@ struct MasterRenderer::Impl
             // Insert post-processing time into frame's render info.
             render_info.insert("post_processing_time", stopwatch.get_seconds());

-            switch (result.m_status)
-            {
-              case RenderingResult::Succeeded: controller.on_rendering_success(); break;
-              case RenderingResult::Aborted: controller.on_rendering_abort(); break;
-              assert_otherwise;
-            }
+            controller.on_rendering_success();
         }
```