### PR TITLE
Fix warnings with gcc 10.2.0

### DIFF
--- a/src/appleseed/foundation/core/exceptions/stringexception.h
+++ b/src/appleseed/foundation/core/exceptions/stringexception.h
@@ -76,7 +76,7 @@ inline StringException::StringException(const char* what)
 
 inline StringException::StringException(const char* what, const char* s)
 {
-    char buf[sizeof(m_what) + sizeof(m_string) + 2];
+    char buf[sizeof(m_what) - 1];
     portable_snprintf(buf, sizeof(buf), "%s: %s", what, s);
     set_what(buf);
 

--- a/src/appleseed/foundation/platform/thread.h
+++ b/src/appleseed/foundation/platform/thread.h
@@ -295,7 +295,7 @@ class APPLESEED_DLLSYMBOL ThreadFlag
 // Spinlock class implementation.
 //
 
-inline Spinlock::Spinlock() : m_sp{BOOST_DETAIL_SPINLOCK_INIT}
+inline Spinlock::Spinlock() : m_sp BOOST_DETAIL_SPINLOCK_INIT
 {
 }
 

--- a/src/appleseed/foundation/platform/thread.h
+++ b/src/appleseed/foundation/platform/thread.h
@@ -295,10 +295,8 @@ class APPLESEED_DLLSYMBOL ThreadFlag
 // Spinlock class implementation.
 //
 
-inline Spinlock::Spinlock()
+inline Spinlock::Spinlock() : m_sp{BOOST_DETAIL_SPINLOCK_INIT}
 {
-    boost::detail::spinlock initialized_sp = BOOST_DETAIL_SPINLOCK_INIT;
-    std::memcpy(&m_sp, &initialized_sp, sizeof(initialized_sp));
 }
 
 inline bool Spinlock::try_lock()

--- a/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
@@ -1114,7 +1114,7 @@ void ShadingPoint::initialize_osl_shader_globals(
 
         // Opaque state pointers.
         m_shader_globals.renderstate = const_cast<ShadingPoint*>(this);
-        memset(&m_osl_trace_data, 0, sizeof(OSLTraceData));
+        m_osl_trace_data = {};
         m_shader_globals.tracedata = &m_osl_trace_data;
         m_shader_globals.objdata = nullptr;
 


### PR DESCRIPTION
Compiling appleseed in Release mode using gcc 10.2.0 causes a couple of warnings that due to "Werror" were failures. These were my changes to address them.
I'm using boost 1.72.0 and OpenShadingLanguage 1.11.8