### PR TITLE
Fix CMake paths Linux/static build

### DIFF
--- a/src/appleseed.python/CMakeLists.txt
+++ b/src/appleseed.python/CMakeLists.txt
@@ -308,7 +308,7 @@ endif ()
 # Installation.
 #--------------------------------------------------------------------------------------------------
 
-set (py_module_dst "lib/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}/appleseed")
+set (py_module_dst "lib/python/appleseed")
 
 install (FILES __init__.py DESTINATION ${py_module_dst})
 install (FILES logtarget.py DESTINATION ${py_module_dst})

--- a/src/appleseed.studio/CMakeLists.txt
+++ b/src/appleseed.studio/CMakeLists.txt
@@ -539,5 +539,5 @@ install (DIRECTORY ../../sandbox/studio
     DESTINATION .
 )
 
-install (DIRECTORY ../../sandbox/lib/python/site-packages DESTINATION "lib/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}")
-install (DIRECTORY python/studio DESTINATION "lib/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}/appleseed")
+install (DIRECTORY ../../sandbox/lib/python/site-packages DESTINATION "lib/python")
+install (DIRECTORY python/studio DESTINATION "lib/python/appleseed")


### PR DESCRIPTION
CMake installs the python files in `<installation_dir>/lib/python2.7`.

But in file: `src/appleseed.studio/python/pythoninterpreter.cpp` they are expected to be in `<installation_dir>/lib/python` (see "Compute path" code). 

As a result when starting appleseed.studio they can't be found and the following warnings appear:
`Python's site-packages directory does not exist.`
`appleseed Python module's directory does not exist.`
as well as errors for not properly imported modules in Python console.

Changed the paths in CMake to match the paths in `pythoninterpreter.cpp`.