### PR TITLE
Fix assert in plasticbrdf.cpp

### DIFF
--- a/src/appleseed/renderer/modeling/bsdf/plasticbrdf.cpp
+++ b/src/appleseed/renderer/modeling/bsdf/plasticbrdf.cpp
@@ -215,7 +215,7 @@ namespace
                 wi = sample_hemisphere_cosine(Vector2f(s[0], s[1]));
 
                 const float probability = wi.y * RcpPi<float>() * (1.0f - specular_probability);
-                assert(probability > 0.0f);
+                assert(probability >= 0.0f);
 
                 if (probability > 1.0e-6f)
                 {


### PR DESCRIPTION
This assert is being triggered because probability can be zero. Since in the specular/glossy case the assert allows zero probability, I assume we can do the same thing for the diffuse case.