### PR TITLE
Headers for the new thirdparty/statmc Files

### DIFF
--- a/src/thirdparty/statmc/CMakeLists.txt
+++ b/src/thirdparty/statmc/CMakeLists.txt
@@ -1,4 +1,29 @@
-# TODO: Proper Head
+#
+# This source file is part of appleseed.
+# Visit https://appleseedhq.net/ for additional information and resources.
+#
+# This software is released under the MIT license.
+#
+# TODO: Copyright
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
 
 #--------------------------------------------------------------------------------------------------
 # Source files.

--- a/src/thirdparty/statmc/statmc/denoiser.cpp
+++ b/src/thirdparty/statmc/statmc/denoiser.cpp
@@ -1,6 +1,10 @@
 
-// TODO: Proper Head
-// TODO: Proper citation of https://github.com/cg-tuwien/StatMC-opencv_contrib. The code here is written after their example.
+// This file comes from the original StatMC-opencv_contrib implementation,
+// with minor changes to fit them into Appleseed.
+// Original license: Apache-2.0 license
+
+// Implementation of the CUDA denoiser for the SIGGRAPH Asia 2024 conference paper "A Statistical Approach to Monte Carlo Denoising" [Sakai et al. 2024] based on OpenCV.
+// Visit https://github.com/cg-tuwien/StatMC-opencv_contrib and https://users.cg.tuwien.ac.at/~hiroyuki/StatMC/ for additional information and resources.
 
 
 // Interface header.

--- a/src/thirdparty/statmc/statmc/denoiser.h
+++ b/src/thirdparty/statmc/statmc/denoiser.h
@@ -1,6 +1,11 @@
 
-// TODO: Proper Head
-// TODO: Proper citation of https://github.com/cg-tuwien/StatMC-opencv_contrib. The input default values are taken from their example.
+// This file comes from the original StatMC-opencv_contrib implementation,
+// with minor changes to fit them into Appleseed.
+// Original license: Apache-2.0 license
+
+// Implementation of the CUDA denoiser for the SIGGRAPH Asia 2024 conference paper "A Statistical Approach to Monte Carlo Denoising" [Sakai et al. 2024] based on OpenCV.
+// Visit https://github.com/cg-tuwien/StatMC-opencv_contrib and https://users.cg.tuwien.ac.at/~hiroyuki/StatMC/ for additional information and resources.
+
 
 #pragma once
 


### PR DESCRIPTION
I copied/oriented my self by the way other Appleseed files and the thirdparty/bcd files have their headers composed.

NOTE: statmc/CMakeLists.txt is missing correct Copyright