### PR TITLE
Fix clamp usage in frensel.h

### DIFF
--- a/src/appleseed/foundation/math/fresnel.h
+++ b/src/appleseed/foundation/math/fresnel.h
@@ -507,7 +507,7 @@ void fresnel_reflectance_lazanyi_schlick(
     h *= cos_theta_i * k6;
     reflectance -= h;
 
-    clamp(reflectance, T(0.0), T(1.0));
+    reflectance = clamp(reflectance, T(0.0), T(1.0));
 }
 
 template <typename SpectrumType, typename T>


### PR DESCRIPTION
clamp is to be used with a return value.

This caused negative values to be calculated for some samples.