### PR TITLE
Fix various typos

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -441,7 +441,7 @@ epub_identifier = 'https://github.com/appleseedhq/appleseed'
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 

--- a/sandbox/examples/python/helloworld/helloworld.py
+++ b/sandbox/examples/python/helloworld/helloworld.py
@@ -305,7 +305,7 @@ def main():
     # Save the project to disk.
     asr.ProjectFileWriter().write(project, "output/test.appleseed")
 
-    # Remove the log target we added previosly.
+    # Remove the log target we added previously.
     asr.global_logger().remove_target(log_target)
 
 if __name__ == "__main__":

--- a/sandbox/lib/python/site-packages/Qt.py
+++ b/sandbox/lib/python/site-packages/Qt.py
@@ -936,7 +936,7 @@ def _reassign_misplaced_members(binding):
         src_module, src_member = src.split(".")
         dst_module, dst_member = dst.split(".")
 
-        # Get the member we want to store in the namesapce.
+        # Get the member we want to store in the namespace.
         try:
             dst_value = getattr(getattr(Qt, "_" + src_module), src_member)
         except AttributeError:

--- a/src/appleseed.shaders/src/appleseed/as_voronoi2d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_voronoi2d.osl
@@ -95,7 +95,7 @@ shader as_voronoi2d
         int as_maya_attribute_connectable = 0,
         int as_maya_attribute_keyable = 0,
         string widget = "mapper",
-        string options = "Euclidian Distance:0|Sum of Square Difference:1|Tchebychev Distance:2|Sum of Absolute Difference:3|Akritean Distance:4|Minkowski Metric:5|Karlsruhe Metric:6",
+        string options = "Euclidean Distance:0|Sum of Square Difference:1|Tchebychev Distance:2|Sum of Absolute Difference:3|Akritean Distance:4|Minkowski Metric:5|Karlsruhe Metric:6",
         string label = "Metric",
         string page = "Cell",
         int as_blender_input_socket = 0,

--- a/src/appleseed.shaders/src/appleseed/as_voronoi3d.osl
+++ b/src/appleseed.shaders/src/appleseed/as_voronoi3d.osl
@@ -93,7 +93,7 @@ shader as_voronoi3d
     [[
         string as_maya_attribute_name = "metric",
         string widget = "mapper",
-        string options = "Euclidian Distance:0|Sum of Square Difference:1|Tchebychev Distance:2|Sum of Absolute Difference:3|Akritean Distance:4|Minkowski Metric:5|Karlsruhe Metric:6",
+        string options = "Euclidean Distance:0|Sum of Square Difference:1|Tchebychev Distance:2|Sum of Absolute Difference:3|Akritean Distance:4|Minkowski Metric:5|Karlsruhe Metric:6",
         string label = "Metric",
         string page = "Cell",
         int as_maya_attribute_connectable = 0,

--- a/src/appleseed.shaders/src/maya/as_maya_remapValue.osl
+++ b/src/appleseed.shaders/src/maya/as_maya_remapValue.osl
@@ -86,25 +86,25 @@ shader as_maya_remapValue
     [[
         string as_maya_attribute_name = "inputMin",
         string label = "Input Min",
-        string page = "Input And Ouput Attributes"
+        string page = "Input And Output Attributes"
     ]],
     float in_inputMax = 0.0
     [[
         string as_maya_attribute_name = "inputMax",
         string label = "Input Max",
-        string page = "Input And Ouput Attributes"
+        string page = "Input And Output Attributes"
     ]],
     float in_outputMin = 0.0
     [[
         string as_maya_attribute_name = "outputMin",
         string label = "Output Min",
-        string page = "Input And Ouput Attributes"
+        string page = "Input And Output Attributes"
     ]],
     float in_outputMax = 0.0
     [[
         string as_maya_attribute_name = "outputMax",
         string label = "Output Max",
-        string page = "Input And Ouput Attributes"
+        string page = "Input And Output Attributes"
     ]],
 
     output float out_outValue = 0.0

--- a/src/appleseed/foundation/image/image.h
+++ b/src/appleseed/foundation/image/image.h
@@ -106,7 +106,7 @@ class APPLESEED_DLLSYMBOL Image
         const size_t        tile_x,
         const size_t        tile_y) const override;
 
-    // Set a given tile. Ownership of the tile is transfered to the Image class.
+    // Set a given tile. Ownership of the tile is transferred to the Image class.
     // If a tile already exists at the given coordinates, it gets replaced.
     void set_tile(
         const size_t        tile_x,

--- a/src/appleseed/foundation/utility/job/jobqueue.h
+++ b/src/appleseed/foundation/utility/job/jobqueue.h
@@ -98,7 +98,7 @@ class APPLESEED_DLLSYMBOL JobQueue
     // Return the number of scheduled and running jobs in the job queue.
     size_t get_total_job_count() const;
 
-    // Schedule a job for execution. Ownership of the job is transfered
+    // Schedule a job for execution. Ownership of the job is transferred
     // to the job queue if and only if transfer_ownership is true.
     void schedule(IJob* job, const bool transfer_ownership = true);
 

--- a/src/appleseed/renderer/device/renderdevicebase.cpp
+++ b/src/appleseed/renderer/device/renderdevicebase.cpp
@@ -113,7 +113,7 @@ IRendererController::Status RenderDeviceBase::wait_for_event(
         }
 
         renderer_controller.on_progress();
-        foundation::sleep(1);   // namespace qualifer required
+        foundation::sleep(1);   // namespace qualifier required
     }
 }
 

--- a/src/appleseed/renderer/kernel/intersection/embreescene.cpp
+++ b/src/appleseed/renderer/kernel/intersection/embreescene.cpp
@@ -194,7 +194,7 @@ namespace
         // Calculate exponent-adaptive offset.
         // Note: float is represented in memory
         // as 1 sign bit, 8 exponent bits and 23 mantissa bits.
-        // Higher 24th bit is always 1 in normalized form, hence it's ommited.
+        // Higher 24th bit is always 1 in normalized form, hence it's omitted.
         // Mantissa of constructed float will overlap no more than 11 last bits of
         // origin components due to exponent shift.
         // Mantissa of constructed float is just a

--- a/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
+++ b/src/appleseed/renderer/kernel/lighting/backwardlightsampler.cpp
@@ -63,7 +63,7 @@ Dictionary BackwardLightSampler::get_params_metadata()
             .insert("values", "cdf|lighttree")
             .insert("default", "cdf")
             .insert("label", "Light Sampler")
-            .insert("help", "Light sampling algoritm")
+            .insert("help", "Light sampling algorithm")
             .insert(
                 "options",
                 Dictionary()
@@ -178,7 +178,7 @@ BackwardLightSampler::BackwardLightSampler(
     }
     else
     {
-        // Prepare the light-emitting shapes CDF for smapling.
+        // Prepare the light-emitting shapes CDF for sampling.
         if (m_emitting_shapes_cdf.valid())
             m_emitting_shapes_cdf.prepare();
 

--- a/src/appleseed/renderer/kernel/rendering/final/pixelsampler.h
+++ b/src/appleseed/renderer/kernel/rendering/final/pixelsampler.h
@@ -60,7 +60,7 @@ class PixelSampler
     // Compute the position of a pixel sample and optionally the initial instance
     // number of the corresponding sampling context, given the integer coordinates
     // of the subpixel grid cell containing the sample. The coordinates of the
-    // pixel sample are expressed in continous image space
+    // pixel sample are expressed in continuous image space
     // (https://github.com/appleseedhq/appleseed/wiki/Terminology).
     void sample(
         const int               sx,

--- a/src/appleseed/renderer/kernel/rendering/generic/tilejob.cpp
+++ b/src/appleseed/renderer/kernel/rendering/generic/tilejob.cpp
@@ -96,7 +96,7 @@ void TileJob::execute(const size_t thread_index)
     // case of 3ds Max and Maya, updating the UI (e.g. displaying rendered tiles) can only
     // be done from a specific thread: the "main thread" or "UI thread".
     //
-    // To accomodate this constraint, plugins pass a single tile callback to the constructor
+    // To accommodate this constraint, plugins pass a single tile callback to the constructor
     // of `MasterRenderer` instead of a tile callback _factory_. `MasterRenderer` then wraps
     // this single tile callback into a `SerialTileCallback` whose sole purpose is to push
     // updates to a `SerialRendererController`, which in turn stores them into a local queue.

--- a/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
+++ b/src/appleseed/renderer/kernel/shading/shadingpoint.cpp
@@ -818,7 +818,7 @@ void ShadingPoint::compute_shading_basis() const
 
     if (m_primitive_type == PrimitiveCurve3)
     {
-        // Contruct shading basis for hair BSDF.
+        // Construct shading basis for hair BSDF.
         // todo: add flag to differentiate curves from hair.
         const Vector3d x = normalize(get_dpdu(0));
         const Vector3d sn_curve = get_original_shading_normal();

--- a/src/appleseed/renderer/modeling/aov/cryptomatteaov.cpp
+++ b/src/appleseed/renderer/modeling/aov/cryptomatteaov.cpp
@@ -117,7 +117,7 @@ namespace
         ~MultiChannelExrFileWriter() override
         {
 #if OIIO_VERSION < 20000
-            // Destroy the ImageOutput stucture.
+            // Destroy the ImageOutput structure.
             if (m_writer != nullptr)
                 OIIO::ImageOutput::destroy(m_writer);
 #endif

--- a/src/appleseed/renderer/modeling/bssrdf/separablebssrdf.cpp
+++ b/src/appleseed/renderer/modeling/bssrdf/separablebssrdf.cpp
@@ -483,7 +483,7 @@ void SeparableBSSRDF::do_evaluate(
         return;
     }
 
-    // The profile function evalutes to zero outside the sampling disk.
+    // The profile function evaluates to zero outside the sampling disk.
     const float square_radius =
         static_cast<float>(
             square_norm(outgoing_point.get_point() - incoming_point.get_point()));

--- a/src/appleseed/renderer/modeling/camera/multilenscamera.cpp
+++ b/src/appleseed/renderer/modeling/camera/multilenscamera.cpp
@@ -604,7 +604,7 @@ class MultiLensCamera
                     return true;
                 }
 
-                p0 = Vector3d(0, 0, image_plane_z); // center of iamge plane
+                p0 = Vector3d(0, 0, image_plane_z); // center of image plane
                 pmin = Vector3d(0, 0, m_last_z); // center of the rear lens
                 pmax = Vector3d(0.5 * m_lens_container.back().diameter, 0, m_last_z); // marginal point of the rear lens
             }
@@ -936,7 +936,7 @@ class MultiLensCamera
         //
 
         // Comments are preceded by a # and can stand on their own line or at the end of a line.
-        // The first non-comment line should contain the number of following lens elments.
+        // The first non-comment line should contain the number of following lens elements.
         // Lens elements have to be space separated values of the format:
         // radius    thickness    ior    aperture
         bool read_lens_file(const Project& project, double factor)

--- a/src/appleseed/renderer/modeling/environmentedf/oslenvironmentedf.cpp
+++ b/src/appleseed/renderer/modeling/environmentedf/oslenvironmentedf.cpp
@@ -126,7 +126,7 @@ namespace
             const Vector3f local_outgoing =
                 Vector3f::make_unit_vector(cos_theta, sin_theta, cos_phi, sin_phi);
 
-            // OSL exectute system.
+            // OSL execute system.
             payload = m_osl_shadergroup_exec.execute_background(*m_shader_group, local_outgoing);
 
             importance = luminance(payload);

--- a/src/appleseed/renderer/modeling/frame/frame.cpp
+++ b/src/appleseed/renderer/modeling/frame/frame.cpp
@@ -765,7 +765,7 @@ namespace
         const ImageAttributes& exr_attributes = std::get<2>(checkpoint_props[0]);
         const std::string initial_layer_name = std::get<0>(checkpoint_props[0]);
 
-        // Check for atttributes.
+        // Check for attributes.
         if (!exr_attributes.exist("appleseed:LastPass"))
         {
             RENDERER_LOG_ERROR("incorrect checkpoint: some attributes are missing.");

--- a/src/appleseed/renderer/modeling/postprocessingstage/effect/resamplex2applier.cpp
+++ b/src/appleseed/renderer/modeling/postprocessingstage/effect/resamplex2applier.cpp
@@ -123,8 +123,8 @@ void ResampleX2Applier::apply(
         static_cast<float>(m_src_height - 1) / (dst_height - 1));
 
     // Note: using "dst / 2 == m_src" instead of "dst == m_src * 2" when upsampling accounts for
-    // the destination image having odd dimenion values, making "dst == 2 * m_src + 1" actually.
-    // Thus, integer truncation also allows a source image with odd dimenions when downsampling.
+    // the destination image having odd dimension values, making "dst == 2 * m_src + 1" actually.
+    // Thus, integer truncation also allows a source image with odd dimensions when downsampling.
     assert(
         m_mode == SamplingMode::DOUBLE
         ? dst_width / 2 == m_src_width && dst_height / 2 == m_src_height    // scale x2 with bilinear filtering

--- a/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
+++ b/src/appleseed/renderer/modeling/project/projectfileupdater.cpp
@@ -1884,7 +1884,7 @@ namespace
 
                     move_if_exist(root, "passes", gfr, "passes");
 
-                    // Remove the dictionnary from the root if it's empty.
+                    // Remove the dictionary from the root if it's empty.
                     if (gfr.empty())
                         root.dictionaries().remove("generic_frame_renderer");
                 }


### PR DESCRIPTION
Fixes various user-facing and non-user-facing typos. Found via `codespell -q 3 -S "./src/thirdparty,./src/appleseed/foundation/utility/minizip" -L fo,localy,mis,ot`