### PR TITLE
Add tooltips for entities with 'help' metadata

### DIFF
--- a/src/appleseed.studio/mainwindow/project/entityeditor.cpp
+++ b/src/appleseed.studio/mainwindow/project/entityeditor.cpp
@@ -260,6 +260,14 @@ namespace
             label->setFont(font);
         }
 
+        if (metadata.strings().exist("help"))
+        {
+            // Add tooltip if a help string has been set.
+            const std::string help = metadata.strings().get<std::string>("help");
+            if (!help.empty())
+                label->setToolTip(QString::fromStdString(help));
+        }
+
         return label;
     }
 

--- a/src/appleseed/renderer/modeling/postprocessingstage/colormappostprocessingstage.cpp
+++ b/src/appleseed/renderer/modeling/postprocessingstage/colormappostprocessingstage.cpp
@@ -699,17 +699,19 @@ DictionaryArray ColorMapPostProcessingStageFactory::get_input_metadata() const
                     .insert("Turbo", "turbo")
                     .insert("Custom", "custom"))
             .insert("use", "required")
+            .insert("help", "Applied color map")
             .insert("default", "inferno")
             .insert("on_change", "rebuild_form"));
 
     metadata.push_back(
         Dictionary()
             .insert("name", "color_map_file_path")
-            .insert("label", "Colormap File Path")
+            .insert("label", "Color Map File Path")
             .insert("type", "file")
             .insert("file_picker_mode", "open")
             .insert("file_picker_type", "image")
             .insert("use", "optional")
+            .insert("help", "Path to a custom color map image")
             .insert("visible_if",
                 Dictionary()
                     .insert("color_map", "custom")));
@@ -720,6 +722,7 @@ DictionaryArray ColorMapPostProcessingStageFactory::get_input_metadata() const
             .insert("label", "Auto Range")
             .insert("type", "boolean")
             .insert("use", "optional")
+            .insert("help", "Maps the full range of luminance values to the color map")
             .insert("default", "true")
             .insert("on_change", "rebuild_form"));
 
@@ -737,6 +740,7 @@ DictionaryArray ColorMapPostProcessingStageFactory::get_input_metadata() const
                     .insert("value", "1.0")
                     .insert("type", "soft"))
             .insert("use", "optional")
+            .insert("help", "Luminance value mapped to the first row in the colormap")
             .insert("default", "0.0")
             .insert("visible_if",
                 Dictionary()
@@ -756,6 +760,7 @@ DictionaryArray ColorMapPostProcessingStageFactory::get_input_metadata() const
                     .insert("value", "1.0")
                     .insert("type", "soft"))
             .insert("use", "optional")
+            .insert("help", "Luminance value mapped to the last row in the colormap")
             .insert("default", "1.0")
             .insert("visible_if",
                 Dictionary()
@@ -767,6 +772,7 @@ DictionaryArray ColorMapPostProcessingStageFactory::get_input_metadata() const
             .insert("label", "Add Legend Bar")
             .insert("type", "boolean")
             .insert("use", "optional")
+            .insert("help", "Include a legend bar next to the color map")
             .insert("default", "true"));
 
     metadata.push_back(
@@ -783,6 +789,7 @@ DictionaryArray ColorMapPostProcessingStageFactory::get_input_metadata() const
                     .insert("value", "64")
                     .insert("type", "soft"))
             .insert("use", "optional")
+            .insert("help", "Set the number of divisions in the legend bar")
             .insert("default", "8")
             .insert("visible_if",
                 Dictionary()
@@ -794,6 +801,7 @@ DictionaryArray ColorMapPostProcessingStageFactory::get_input_metadata() const
             .insert("label", "Render Isolines")
             .insert("type", "boolean")
             .insert("use", "optional")
+            .insert("help", "Draw lines of equal relative luminance")
             .insert("default", "false")
             .insert("on_change", "rebuild_form"));
 
@@ -811,6 +819,7 @@ DictionaryArray ColorMapPostProcessingStageFactory::get_input_metadata() const
                     .insert("value", "5.0")
                     .insert("type", "soft"))
             .insert("use", "optional")
+            .insert("help", "Set the thickness of luminance isolines")
             .insert("default", "1.0")
             .insert("visible_if",
                 Dictionary()

--- a/src/appleseed/renderer/modeling/postprocessingstage/ipostprocessingstagefactory.cpp
+++ b/src/appleseed/renderer/modeling/postprocessingstage/ipostprocessingstagefactory.cpp
@@ -54,6 +54,7 @@ void IPostProcessingStageFactory::add_common_input_metadata(DictionaryArray& met
                     .insert("value", "10")
                     .insert("type", "soft"))
             .insert("use", "required")
+            .insert("help", "Determines the order in which this stage is applied")
             .insert("default", "0"));
 }
 

--- a/src/appleseed/renderer/modeling/postprocessingstage/renderstamppostprocessingstage.cpp
+++ b/src/appleseed/renderer/modeling/postprocessingstage/renderstamppostprocessingstage.cpp
@@ -246,6 +246,17 @@ DictionaryArray RenderStampPostProcessingStageFactory::get_input_metadata() cons
             .insert("label", "Format String")
             .insert("type", "text")
             .insert("use", "optional")
+            .insert("help",
+                    "Render stamp text\n"
+                    "Available predefined variables:\n"
+                    "{lib-name}, "
+                    "{lib-version},\n"
+                    "{lib-cpu-features}, "
+                    "{lib-config},\n"
+                    "{lib-build-date}, "
+                    "{lib-build-time},\n"
+                    "{render-time}, "
+                    "{peak-memory}")
             .insert("default", DefaultFormatString));
 
     metadata.push_back(
@@ -262,6 +273,7 @@ DictionaryArray RenderStampPostProcessingStageFactory::get_input_metadata() cons
                         .insert("value", "20.0")
                         .insert("type", "hard"))
             .insert("use", "optional")
+            .insert("help", "Controls the size of the render stamp")
             .insert("default", "1.0"));
 
     return metadata;

--- a/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.cpp
+++ b/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.cpp
@@ -190,7 +190,7 @@ DictionaryArray VignettePostProcessingStageFactory::get_input_metadata() const
             .insert("use", "optional")
             .insert("help",
                     "Vignette's degree of deviation from a circle\n"
-                    "(0.0 = perfectly rounded, 1.0 = mimic the image aspect ratio)")
+                    "(0.0 = perfectly rounded, 1.0 = mimics the image aspect ratio)")
             .insert("default", "0.0"));
 
     return metadata;

--- a/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.cpp
+++ b/src/appleseed/renderer/modeling/postprocessingstage/vignettepostprocessingstage.cpp
@@ -59,9 +59,8 @@ namespace
 
     const char* Model = "vignette_post_processing_stage";
 
-    static constexpr float DefaultIntensity = 0.5f;
-
-    static constexpr float DefaultAnisotropy = 0.0f;
+    constexpr float DefaultIntensity = 0.5f;
+    constexpr float DefaultAnisotropy = 0.0f;
 
     class VignettePostProcessingStage
       : public PostProcessingStage
@@ -170,6 +169,9 @@ DictionaryArray VignettePostProcessingStageFactory::get_input_metadata() const
                         .insert("value", "1.0")
                         .insert("type", "hard"))
             .insert("use", "optional")
+            .insert("help",
+                    "Strength of the vignetting effect\n"
+                    "(higher values lead to stronger darkening of the image edges)")
             .insert("default", "0.5"));
 
     metadata.push_back(
@@ -186,6 +188,9 @@ DictionaryArray VignettePostProcessingStageFactory::get_input_metadata() const
                         .insert("value", "1.0")
                         .insert("type", "hard"))
             .insert("use", "optional")
+            .insert("help",
+                    "Vignette's degree of deviation from a circle\n"
+                    "(0.0 = perfectly rounded, 1.0 = mimic the image aspect ratio)")
             .insert("default", "0.0"));
 
     return metadata;


### PR DESCRIPTION
Included tooltips for labels when `metadata` contains the `"help"` key.

Also added `"help"` values for the Vignette, Render Stamp and Color Map post-processing stages, based on the [Wiki page draft](https://gist.github.com/laurelkeys/f105b8273b30b1207f4d7ebaa932a6e2) shared on Discord.

_obs.: removed unnecessary `static` keyword from `vignettepostprocessingstage.cpp`_

---
![4VWOhZk45D](https://user-images.githubusercontent.com/13294013/91205710-5e72d900-e6dc-11ea-9165-9f8253920d4e.gif)