### PR TITLE
Fixing double wrapping for OSLBRDF, BSDFBlend and BSDFMix children

### DIFF
--- a/src/appleseed/renderer/modeling/bsdf/bsdfblend.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfblend.cpp
@@ -169,7 +169,7 @@ namespace
                 sampling_context,
                 values->m_child_inputs[bsdf_index],
                 adjoint,
-                false,                  // do not multiply by |cos(incoming, normal)|
+                cosine_mult,
                 local_geometry,
                 outgoing,
                 modes,
@@ -201,7 +201,7 @@ namespace
                     ? m_bsdf[0]->evaluate(
                           values->m_child_inputs[0],
                           adjoint,
-                          false,                // do not multiply by |cos(incoming, normal)|
+                          cosine_mult,
                           local_geometry,
                           outgoing,
                           incoming,
@@ -216,7 +216,7 @@ namespace
                     ? m_bsdf[1]->evaluate(
                           values->m_child_inputs[1],
                           adjoint,
-                          false,                // do not multiply by |cos(incoming, normal)|
+                          cosine_mult,
                           local_geometry,
                           outgoing,
                           incoming,

--- a/src/appleseed/renderer/modeling/bsdf/bsdfmix.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfmix.cpp
@@ -175,7 +175,7 @@ namespace
                 sampling_context,
                 values->m_child_inputs[bsdf_index],
                 adjoint,
-                false,                  // do not multiply by |cos(incoming, normal)|
+                cosine_mult,
                 local_geometry,
                 outgoing,
                 modes,
@@ -217,7 +217,7 @@ namespace
                     ? m_bsdf[0]->evaluate(
                           values->m_child_inputs[0],
                           adjoint,
-                          false,                // do not multiply by |cos(incoming, normal)|
+                          cosine_mult,
                           local_geometry,
                           outgoing,
                           incoming,
@@ -232,7 +232,7 @@ namespace
                     ? m_bsdf[1]->evaluate(
                           values->m_child_inputs[1],
                           adjoint,
-                          false,                // do not multiply by |cos(incoming, normal)|
+                          cosine_mult,
                           local_geometry,
                           outgoing,
                           incoming,

--- a/src/appleseed/renderer/modeling/bsdf/bsdfwrapper.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfwrapper.h
@@ -129,6 +129,22 @@ void BSDFWrapper<BSDFImpl, Cull>::sample(
     const int                           modes,
     BSDFSample&                         sample) const
 {
+    // OSLBSDF is containing children which are also wrapped by BSDFWrapper.
+    // Therefore, BSDFWRapper methods should be only applied to its children.
+    if (std::strcmp(BSDFImpl::get_model(), "osl_bsdf") == 0)
+    {
+        BSDFImpl::sample(
+            sampling_context,
+            data,
+            adjoint,
+            cosine_mult,
+            local_geometry,
+            outgoing,
+            modes,
+            sample);
+        return;
+    }
+
     assert(foundation::is_normalized(local_geometry.m_geometric_normal));
     assert(foundation::is_normalized(outgoing.get_value()));
 
@@ -206,6 +222,22 @@ float BSDFWrapper<BSDFImpl, Cull>::evaluate(
     const int                           modes,
     DirectShadingComponents&            value) const
 {
+    // OSLBSDF is containing children which are also wrapped by BSDFWrapper.
+    // Therefore, BSDFWRapper methods should be only applied to its children.
+    if (std::strcmp(BSDFImpl::get_model(), "osl_bsdf") == 0)
+    {
+        return 
+            BSDFImpl::evaluate(
+                data,
+                adjoint,
+                cosine_mult,
+                local_geometry,
+                outgoing,
+                incoming,
+                modes,
+                value);
+    }
+
     assert(foundation::is_normalized(local_geometry.m_geometric_normal));
     assert(foundation::is_normalized(outgoing));
     assert(foundation::is_normalized(incoming));
@@ -259,6 +291,20 @@ float BSDFWrapper<BSDFImpl, Cull>::evaluate_pdf(
     const foundation::Vector3f&         incoming,
     const int                           modes) const
 {
+    // OSLBSDF is containing children which are also wrapped by BSDFWrapper.
+    // Therefore, BSDFWRapper methods should be only applied to its children.
+    if (std::strcmp(BSDFImpl::get_model(), "osl_bsdf") == 0)
+    {
+        return 
+            BSDFImpl::evaluate_pdf(
+                data,
+                adjoint,
+                local_geometry,
+                outgoing,
+                incoming,
+                modes);
+    }
+    
     assert(foundation::is_normalized(local_geometry.m_geometric_normal));
     assert(foundation::is_normalized(outgoing));
     assert(foundation::is_normalized(incoming));

--- a/src/appleseed/renderer/modeling/bsdf/bsdfwrapper.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfwrapper.h
@@ -129,7 +129,7 @@ void BSDFWrapper<BSDFImpl, Cull>::sample(
     const int                           modes,
     BSDFSample&                         sample) const
 {
-    // OSLBSDF, MIXBSDF and BLENDBSDF are containing children which are
+    // OSLBSDF, BSDFBlend and BSDFMix are containing children which are
     // also wrapped by BSDFWrapper.
     // Therefore, BSDFWRapper methods should be only applied to its children.
     if (std::strcmp(BSDFImpl::get_model(), "osl_bsdf") == 0 ||
@@ -225,7 +225,7 @@ float BSDFWrapper<BSDFImpl, Cull>::evaluate(
     const int                           modes,
     DirectShadingComponents&            value) const
 {
-    // OSLBSDF, MIXBSDF and BLENDBSDF are containing children which are
+    // OSLBSDF, BSDFBlend and BSDFMix are containing children which are
     // also wrapped by BSDFWrapper.
     // Therefore, BSDFWRapper methods should be only applied to its children.
     if (std::strcmp(BSDFImpl::get_model(), "osl_bsdf") == 0 ||
@@ -297,7 +297,7 @@ float BSDFWrapper<BSDFImpl, Cull>::evaluate_pdf(
     const foundation::Vector3f&         incoming,
     const int                           modes) const
 {
-    // OSLBSDF, MIXBSDF and BLENDBSDF are containing children which are
+    // OSLBSDF, BSDFBlend and BSDFMix are containing children which are
     // also wrapped by BSDFWrapper.
     // Therefore, BSDFWRapper methods should be only applied to its children.
     if (std::strcmp(BSDFImpl::get_model(), "osl_bsdf") == 0 ||

--- a/src/appleseed/renderer/modeling/bsdf/bsdfwrapper.h
+++ b/src/appleseed/renderer/modeling/bsdf/bsdfwrapper.h
@@ -129,9 +129,12 @@ void BSDFWrapper<BSDFImpl, Cull>::sample(
     const int                           modes,
     BSDFSample&                         sample) const
 {
-    // OSLBSDF is containing children which are also wrapped by BSDFWrapper.
+    // OSLBSDF, MIXBSDF and BLENDBSDF are containing children which are
+    // also wrapped by BSDFWrapper.
     // Therefore, BSDFWRapper methods should be only applied to its children.
-    if (std::strcmp(BSDFImpl::get_model(), "osl_bsdf") == 0)
+    if (std::strcmp(BSDFImpl::get_model(), "osl_bsdf") == 0 ||
+        std::strcmp(BSDFImpl::get_model(), "bsdf_mix") == 0 ||
+        std::strcmp(BSDFImpl::get_model(), "bsdf_blend") == 0)
     {
         BSDFImpl::sample(
             sampling_context,
@@ -222,9 +225,12 @@ float BSDFWrapper<BSDFImpl, Cull>::evaluate(
     const int                           modes,
     DirectShadingComponents&            value) const
 {
-    // OSLBSDF is containing children which are also wrapped by BSDFWrapper.
+    // OSLBSDF, MIXBSDF and BLENDBSDF are containing children which are
+    // also wrapped by BSDFWrapper.
     // Therefore, BSDFWRapper methods should be only applied to its children.
-    if (std::strcmp(BSDFImpl::get_model(), "osl_bsdf") == 0)
+    if (std::strcmp(BSDFImpl::get_model(), "osl_bsdf") == 0 ||
+        std::strcmp(BSDFImpl::get_model(), "bsdf_mix") == 0 ||
+        std::strcmp(BSDFImpl::get_model(), "bsdf_blend") == 0)
     {
         return 
             BSDFImpl::evaluate(
@@ -291,9 +297,12 @@ float BSDFWrapper<BSDFImpl, Cull>::evaluate_pdf(
     const foundation::Vector3f&         incoming,
     const int                           modes) const
 {
-    // OSLBSDF is containing children which are also wrapped by BSDFWrapper.
+    // OSLBSDF, MIXBSDF and BLENDBSDF are containing children which are
+    // also wrapped by BSDFWrapper.
     // Therefore, BSDFWRapper methods should be only applied to its children.
-    if (std::strcmp(BSDFImpl::get_model(), "osl_bsdf") == 0)
+    if (std::strcmp(BSDFImpl::get_model(), "osl_bsdf") == 0 ||
+        std::strcmp(BSDFImpl::get_model(), "bsdf_mix") == 0 ||
+        std::strcmp(BSDFImpl::get_model(), "bsdf_blend") == 0)
     {
         return 
             BSDFImpl::evaluate_pdf(

--- a/src/appleseed/renderer/modeling/bsdf/oslbsdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/oslbsdf.cpp
@@ -215,7 +215,7 @@ namespace
                     sampling_context,
                     c->get_closure_input_values(closure_index),
                     adjoint,
-                    false,
+                    cosine_mult,
                     closure_geometry,
                     outgoing,
                     modes,
@@ -251,7 +251,7 @@ namespace
                             .evaluate(
                                 c->get_closure_input_values(i),
                                 adjoint,
-                                false,
+                                cosine_mult,
                                 closure_geometry,
                                 outgoing.get_value(),
                                 sample.m_incoming.get_value(),
@@ -304,7 +304,7 @@ namespace
                             .evaluate(
                                 c->get_closure_input_values(i),
                                 adjoint,
-                                false,
+                                cosine_mult,
                                 closure_geometry,
                                 outgoing,
                                 incoming,


### PR DESCRIPTION
## Description

This PR related to issue Double wrapping of child BSDFs in BSDFBlend, BSDFMix and OSLBSDF #1243.
It fixes double wrapping when OSLBRDF, BSDFBlend or BSDFMix are used.
Idea is that BSDFWrapper is not applied if the current wrapped BRDF is OSLBRDF, BSDFBlend or BSDFMix.

NOTE: this PR is also required for #2886.

