### PR TITLE
Fix race condition in localsampleaccumulationbuffer.cpp

### DIFF
--- a/src/appleseed/renderer/kernel/rendering/localsampleaccumulationbuffer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/localsampleaccumulationbuffer.cpp
@@ -257,7 +257,7 @@ void LocalSampleAccumulationBuffer::develop_to_frame(
 #endif
 
     // Copy tile first so the critical section can end before doing the expensive develop_to_tile.
-    const std::uint32_t active_level = m_active_level.value(); // Ensure the same active_level is used for both arrays.
+    const std::uint32_t active_level = m_active_level; // Ensure the same active_level is used for both arrays.
     const AccumulatorTile& level = *m_levels[active_level];
     AccumulatorTile& read_level = *m_read_levels[active_level];    
     read_level.copy_from(level);

--- a/src/appleseed/renderer/kernel/rendering/localsampleaccumulationbuffer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/localsampleaccumulationbuffer.cpp
@@ -257,11 +257,9 @@ void LocalSampleAccumulationBuffer::develop_to_frame(
 #endif
 
     // Copy tile first so the critical section can end before doing the expensive develop_to_tile.
-    const AccumulatorTile& level = *m_levels[m_active_level];
-    AccumulatorTile& read_level = *m_read_levels[m_active_level];
     const std::uint32_t active_level = m_active_level.value(); // Ensure the same active_level is used for both arrays.
     const AccumulatorTile& level = *m_levels[active_level];
-    AccumulatorTile& read_level = *m_read_levels[active_level];
+    AccumulatorTile& read_level = *m_read_levels[active_level];    
     read_level.copy_from(level);
 
     m_lock.unlock_write();

--- a/src/appleseed/renderer/kernel/rendering/localsampleaccumulationbuffer.cpp
+++ b/src/appleseed/renderer/kernel/rendering/localsampleaccumulationbuffer.cpp
@@ -259,6 +259,9 @@ void LocalSampleAccumulationBuffer::develop_to_frame(
     // Copy tile first so the critical section can end before doing the expensive develop_to_tile.
     const AccumulatorTile& level = *m_levels[m_active_level];
     AccumulatorTile& read_level = *m_read_levels[m_active_level];
+    const std::uint32_t active_level = m_active_level.value(); // Ensure the same active_level is used for both arrays.
+    const AccumulatorTile& level = *m_levels[active_level];
+    AccumulatorTile& read_level = *m_read_levels[active_level];
     read_level.copy_from(level);
 
     m_lock.unlock_write();


### PR DESCRIPTION
The m_active_level atomic is modified in store_samples outside the critical section protected by m_lock. Ensure the same level is used as source and target level.
